### PR TITLE
feat: redesign pricing section as feature comparison table

### DIFF
--- a/src/main/resources/static/eterna/assets/css/style.css
+++ b/src/main/resources/static/eterna/assets/css/style.css
@@ -2221,3 +2221,59 @@ section {
   font-size: 13px;
   color: #fff;
 }
+
+/*--------------------------------------------------------------
+# Pricing Comparison Table
+--------------------------------------------------------------*/
+.pricing .pricing-comparison {
+  margin-top: 30px;
+}
+.pricing .pricing-table {
+  background: #fff;
+}
+.pricing .pricing-table th,
+.pricing .pricing-table td {
+  vertical-align: middle;
+  text-align: center;
+  padding: 14px 16px;
+  border-color: #e6e6e6;
+}
+.pricing .pricing-table thead th {
+  background: #f7f9fc;
+  font-weight: 600;
+  border-bottom: 2px solid #2dc997;
+}
+.pricing .pricing-table .feature-col {
+  text-align: left;
+  font-weight: 500;
+  position: sticky;
+  left: 0;
+  background: #fff;
+  z-index: 2;
+  min-width: 200px;
+}
+.pricing .pricing-table thead .feature-col {
+  background: #f7f9fc;
+}
+.pricing .pricing-table .featured-col {
+  background: rgba(45, 201, 151, 0.08);
+  font-weight: 500;
+}
+.pricing .pricing-table thead .featured-col {
+  background: #2dc997;
+  color: #fff;
+  border-bottom-color: #2dc997;
+}
+.pricing .pricing-table .bx-check {
+  color: #2dc997;
+  font-size: 1.4rem;
+}
+.pricing .pricing-table .bx-x {
+  color: #c0392b;
+  font-size: 1.4rem;
+}
+@media (max-width: 768px) {
+  .pricing .pricing-table .feature-col {
+    min-width: 160px;
+  }
+}

--- a/src/main/resources/templates/eterna/index.html
+++ b/src/main/resources/templates/eterna/index.html
@@ -31,18 +31,18 @@
   <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 
   <style th:inline="text">
-    .carousel-pic1 {
-      background-image: url('[(@{/eterna/assets/img/carousel/bienvenido.png})]');
-    }
-    .carousel-pic2 {
-      background-image: url('[(@{/eterna/assets/img/carousel/gestion_profesional.jpeg})]');
-    }
-    .carousel-pic3 {
-      background-image: url('[(@{/eterna/assets/img/carousel/personas-ejercitandose.jpeg})]');
-    }
-    #main {
-      padding-top: 150px;
-    }
+  .carousel-pic1 {
+    background-image: url('[(@{/eterna/assets/img/carousel/bienvenido.png})]');
+  }
+  .carousel-pic2 {
+    background-image: url('[(@{/eterna/assets/img/carousel/gestion_profesional.jpeg})]');
+  }
+  .carousel-pic3 {
+    background-image: url('[(@{/eterna/assets/img/carousel/personas-ejercitandose.jpeg})]');
+  }
+  #main {
+    padding-top: 150px;
+  }
   </style>
 </head>
 
@@ -252,76 +252,132 @@
           <div class="col-lg-3 box">
             <h3>Básico</h3>
             <h4>$5<span>/mes</span></h4>
-            <p class="text-muted small">Pago mensual: 12 meses</p>
-            <p class="text-success small"><strong>Pago anual: $50/año</strong> (10 meses, ahorra $10)</p>
-            <ul>
-              <li><i class="bx bx-check"></i> Hasta 10 pacientes</li>
-              <li><i class="bx bx-check"></i> Gestión de pacientes</li>
-              <li><i class="bx bx-check"></i> Planes de alimentación</li>
-              <li><i class="bx bx-check"></i> Seguimiento nutricional</li>
-              <li><i class="bx bx-check"></i> Calendario de citas</li>
-              <li><i class="bx bx-check"></i> Reportes básicos</li>
-              <li class="na"><i class="bx bx-x"></i> <span>Reportes avanzados</span></li>
-            </ul>
             <a href="#contact" class="buy-btn">Solicitar Acceso</a>
           </div>
 
           <div class="col-lg-3 box">
             <h3>Profesional</h3>
             <h4>$10<span>/mes</span></h4>
-            <p class="text-muted small">Pago mensual: 12 meses</p>
-            <p class="text-success small"><strong>Pago anual: $100/año</strong> (10 meses, ahorra $20)</p>
-            <ul>
-              <li><i class="bx bx-check"></i> Hasta 50 pacientes</li>
-              <li><i class="bx bx-check"></i> Gestión de pacientes</li>
-              <li><i class="bx bx-check"></i> Planes de alimentación</li>
-              <li><i class="bx bx-check"></i> Seguimiento nutricional</li>
-              <li><i class="bx bx-check"></i> Calendario de citas</li>
-              <li><i class="bx bx-check"></i> Reportes completos</li>
-              <li><i class="bx bx-check"></i> Exportación PDF</li>
-            </ul>
             <a href="#contact" class="buy-btn">Solicitar Acceso</a>
           </div>
 
           <div class="col-lg-3 box featured">
             <span class="featured-badge">Popular</span>
             <h3>Plus</h3>
