### PR TITLE
fix(infra): Certbot on AL2023, domain-setup HTTPS notes

### DIFF
--- a/infrastructure/domain-setup.md
+++ b/infrastructure/domain-setup.md
@@ -55,4 +55,12 @@ You can either **delegate the whole domain to Route 53** (useful if you want al
 - From a laptop: `dig +short minutriporcion.com` (or an online “DNS checker”) should return the app’s **public** IPv4 after TTL expires.
 - From a browser: `http://minutriporcion.com` should hit **nginx** on 80, which reverse-proxies to the Spring Boot port **3000** on the same instance.
 
+### HTTP works but HTTPS does not (connection refused, `curl` shows `000`)
+
+The security group allows **443**, but **nginx only listens on 80** until **Let’s Encrypt (Certbot)** has run successfully. Certbot is triggered from **EC2 user data** when `public_site_domain` and `certbot_admin_email` are set in Terraform. If first-boot Certbot did not complete (e.g. DNS not ready yet, or package install failed on Amazon Linux 2023), you will have HTTP but **no listener on 443** until you fix it on the host.
+
+- **Re-running CodePipeline** only uploads the JAR and restarts the app via SSM. It does **not** re-run cloud-init, reinstall Certbot, or add the HTTPS listener. **A pipeline re-run alone will not fix port 443.**
+- **To enable HTTPS on the current instance:** use **SSM Session Manager** on the app EC2, install `certbot` and `python3-certbot-nginx` if needed, then run `certbot --nginx` for your domain(s) (same hostnames as in Terraform). See `templates/app.user_data.sh` and variable `certbot_admin_email`.
+- **New instances only:** after fixing `templates/app.user_data.sh`, `terraform apply` can replace the instance (`user_data_replace_on_change`); that runs user data again. Prefer one-off **manual Certbot** for production unless you plan a controlled replacement.
+
 **IPv6** is not configured in the Terraform here; you can add AAAA to an Elastic IP that supports it or use a dual-stack design later. For a minimal first deployment, **A** to the IPv4 EIP is enough.

--- a/infrastructure/templates/app.user_data.sh
+++ b/infrastructure/templates/app.user_data.sh
@@ -87,10 +87,10 @@ chown -R root:nutri /opt/nutriconsultas
 systemctl daemon-reload
 
 # Let's Encrypt (HTTP-01): DNS for all names must point to this host before this runs.
+# On Amazon Linux 2023, use OS repos only — do not install EPEL; it breaks Python deps for certbot.
 if [ '${certbot_run_flag}' = '1' ] && [ -n '${certbot_d_flags}' ]; then
-  dnf -y install epel-release || true
   if ! dnf -y install certbot python3-certbot-nginx; then
-    echo "WARN: certbot install failed; install EPEL + certbot manually, then: certbot --nginx ..." >&2
+    echo "WARN: certbot install failed; on AL2023 run: dnf install -y certbot python3-certbot-nginx then certbot --nginx ..." >&2
   else
     CERTBOT_EMAIL="$(printf '%s' '${certbot_email_b64}' | base64 -d)"
     certbot_ok=0


### PR DESCRIPTION
## Summary
- User data: install Certbot without EPEL on Amazon Linux 2023 (reliable `certbot` + `python3-certbot-nginx`).
- `domain-setup.md`: document HTTP vs HTTPS, that CodePipeline does not enable 443, and how to fix (SSM / instance replacement).

## Test plan
- [ ] `terraform validate` (optional)
- [ ] After merge: `terraform apply -replace=aws_instance.app` when ready; confirm Certbot + HTTPS on new instance

Made with [Cursor](https://cursor.com)