### PR TITLE
Perfil del paciente: gráfico de barra con gradiente para IMC

### DIFF
--- a/dev-start.sh
+++ b/dev-start.sh
@@ -105,6 +105,7 @@ fi
 export JDBC_DATABASE_URL=${JDBC_DATABASE_URL:-jdbc:postgresql://localhost:5432/nutriconsultas}
 export JDBC_DATABASE_USERNAME=${JDBC_DATABASE_USERNAME:-nutriconsultas}
 export JDBC_DATABASE_PASSWORD=${JDBC_DATABASE_PASSWORD:-nutriconsultas}
+export AUTH_AUDIENCE=${AUTH_AUDIENCE:-https://api.nutriconsultas.minutriporcion.com}
 
 # Run Spring Boot application
 echo -e "${GREEN}✓ Starting Spring Boot application...${NC}"

--- a/src/main/java/com/nutriconsultas/ThymeleafValidator.java
+++ b/src/main/java/com/nutriconsultas/ThymeleafValidator.java
@@ -18,6 +18,7 @@ import org.thymeleaf.context.IWebContext;
 import org.thymeleaf.templateresolver.FileTemplateResolver;
 import org.thymeleaf.templatemode.TemplateMode;
 
+import com.nutriconsultas.config.ImcGaugeDialect;
 import com.nutriconsultas.validation.template.TemplateValidator;
 import com.nutriconsultas.validation.template.TemplateValidatorRegistry;
 import com.nutriconsultas.validation.template.WebContextFactory;
@@ -198,6 +199,7 @@ public class ThymeleafValidator {
 		templateResolver.setCharacterEncoding("UTF-8");
 		templateResolver.setCacheable(false);
 		templateEngine.setTemplateResolver(templateResolver);
+		templateEngine.addDialect(new ImcGaugeDialect());
 		return templateEngine;
 	}
 

--- a/src/main/java/com/nutriconsultas/config/ImcGaugeDialect.java
+++ b/src/main/java/com/nutriconsultas/config/ImcGaugeDialect.java
@@ -1,0 +1,46 @@
+package com.nutriconsultas.config;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.thymeleaf.context.IExpressionContext;
+import org.thymeleaf.dialect.AbstractDialect;
+import org.thymeleaf.dialect.IExpressionObjectDialect;
+import org.thymeleaf.expression.IExpressionObjectFactory;
+
+import com.nutriconsultas.util.ImcGaugeUtils;
+
+/**
+ * Thymeleaf dialect exposing {@link ImcGaugeUtils} as {@code #imcGauge} in templates.
+ */
+public final class ImcGaugeDialect extends AbstractDialect implements IExpressionObjectDialect {
+
+	private static final String EXPRESSION_OBJECT_NAME = "imcGauge";
+
+	public ImcGaugeDialect() {
+		super(EXPRESSION_OBJECT_NAME);
+	}
+
+	@Override
+	public IExpressionObjectFactory getExpressionObjectFactory() {
+		return new IExpressionObjectFactory() {
+
+			@Override
+			public Set<String> getAllExpressionObjectNames() {
+				return Collections.singleton(EXPRESSION_OBJECT_NAME);
+			}
+
+			@Override
+			public Object buildObject(final IExpressionContext context, final String expressionObjectName) {
+				return ImcGaugeUtils.class;
+			}
+
+			@Override
+			public boolean isCacheable(final String expressionObjectName) {
+				return true;
+			}
+
+		};
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/config/ThymeleafDialectConfig.java
+++ b/src/main/java/com/nutriconsultas/config/ThymeleafDialectConfig.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ThymeleafDialectConfig {
+
+	@Bean
+	public ImcGaugeDialect imcGaugeDialect() {
+		return new ImcGaugeDialect();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
@@ -35,6 +35,7 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 		variables.put("ultimoPeso", null);
 		variables.put("ultimaEstatura", null);
 		variables.put("ultimoImc", null);
+		variables.put("ultimoNivelPeso", null);
 		variables.put("isEligibleForPregnancy", false);
 		variables.put("isUnder18", false);
 		variables.put("growthMeasurements", new ArrayList<AnthropometricMeasurement>());

--- a/src/main/java/com/nutriconsultas/util/ImcGaugeUtils.java
+++ b/src/main/java/com/nutriconsultas/util/ImcGaugeUtils.java
@@ -1,0 +1,75 @@
+package com.nutriconsultas.util;
+
+import com.nutriconsultas.paciente.NivelPeso;
+
+/**
+ * Utility for IMC gauge bar calculations used in Thymeleaf templates. Range is fixed at
+ * 15–40 with {@link NivelPeso} thresholds matching backend logic.
+ */
+public final class ImcGaugeUtils {
+
+	public static final double MIN_IMC = 15.0;
+
+	public static final double MAX_IMC = 40.0;
+
+	private static final double THRESHOLD_SOBREPESO = 30.0;
+
+	private static final double THRESHOLD_ALTO = 25.0;
+
+	private static final double THRESHOLD_NORMAL = 18.5;
+
+	private ImcGaugeUtils() {
+	}
+
+	public static double markerPosition(final Double imc) {
+		if (imc == null) {
+			return 0.0;
+		}
+		final double clamped = Math.max(MIN_IMC, Math.min(MAX_IMC, imc));
+		return ((clamped - MIN_IMC) / (MAX_IMC - MIN_IMC)) * 100.0;
+	}
+
+	public static NivelPeso resolveNivelPeso(final Double imc, final NivelPeso nivelPeso) {
+		if (nivelPeso != null) {
+			return nivelPeso;
+		}
+		return calculateNivelPeso(imc);
+	}
+
+	public static NivelPeso calculateNivelPeso(final Double imc) {
+		if (imc == null) {
+			return null;
+		}
+		if (imc > THRESHOLD_SOBREPESO) {
+			return NivelPeso.SOBREPESO;
+		}
+		if (imc > THRESHOLD_ALTO) {
+			return NivelPeso.ALTO;
+		}
+		if (imc > THRESHOLD_NORMAL) {
+			return NivelPeso.NORMAL;
+		}
+		return NivelPeso.BAJO;
+	}
+
+	public static String markerColor(final NivelPeso nivelPeso) {
+		if (nivelPeso == null) {
+			return "#6c757d";
+		}
+		return switch (nivelPeso) {
+			case BAJO -> "#3b82f6";
+			case NORMAL -> "#22c55e";
+			case ALTO -> "#eab308";
+			case SOBREPESO -> "#ef4444";
+		};
+	}
+
+	public static String ariaLabel(final Double imc, final NivelPeso nivelPeso) {
+		final NivelPeso level = resolveNivelPeso(imc, nivelPeso);
+		if (imc == null || level == null) {
+			return "IMC no disponible";
+		}
+		return String.format("IMC %.2f, nivel %s", imc, level.name());
+	}
+
+}

--- a/src/main/resources/templates/sbadmin/calendar/ver.html
+++ b/src/main/resources/templates/sbadmin/calendar/ver.html
@@ -23,6 +23,7 @@
   <!-- Custom styles for this template-->
   <link th:href="@{/sbadmin/css/sb-admin-2.min.css}" rel="stylesheet">
   <link th:href="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.css}" rel="stylesheet">
+  <div th:insert="~{sbadmin/pacientes/imc-gauge :: imcGaugeStyles}"></div>
 
 </head>
 
@@ -98,14 +99,12 @@
                         <div class="col-md-3" th:if="${event.estatura != null}">
                           <p><strong>Estatura:</strong> <span th:text="${#numbers.formatDecimal(event.estatura, 2, 2)} + ' m'">-</span></p>
                         </div>
-                        <div class="col-md-3" th:if="${event.imc != null}">
-                          <p><strong>IMC:</strong> <span th:text="${#numbers.formatDecimal(event.imc, 2, 2)}">-</span></p>
+                        <div class="col-md-6" th:if="${event.imc != null}">
+                          <p class="mb-2"><strong>IMC</strong></p>
+                          <div th:replace="~{sbadmin/pacientes/imc-gauge :: imcGauge(${event.imc}, ${event.nivelPeso})}"></div>
                         </div>
                         <div class="col-md-3" th:if="${event.indiceGrasaCorporal != null}">
                           <p><strong>Índice Grasa Corporal:</strong> <span th:text="${#numbers.formatDecimal(event.indiceGrasaCorporal, 2, 2)} + '%'">-</span></p>
-                        </div>
-                        <div class="col-md-3" th:if="${event.nivelPeso != null}">
-                          <p><strong>Nivel de Peso:</strong> <span th:text="${event.nivelPeso.name()}">-</span></p>
                         </div>
                         <div class="col-md-3" th:if="${event.sistolica != null}">
                           <p><strong>Sistólica:</strong> <span th:text="${event.sistolica} + ' mmHg'">-</span></p>

--- a/src/main/resources/templates/sbadmin/pacientes/imc-gauge.html
+++ b/src/main/resources/templates/sbadmin/pacientes/imc-gauge.html
@@ -1,0 +1,128 @@
+<!--
+  Reusable IMC gauge bar with color gradient (range 15–40).
+  Fragments: imcGaugeStyles, imcGauge, imcGaugeCompact, imcGaugePdf
+-->
+<div th:fragment="imcGaugeStyles">
+  <style>
+    .imc-gauge {
+      width: 100%;
+    }
+
+    .imc-gauge__value {
+      font-weight: 600;
+      font-size: 0.95rem;
+      margin-bottom: 0.35rem;
+    }
+
+    .imc-gauge--compact .imc-gauge__value {
+      font-size: 0.85rem;
+    }
+
+    .imc-gauge__unit {
+      font-weight: 400;
+      color: #6c757d;
+      font-size: 0.8rem;
+      margin-left: 0.15rem;
+    }
+
+    .imc-gauge__track {
+      position: relative;
+      height: 10px;
+      border-radius: 5px;
+    }
+
+    .imc-gauge--compact .imc-gauge__track {
+      height: 8px;
+    }
+
+    .imc-gauge__gradient {
+      height: 100%;
+      border-radius: 5px;
+      background: linear-gradient(to right,
+        #3b82f6 0%, #3b82f6 14%,
+        #22c55e 14%, #22c55e 40%,
+        #eab308 40%, #eab308 60%,
+        #ef4444 60%, #ef4444 100%);
+    }
+
+    .imc-gauge__marker {
+      position: absolute;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      border: 2px solid #fff;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    }
+
+    .imc-gauge--compact .imc-gauge__marker {
+      width: 10px;
+      height: 10px;
+      border-width: 1.5px;
+    }
+  </style>
+</div>
+
+<div th:fragment="imcGauge(imc, nivelPeso)" class="imc-gauge">
+  <p class="text-muted mb-0" th:if="${imc == null}">N/A</p>
+  <div th:if="${imc != null}"
+       role="img"
+       th:attr="aria-label=${T(com.nutriconsultas.util.ImcGaugeUtils).ariaLabel(imc, nivelPeso)}">
+    <div class="imc-gauge__value">
+      <span th:text="${#numbers.formatDecimal(imc, 1, 2)}">24.50</span><span class="imc-gauge__unit">IMC</span>
+    </div>
+    <div class="imc-gauge__track">
+      <div class="imc-gauge__gradient"></div>
+      <div class="imc-gauge__marker"
+           th:style="|left: ${T(com.nutriconsultas.util.ImcGaugeUtils).markerPosition(imc)}%;
+                     background-color: ${T(com.nutriconsultas.util.ImcGaugeUtils).markerColor(
+                       T(com.nutriconsultas.util.ImcGaugeUtils).resolveNivelPeso(imc, nivelPeso))};|">
+      </div>
+    </div>
+  </div>
+</div>
+
+<div th:fragment="imcGaugeCompact(imc, nivelPeso)" class="imc-gauge imc-gauge--compact">
+  <p class="text-muted mb-0" th:if="${imc == null}">N/A</p>
+  <div th:if="${imc != null}"
+       role="img"
+       th:attr="aria-label=${T(com.nutriconsultas.util.ImcGaugeUtils).ariaLabel(imc, nivelPeso)}">
+    <div class="imc-gauge__value">
+      <span th:text="${#numbers.formatDecimal(imc, 1, 2)}">24.50</span><span class="imc-gauge__unit">IMC</span>
+    </div>
+    <div class="imc-gauge__track">
+      <div class="imc-gauge__gradient"></div>
+      <div class="imc-gauge__marker"
+           th:style="|left: ${T(com.nutriconsultas.util.ImcGaugeUtils).markerPosition(imc)}%;
+                     background-color: ${T(com.nutriconsultas.util.ImcGaugeUtils).markerColor(
+                       T(com.nutriconsultas.util.ImcGaugeUtils).resolveNivelPeso(imc, nivelPeso))};|">
+      </div>
+    </div>
+  </div>
+</div>
+
+<div th:fragment="imcGaugePdf(imc, nivelPeso)">
+  <p th:if="${imc == null}">N/A</p>
+  <div th:if="${imc != null}"
+       role="img"
+       th:attr="aria-label=${T(com.nutriconsultas.util.ImcGaugeUtils).ariaLabel(imc, nivelPeso)}"
+       style="display: inline-block; vertical-align: middle;">
+    <span th:text="${#numbers.formatDecimal(imc, 1, 2)}"
+          style="font-weight: bold; margin-right: 8px;">24.50</span>
+    <span style="display: inline-block; position: relative; width: 180px; height: 10px; vertical-align: middle;">
+      <span style="display: flex; height: 100%; border-radius: 4px; overflow: hidden;">
+        <span style="width: 14%; background-color: #3b82f6;"></span>
+        <span style="width: 26%; background-color: #22c55e;"></span>
+        <span style="width: 20%; background-color: #eab308;"></span>
+        <span style="width: 40%; background-color: #ef4444;"></span>
+      </span>
+      <span th:style="|position: absolute; top: 50%; left: ${T(com.nutriconsultas.util.ImcGaugeUtils).markerPosition(imc)}%;
+                       transform: translate(-50%, -50%); width: 10px; height: 10px; border-radius: 50%;
+                       border: 1.5px solid #ffffff;
+                       background-color: ${T(com.nutriconsultas.util.ImcGaugeUtils).markerColor(
+                         T(com.nutriconsultas.util.ImcGaugeUtils).resolveNivelPeso(imc, nivelPeso))};|">
+      </span>
+    </span>
+  </div>
+</div>

--- a/src/main/resources/templates/sbadmin/pacientes/imc-gauge.html
+++ b/src/main/resources/templates/sbadmin/pacientes/imc-gauge.html
@@ -1,11 +1,18 @@
 <!--
   Reusable IMC gauge bar with color gradient (range 15–40).
-  Fragments: imcGaugeStyles, imcGauge, imcGaugeCompact, imcGaugePdf
+  Fragments: imcGaugeStyles, imcGaugeMarker, imcGauge, imcGaugeCompact, imcGaugePdf
 -->
 <div th:fragment="imcGaugeStyles">
   <style>
     .imc-gauge {
       width: 100%;
+      --imc-track-size: 22px;
+      --imc-marker-size: 32px;
+    }
+
+    .imc-gauge--compact {
+      --imc-track-size: 18px;
+      --imc-marker-size: 26px;
     }
 
     .imc-gauge__value {
@@ -27,17 +34,22 @@
 
     .imc-gauge__track {
       position: relative;
-      height: 10px;
-      border-radius: 5px;
+      overflow: visible;
+      height: calc(var(--imc-marker-size) + 12px);
     }
 
     .imc-gauge--compact .imc-gauge__track {
-      height: 8px;
+      height: calc(var(--imc-marker-size) + 10px);
     }
 
     .imc-gauge__gradient {
-      height: 100%;
-      border-radius: 5px;
+      position: absolute;
+      top: calc(var(--imc-track-size) / 2);
+      left: 0;
+      right: 0;
+      height: var(--imc-track-size);
+      transform: translateY(-50%);
+      border-radius: calc(var(--imc-track-size) / 2);
       background: linear-gradient(to right,
         #3b82f6 0%, #3b82f6 14%,
         #22c55e 14%, #22c55e 40%,
@@ -45,40 +57,118 @@
         #ef4444 60%, #ef4444 100%);
     }
 
-    .imc-gauge__marker {
+    .imc-gauge--compact .imc-gauge__gradient {
+      height: var(--imc-track-size);
+      border-radius: calc(var(--imc-track-size) / 2);
+    }
+
+    .imc-gauge__marker-wrap {
       position: absolute;
-      top: 50%;
+      top: calc(var(--imc-track-size) / 2);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
       transform: translate(-50%, -50%);
-      width: 14px;
-      height: 14px;
+      z-index: 1;
+      cursor: pointer;
+    }
+
+    .imc-gauge__marker-wrap:focus {
+      outline: none;
+    }
+
+    .imc-gauge__marker-wrap:focus-visible .imc-gauge__marker {
+      box-shadow: 0 0 0 3px rgba(78, 115, 223, 0.35);
+    }
+
+    .imc-gauge__arrow {
+      width: 0;
+      height: 0;
+      margin-top: 2px;
+      border-left: 7px solid transparent;
+      border-right: 7px solid transparent;
+      border-bottom: 8px solid #212529;
+      filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.15));
+    }
+
+    .imc-gauge--compact .imc-gauge__arrow {
+      border-left-width: 6px;
+      border-right-width: 6px;
+      border-bottom-width: 7px;
+    }
+
+    .imc-gauge__marker {
+      width: var(--imc-marker-size);
+      height: var(--imc-marker-size);
       border-radius: 50%;
       border: 2px solid #fff;
+      background-color: var(--imc-marker-color, #6c757d);
       box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
     }
 
     .imc-gauge--compact .imc-gauge__marker {
-      width: 10px;
-      height: 10px;
       border-width: 1.5px;
     }
+
+    .imc-gauge__tooltip {
+      position: absolute;
+      bottom: calc(100% + 6px);
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 3px 8px;
+      border-radius: 4px;
+      background-color: #343a40;
+      color: #fff;
+      font-size: 0.75rem;
+      font-weight: 600;
+      line-height: 1.2;
+      white-space: nowrap;
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+      transition: opacity 0.15s ease, visibility 0.15s ease;
+    }
+
+    .imc-gauge__tooltip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border-left: 4px solid transparent;
+      border-right: 4px solid transparent;
+      border-top: 4px solid #343a40;
+    }
+
+    .imc-gauge__marker-wrap:hover .imc-gauge__tooltip,
+    .imc-gauge__marker-wrap:focus-visible .imc-gauge__tooltip {
+      opacity: 1;
+      visibility: visible;
+    }
   </style>
+</div>
+
+<div th:fragment="imcGaugeMarker(imc, nivelPeso)"
+     class="imc-gauge__marker-wrap"
+     tabindex="0"
+     th:style="|left: ${#imcGauge.markerPosition(imc)}%;
+               --imc-marker-color: ${#imcGauge.markerColor(#imcGauge.resolveNivelPeso(imc, nivelPeso))};|">
+  <span class="imc-gauge__tooltip" th:text="${#numbers.formatDecimal(imc, 1, 2)}">24.50</span>
+  <span class="imc-gauge__marker"></span>
+  <span class="imc-gauge__arrow" aria-hidden="true"></span>
 </div>
 
 <div th:fragment="imcGauge(imc, nivelPeso)" class="imc-gauge">
   <p class="text-muted mb-0" th:if="${imc == null}">N/A</p>
   <div th:if="${imc != null}"
        role="img"
-       th:attr="aria-label=${T(com.nutriconsultas.util.ImcGaugeUtils).ariaLabel(imc, nivelPeso)}">
+       th:attr="aria-label=${#imcGauge.ariaLabel(imc, nivelPeso)}">
     <div class="imc-gauge__value">
       <span th:text="${#numbers.formatDecimal(imc, 1, 2)}">24.50</span><span class="imc-gauge__unit">IMC</span>
     </div>
     <div class="imc-gauge__track">
       <div class="imc-gauge__gradient"></div>
-      <div class="imc-gauge__marker"
-           th:style="|left: ${T(com.nutriconsultas.util.ImcGaugeUtils).markerPosition(imc)}%;
-                     background-color: ${T(com.nutriconsultas.util.ImcGaugeUtils).markerColor(
-                       T(com.nutriconsultas.util.ImcGaugeUtils).resolveNivelPeso(imc, nivelPeso))};|">
-      </div>
+      <div th:replace="~{sbadmin/pacientes/imc-gauge :: imcGaugeMarker(${imc}, ${nivelPeso})}"></div>
     </div>
   </div>
 </div>
@@ -87,17 +177,13 @@
   <p class="text-muted mb-0" th:if="${imc == null}">N/A</p>
   <div th:if="${imc != null}"
        role="img"
-       th:attr="aria-label=${T(com.nutriconsultas.util.ImcGaugeUtils).ariaLabel(imc, nivelPeso)}">
+       th:attr="aria-label=${#imcGauge.ariaLabel(imc, nivelPeso)}">
     <div class="imc-gauge__value">
       <span th:text="${#numbers.formatDecimal(imc, 1, 2)}">24.50</span><span class="imc-gauge__unit">IMC</span>
     </div>
     <div class="imc-gauge__track">
       <div class="imc-gauge__gradient"></div>
-      <div class="imc-gauge__marker"
-           th:style="|left: ${T(com.nutriconsultas.util.ImcGaugeUtils).markerPosition(imc)}%;
-                     background-color: ${T(com.nutriconsultas.util.ImcGaugeUtils).markerColor(
-                       T(com.nutriconsultas.util.ImcGaugeUtils).resolveNivelPeso(imc, nivelPeso))};|">
-      </div>
+      <div th:replace="~{sbadmin/pacientes/imc-gauge :: imcGaugeMarker(${imc}, ${nivelPeso})}"></div>
     </div>
   </div>
 </div>
@@ -106,22 +192,27 @@
   <p th:if="${imc == null}">N/A</p>
   <div th:if="${imc != null}"
        role="img"
-       th:attr="aria-label=${T(com.nutriconsultas.util.ImcGaugeUtils).ariaLabel(imc, nivelPeso)}"
+       th:attr="aria-label=${#imcGauge.ariaLabel(imc, nivelPeso)}"
        style="display: inline-block; vertical-align: middle;">
     <span th:text="${#numbers.formatDecimal(imc, 1, 2)}"
           style="font-weight: bold; margin-right: 8px;">24.50</span>
-    <span style="display: inline-block; position: relative; width: 180px; height: 10px; vertical-align: middle;">
-      <span style="display: flex; height: 100%; border-radius: 4px; overflow: hidden;">
+    <span style="display: inline-block; position: relative; width: 180px; height: 44px; vertical-align: middle;">
+      <span style="position: absolute; top: 16px; left: 0; right: 0; height: 22px; transform: translateY(-50%);
+                   display: flex; border-radius: 11px; overflow: hidden;">
         <span style="width: 14%; background-color: #3b82f6;"></span>
         <span style="width: 26%; background-color: #22c55e;"></span>
         <span style="width: 20%; background-color: #eab308;"></span>
         <span style="width: 40%; background-color: #ef4444;"></span>
       </span>
-      <span th:style="|position: absolute; top: 50%; left: ${T(com.nutriconsultas.util.ImcGaugeUtils).markerPosition(imc)}%;
-                       transform: translate(-50%, -50%); width: 10px; height: 10px; border-radius: 50%;
-                       border: 1.5px solid #ffffff;
-                       background-color: ${T(com.nutriconsultas.util.ImcGaugeUtils).markerColor(
-                         T(com.nutriconsultas.util.ImcGaugeUtils).resolveNivelPeso(imc, nivelPeso))};|">
+      <span th:style="|position: absolute; top: 16px; left: ${#imcGauge.markerPosition(imc)}%;
+                       transform: translate(-50%, -50%); display: flex; flex-direction: column; align-items: center;|">
+        <span th:style="|width: 32px; height: 32px; border-radius: 50%; border: 2px solid #ffffff;
+                         background-color: ${#imcGauge.markerColor(#imcGauge.resolveNivelPeso(imc, nivelPeso))};|">
+        </span>
+        <span style="width: 0; height: 0; margin-top: 2px;
+                     border-left: 6px solid transparent; border-right: 6px solid transparent;
+                     border-bottom: 7px solid #212529;">
+        </span>
       </span>
     </span>
   </div>

--- a/src/main/resources/templates/sbadmin/pacientes/perfil.html
+++ b/src/main/resources/templates/sbadmin/pacientes/perfil.html
@@ -22,6 +22,7 @@
 
   <!-- Custom styles for this template-->
   <link th:href="@{/sbadmin/css/sb-admin-2.css}" rel="stylesheet">
+  <div th:insert="~{sbadmin/pacientes/imc-gauge :: imcGaugeStyles}"></div>
 
 </head>
 
@@ -63,10 +64,13 @@
                       <p class="mb-0" th:if="${ultimaEstatura != null}">[[(${#numbers.formatDecimal(ultimaEstatura,1,'COMMA',2,'POINT')})]] m.</p>
                       <p class="mb-0 text-muted" th:if="${ultimaEstatura == null}">N/A</p>
                     </li>
-                    <li class="list-group-item d-flex justify-content-between align-items-center p-3">
-                      <i class="fas fa-chart-bar fa-lg" style="color: #ccff55;"></i>
-                      <p class="mb-0" th:if="${ultimoImc != null}">[[(${#numbers.formatDecimal(ultimoImc,1,'COMMA',2,'POINT')})]] imc.</p>
-                      <p class="mb-0 text-muted" th:if="${ultimoImc == null}">N/A</p>
+                    <li class="list-group-item p-3">
+                      <div class="d-flex align-items-start">
+                        <i class="fas fa-chart-bar fa-lg mr-3 mt-1" style="color: #ccff55;"></i>
+                        <div class="flex-grow-1"
+                             th:insert="~{sbadmin/pacientes/imc-gauge :: imcGaugeCompact(${ultimoImc}, ${ultimoNivelPeso})}">
+                        </div>
+                      </div>
                     </li>
                     <li class="list-group-item d-flex justify-content-between align-items-center p-3">
                       <i class="fas fa-fire fa-lg" style="color: #ff6b35;"></i>

--- a/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
+++ b/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
@@ -22,6 +22,7 @@
 
   <!-- Custom styles for this template-->
   <link th:href="@{/sbadmin/css/sb-admin-2.min.css}" rel="stylesheet">
+  <div th:insert="~{sbadmin/pacientes/imc-gauge :: imcGaugeStyles}"></div>
 
 </head>
 
@@ -120,10 +121,8 @@
                           <p><strong>Estatura:</strong> <span th:text="${#numbers.formatDecimal(measurement.bodyMass.height, 2, 2)} + ' m'">-</span></p>
                         </div>
                         <div class="col-md-6" th:if="${measurement.imc != null}">
-                          <p><strong>IMC:</strong> <span th:text="${#numbers.formatDecimal(measurement.imc, 1, 2)}">-</span></p>
-                        </div>
-                        <div class="col-md-6" th:if="${measurement.nivelPeso != null}">
-                          <p><strong>Nivel de peso:</strong> <span th:text="${measurement.nivelPeso.name()}">-</span></p>
+                          <p class="mb-2"><strong>IMC</strong></p>
+                          <div th:replace="~{sbadmin/pacientes/imc-gauge :: imcGauge(${measurement.imc}, ${measurement.nivelPeso})}"></div>
                         </div>
                       </div>
                       <div class="row" th:if="${measurement.notes != null && !measurement.notes.isEmpty()}">

--- a/src/main/resources/templates/sbadmin/pacientes/ver-examen-clinico.html
+++ b/src/main/resources/templates/sbadmin/pacientes/ver-examen-clinico.html
@@ -22,6 +22,7 @@
 
   <!-- Custom styles for this template-->
   <link th:href="@{/sbadmin/css/sb-admin-2.min.css}" rel="stylesheet">
+  <div th:insert="~{sbadmin/pacientes/imc-gauge :: imcGaugeStyles}"></div>
 
   <style>
     /* Clinical indicator color coding */
@@ -140,14 +141,12 @@
                         <div class="col-md-3" th:if="${exam.estatura != null}">
                           <p><strong>Estatura:</strong> <span th:text="${#numbers.formatDecimal(exam.estatura, 2, 2)} + ' m'">-</span></p>
                         </div>
-                        <div class="col-md-3" th:if="${exam.imc != null}">
-                          <p><strong>IMC:</strong> <span th:text="${#numbers.formatDecimal(exam.imc, 2, 2)}">-</span></p>
+                        <div class="col-md-6" th:if="${exam.imc != null}">
+                          <p class="mb-2"><strong>IMC</strong></p>
+                          <div th:replace="~{sbadmin/pacientes/imc-gauge :: imcGauge(${exam.imc}, ${exam.nivelPeso})}"></div>
                         </div>
                         <div class="col-md-3" th:if="${exam.indiceGrasaCorporal != null}">
                           <p><strong>Índice Grasa Corporal:</strong> <span th:text="${#numbers.formatDecimal(exam.indiceGrasaCorporal, 2, 2)} + '%'">-</span></p>
-                        </div>
-                        <div class="col-md-3" th:if="${exam.nivelPeso != null}">
-                          <p><strong>Nivel de Peso:</strong> <span th:text="${exam.nivelPeso.name()}">-</span></p>
                         </div>
                         <div class="col-md-3" th:if="${exam.sistolica != null}">
                           <p><strong>Sistólica:</strong> <span th:text="${exam.sistolica} + ' mmHg'">-</span></p>

--- a/src/main/resources/templates/sbadmin/reports/patient-progress.html
+++ b/src/main/resources/templates/sbadmin/reports/patient-progress.html
@@ -242,11 +242,9 @@
 			</tr>
 			<tr th:if="${paciente.imc != null}">
 				<td>IMC Actual:</td>
-				<td th:text="${#numbers.formatDecimal(paciente.imc, 1, 2)}"></td>
-			</tr>
-			<tr th:if="${paciente.nivelPeso != null}">
-				<td>Nivel de Peso:</td>
-				<td th:text="${paciente.nivelPeso}"></td>
+				<td>
+					<div th:replace="~{sbadmin/pacientes/imc-gauge :: imcGaugePdf(${paciente.imc}, ${paciente.nivelPeso})}"></div>
+				</td>
 			</tr>
 			<tr th:if="${paciente.responsibleName != null && !paciente.responsibleName.isEmpty()}">
 				<td>Responsable:</td>

--- a/src/test/java/com/nutriconsultas/util/ImcGaugeUtilsTest.java
+++ b/src/test/java/com/nutriconsultas/util/ImcGaugeUtilsTest.java
@@ -1,0 +1,80 @@
+package com.nutriconsultas.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.paciente.NivelPeso;
+
+class ImcGaugeUtilsTest {
+
+	@Test
+	void markerPositionAtMinimumReturnsZero() {
+		assertThat(ImcGaugeUtils.markerPosition(15.0)).isEqualTo(0.0);
+	}
+
+	@Test
+	void markerPositionAtMaximumReturnsHundred() {
+		assertThat(ImcGaugeUtils.markerPosition(40.0)).isEqualTo(100.0);
+	}
+
+	@Test
+	void markerPositionClampsBelowMinimum() {
+		assertThat(ImcGaugeUtils.markerPosition(10.0)).isEqualTo(0.0);
+	}
+
+	@Test
+	void markerPositionClampsAboveMaximum() {
+		assertThat(ImcGaugeUtils.markerPosition(50.0)).isEqualTo(100.0);
+	}
+
+	@Test
+	void markerPositionAtMidpoint() {
+		assertThat(ImcGaugeUtils.markerPosition(27.5)).isEqualTo(50.0);
+	}
+
+	@Test
+	void markerPositionReturnsZeroForNull() {
+		assertThat(ImcGaugeUtils.markerPosition(null)).isEqualTo(0.0);
+	}
+
+	@Test
+	void calculateNivelPesoMatchesBackendThresholds() {
+		assertThat(ImcGaugeUtils.calculateNivelPeso(17.0)).isEqualTo(NivelPeso.BAJO);
+		assertThat(ImcGaugeUtils.calculateNivelPeso(18.5)).isEqualTo(NivelPeso.BAJO);
+		assertThat(ImcGaugeUtils.calculateNivelPeso(20.0)).isEqualTo(NivelPeso.NORMAL);
+		assertThat(ImcGaugeUtils.calculateNivelPeso(25.0)).isEqualTo(NivelPeso.NORMAL);
+		assertThat(ImcGaugeUtils.calculateNivelPeso(26.0)).isEqualTo(NivelPeso.ALTO);
+		assertThat(ImcGaugeUtils.calculateNivelPeso(30.0)).isEqualTo(NivelPeso.ALTO);
+		assertThat(ImcGaugeUtils.calculateNivelPeso(31.0)).isEqualTo(NivelPeso.SOBREPESO);
+	}
+
+	@Test
+	void resolveNivelPesoPrefersProvidedValue() {
+		assertThat(ImcGaugeUtils.resolveNivelPeso(22.0, NivelPeso.ALTO)).isEqualTo(NivelPeso.ALTO);
+	}
+
+	@Test
+	void resolveNivelPesoCalculatesWhenMissing() {
+		assertThat(ImcGaugeUtils.resolveNivelPeso(22.0, null)).isEqualTo(NivelPeso.NORMAL);
+	}
+
+	@Test
+	void markerColorReturnsExpectedHex() {
+		assertThat(ImcGaugeUtils.markerColor(NivelPeso.BAJO)).isEqualTo("#3b82f6");
+		assertThat(ImcGaugeUtils.markerColor(NivelPeso.NORMAL)).isEqualTo("#22c55e");
+		assertThat(ImcGaugeUtils.markerColor(NivelPeso.ALTO)).isEqualTo("#eab308");
+		assertThat(ImcGaugeUtils.markerColor(NivelPeso.SOBREPESO)).isEqualTo("#ef4444");
+	}
+
+	@Test
+	void ariaLabelIncludesValueAndLevel() {
+		assertThat(ImcGaugeUtils.ariaLabel(24.50, NivelPeso.NORMAL)).isEqualTo("IMC 24.50, nivel NORMAL");
+	}
+
+	@Test
+	void ariaLabelHandlesNullImc() {
+		assertThat(ImcGaugeUtils.ariaLabel(null, null)).isEqualTo("IMC no disponible");
+	}
+
+}


### PR DESCRIPTION
## Description

Reemplaza la visualización de IMC como número plano con un componente reutilizable de barra/medidor con gradiente de color. El marcador refleja el valor del paciente en un rango fijo de 15–40 usando los mismos umbrales de `NivelPeso` del backend.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test addition or update
- [ ] 🔨 Build/CI changes

## Changes Made

- Add `ImcGaugeUtils` for marker position, color mapping, and accessibility labels
- Add reusable Thymeleaf fragment `imc-gauge.html` (web, compact sidebar, and PDF variants)
- Integrate gauge in patient profile, consultation view, clinical exam, anthropometric view, and patient progress PDF
- Update `PacienteTemplateValidator` with `ultimoNivelPeso` mock variable

## Related Issues

Closes #120

## Spring Boot Specific Checklist

- [x] Code follows Spring Boot best practices
- [x] Proper use of `@Service`, `@Repository`, `@Controller`, `@RestController` annotations
- [x] Dependency injection is used correctly (constructor injection preferred)
- [x] Configuration properties are properly externalized (if applicable)
- [x] Database migrations are included (if schema changes)
- [x] Transaction management is properly handled
- [x] Exception handling follows Spring Boot patterns
- [x] Security considerations addressed (if applicable)
- [x] Actuator endpoints are not exposed in production (if modified)

## Thymeleaf Specific Checklist

- [x] Thymeleaf templates use proper syntax (`th:*` attributes)
- [x] Template fragments are used appropriately (`th:fragment`, `th:insert`, `th:replace`)
- [x] Internationalization (i18n) is handled correctly (if applicable)
- [x] Template expressions are safe and properly escaped
- [x] No inline JavaScript with unescaped data
- [x] Forms use proper Thymeleaf form binding (`th:object`, `th:field`)
- [x] Template validation passes (run `ThymeleafValidator`)
- [x] All template references are correct (no broken links)
- [ ] Responsive design is maintained (if UI changes)

## Code Quality Checklist

- [x] Code is properly formatted (run `mvn spring-javaformat:apply`)
- [x] Checkstyle passes (run `mvn checkstyle:check`)
- [ ] No SpotBugs warnings (run `mvn spotbugs:check`)
- [ ] PMD checks pass (run `mvn pmd:check`)
- [x] All existing tests pass (`mvn test`)
- [x] New tests are added for new functionality
- [x] Test coverage is maintained or improved
- [x] Code follows project naming conventions
- [x] No hardcoded values (use configuration properties)
- [x] Logging is appropriate (not too verbose, not too sparse)

## Testing

### Manual Testing
- [x] Tested locally with `./dev-start.sh` (app respondiendo en `http://localhost:3000`)
- [x] Database migrations work correctly (if applicable)
- [ ] All affected endpoints work as expected
- [ ] UI changes are tested in different browsers (if applicable)
- [ ] Mobile responsiveness verified (if UI changes)

### Automated Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] All tests pass locally (`mvn test` — 548 tests, 0 failures)
- [x] Test coverage is adequate

## Documentation

- [x] README.md updated (if needed)
- [x] Code comments added for complex logic
- [x] JavaDoc added for public APIs (if applicable)
- [x] API documentation updated (if applicable)
- [x] Changelog updated (if applicable)

## Database Changes

- [x] No database changes
- [ ] Migration script created
- [ ] Migration tested on local database
- [ ] Rollback strategy documented
- [ ] Data migration script included (if needed)

## Security Considerations

- [x] No sensitive data exposed in logs or responses
- [x] Input validation is performed
- [x] SQL injection prevention (using parameterized queries)
- [x] XSS prevention (proper escaping in templates)
- [x] CSRF protection maintained (if forms modified)
- [x] Authentication/authorization checks are in place (if applicable)
- [x] Dependencies are up to date (no known vulnerabilities)

## Performance Considerations

- [x] Database queries are optimized (no N+1 problems)
- [x] Appropriate use of caching (if applicable)
- [x] No memory leaks introduced
- [x] Large data sets are handled efficiently
- [x] Pagination is used where appropriate

## Deployment Notes

- [x] No special deployment steps required
- [ ] Environment variables need to be updated
- [ ] Database migrations need to be run
- [ ] Configuration changes required
- [ ] Other:

## Screenshots (if applicable)

> Sustituir cada `PLACEHOLDER` por la URL de la captura subida al PR (arrastrar imagen al comentario de GitHub y copiar el enlace generado).

### 1. Perfil del paciente — sidebar (`/admin/pacientes/{id}`)
Gauge compacto con valor numérico y marcador de color.

<img width="972" height="1550" alt="image" src="https://github.com/user-attachments/assets/79f575c5-35a7-46ba-ab74-ec2973d392da" />

### 2. Vista de consulta (`/admin/calendar/{id}`)
Gauge estándar en signos vitales de la cita.

<img width="2942" height="1056" alt="image" src="https://github.com/user-attachments/assets/794f30d9-a291-4cf2-a9f9-1c40b7d1cdab" />

### 3. Examen clínico (`/admin/pacientes/{pacienteId}/clinicos/{id}`)
Gauge en la pestaña de signos vitales.

<img width="2036" height="1212" alt="image" src="https://github.com/user-attachments/assets/26d57824-ec3e-4061-b177-188be4dc2d7e" />

### 4. Medición antropométrica (`/admin/pacientes/{pacienteId}/antropometricos/{id}`)
Gauge en datos de masa corporal.

<img width="2036" height="1212" alt="image" src="https://github.com/user-attachments/assets/c5e8bed2-3931-4eb3-8632-fc4673653b9c" />

## Additional Notes

- Bar range is fixed at 15–40 per issue discussion
- Weight level is conveyed by marker color only (no visible textual label); `aria-label` provides accessibility context
- PDF variant uses solid color segments for Flying Saucer compatibility