-            <h4>$20<span>/mes</span></h4>
-            <p class="text-muted small">Pago mensual: 12 meses</p>
-            <p class="text-success small"><strong>Pago anual: $200/año</strong> (10 meses, ahorra $40)</p>
-            <ul>
-              <li><i class="bx bx-check"></i> Pacientes ilimitados</li>
-              <li><i class="bx bx-check"></i> Gestión de pacientes</li>
-              <li><i class="bx bx-check"></i> Planes de alimentación</li>
-              <li><i class="bx bx-check"></i> Seguimiento nutricional</li>
-              <li><i class="bx bx-check"></i> Calendario de citas</li>
-              <li><i class="bx bx-check"></i> Reportes completos</li>
-              <li><i class="bx bx-check"></i> Exportación PDF</li>
-              <li><i class="bx bx-check"></i> Soporte prioritario</li>
-            </ul>
+            <h4>$30<span>/mes</span></h4>
             <a href="#contact" class="buy-btn">Solicitar Acceso</a>
           </div>
 
           <div class="col-lg-3 box">
             <h3>Consultorio</h3>
             <h4>$45<span>/mes</span></h4>
-            <p class="text-muted small">Pago mensual: 12 meses</p>
-            <p class="text-success small"><strong>Pago anual: $450/año</strong> (10 meses, ahorra $90)</p>
-            <ul>
-              <li><i class="bx bx-check"></i> Pacientes ilimitados</li>
-              <li><i class="bx bx-check"></i> Hasta 20 nutriólogos</li>
-              <li><i class="bx bx-check"></i> Gestión de pacientes</li>
-              <li><i class="bx bx-check"></i> Planes de alimentación</li>
-              <li><i class="bx bx-check"></i> Seguimiento nutricional</li>
-              <li><i class="bx bx-check"></i> Calendario de citas</li>
-              <li><i class="bx bx-check"></i> Reportes completos</li>
-              <li><i class="bx bx-check"></i> Exportación PDF</li>
-              <li><i class="bx bx-check"></i> Soporte prioritario</li>
-              <li><i class="bx bx-check"></i> Administración de usuarios</li>
-            </ul>
             <a href="#contact" class="buy-btn">Solicitar Acceso</a>
           </div>
 
+        </div>
+
+        <div class="row mt-4">
+          <div class="col-lg-12">
+            <div class="table-responsive pricing-comparison">
+              <table class="table pricing-table">
+                <thead>
+                  <tr>
+                    <th class="feature-col">Característica</th>
+                    <th>Básico</th>
+                    <th>Profesional</th>
+                    <th class="featured-col">Plus</th>
+                    <th>Consultorio</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td class="feature-col">Pacientes</td>
+                    <td>Hasta 10</td>
+                    <td>Hasta 50</td>
+                    <td class="featured-col">Ilimitados</td>
+                    <td>Ilimitados</td>
+                  </tr>
+                  <tr>
+                    <td class="feature-col">Gestión de pacientes</td>
+                    <td><i class="bx bx-check"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                    <td class="featured-col"><i class="bx bx-check"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                  </tr>
+                  <tr>
+                    <td class="feature-col">Planes de alimentación</td>
+                    <td><i class="bx bx-check"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                    <td class="featured-col"><i class="bx bx-check"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                  </tr>
+                  <tr>
+                    <td class="feature-col">Seguimiento nutricional</td>
+                    <td><i class="bx bx-check"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                    <td class="featured-col"><i class="bx bx-check"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                  </tr>
+                  <tr>
+                    <td class="feature-col">Calendario de citas</td>
+                    <td><i class="bx bx-check"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                    <td class="featured-col"><i class="bx bx-check"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                  </tr>
+                  <tr>
+                    <td class="feature-col">Reportes básicos</td>
+                    <td><i class="bx bx-check"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                    <td class="featured-col"><i class="bx bx-check"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                  </tr>
+                  <tr>
+                    <td class="feature-col">Reportes avanzados</td>
+                    <td><i class="bx bx-x"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                    <td class="featured-col"><i class="bx bx-check"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                  </tr>
+                  <tr>
+                    <td class="feature-col">Reportes completos</td>
+                    <td><i class="bx bx-x"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                    <td class="featured-col"><i class="bx bx-check"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                  </tr>
+                  <tr>
+                    <td class="feature-col">Exportación PDF</td>
+                    <td><i class="bx bx-x"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                    <td class="featured-col"><i class="bx bx-check"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                  </tr>
+                  <tr>
+                    <td class="feature-col">Soporte prioritario</td>
+                    <td><i class="bx bx-x"></i></td>
+                    <td><i class="bx bx-x"></i></td>
+                    <td class="featured-col"><i class="bx bx-check"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                  </tr>
+                  <tr>
+                    <td class="feature-col">Nutriólogos</td>
+                    <td>1</td>
+                    <td>1</td>
+                    <td class="featured-col">1</td>
+                    <td>Hasta 20</td>
+                  </tr>
+                  <tr>
+                    <td class="feature-col">Administración de usuarios</td>
+                    <td><i class="bx bx-x"></i></td>
+                    <td><i class="bx bx-x"></i></td>
+                    <td class="featured-col"><i class="bx bx-x"></i></td>
+                    <td><i class="bx bx-check"></i></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
 
         <div class="row mt-4">


### PR DESCRIPTION
## Summary
- Update Plus tier pricing from $20/mes to $30/mes ($300/año)
- Redesign pricing section: compact cards (tier name, price, CTA only) + feature comparison table below
- Add 12-row feature comparison table with all tier capabilities side-by-side
- Append scoped CSS (`.pricing-comparison`/`.pricing-table`) for table styling and responsive behavior

## Definition of Done
- [x] Plus tier displays $30/mes
- [x] Pricing cards show only: tier name, price, "Solicitar Acceso" CTA, and "Popular" badge on Plus
- [x] Feature comparison table added below cards with all 12 feature rows per issue #72 spec
- [x] Plus column highlighted with `featured-col` class
- [x] Proceso de Suscripción alert block preserved unchanged
- [x] CSS scoped under `.pricing .pricing-comparison`/`.pricing-table` to avoid collisions
- [x] Responsive styling via `@media (max-width: 768px)`
- [x] `mvn compile` succeeds

Closes #71
Closes #72