### PR TITLE
fix(infra): CodePipeline deploy IAM, faster CodeBuild package

### DIFF
--- a/infrastructure/buildspecs/app-build.yml
+++ b/infrastructure/buildspecs/app-build.yml
@@ -1,5 +1,7 @@
 # CodeBuild: Maven package + artifact for CodePipeline (include deploy helper script).
-# Used when source = CODEPIPELINE.
+# Used when source = CODEPIPELINE. -Dmaven.test.skip=true skips test compile and run (faster).
+# The POM has no test-generated sources feeding main; `mvn -Dmaven.test.skip=true package` is green locally.
+# Full tests + Thymeleaf template checks run in GitHub CI.
 version: 0.2
 env:
   shell: bash
@@ -10,7 +12,7 @@ phases:
   build:
     commands:
       - set -euxo pipefail
-      - mvn -B package --file pom.xml
+      - mvn -B package -Dmaven.test.skip=true --file pom.xml
 artifacts:
   name: build_output
   base-directory: .

--- a/infrastructure/codepipeline.tf
+++ b/infrastructure/codepipeline.tf
@@ -46,11 +46,30 @@ resource "aws_codestarconnections_connection" "github" {
 }
 
 # -----------------------------------------------------------------------------
-# IAM: CodeBuild (deploy) - S3 JAR + SSM (same surface as the old GHA role)
+# IAM: CodeBuild (deploy) - pipeline artifacts (read prior stage) + S3 JAR + SSM
 # -----------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "codebuild_app_deploy" {
   count = local.codepipeline_enabled ? 1 : 0
+  # Same bucket as the build project: input artifacts from the Build stage (CODEPIPELINE).
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:AbortMultipartUpload",
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+    ]
+    resources = [
+      "${aws_s3_bucket.codepipeline[0].arn}",
+      "${aws_s3_bucket.codepipeline[0].arn}/*",
+    ]
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.codepipeline[0].arn]
+  }
   statement {
     effect    = "Allow"
     actions   = ["s3:PutObject", "s3:AbortMultipartUpload"]


### PR DESCRIPTION
## Summary
- Grant `nutriconsultas-codebuild-deploy` S3 read/list (and same pipeline-bucket object access as build) on the CodePipeline artifacts bucket so the deploy stage can download the Build output (`s3:GetObject` was denied).
- Speed up CodeBuild app build: `mvn package -Dmaven.test.skip=true` (full tests remain on GitHub CI).

## Test plan
- [ ] `terraform apply` (already applied or apply in target account) for IAM
- [ ] Re-run CodePipeline; Build + Deploy succeed
- [ ] Local: `mvn -Dmaven.test.skip=true package` (verified green)

Made with [Cursor](https://cursor.com)