### PR TITLE
feat: update patient BMI/BMR from appointment save and anthropometrics (#58)

### DIFF
--- a/src/main/java/com/nutriconsultas/calendar/CalendarEventRestController.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarEventRestController.java
@@ -40,6 +40,7 @@ import com.nutriconsultas.paciente.BodyFatCalculatorService;
 import com.nutriconsultas.paciente.NivelPeso;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.calculation.BmrCalculationService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -638,6 +639,7 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 				existingEvent.setTemperatura(Double.parseDouble(eventData.get("temperatura").toString()));
 			}
 			final CalendarEvent savedEvent = service.save(existingEvent);
+			updatePatientSnapshot(savedEvent);
 			final Map<String, Object> response = new HashMap<>();
 			response.put("success", true);
 			response.put("event", toCalendarEventMap(savedEvent));
@@ -649,6 +651,33 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 			errorResponse.put("success", false);
 			errorResponse.put("error", e.getMessage());
 			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+		}
+	}
+
+	private void updatePatientSnapshot(final CalendarEvent event) {
+		final Paciente paciente = event.getPaciente();
+		if (paciente == null) {
+			return;
+		}
+		boolean changed = false;
+		if (event.getImc() != null) {
+			paciente.setImc(event.getImc());
+			changed = true;
+		}
+		if (event.getPeso() != null && event.getEstatura() != null) {
+			final Integer age = calculateAge(paciente.getDob());
+			final Boolean isMale = "M".equalsIgnoreCase(paciente.getGender());
+			final Double bmr = BmrCalculationService.calculatePromedioBmr(
+					event.getPeso(), event.getEstatura(), age, isMale);
+			if (bmr != null) {
+				paciente.setBmr(bmr);
+				changed = true;
+			}
+		}
+		if (changed) {
+			pacienteRepository.save(paciente);
+			log.debug("Updated patient {} snapshot: imc={}, bmr={}",
+					paciente.getId(), paciente.getImc(), paciente.getBmr());
 		}
 	}
 

--- a/src/main/java/com/nutriconsultas/paciente/Paciente.java
+++ b/src/main/java/com/nutriconsultas/paciente/Paciente.java
@@ -71,6 +71,9 @@ public class Paciente {
 	@Column(precision = 3)
 	private Double imc;
 
+	@Column(precision = 7)
+	private Double bmr;
+
 	private NivelPeso nivelPeso;
 
 	// ANTECEDENTES

--- a/src/main/java/com/nutriconsultas/paciente/PacienteRestController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteRestController.java
@@ -16,9 +16,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -211,6 +215,64 @@ public class PacienteRestController extends AbstractGridController<Paciente> {
 		return Stream.of("nombre", "dob", "email", "phone", "gender", "responsible")
 			.map(Column::new)
 			.collect(Collectors.toList());
+	}
+
+	@PostMapping("/{id}/assign-bmi")
+	public ResponseEntity<java.util.Map<String, Object>> assignBmi(
+			@PathVariable @NonNull final Long id,
+			@RequestBody final java.util.Map<String, Object> body,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = principal != null ? principal.getSubject() : null;
+		if (userId == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+				.body(java.util.Map.of("success", false, "error", "Not authenticated"));
+		}
+		try {
+			final Paciente paciente = service.findByIdAndUserId(id, userId);
+			if (paciente == null) {
+				return ResponseEntity.status(HttpStatus.NOT_FOUND)
+					.body(java.util.Map.of("success", false, "error", "Paciente no encontrado"));
+			}
+			final Double bmi = Double.parseDouble(body.get("bmi").toString());
+			paciente.setImc(bmi);
+			service.save(paciente);
+			log.debug("Assigned BMI {} to patient {}", bmi, id);
+			return ResponseEntity.ok(java.util.Map.of("success", true, "imc", bmi));
+		}
+		catch (Exception e) {
+			log.error("Error assigning BMI to patient {}", id, e);
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+				.body(java.util.Map.of("success", false, "error", e.getMessage()));
+		}
+	}
+
+	@PostMapping("/{id}/assign-bmr")
+	public ResponseEntity<java.util.Map<String, Object>> assignBmr(
+			@PathVariable @NonNull final Long id,
+			@RequestBody final java.util.Map<String, Object> body,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = principal != null ? principal.getSubject() : null;
+		if (userId == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+				.body(java.util.Map.of("success", false, "error", "Not authenticated"));
+		}
+		try {
+			final Paciente paciente = service.findByIdAndUserId(id, userId);
+			if (paciente == null) {
+				return ResponseEntity.status(HttpStatus.NOT_FOUND)
+					.body(java.util.Map.of("success", false, "error", "Paciente no encontrado"));
+			}
+			final Double bmr = Double.parseDouble(body.get("bmr").toString());
+			paciente.setBmr(bmr);
+			service.save(paciente);
+			log.debug("Assigned BMR {} to patient {}", bmr, id);
+			return ResponseEntity.ok(java.util.Map.of("success", true, "bmr", bmr));
+		}
+		catch (Exception e) {
+			log.error("Error assigning BMR to patient {}", id, e);
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+				.body(java.util.Map.of("success", false, "error", e.getMessage()));
+		}
 	}
 
 }

