### PR TITLE
feat: update Plus tier pricing to $30/mes

### DIFF
--- a/src/main/resources/templates/eterna/index.html
+++ b/src/main/resources/templates/eterna/index.html
@@ -286,9 +286,9 @@
           <div class="col-lg-3 box featured">
             <span class="featured-badge">Popular</span>
             <h3>Plus</h3>
-            <h4>$20<span>/mes</span></h4>
+            <h4>$30<span>/mes</span></h4>
             <p class="text-muted small">Pago mensual: 12 meses</p>
-            <p class="text-success small"><strong>Pago anual: $200/año</strong> (10 meses, ahorra $40)</p>
+            <p class="text-success small"><strong>Pago anual: $300/año</strong> (10 meses, ahorra $60)</p>
             <ul>
               <li><i class="bx bx-check"></i> Pacientes ilimitados</li>
               <li><i class="bx bx-check"></i> Gestión de pacientes</li>


### PR DESCRIPTION
## Summary
- Update Plus tier monthly pricing from $20/mes to $30/mes
- Update Plus tier annual pricing from $200/año to $300/año (10 meses, ahorra $60)

## Acceptance Criteria
- [x] Plus tier displays $30/mes
- [x] Plus tier displays $300/año with updated savings ($60)
- [x] Other tiers (Básico $5, Profesional $10, Consultorio $45) unchanged
- [x] "Popular" badge remains on Plus card
- [x] `mvn compile` succeeds

Closes #71