### PR TITLE
feat(mobile-api): Auth0 JWT resource server + patientAuthSub (#107)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,5 @@ RECAPTCHA_SECRET_KEY=secretkey
 # AUTH_CLIENT=your_auth0_client_id
 # AUTH_SECRET=your_auth0_client_secret
 # AUTH_ISSUER=https://your-domain.auth0.com/
+# Patient mobile API JWT audience (Auth0 API identifier — see issue #108)
+# AUTH_AUDIENCE=https://api.nutriconsultas.minutriporcion.com

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -1,0 +1,156 @@
+# Issue Registry — `[Mobile API]` track
+
+Living index of the GitHub issues that build the **patient mobile API** (`/rest/mobile/patient/**`) on the Spring Boot backend. Update **local and remote** (via a commit on the PR that closes the work) whenever status changes.
+
+**Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas) (Spring Boot · Java 21 · Maven)
+**Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
+**Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
+**Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
+**Last updated:** 2026-06-12 — **#107 in-progress** on branch `mobile-api/107-jwt-resource-server`. Next unblocked after merge: **#110**.
+
+> **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116) plus the directly-related `[Dashboard]` IMC gauge (#106). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
+
+---
+
+## Audience reconciliation (authoritative — ALIGNMENT-SPEC §F7)
+
+| Decision | Status |
+|----------|--------|
+| Mobile API audience | **Patient-only** — `/rest/mobile/patient/**` serves a patient their **own** visits, diet plans, progress, messages. Never another patient's, never cross-tenant. |
+| Nutritionist mobile app | **Out of scope** — roster/consultation/meal-plan authoring stays on the existing Thymeleaf web app. No `[Mobile API]` endpoint exposes authoring. |
+| `[Mobile API] #114` (nutritionist reply) | **Web/backend feature** — lives in this repo, but it is **not** consumed by the patient mobile app. It feeds the patient `messages` thread (#96). |
+| Patient identity | JWT `sub` resolves to **`Paciente.patientAuthSub`** (NEW field, #107). **Never `Paciente.userId`** — that is the NUTRITIONIST's Auth0 sub / tenant owner (ALIGNMENT-SPEC §F2). 403 if no linked `Paciente`. |
+| Linkage mechanism | **Undefined** — how an Auth0 `sub` first binds to a `Paciente` (admin invite / email match / assign) is designed in **#109** and gates live integration. |
+
+## Design & schema ground truth (ALIGNMENT-SPEC §F8 — verified at `228bbc3`)
+
+| Topic | Ground truth |
+|-------|-------------|
+| **DTO field map** | Serialize aliases, **no schema changes**: `Dieta.nombre→dietaName`, `Dieta.energia→totalKcal`, `Dieta.proteina→totalProteina`, `Dieta.lipidos→totalGrasas`, `Dieta.hidratosDeCarbono→totalCarbohidratos`; `Ingesta.nombre→tipo`; `PlatilloIngesta.name/portions/energia→nombre/porciones/kcal`. |
+| **Enums (expose all values)** | `EventStatus = SCHEDULED / COMPLETED / CANCELLED` (`calendar/EventStatus.java`); `PacienteDietaStatus = ACTIVE / COMPLETED / CANCELLED` — **no INACTIVE** (`paciente/PacienteDietaStatus.java`); `NivelPeso = BAJO / NORMAL / ALTO / SOBREPESO` → service maps to `imcLabel` display string. |
+| **Body-fat field** | Prefer **`bodyComposition.porcentajeGrasaCorporal`** (patient-facing %) over `indiceGrasaCorporal` for #98/#99 consistency. |
+| **Computed fields** | `deltaPeso` / `deltaImc` are **computed at query time**, not stored — aggregate in the service layer (#98). |
+| **Greenfield** | **No** message entity/repo/service/controller exists — #96/#97 are built from scratch. |
+| **Branding** | `NutritionistProfile` (entity @ `228bbc3`: `userId`, `displayName`, `cedulaProfesional`, `logoExtension`, `registro`) already brands diet PDFs (#95) transparently; supplies optional `senderDisplayName` for #96 (#116). |
+| **Package note** | Actual entity package is `com.nutriconsultas.paciente` (singular) — issue #107 text says `pacientes`; follow the code. |
+
+---
+
+## Legend
+
+| State | Meaning |
+|-------|---------|
+| `NEXT` | Active — pick this up now |
+| `open` | Not started; blocked only if a dependency below is incomplete |
+| `in-progress` | Branch exists; PR not merged yet |
+| `done` | Merged to `main` |
+| `deferred` | Intentionally paused — decision pending |
+
+All `[Mobile API]` issues are currently `open` — none of Phase 0 has shipped.
+
+---
+
+## Phase 0 — Foundation (P0 · blocks every endpoint)
+
+No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `done`.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| **107** | Phase 0 — Auth0 JWT resource server + patient Auth0 linkage | https://github.com/diego-torres/nutriconsultas/issues/107 | **in-progress** | — | New `MobileSecurityConfig` `@Order(1)` stateless chain on `/rest/mobile/**`; add `Paciente.patientAuthSub` (unique, nullable) + principal resolver; Liquibase column (coord. #46). **Blocks #91–#99.** Mirror of mobile [#22](https://github.com/Escanor4323/nutriconsultas-mobile/issues/22). |
+| 108 | Auth0 API resource + audience + scopes setup | https://github.com/diego-torres/nutriconsultas/issues/108 | open | 107 | Auth0-tenant config: API identifier (audience), scopes; feeds `issuer-uri`/`audience` validation in #107. |
+| 109 | Patient-Auth0 account linkage (admin invite/assign flow) | https://github.com/diego-torres/nutriconsultas/issues/109 | open | 107 | Defines how a `sub` first binds to `patientAuthSub`. Gates **live** E2E; endpoints can be built/tested with seeded linkage before this lands. |
+| 110 | DTO conventions + `ApiResponse`/`PagedResponse` wrappers | https://github.com/diego-torres/nutriconsultas/issues/110 | open | — | `com.nutriconsultas.mobile.dto`: `ApiResponse<T>`, `PagedResponse<T>` (+ cursor variant for #96); ISO-8601 dates (Jackson `JavaTimeModule`, `WRITE_DATES_AS_TIMESTAMPS=false`). **Blocks #91–#99.** |
+
+## Phase 1 — Cross-cutting foundation (P1 · applies to all endpoints)
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| 111 | Accept-Language filter + MessageSource i18n for REST errors | https://github.com/diego-torres/nutriconsultas/issues/111 | open | 110 | `LocaleContextFilter` (es-MX default) + `MessageSource` error bodies. Mobile sends `Accept-Language` (mobile #25). |
+| 115 | PHI log redaction audit for all mobile controllers | https://github.com/diego-torres/nutriconsultas/issues/115 | open | 110 | Audit every `/rest/mobile/**` controller against `util/LogRedaction`; CI gate `scripts/audit-logging.sh`. No names/emails/DOB at INFO. |
+| 112 | OpenAPI spec for `/rest/mobile/patient/**` | https://github.com/diego-torres/nutriconsultas/issues/112 | open | 110, endpoints | springdoc spec; mobile reads it as the integration contract. Track per-endpoint as they land. |
+
+---
+
+## Endpoints (P0/P1 · each depends on #107 + #110)
+
+### Visits — `CalendarEvent`
+
+| # | Endpoint | URL | State | Backend source |
+|---|----------|-----|-------|----------------|
+| 91 | `GET /rest/mobile/patient/visits` — list session summaries | https://github.com/diego-torres/nutriconsultas/issues/91 | open | `CalendarEventService.findByPacienteId`; `EventStatus`; paged summary DTO |
+| 92 | `GET /rest/mobile/patient/visits/{visitId}` — single detail | https://github.com/diego-torres/nutriconsultas/issues/92 | open | `CalendarEvent` detail. **IDOR guard: 404 (not 403) on ownership miss** — don't leak existence. |
+
+### Diet Plans — `PacienteDieta` / `Dieta`
+
+| # | Endpoint | URL | State | Backend source |
+|---|----------|-----|-------|----------------|
+| 93 | `GET /rest/mobile/patient/diet-plans` — list assigned plans | https://github.com/diego-torres/nutriconsultas/issues/93 | open | `PacienteDietaService`; `PacienteDietaStatus`; `activeOnly` query param |
+| 94 | `GET /rest/mobile/patient/diet-plans/{assignmentId}` — structured meal JSON | https://github.com/diego-torres/nutriconsultas/issues/94 | open | `Dieta`→`Ingesta`→`PlatilloIngesta`/`AlimentoIngesta` tree; strip nutritionist-internal fields; field map per §F8 |
+| 95 | `GET /rest/mobile/patient/diet-plans/{assignmentId}/pdf` — printable PDF | https://github.com/diego-torres/nutriconsultas/issues/95 | open | Reuses existing PDF export (#14) + `NutritionistProfile` branding (#101 ✓); `Content-Disposition`; ownership check |
+
+### Messages — **greenfield** (no entity exists)
+
+| # | Endpoint | URL | State | Backend source |
+|---|----------|-----|-------|----------------|
+| 96 | `GET /rest/mobile/patient/messages` — list thread | https://github.com/diego-torres/nutriconsultas/issues/96 | open | NEW entity/repo/service; **cursor** pagination (not offset); never log body; optional `senderDisplayName` (#116) |
+| 97 | `POST /rest/mobile/patient/messages` — send to nutritionist | https://github.com/diego-torres/nutriconsultas/issues/97 | open | `senderRole=PATIENT` from JWT only; `@Valid @Size(max=2000)`; rate limit via #113 |
+
+### Progress — `AnthropometricMeasurement` / `Paciente`
+
+| # | Endpoint | URL | State | Backend source |
+|---|----------|-----|-------|----------------|
+| 98 | `GET /rest/mobile/patient/progress` — BMI/indicator snapshot | https://github.com/diego-torres/nutriconsultas/issues/98 | open | Aggregate in service; `deltaPeso`/`deltaImc` vs prior measurement; `NivelPeso`→`imcLabel`; BMI/BMR on `Paciente` |
+| 99 | `GET /rest/mobile/patient/progress/measurements` — time series | https://github.com/diego-torres/nutriconsultas/issues/99 | open | `from`/`to` ISO-8601; cap `maxRows=365`; ASC order; prefer `porcentajeGrasaCorporal` |
+
+---
+
+## Cross-cutting / additive (P2)
+
+| # | Title | URL | State | Notes |
+|---|-------|-----|-------|-------|
+| 113 | Rate limiting on patient write endpoints (Resilience4j) | https://github.com/diego-torres/nutriconsultas/issues/113 | open | 10/min on #97; returns 429 + i18n message (#111) |
+| 116 | Additive: `senderDisplayName` in message DTOs from `NutritionistProfile` | https://github.com/diego-torres/nutriconsultas/issues/116 | open | Additive to #96 DTO; **non-blocking** for mobile #19. Source `NutritionistProfile.displayName`. |
+| 114 | Nutritionist reply to patient messages | https://github.com/diego-torres/nutriconsultas/issues/114 | open | **Web/backend only** — not a mobile-app endpoint; writes into the same thread #96 reads. |
+| 106 | `[Dashboard]` IMC gauge with color bands (anthropometric tablero) | https://github.com/diego-torres/nutriconsultas/issues/106 | open | Web dashboard; shares `NivelPeso` color-band logic the mobile `ImcGauge` (mobile #21) mirrors. Not a `/rest/mobile/**` endpoint. |
+
+---
+
+## Data contracts
+
+Each mobile feature consumes these backend endpoints. Two-way linking with the mobile registry ([`mobile/ISSUE.md`](../mobile/ISSUE.md) → "Backend cross-reference").
+
+| Backend # | Patient feature | Mobile consumer (issue) | Read / write |
+|-----------|-----------------|-------------------------|--------------|
+| 91, 92 | Visitas | mobile #17 (feature), #10 (repo), #1 (models) | Read-only |
+| 93, 94, 95 | Planes de Dieta (+ PDF) | mobile #18, #12, #3 | Read-only |
+| 96, 97 | Mensajes | mobile #19, #14, #6 | Read + patient send |
+| 98, 99 | Progreso | mobile #16/#20, #15, #8 | Read-only |
+| 107, 108, 109 | Auth / linkage | mobile #5, #7, #13, #22 | Auth |
+| 116 | `senderDisplayName` (optional) | mobile #19 | Read-only (additive) |
+| 114 | nutritionist reply | — (web only; feeds #96) | — |
+
+**Common contract for every #91–#99** (ALIGNMENT-SPEC §"CORRECTED SCOPE"):
+- Auth: OAuth2 Resource Server JWT, separate `@Order(1)` `SecurityFilterChain`, stateless.
+- Principal: JWT `sub` → `Paciente.patientAuthSub` (#107). 403 if unlinked.
+- Envelope: `ApiResponse<T>`; lists in `PagedResponse<T>` (#110); ISO-8601 dates.
+- i18n: `Accept-Language` (es-MX default) error bodies (#111).
+- PHI-safe logging (`LogRedaction`, #115); no names/emails/DOB at INFO.
+
+---
+
+## How to update this file
+
+**Starting work** — mark `in-progress`, keep `NEXT` on it until the PR merges:
+
+```text
+| 107 | Phase 0 — Auth0 JWT resource server ... | https://... | in-progress | — | ... |
+```
+
+**After PR merges** — mark `done` and advance `NEXT` to the next unblocked row (Phase 0 order: #107 → #110 → #108/#109 → endpoints):
+
+```text
+| 107 | Phase 0 ... | https://... | done | — | ... |
+| 110 | DTO conventions ... | https://... | **NEXT** | — | ... |
+```
+
+Commit registry updates in the same PR that implements the issue (Phase 9 of [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)). Keep the mobile registry's "Backend cross-reference" in sync when an endpoint's state changes.

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/com/nutriconsultas/SecurityConfig.java
+++ b/src/main/java/com/nutriconsultas/SecurityConfig.java
@@ -4,10 +4,12 @@ import static org.springframework.security.config.Customizer.withDefaults;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
 
 import com.nutriconsultas.admin.LogoutHandler;
 
@@ -25,11 +27,13 @@ public class SecurityConfig {
 	}
 
 	@Bean
+	@Order(2)
 	// package-private
 	SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
-		log.info("ENABLING security filter chain.");
+		log.info("ENABLING nutritionist web security filter chain.");
 
-		http.cors(withDefaults())
+		http.securityMatcher(new NegatedRequestMatcher(new AntPathRequestMatcher("/rest/mobile/**")))
+			.cors(withDefaults())
 			.csrf(csrf -> csrf.disable())
 			.headers(headers -> headers.frameOptions(options -> options.sameOrigin()))
 			.authorizeHttpRequests(ar -> ar.requestMatchers("/rest/**")

--- a/src/main/java/com/nutriconsultas/mobile/AbstractMobilePatientController.java
+++ b/src/main/java/com/nutriconsultas/mobile/AbstractMobilePatientController.java
@@ -1,0 +1,30 @@
+package com.nutriconsultas.mobile;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import com.nutriconsultas.paciente.Paciente;
+
+/**
+ * Base controller for patient mobile endpoints. Resolves the authenticated
+ * {@link Paciente} from JWT {@code sub} → {@code Paciente.patientAuthSub}.
+ */
+public abstract class AbstractMobilePatientController {
+
+	private final PatientAuthService patientAuthService;
+
+	protected AbstractMobilePatientController(final PatientAuthService patientAuthService) {
+		this.patientAuthService = patientAuthService;
+	}
+
+	protected Paciente getAuthenticatedPaciente(@AuthenticationPrincipal final JwtAuthenticationToken authentication) {
+		if (authentication == null) {
+			throw new PatientNotLinkedException();
+		}
+		if (authentication.getDetails() instanceof PatientPrincipal patientPrincipal) {
+			return patientAuthService.requirePacienteById(patientPrincipal.getPacienteId());
+		}
+		return patientAuthService.requirePacienteByJwt(authentication.getToken());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/PatientAuthService.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientAuthService.java
@@ -1,0 +1,52 @@
+package com.nutriconsultas.mobile;
+
+import java.util.Optional;
+
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class PatientAuthService {
+
+	private final PacienteRepository pacienteRepository;
+
+	public PatientAuthService(final PacienteRepository pacienteRepository) {
+		this.pacienteRepository = pacienteRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public Optional<Paciente> findByJwt(final Jwt jwt) {
+		if (jwt == null || jwt.getSubject() == null) {
+			return Optional.empty();
+		}
+		return pacienteRepository.findByPatientAuthSub(jwt.getSubject());
+	}
+
+	@Transactional(readOnly = true)
+	public Paciente requirePacienteByJwt(final Jwt jwt) {
+		return findByJwt(jwt).orElseThrow(PatientNotLinkedException::new);
+	}
+
+	@Transactional(readOnly = true)
+	public Paciente requirePacienteById(final Long pacienteId) {
+		return pacienteRepository.findById(pacienteId).orElseThrow(PatientNotLinkedException::new);
+	}
+
+	@Transactional(readOnly = true)
+	public PatientPrincipal resolvePrincipal(final Jwt jwt) {
+		final Paciente paciente = requirePacienteByJwt(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Resolved mobile patient principal: {}", LogRedaction.redactPaciente(paciente.getId()));
+		}
+		return new PatientPrincipal(paciente.getId(), jwt.getSubject());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/PatientLinkageFilter.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientLinkageFilter.java
@@ -1,0 +1,67 @@
+package com.nutriconsultas.mobile;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class PatientLinkageFilter extends OncePerRequestFilter {
+
+	private static final String PATIENT_API_PREFIX = "/rest/mobile/patient/";
+
+	private final PatientAuthService patientAuthService;
+
+	public PatientLinkageFilter(final PatientAuthService patientAuthService) {
+		this.patientAuthService = patientAuthService;
+	}
+
+	@Override
+	protected boolean shouldNotFilter(final HttpServletRequest request) {
+		final String path = request.getRequestURI();
+		return path == null || !path.startsWith(PATIENT_API_PREFIX);
+	}
+
+	@Override
+	protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response,
+			final FilterChain filterChain) throws ServletException, IOException {
+		if (!(SecurityContextHolder.getContext().getAuthentication() instanceof JwtAuthenticationToken jwtAuth)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		final Jwt jwt = jwtAuth.getToken();
+		try {
+			final PatientPrincipal principal = patientAuthService.resolvePrincipal(jwt);
+			jwtAuth.setDetails(principal);
+			filterChain.doFilter(request, response);
+		}
+		catch (PatientNotLinkedException ex) {
+			if (log.isDebugEnabled()) {
+				log.debug("Mobile JWT sub has no linked Paciente.patientAuthSub");
+			}
+			writeForbidden(response);
+		}
+	}
+
+	private void writeForbidden(final HttpServletResponse response) throws IOException {
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.getWriter().write("{\"error\":\"patient_not_linked\"}");
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/PatientNotLinkedException.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientNotLinkedException.java
@@ -1,10 +1,15 @@
 package com.nutriconsultas.mobile;
 
+import java.io.Serial;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(HttpStatus.FORBIDDEN)
 public class PatientNotLinkedException extends RuntimeException {
+
+	@Serial
+	private static final long serialVersionUID = 1L;
 
 	public PatientNotLinkedException() {
 		super("patient_not_linked");

--- a/src/main/java/com/nutriconsultas/mobile/PatientNotLinkedException.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientNotLinkedException.java
@@ -1,0 +1,13 @@
+package com.nutriconsultas.mobile;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class PatientNotLinkedException extends RuntimeException {
+
+	public PatientNotLinkedException() {
+		super("patient_not_linked");
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/PatientPrincipal.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientPrincipal.java
@@ -1,0 +1,32 @@
+package com.nutriconsultas.mobile;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * Authenticated patient identity for mobile API requests. Contains only non-PHI
+ * identifiers.
+ */
+public final class PatientPrincipal implements Serializable {
+
+	@Serial
+	private static final long serialVersionUID = 1L;
+
+	private final Long pacienteId;
+
+	private final String patientAuthSub;
+
+	public PatientPrincipal(final Long pacienteId, final String patientAuthSub) {
+		this.pacienteId = pacienteId;
+		this.patientAuthSub = patientAuthSub;
+	}
+
+	public Long getPacienteId() {
+		return pacienteId;
+	}
+
+	public String getPatientAuthSub() {
+		return patientAuthSub;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/Paciente.java
+++ b/src/main/java/com/nutriconsultas/paciente/Paciente.java
@@ -37,6 +37,14 @@ public class Paciente {
 	@Column(nullable = false, length = 255)
 	private String userId;
 
+	/**
+	 * Patient Auth0 {@code sub} claim for mobile JWT identity. Distinct from
+	 * {@link #userId} (nutritionist tenant owner). Formal Liquibase changeset tracked in
+	 * issue #46.
+	 */
+	@Column(unique = true, length = 255)
+	private String patientAuthSub;
+
 	@DateTimeFormat(pattern = "yyyy-MM-dd")
 	@Temporal(TemporalType.DATE)
 	@NotNull(message = "La fecha de nacimiento es requerida")

--- a/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
@@ -19,6 +19,8 @@ public interface PacienteRepository extends JpaRepository<Paciente, Long> {
 
 	Optional<Paciente> findByIdAndUserId(Long id, String userId);
 
+	Optional<Paciente> findByPatientAuthSub(String patientAuthSub);
+
 	@Query("SELECT p FROM Paciente p WHERE p.userId = :userId AND "
 			+ "(LOWER(p.name) LIKE LOWER(:searchTerm) OR LOWER(p.email) LIKE LOWER(:searchTerm) "
 			+ "OR LOWER(p.phone) LIKE LOWER(:searchTerm))")

--- a/src/main/java/com/nutriconsultas/security/MobileJwtDecoderConfig.java
+++ b/src/main/java/com/nutriconsultas/security/MobileJwtDecoderConfig.java
@@ -1,0 +1,32 @@
+package com.nutriconsultas.security;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimValidator;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+@Configuration
+public class MobileJwtDecoderConfig {
+
+	@Bean
+	JwtDecoder mobileJwtDecoder(
+			@Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}") final String issuerUri,
+			@Value("${app.security.jwt.audience}") final String expectedAudience) {
+		final NimbusJwtDecoder decoder = NimbusJwtDecoder.withIssuerLocation(issuerUri).build();
+		final OAuth2TokenValidator<Jwt> audienceValidator = new JwtClaimValidator<List<String>>("aud",
+				aud -> aud != null && aud.contains(expectedAudience));
+		final OAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(
+				JwtValidators.createDefaultWithIssuer(issuerUri), audienceValidator);
+		decoder.setJwtValidator(validator);
+		return decoder;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/security/MobileSecurityConfig.java
+++ b/src/main/java/com/nutriconsultas/security/MobileSecurityConfig.java
@@ -1,0 +1,47 @@
+package com.nutriconsultas.security;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
+import org.springframework.security.web.SecurityFilterChain;
+
+import com.nutriconsultas.mobile.PatientLinkageFilter;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@Slf4j
+public class MobileSecurityConfig {
+
+	private final PatientLinkageFilter patientLinkageFilter;
+
+	private final JwtDecoder mobileJwtDecoder;
+
+	public MobileSecurityConfig(final PatientLinkageFilter patientLinkageFilter, final JwtDecoder mobileJwtDecoder) {
+		this.patientLinkageFilter = patientLinkageFilter;
+		this.mobileJwtDecoder = mobileJwtDecoder;
+	}
+
+	@Bean
+	@Order(1)
+	SecurityFilterChain mobileFilterChain(final HttpSecurity http) throws Exception {
+		log.info("ENABLING mobile JWT security filter chain for /rest/mobile/**");
+
+		http.securityMatcher("/rest/mobile/**")
+			.cors(withDefaults())
+			.csrf(csrf -> csrf.disable())
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+			.oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(mobileJwtDecoder)))
+			.addFilterAfter(patientLinkageFilter, BearerTokenAuthenticationFilter.class);
+
+		return http.build();
+	}
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,6 +29,9 @@ spring.security.oauth2.client.registration.auth0.scope=openid,profile,email
 spring.security.oauth2.client.registration.auth0.client-id=${AUTH_CLIENT}
 spring.security.oauth2.client.registration.auth0.client-secret=${AUTH_SECRET}
 spring.security.oauth2.client.provider.auth0.issuer-uri=${AUTH_ISSUER}
+# Patient mobile API — JWT resource server (separate from nutritionist oauth2Login session)
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${AUTH_ISSUER}
+app.security.jwt.audience=${AUTH_AUDIENCE}
 # reCAPTCHA configuration
 recaptcha.secret-key=${RECAPTCHA_SECRET_KEY}
 #logging.level.org.hibernate.SQL=debug

--- a/src/test/java/com/nutriconsultas/mobile/MobileSecurityIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileSecurityIntegrationTest.java
@@ -1,0 +1,80 @@
+package com.nutriconsultas.mobile;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MobileSecurityIntegrationTest {
+
+	private static final String LINKED_SUB = "auth0|mobile-security-linked";
+
+	private static final String UNLINKED_SUB = "auth0|mobile-security-unlinked";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@BeforeEach
+	void seedLinkedPatient() {
+		if (pacienteRepository.findByPatientAuthSub(LINKED_SUB).isEmpty()) {
+			pacienteRepository.save(samplePaciente(LINKED_SUB));
+		}
+	}
+
+	@Test
+	void patientEndpoint_withoutJwt_returnsUnauthorized() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/visits")).andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void patientEndpoint_withUnlinkedJwt_returnsForbidden() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/visits").with(jwt().jwt(j -> j.subject(UNLINKED_SUB))))
+			.andExpect(status().isForbidden())
+			.andExpect(content().json("{\"error\":\"patient_not_linked\"}"));
+	}
+
+	@Test
+	void patientEndpoint_withLinkedJwt_passesLinkageFilter() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/visits").with(jwt().jwt(j -> j.subject(LINKED_SUB))))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void nonPatientMobilePath_doesNotRequirePatientLinkage() throws Exception {
+		mockMvc.perform(get("/rest/mobile/status").with(jwt().jwt(j -> j.subject(UNLINKED_SUB))))
+			.andExpect(status().isNotFound());
+	}
+
+	private static Paciente samplePaciente(final String patientAuthSub) {
+		final Paciente paciente = new Paciente();
+		paciente.setName("Mobile Security Patient");
+		paciente.setUserId("nutritionist-sub");
+		paciente.setPatientAuthSub(patientAuthSub);
+		final LocalDate dob = LocalDate.now().minusYears(28);
+		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		paciente.setGender("M");
+		return paciente;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/PatientAuthServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/PatientAuthServiceTest.java
@@ -1,0 +1,82 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PatientAuthServiceTest {
+
+	private static final String LINKED_SUB = "auth0|linked-patient";
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@InjectMocks
+	private PatientAuthService patientAuthService;
+
+	@Test
+	void findByJwt_returnsPacienteWhenPatientAuthSubMatches() {
+		final Paciente paciente = samplePaciente(LINKED_SUB);
+		when(pacienteRepository.findByPatientAuthSub(LINKED_SUB)).thenReturn(Optional.of(paciente));
+
+		final Optional<Paciente> result = patientAuthService.findByJwt(jwtWithSub(LINKED_SUB));
+
+		assertThat(result).contains(paciente);
+	}
+
+	@Test
+	void requirePacienteByJwt_throwsWhenSubIsUnlinked() {
+		when(pacienteRepository.findByPatientAuthSub("auth0|unknown")).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> patientAuthService.requirePacienteByJwt(jwtWithSub("auth0|unknown")))
+			.isInstanceOf(PatientNotLinkedException.class);
+	}
+
+	@Test
+	void resolvePrincipal_returnsNonPhiIdentifiers() {
+		final Paciente paciente = samplePaciente(LINKED_SUB);
+		paciente.setId(42L);
+		when(pacienteRepository.findByPatientAuthSub(LINKED_SUB)).thenReturn(Optional.of(paciente));
+
+		final PatientPrincipal principal = patientAuthService.resolvePrincipal(jwtWithSub(LINKED_SUB));
+
+		assertThat(principal.getPacienteId()).isEqualTo(42L);
+		assertThat(principal.getPatientAuthSub()).isEqualTo(LINKED_SUB);
+	}
+
+	private static Jwt jwtWithSub(final String sub) {
+		return Jwt.withTokenValue("test-token")
+			.header("alg", "none")
+			.subject(sub)
+			.claim("aud", "https://api.nutriconsultas.test/mobile")
+			.build();
+	}
+
+	private static Paciente samplePaciente(final String patientAuthSub) {
+		final Paciente paciente = new Paciente();
+		paciente.setName("Test Patient");
+		paciente.setUserId("nutritionist-sub");
+		paciente.setPatientAuthSub(patientAuthSub);
+		final LocalDate dob = LocalDate.now().minusYears(30);
+		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		paciente.setGender("M");
+		return paciente;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/PacientePatientAuthSubRepositoryTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacientePatientAuthSubRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.nutriconsultas.paciente;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class PacientePatientAuthSubRepositoryTest {
+
+	private static final String PATIENT_SUB = "auth0|patient-repo-test";
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@Test
+	void findByPatientAuthSub_returnsLinkedPaciente() {
+		final Paciente saved = pacienteRepository.save(samplePaciente(PATIENT_SUB));
+
+		final Optional<Paciente> found = pacienteRepository.findByPatientAuthSub(PATIENT_SUB);
+
+		assertThat(found).isPresent();
+		assertThat(found.orElseThrow().getId()).isEqualTo(saved.getId());
+	}
+
+	@Test
+	void findByPatientAuthSub_returnsEmptyWhenUnlinked() {
+		assertThat(pacienteRepository.findByPatientAuthSub("auth0|missing")).isEmpty();
+	}
+
+	private static Paciente samplePaciente(final String patientAuthSub) {
+		final Paciente paciente = new Paciente();
+		paciente.setName("Repo Test Patient");
+		paciente.setUserId("nutritionist-sub");
+		paciente.setPatientAuthSub(patientAuthSub);
+		final LocalDate dob = LocalDate.now().minusYears(25);
+		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		paciente.setGender("F");
+		return paciente;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/security/WebSecurityConfigRegressionTest.java
+++ b/src/test/java/com/nutriconsultas/security/WebSecurityConfigRegressionTest.java
@@ -3,10 +3,12 @@ package com.nutriconsultas.security;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -17,6 +19,11 @@ class WebSecurityConfigRegressionTest {
 
 	@Autowired
 	private MockMvc mockMvc;
+
+	@BeforeEach
+	void clearSecurityContext() {
+		SecurityContextHolder.clearContext();
+	}
 
 	@Test
 	void adminPath_withoutSession_isNotServedByMobileJwtChain() throws Exception {

--- a/src/test/java/com/nutriconsultas/security/WebSecurityConfigRegressionTest.java
+++ b/src/test/java/com/nutriconsultas/security/WebSecurityConfigRegressionTest.java
@@ -1,0 +1,26 @@
+package com.nutriconsultas.security;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class WebSecurityConfigRegressionTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void adminPath_withoutSession_isNotServedByMobileJwtChain() throws Exception {
+		mockMvc.perform(get("/admin/pacientes")).andExpect(status().is3xxRedirection());
+	}
+
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -11,6 +11,8 @@ spring.security.oauth2.client.registration.auth0.scope=openid,profile,email
 spring.security.oauth2.client.registration.auth0.client-id=NOVAL
 spring.security.oauth2.client.registration.auth0.client-secret=NOVAL
 spring.security.oauth2.client.provider.auth0.issuer-uri=https://dev-imd1udg26uvzvfto.us.auth0.com/
+spring.security.oauth2.resourceserver.jwt.issuer-uri=https://dev-imd1udg26uvzvfto.us.auth0.com/
+app.security.jwt.audience=https://api.nutriconsultas.test/mobile
 
 maps.api.key=${MAPS_KEY:default-maps-key}
 amazon.s3.bucket=${AWS_BUCKET:noval}


### PR DESCRIPTION
## Summary
- Implements #107 — `MobileSecurityConfig` `@Order(1)` resource-server chain on `/rest/mobile/**` (stateless JWT, separate from nutritionist `oauth2Login` session)
- Adds `Paciente.patientAuthSub` + `PatientAuthService` / `PatientLinkageFilter` (403 when JWT `sub` has no linked patient)
- Documents `AUTH_AUDIENCE` for Auth0 API audience validation (#108)

## Test plan
- [x] `PatientAuthServiceTest`, `PacientePatientAuthSubRepositoryTest`
- [x] `MobileSecurityIntegrationTest` — 401 without JWT, 403 unlinked sub, linked sub passes filter
- [x] `WebSecurityConfigRegressionTest` — `/admin/**` still uses web OAuth2 login
- [ ] CI: `./lint.sh && bash scripts/audit-logging.sh && mvn -B verify`

Closes #107

Made with [Cursor](https://cursor.com)