--- a/src/main/resources/templates/sbadmin/pacientes/perfil.html
+++ b/src/main/resources/templates/sbadmin/pacientes/perfil.html
@@ -69,6 +69,11 @@
                       <p class="mb-0 text-muted" th:if="${ultimoImc == null}">N/A</p>
                     </li>
                     <li class="list-group-item d-flex justify-content-between align-items-center p-3">
+                      <i class="fas fa-fire fa-lg" style="color: #ff6b35;"></i>
+                      <p class="mb-0" th:if="${paciente.bmr != null}">[[(${#numbers.formatDecimal(paciente.bmr,1,'COMMA',0,'POINT')})]] kcal/día (BMR)</p>
+                      <p class="mb-0 text-muted" th:if="${paciente.bmr == null}">BMR N/A</p>
+                    </li>
+                    <li class="list-group-item d-flex justify-content-between align-items-center p-3">
                       <i class="fas fa-calendar fa-lg" style="color: #ac2bac;"></i>
                       <p class="mb-0">[[(${citaAnterior})]] - Cita Anterior</p>
                     </li>

--- a/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
+++ b/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
@@ -460,6 +460,9 @@
                               </div>
                               <div class="alert alert-light mb-0">
                                 <strong>Resultado:</strong> <span id="classic-bmi-result" class="text-primary">-</span>
+                                <div class="mt-1">
+                                  <button type="button" class="btn btn-sm btn-outline-primary assign-bmi-btn" data-source="classic-bmi-result">Asignar al paciente</button>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -483,6 +486,9 @@
                               </div>
                               <div class="alert alert-light mb-0">
                                 <strong>Resultado:</strong> <span id="trefethen-bmi-result" class="text-primary">-</span>
+                                <div class="mt-1">
+                                  <button type="button" class="btn btn-sm btn-outline-primary assign-bmi-btn" data-source="trefethen-bmi-result">Asignar al paciente</button>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -531,6 +537,9 @@
                               <p class="text-muted small mb-2">Mismo valor que BMI Clásico</p>
                               <div class="alert alert-light mb-0">
                                 <strong>Resultado:</strong> <span id="imc-result" class="text-primary">-</span>
+                                <div class="mt-1">
+                                  <button type="button" class="btn btn-sm btn-outline-primary assign-bmi-btn" data-source="imc-result">Asignar al paciente</button>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -573,6 +582,9 @@
                               </div>
                               <div class="alert alert-light mb-0">
                                 <strong>Resultado:</strong> <span id="msj-bmr-result" class="text-primary">-</span> <small>kcal/día</small>
+                                <div class="mt-1">
+                                  <button type="button" class="btn btn-sm btn-outline-success assign-bmr-btn" data-source="msj-bmr-result">Asignar al paciente</button>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -609,6 +621,9 @@
                               </div>
                               <div class="alert alert-light mb-0">
                                 <strong>Resultado:</strong> <span id="hb-bmr-result" class="text-primary">-</span> <small>kcal/día</small>
+                                <div class="mt-1">
+                                  <button type="button" class="btn btn-sm btn-outline-success assign-bmr-btn" data-source="hb-bmr-result">Asignar al paciente</button>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -654,6 +669,9 @@
                               </div>
                               <div class="alert alert-light mb-0">
                                 <strong>Resultado:</strong> <span id="fao-bmr-result" class="text-primary">-</span> <small>kcal/día</small>
+                                <div class="mt-1">
+                                  <button type="button" class="btn btn-sm btn-outline-success assign-bmr-btn" data-source="fao-bmr-result">Asignar al paciente</button>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -691,6 +709,9 @@
                               </div>
                               <div class="alert alert-light mb-0">
                                 <strong>Resultado:</strong> <span id="val-bmr-result" class="text-primary">-</span> <small>kcal/día</small>
+                                <div class="mt-1">
+                                  <button type="button" class="btn btn-sm btn-outline-success assign-bmr-btn" data-source="val-bmr-result">Asignar al paciente</button>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -727,6 +748,9 @@
                               </div>
                               <div class="alert alert-light mb-0">
                                 <strong>Resultado:</strong> <span id="prom-bmr-result" class="text-primary">-</span> <small>kcal/día</small>
+                                <div class="mt-1">
+                                  <button type="button" class="btn btn-sm btn-outline-success assign-bmr-btn" data-source="prom-bmr-result">Asignar al paciente</button>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -933,6 +957,67 @@
 
     <!-- Calculation Tab JavaScript -->
     <div th:insert="~{sbadmin/pacientes/calculation-script :: calculationScript(false)}"></div>
+
+    <!-- Assign BMI/BMR to Patient -->
+    <script th:inline="javascript">
+      /*<![CDATA[*/
+      (function () {
+        var pacienteId = /*[[${paciente.id}]]*/ null;
+
+        function showToast(message, success) {
+          if (typeof toastr !== 'undefined') {
+            if (success) { toastr.success(message); } else { toastr.error(message); }
+            return;
+          }
+          var cls = success ? 'alert-success' : 'alert-danger';
+          var div = document.createElement('div');
+          div.className = 'alert ' + cls + ' alert-dismissible fade show position-fixed';
+          div.style.cssText = 'top:1rem;right:1rem;z-index:9999;min-width:250px';
+          div.innerHTML = message + '<button type="button" class="close" data-dismiss="alert"><span>&times;</span></button>';
+          document.body.appendChild(div);
+          setTimeout(function () { div.remove(); }, 4000);
+        }
+
+        function assignValue(endpoint, value, label) {
+          if (!pacienteId || isNaN(value) || value <= 0) {
+            showToast('Calcule ' + label + ' antes de asignar.', false);
+            return;
+          }
+          var body = {};
+          body[label === 'BMI' ? 'imc' : 'bmr'] = value;
+          fetch('/rest/pacientes/' + pacienteId + '/' + endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+          }).then(function (res) {
+            if (res.ok) {
+              showToast(label + ' asignado correctamente al paciente.', true);
+            } else {
+              showToast('Error al asignar ' + label + '. Código: ' + res.status, false);
+            }
+          }).catch(function () {
+            showToast('Error de red al asignar ' + label + '.', false);
+          });
+        }
+
+        document.addEventListener('click', function (e) {
+          var btn = e.target.closest('.assign-bmi-btn');
+          if (btn) {
+            var spanId = btn.getAttribute('data-source');
+            var val = parseFloat(document.getElementById(spanId).textContent);
+            assignValue('assign-bmi', val, 'BMI');
+            return;
+          }
+          btn = e.target.closest('.assign-bmr-btn');
+          if (btn) {
+            var spanId2 = btn.getAttribute('data-source');
+            var val2 = parseFloat(document.getElementById(spanId2).textContent);
+            assignValue('assign-bmr', val2, 'BMR');
+          }
+        });
+      })();
+      /*]]>*/
+    </script>
 
 </body>
 

--- a/src/test/java/com/nutriconsultas/calendar/CalendarEventRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/calendar/CalendarEventRestControllerTest.java
@@ -1987,7 +1987,7 @@ public class CalendarEventRestControllerTest {
 		eventData.put("estatura", 1.75);
 
 		when(service.findById(1L)).thenReturn(existingEvent);
-		when(service.save(any(CalendarEvent.class))).thenAnswer(inv -> inv.getArgument(0));
+		lenient().when(service.save(any(CalendarEvent.class))).thenAnswer(inv -> inv.getArgument(0));
 
 		// Act & Assert
 		org.assertj.core.api.Assertions.assertThatCode(

--- a/src/test/java/com/nutriconsultas/calendar/CalendarEventRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/calendar/CalendarEventRestControllerTest.java
@@ -1922,4 +1922,102 @@ public class CalendarEventRestControllerTest {
 		log.info("finished testUpdateEventWithSqlDate");
 	}
 
+	@Test
+	@org.junit.jupiter.api.DisplayName("updateEvent with peso and estatura propagates imc and bmr to patient")
+	public void updateEvent_withPesoAndEstatura_propagatesImcAndBmrToPatient() {
+		log.info("starting updateEvent_withPesoAndEstatura_propagatesImcAndBmrToPatient");
+		// Arrange
+		final CalendarEvent existingEvent = events.get(0); // has paciente with dob and gender set
+		final Map<String, Object> eventData = new HashMap<>();
+		eventData.put("peso", 70.0);
+		eventData.put("estatura", 1.75);
+		eventData.put("imc", 22.9);
+
+		when(service.findById(1L)).thenReturn(existingEvent);
+		when(service.save(any(CalendarEvent.class))).thenAnswer(inv -> inv.getArgument(0));
+
+		// Act
+		final ResponseEntity<Map<String, Object>> response = calendarEventRestController.updateEvent(1L, eventData,
+				principal);
+
+		// Assert
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		verify(pacienteRepository).save(org.mockito.ArgumentMatchers.argThat(
+				p -> p.getImc() != null && p.getBmr() != null && p.getBmr() > 0));
+		log.info("finished updateEvent_withPesoAndEstatura_propagatesImcAndBmrToPatient");
+	}
+
+	@Test
+	@org.junit.jupiter.api.DisplayName("updateEvent without peso does not update patient snapshot")
+	public void updateEvent_withoutPeso_doesNotUpdatePatientSnapshot() {
+		log.info("starting updateEvent_withoutPeso_doesNotUpdatePatientSnapshot");
+		// Arrange
+		final CalendarEvent existingEvent = events.get(0);
+		final Map<String, Object> eventData = new HashMap<>();
+		eventData.put("status", "SCHEDULED");
+
+		when(service.findById(1L)).thenReturn(existingEvent);
+		when(service.save(any(CalendarEvent.class))).thenAnswer(inv -> inv.getArgument(0));
+
+		// Act
+		final ResponseEntity<Map<String, Object>> response = calendarEventRestController.updateEvent(1L, eventData,
+				principal);
+
+		// Assert
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		verify(pacienteRepository, never()).save(any());
+		log.info("finished updateEvent_withoutPeso_doesNotUpdatePatientSnapshot");
+	}
+
+	@Test
+	@org.junit.jupiter.api.DisplayName("updateEvent with null paciente does not throw")
+	public void updateEvent_withNullPaciente_doesNotThrow() {
+		log.info("starting updateEvent_withNullPaciente_doesNotThrow");
+		// Arrange
+		final CalendarEvent existingEvent = new CalendarEvent();
+		existingEvent.setId(1L);
+		existingEvent.setTitle("Sin paciente");
+		existingEvent.setEventDateTime(new Date());
+		existingEvent.setDurationMinutes(30);
+		existingEvent.setStatus(EventStatus.SCHEDULED);
+		existingEvent.setPaciente(null);
+
+		final Map<String, Object> eventData = new HashMap<>();
+		eventData.put("peso", 70.0);
+		eventData.put("estatura", 1.75);
+
+		when(service.findById(1L)).thenReturn(existingEvent);
+		when(service.save(any(CalendarEvent.class))).thenAnswer(inv -> inv.getArgument(0));
+
+		// Act & Assert
+		org.assertj.core.api.Assertions.assertThatCode(
+				() -> calendarEventRestController.updateEvent(1L, eventData, principal))
+				.doesNotThrowAnyException();
+		verify(pacienteRepository, never()).save(any());
+		log.info("finished updateEvent_withNullPaciente_doesNotThrow");
+	}
+
+	@Test
+	@org.junit.jupiter.api.DisplayName("updateEvent with explicit imc only updates imc without bmr")
+	public void updateEvent_withExplicitImcOnly_updatesImcWithoutBmr() {
+		log.info("starting updateEvent_withExplicitImcOnly_updatesImcWithoutBmr");
+		// Arrange
+		final CalendarEvent existingEvent = events.get(0);
+		final Map<String, Object> eventData = new HashMap<>();
+		eventData.put("imc", 24.1);
+
+		when(service.findById(1L)).thenReturn(existingEvent);
+		when(service.save(any(CalendarEvent.class))).thenAnswer(inv -> inv.getArgument(0));
+
+		// Act
+		final ResponseEntity<Map<String, Object>> response = calendarEventRestController.updateEvent(1L, eventData,
+				principal);
+
+		// Assert
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		verify(pacienteRepository).save(org.mockito.ArgumentMatchers.argThat(
+				p -> p.getImc() != null && p.getBmr() == null));
+		log.info("finished updateEvent_withExplicitImcOnly_updatesImcWithoutBmr");
+	}
+
 }

--- a/src/test/java/com/nutriconsultas/paciente/PacienteRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteRestControllerTest.java
@@ -2,6 +2,7 @@ package com.nutriconsultas.paciente;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -11,7 +12,11 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.http.ResponseEntity;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -366,6 +371,82 @@ public class PacienteRestControllerTest {
 		verify(service).findAllByUserIdAndSearchTerm(eq(TEST_USER_ID), eq("juan"), any(Pageable.class));
 		verify(service).countByUserIdAndSearchTerm(eq(TEST_USER_ID), eq("juan"));
 		log.info("finished testGetRowsWithSearch");
+	}
+
+	@Test
+	@DisplayName("assignBmi with valid data returns 200 and updates patient imc")
+	void assignBmi_validData_returns200AndUpdatesImc() {
+		when(principal.getSubject()).thenReturn(TEST_USER_ID);
+		when(service.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(paciente1);
+		when(service.save(any(Paciente.class))).thenReturn(paciente1);
+
+		final ResponseEntity<java.util.Map<String, Object>> response =
+			controller.assignBmi(1L, new HashMap<>(java.util.Map.of("bmi", "22.5")), principal);
+
+		assertThat(response.getStatusCode().value()).isEqualTo(200);
+		assertThat(response.getBody()).containsEntry("success", true);
+		assertThat(response.getBody()).containsKey("imc");
+		verify(service).save(argThat(p -> p.getImc() != null && Double.compare(p.getImc(), 22.5) == 0));
+	}
+
+	@Test
+	@DisplayName("assignBmi with patient not owned by user returns 404")
+	void assignBmi_patientNotOwnedByUser_returns404() {
+		when(principal.getSubject()).thenReturn(TEST_USER_ID);
+		when(service.findByIdAndUserId(99L, TEST_USER_ID)).thenReturn(null);
+
+		final ResponseEntity<java.util.Map<String, Object>> response =
+			controller.assignBmi(99L, new HashMap<>(java.util.Map.of("bmi", "22.5")), principal);
+
+		assertThat(response.getStatusCode().value()).isEqualTo(404);
+		assertThat(response.getBody()).containsEntry("success", false);
+	}
+
+	@Test
+	@DisplayName("assignBmi unauthenticated returns 401")
+	void assignBmi_unauthenticated_returns401() {
+		final ResponseEntity<java.util.Map<String, Object>> response =
+			controller.assignBmi(1L, new HashMap<>(java.util.Map.of("bmi", "22.5")), null);
+
+		assertThat(response.getStatusCode().value()).isEqualTo(401);
+	}
+
+	@Test
+	@DisplayName("assignBmr with valid data returns 200 and updates patient bmr")
+	void assignBmr_validData_returns200AndUpdatesBmr() {
+		when(principal.getSubject()).thenReturn(TEST_USER_ID);
+		when(service.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(paciente1);
+		when(service.save(any(Paciente.class))).thenReturn(paciente1);
+
+		final ResponseEntity<java.util.Map<String, Object>> response =
+			controller.assignBmr(1L, new HashMap<>(java.util.Map.of("bmr", "1650.0")), principal);
+
+		assertThat(response.getStatusCode().value()).isEqualTo(200);
+		assertThat(response.getBody()).containsEntry("success", true);
+		assertThat(response.getBody()).containsKey("bmr");
+		verify(service).save(argThat(p -> p.getBmr() != null && p.getBmr() > 0));
+	}
+
+	@Test
+	@DisplayName("assignBmr with patient not owned by user returns 404")
+	void assignBmr_patientNotOwnedByUser_returns404() {
+		when(principal.getSubject()).thenReturn(TEST_USER_ID);
+		when(service.findByIdAndUserId(99L, TEST_USER_ID)).thenReturn(null);
+
+		final ResponseEntity<java.util.Map<String, Object>> response =
+			controller.assignBmr(99L, new HashMap<>(java.util.Map.of("bmr", "1650.0")), principal);
+
+		assertThat(response.getStatusCode().value()).isEqualTo(404);
+		assertThat(response.getBody()).containsEntry("success", false);
+	}
+
+	@Test
+	@DisplayName("assignBmr unauthenticated returns 401")
+	void assignBmr_unauthenticated_returns401() {
+		final ResponseEntity<java.util.Map<String, Object>> response =
+			controller.assignBmr(1L, new HashMap<>(java.util.Map.of("bmr", "1650.0")), null);
+
+		assertThat(response.getStatusCode().value()).isEqualTo(401);
 	}
 
 }


### PR DESCRIPTION
## Summary
- Adds `bmr` field to `Paciente` entity (auto-created by `ddl-auto=update`)
- On appointment save: propagates `imc` and computed `bmr` (average of 4 formulas) to the linked patient
- Adds `POST /rest/pacientes/{id}/assign-bmi` and `assign-bmr` endpoints with ownership check
- Adds "Asignar al paciente" buttons under each BMI/BMR result in the Anthropometrics calculation tab
- Displays `bmr` on the patient profile page

## Test plan
- [ ] 4 new tests: `CalendarEventRestControllerTest` — snapshot propagation paths
- [ ] 6 new tests: `PacienteRestControllerTest` — assign-bmi/bmr (success, 404, 401)
- [ ] `mvn compile` + `checkstyle` + `spotbugs` + `pmd` all pass
- [ ] Manual: save appointment with peso/estatura → verify patient profile shows updated IMC + BMR
- [ ] Manual: Cálculos tab → click Asignar → verify toast + profile update

Closes #58