### PR TITLE
fix(infra): CodeBuild buildspecs use bash for pipefail

### DIFF
--- a/infrastructure/buildspecs/app-build.yml
+++ b/infrastructure/buildspecs/app-build.yml
@@ -1,6 +1,8 @@
 # CodeBuild: Maven package + artifact for CodePipeline (include deploy helper script).
 # Used when source = CODEPIPELINE.
 version: 0.2
+env:
+  shell: bash
 phases:
   install:
     runtime-versions:

--- a/infrastructure/buildspecs/app-deploy.yml
+++ b/infrastructure/buildspecs/app-deploy.yml
@@ -1,5 +1,7 @@
 # CodeBuild deploy: S3 + SSM (NUTR_PROJECT = Terraform var.project, set in the CodeBuild project).
 version: 0.2
+env:
+  shell: bash
 phases:
   build:
     commands:


### PR DESCRIPTION
CodeBuild runs commands with `/bin/sh` by default; on `aws/codebuild/standard:7.0` that is often dash, which does not support `set -o pipefail`.

Adds `env.shell: bash` to `infrastructure/buildspecs/app-build.yml` and `infrastructure/buildspecs/app-deploy.yml` per the [CodeBuild buildspec reference](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html).

**After merge:** run `terraform apply` once so the deploy CodeBuild project picks up the updated inlined `app-deploy.yml`.

Made with [Cursor](https://cursor.com)