### PR TITLE
feat(mobile-api): DTO wrappers, visits & diet plans (#110, #91–#93)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,9 @@ RECAPTCHA_SECRET_KEY=secretkey
 # Patient mobile API JWT audience (Auth0 API identifier — required for /rest/mobile/**; see issue #108)
 # Must match mobile AUTH0_AUDIENCE exactly.
 # AUTH_AUDIENCE=https://api.nutriconsultas.minutriporcion.com
+
+# Auth0 Management API — optional; enables nutritionist to link patient mobile accounts by email (#109)
+# Create a Machine-to-Machine app with read:users scope on the Auth0 tenant.
+# AUTH0_MGMT_CLIENT_ID=your_m2m_client_id
+# AUTH0_MGMT_CLIENT_SECRET=your_m2m_client_secret
+# AUTH0_MGMT_DOMAIN=https://your-domain.auth0.com/   # defaults to AUTH_ISSUER when omitted

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-13 — **#91 done** on branch `mobile-api/91-patient-visits` (stacked on #110). **#110** pushed on `mobile-api/110-dto-wrappers`. **#109** on `mobile-api/109-patient-auth0-linkage`.
+**Last updated:** 2026-06-13 — **#92 done** on branch `mobile-api/92-patient-visit-detail` (stacked on #91).
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116) plus the directly-related `[Dashboard]` IMC gauge (#106). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -84,7 +84,7 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 | # | Endpoint | URL | State | Backend source |
 |---|----------|-----|-------|----------------|
 | **91** | `GET /rest/mobile/patient/visits` — list session summaries | https://github.com/diego-torres/nutriconsultas/issues/91 | **done** | 107, 110 | Branch `mobile-api/91-patient-visits`: paged `VisitSummaryDto`, filters (`status`, `from`, `to`), `ApiResponse`/`PagedResponse` envelope; `@AuthenticationPrincipal Jwt`. |
-| 92 | `GET /rest/mobile/patient/visits/{visitId}` — single detail | https://github.com/diego-torres/nutriconsultas/issues/92 | open | 91 | `CalendarEvent` detail. **IDOR guard: 404 (not 403) on ownership miss** — don't leak existence. |
+| **92** | `GET /rest/mobile/patient/visits/{visitId}` — single detail | https://github.com/diego-torres/nutriconsultas/issues/92 | **done** | 91 | Branch `mobile-api/92-patient-visit-detail`: `VisitDetailDto`, `findByIdAndPacienteId` IDOR guard → 404. |
 
 ### Diet Plans — `PacienteDieta` / `Dieta`
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-12 — **#107 in-progress** on branch `mobile-api/107-jwt-resource-server`. Next unblocked after merge: **#110**.
+**Last updated:** 2026-06-13 — **#109 in-progress** on branch `mobile-api/109-patient-auth0-linkage`. **#107 done** (`aa4db72`). **#118 done** (`0437a6c`, `AUTH_AUDIENCE` on prod EC2). Next after #109: **#110**.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116) plus the directly-related `[Dashboard]` IMC gauge (#106). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -19,8 +19,8 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | Mobile API audience | **Patient-only** — `/rest/mobile/patient/**` serves a patient their **own** visits, diet plans, progress, messages. Never another patient's, never cross-tenant. |
 | Nutritionist mobile app | **Out of scope** — roster/consultation/meal-plan authoring stays on the existing Thymeleaf web app. No `[Mobile API]` endpoint exposes authoring. |
 | `[Mobile API] #114` (nutritionist reply) | **Web/backend feature** — lives in this repo, but it is **not** consumed by the patient mobile app. It feeds the patient `messages` thread (#96). |
-| Patient identity | JWT `sub` resolves to **`Paciente.patientAuthSub`** (NEW field, #107). **Never `Paciente.userId`** — that is the NUTRITIONIST's Auth0 sub / tenant owner (ALIGNMENT-SPEC §F2). 403 if no linked `Paciente`. |
-| Linkage mechanism | **Undefined** — how an Auth0 `sub` first binds to a `Paciente` (admin invite / email match / assign) is designed in **#109** and gates live integration. |
+| Patient identity | JWT `sub` resolves to **`Paciente.patientAuthSub`** (#107). **Never `Paciente.userId`** — that is the NUTRITIONIST's Auth0 sub / tenant owner (ALIGNMENT-SPEC §F2). 403 if no linked `Paciente`. |
+| Linkage mechanism | **Option A (nutritionist-initiated)** — #109: nutritionist links from **Afiliación** via patient email (Auth0 Management API lookup) or manual `sub` assign; unlink clears `patientAuthSub`. Requires optional `AUTH0_MGMT_*` env for email lookup. |
 
 ## Design & schema ground truth (ALIGNMENT-SPEC §F8 — verified at `228bbc3`)
 
@@ -46,20 +46,26 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-All `[Mobile API]` issues are currently `open` — none of Phase 0 has shipped.
+Phase 0 JWT resource server (#107) is **done**. Patient linkage (#109) is **in-progress**.
 
 ---
 
 ## Phase 0 — Foundation (P0 · blocks every endpoint)
 
-No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `done`.
+No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `done`. Linkage (#109) gates **live** mobile E2E but not endpoint development (seed `patientAuthSub` for tests).
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| **107** | Phase 0 — Auth0 JWT resource server + patient Auth0 linkage | https://github.com/diego-torres/nutriconsultas/issues/107 | **in-progress** | — | New `MobileSecurityConfig` `@Order(1)` stateless chain on `/rest/mobile/**`; add `Paciente.patientAuthSub` (unique, nullable) + principal resolver; Liquibase column (coord. #46). **Blocks #91–#99.** Mirror of mobile [#22](https://github.com/Escanor4323/nutriconsultas-mobile/issues/22). |
-| 108 | Auth0 API resource + audience + scopes setup | https://github.com/diego-torres/nutriconsultas/issues/108 | open | 107 | Auth0-tenant config: API identifier (audience), scopes; feeds `issuer-uri`/`audience` validation in #107. |
-| 109 | Patient-Auth0 account linkage (admin invite/assign flow) | https://github.com/diego-torres/nutriconsultas/issues/109 | open | 107 | Defines how a `sub` first binds to `patientAuthSub`. Gates **live** E2E; endpoints can be built/tested with seeded linkage before this lands. |
-| 110 | DTO conventions + `ApiResponse`/`PagedResponse` wrappers | https://github.com/diego-torres/nutriconsultas/issues/110 | open | — | `com.nutriconsultas.mobile.dto`: `ApiResponse<T>`, `PagedResponse<T>` (+ cursor variant for #96); ISO-8601 dates (Jackson `JavaTimeModule`, `WRITE_DATES_AS_TIMESTAMPS=false`). **Blocks #91–#99.** |
+| **107** | Phase 0 — Auth0 JWT resource server + patient Auth0 linkage | https://github.com/diego-torres/nutriconsultas/issues/107 | **done** | — | Merged `aa4db72`: `MobileSecurityConfig` `@Order(1)` on `/rest/mobile/**`; `Paciente.patientAuthSub` + `PatientAuthService` / `PatientLinkageFilter`. |
+| 108 | Auth0 API resource + audience + scopes setup | https://github.com/diego-torres/nutriconsultas/issues/108 | open | 107 | Auth0-tenant config: API identifier `https://api.nutriconsultas.minutriporcion.com`, scopes; prod `AUTH_AUDIENCE` deployed via #118. |
+| **109** | Patient-Auth0 account linkage (admin invite/assign flow) | https://github.com/diego-torres/nutriconsultas/issues/109 | **in-progress** | 107 | Branch `mobile-api/109-patient-auth0-linkage`: admin Afiliación UI + `POST/DELETE /rest/pacientes/{id}/mobile-auth`. Option A: email lookup via Auth0 Management API. |
+| 110 | DTO conventions + `ApiResponse`/`PagedResponse` wrappers | https://github.com/diego-torres/nutriconsultas/issues/110 | open | — | `com.nutriconsultas.mobile.dto`: `ApiResponse<T>`, `PagedResponse<T>` (+ cursor variant for #96); ISO-8601 dates. **Blocks #91–#99.** |
+
+### Infra (mobile JWT)
+
+| PR | Title | State | Notes |
+|----|-------|-------|-------|
+| **118** | deploy `AUTH_AUDIENCE` for mobile JWT validation | **done** | Merged `0437a6c`; prod EC2 `app.env` has `AUTH_AUDIENCE` (verified 2026-06-13). |
 
 ## Phase 1 — Cross-cutting foundation (P1 · applies to all endpoints)
 
@@ -136,6 +142,11 @@ Each mobile feature consumes these backend endpoints. Two-way linking with the m
 - i18n: `Accept-Language` (es-MX default) error bodies (#111).
 - PHI-safe logging (`LogRedaction`, #115); no names/emails/DOB at INFO.
 
+**E2E HTTP codes (2026-06-13):**
+- **401** — missing/invalid JWT or wrong `aud` (check mobile `AUTH0_AUDIENCE` = `https://api.nutriconsultas.minutriporcion.com`).
+- **403** `patient_not_linked` — JWT valid, no `Paciente.patientAuthSub` match (#109 linkage required).
+- **404** — linkage OK but endpoint not implemented yet (#91+).
+
 ---
 
 ## How to update this file
@@ -143,13 +154,13 @@ Each mobile feature consumes these backend endpoints. Two-way linking with the m
 **Starting work** — mark `in-progress`, keep `NEXT` on it until the PR merges:
 
 ```text
-| 107 | Phase 0 — Auth0 JWT resource server ... | https://... | in-progress | — | ... |
+| 109 | Patient-Auth0 account linkage ... | https://... | in-progress | 107 | ... |
 ```
 
-**After PR merges** — mark `done` and advance `NEXT` to the next unblocked row (Phase 0 order: #107 → #110 → #108/#109 → endpoints):
+**After PR merges** — mark `done` and advance `NEXT` to the next unblocked row (Phase 0 order: #109 → #110 → #108 → endpoints):
 
 ```text
-| 107 | Phase 0 ... | https://... | done | — | ... |
+| 109 | Patient-Auth0 account linkage ... | https://... | done | 107 | ... |
 | 110 | DTO conventions ... | https://... | **NEXT** | — | ... |
 ```
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-13 — **#110 in-progress** on branch `mobile-api/110-dto-wrappers` (stacked on #109). **#107 done** (`aa4db72`). **#118 done** (`0437a6c`). **#109** pushed on `mobile-api/109-patient-auth0-linkage`.
+**Last updated:** 2026-06-13 — **#91 done** on branch `mobile-api/91-patient-visits` (stacked on #110). **#110** pushed on `mobile-api/110-dto-wrappers`. **#109** on `mobile-api/109-patient-auth0-linkage`.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116) plus the directly-related `[Dashboard]` IMC gauge (#106). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -46,7 +46,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 JWT resource server (#107) is **done**. Patient linkage (#109) is **pushed** (PR pending). DTO wrappers (#110) are **in-progress**.
+Phase 0 JWT (#107) and DTO wrappers (#110) are **done** on stacked branches. Patient linkage (#109) is **pushed**. Visits list endpoint (#91) is **done** on `mobile-api/91-patient-visits`.
 
 ---
 
@@ -59,7 +59,7 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 | **107** | Phase 0 — Auth0 JWT resource server + patient Auth0 linkage | https://github.com/diego-torres/nutriconsultas/issues/107 | **done** | — | Merged `aa4db72`: `MobileSecurityConfig` `@Order(1)` on `/rest/mobile/**`; `Paciente.patientAuthSub` + `PatientAuthService` / `PatientLinkageFilter`. |
 | 108 | Auth0 API resource + audience + scopes setup | https://github.com/diego-torres/nutriconsultas/issues/108 | open | 107 | Auth0-tenant config: API identifier `https://api.nutriconsultas.minutriporcion.com`, scopes; prod `AUTH_AUDIENCE` deployed via #118. |
 | **109** | Patient-Auth0 account linkage (admin invite/assign flow) | https://github.com/diego-torres/nutriconsultas/issues/109 | **in-progress** | 107 | Branch `mobile-api/109-patient-auth0-linkage` (pushed): admin Afiliación UI + `POST/DELETE /rest/pacientes/{id}/mobile-auth`. Option A: email lookup via Auth0 Management API. |
-| **110** | DTO conventions + `ApiResponse`/`PagedResponse` wrappers | https://github.com/diego-torres/nutriconsultas/issues/110 | **in-progress** | — | Branch `mobile-api/110-dto-wrappers`: `com.nutriconsultas.mobile.dto` records + Jackson ISO-8601. **Blocks #91–#99.** |
+| **110** | DTO conventions + `ApiResponse`/`PagedResponse` wrappers | https://github.com/diego-torres/nutriconsultas/issues/110 | **done** | — | Merged on branch `mobile-api/110-dto-wrappers`: `com.nutriconsultas.mobile.dto` records + Jackson ISO-8601. |
 
 ### Infra (mobile JWT)
 
@@ -83,8 +83,8 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 
 | # | Endpoint | URL | State | Backend source |
 |---|----------|-----|-------|----------------|
-| 91 | `GET /rest/mobile/patient/visits` — list session summaries | https://github.com/diego-torres/nutriconsultas/issues/91 | open | `CalendarEventService.findByPacienteId`; `EventStatus`; paged summary DTO |
-| 92 | `GET /rest/mobile/patient/visits/{visitId}` — single detail | https://github.com/diego-torres/nutriconsultas/issues/92 | open | `CalendarEvent` detail. **IDOR guard: 404 (not 403) on ownership miss** — don't leak existence. |
+| **91** | `GET /rest/mobile/patient/visits` — list session summaries | https://github.com/diego-torres/nutriconsultas/issues/91 | **done** | 107, 110 | Branch `mobile-api/91-patient-visits`: paged `VisitSummaryDto`, filters (`status`, `from`, `to`), `ApiResponse`/`PagedResponse` envelope; `@AuthenticationPrincipal Jwt`. |
+| 92 | `GET /rest/mobile/patient/visits/{visitId}` — single detail | https://github.com/diego-torres/nutriconsultas/issues/92 | open | 91 | `CalendarEvent` detail. **IDOR guard: 404 (not 403) on ownership miss** — don't leak existence. |
 
 ### Diet Plans — `PacienteDieta` / `Dieta`
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-13 — **#109 in-progress** on branch `mobile-api/109-patient-auth0-linkage`. **#107 done** (`aa4db72`). **#118 done** (`0437a6c`, `AUTH_AUDIENCE` on prod EC2). Next after #109: **#110**.
+**Last updated:** 2026-06-13 — **#110 in-progress** on branch `mobile-api/110-dto-wrappers` (stacked on #109). **#107 done** (`aa4db72`). **#118 done** (`0437a6c`). **#109** pushed on `mobile-api/109-patient-auth0-linkage`.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116) plus the directly-related `[Dashboard]` IMC gauge (#106). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -46,7 +46,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 JWT resource server (#107) is **done**. Patient linkage (#109) is **in-progress**.
+Phase 0 JWT resource server (#107) is **done**. Patient linkage (#109) is **pushed** (PR pending). DTO wrappers (#110) are **in-progress**.
 
 ---
 
@@ -58,8 +58,8 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 |---|-------|-----|-------|-----------|-------|
 | **107** | Phase 0 — Auth0 JWT resource server + patient Auth0 linkage | https://github.com/diego-torres/nutriconsultas/issues/107 | **done** | — | Merged `aa4db72`: `MobileSecurityConfig` `@Order(1)` on `/rest/mobile/**`; `Paciente.patientAuthSub` + `PatientAuthService` / `PatientLinkageFilter`. |
 | 108 | Auth0 API resource + audience + scopes setup | https://github.com/diego-torres/nutriconsultas/issues/108 | open | 107 | Auth0-tenant config: API identifier `https://api.nutriconsultas.minutriporcion.com`, scopes; prod `AUTH_AUDIENCE` deployed via #118. |
-| **109** | Patient-Auth0 account linkage (admin invite/assign flow) | https://github.com/diego-torres/nutriconsultas/issues/109 | **in-progress** | 107 | Branch `mobile-api/109-patient-auth0-linkage`: admin Afiliación UI + `POST/DELETE /rest/pacientes/{id}/mobile-auth`. Option A: email lookup via Auth0 Management API. |
-| 110 | DTO conventions + `ApiResponse`/`PagedResponse` wrappers | https://github.com/diego-torres/nutriconsultas/issues/110 | open | — | `com.nutriconsultas.mobile.dto`: `ApiResponse<T>`, `PagedResponse<T>` (+ cursor variant for #96); ISO-8601 dates. **Blocks #91–#99.** |
+| **109** | Patient-Auth0 account linkage (admin invite/assign flow) | https://github.com/diego-torres/nutriconsultas/issues/109 | **in-progress** | 107 | Branch `mobile-api/109-patient-auth0-linkage` (pushed): admin Afiliación UI + `POST/DELETE /rest/pacientes/{id}/mobile-auth`. Option A: email lookup via Auth0 Management API. |
+| **110** | DTO conventions + `ApiResponse`/`PagedResponse` wrappers | https://github.com/diego-torres/nutriconsultas/issues/110 | **in-progress** | — | Branch `mobile-api/110-dto-wrappers`: `com.nutriconsultas.mobile.dto` records + Jackson ISO-8601. **Blocks #91–#99.** |
 
 ### Infra (mobile JWT)
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-13 — **#92 done** on branch `mobile-api/92-patient-visit-detail` (stacked on #91).
+**Last updated:** 2026-06-13 — **#93 done** on branch `mobile-api/93-patient-diet-plans` (PR #142).
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116) plus the directly-related `[Dashboard]` IMC gauge (#106). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -46,7 +46,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 JWT (#107) and DTO wrappers (#110) are **done** on stacked branches. Patient linkage (#109) is **pushed**. Visits list endpoint (#91) is **done** on `mobile-api/91-patient-visits`.
+Phase 0 JWT (#107) and DTO wrappers (#110) are **done** on stacked branches. Patient linkage (#109) is **pushed**. Visits (#91–#92) and diet plan list (#93) land on `mobile-api/93-patient-diet-plans`.
 
 ---
 
@@ -90,7 +90,7 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 
 | # | Endpoint | URL | State | Backend source |
 |---|----------|-----|-------|----------------|
-| 93 | `GET /rest/mobile/patient/diet-plans` — list assigned plans | https://github.com/diego-torres/nutriconsultas/issues/93 | open | `PacienteDietaService`; `PacienteDietaStatus`; `activeOnly` query param |
+| **93** | `GET /rest/mobile/patient/diet-plans` — list assigned plans | https://github.com/diego-torres/nutriconsultas/issues/93 | **done** | 110 | Branch `mobile-api/93-patient-diet-plans`: paged `DietPlanSummaryDto`, `activeOnly` filter, macro aliases per §F8. |
 | 94 | `GET /rest/mobile/patient/diet-plans/{assignmentId}` — structured meal JSON | https://github.com/diego-torres/nutriconsultas/issues/94 | open | `Dieta`→`Ingesta`→`PlatilloIngesta`/`AlimentoIngesta` tree; strip nutritionist-internal fields; field map per §F8 |
 | 95 | `GET /rest/mobile/patient/diet-plans/{assignmentId}/pdf` — printable PDF | https://github.com/diego-torres/nutriconsultas/issues/95 | open | Reuses existing PDF export (#14) + `NutritionistProfile` branding (#101 ✓); `Content-Disposition`; ownership check |
 

--- a/src/main/java/com/nutriconsultas/auth0/Auth0UserLookup.java
+++ b/src/main/java/com/nutriconsultas/auth0/Auth0UserLookup.java
@@ -9,6 +9,6 @@ public interface Auth0UserLookup {
 
 	boolean isConfigured();
 
-	Optional<String> findUserIdByEmail(final String email);
+	Optional<String> findUserIdByEmail(String email);
 
 }

--- a/src/main/java/com/nutriconsultas/auth0/Auth0UserLookup.java
+++ b/src/main/java/com/nutriconsultas/auth0/Auth0UserLookup.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.auth0;
+
+import java.util.Optional;
+
+/**
+ * Resolves Auth0 user identifiers ({@code sub}) by email via the Management API.
+ */
+public interface Auth0UserLookup {
+
+	boolean isConfigured();
+
+	Optional<String> findUserIdByEmail(final String email);
+
+}

--- a/src/main/java/com/nutriconsultas/auth0/Auth0UserLookupImpl.java
+++ b/src/main/java/com/nutriconsultas/auth0/Auth0UserLookupImpl.java
@@ -1,0 +1,138 @@
+package com.nutriconsultas.auth0;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@ConditionalOnExpression("'${app.auth0.management.client-id:}'.length() > 0")
+@Slf4j
+public class Auth0UserLookupImpl implements Auth0UserLookup {
+
+	private static final ParameterizedTypeReference<List<Map<String, Object>>> USER_LIST_TYPE = new ParameterizedTypeReference<>() {
+	};
+
+	private final RestClient restClient;
+
+	private final String clientId;
+
+	private final String clientSecret;
+
+	private final String domain;
+
+	private volatile CachedToken cachedToken;
+
+	public Auth0UserLookupImpl(final RestClient.Builder restClientBuilder,
+			@Value("${app.auth0.management.client-id}") final String clientId,
+			@Value("${app.auth0.management.client-secret}") final String clientSecret,
+			@Value("${app.auth0.management.domain}") final String domain) {
+		this.restClient = restClientBuilder.build();
+		this.clientId = clientId;
+		this.clientSecret = clientSecret;
+		this.domain = normalizeDomain(domain);
+	}
+
+	@Override
+	public boolean isConfigured() {
+		return StringUtils.hasText(clientId) && StringUtils.hasText(clientSecret) && StringUtils.hasText(domain);
+	}
+
+	@Override
+	public Optional<String> findUserIdByEmail(final String email) {
+		if (!isConfigured()) {
+			return Optional.empty();
+		}
+		if (!StringUtils.hasText(email)) {
+			return Optional.empty();
+		}
+		final String token = obtainManagementToken();
+		final URI uri = UriComponentsBuilder.fromHttpUrl("https://" + domain + "/api/v2/users-by-email")
+			.queryParam("email", email.trim().toLowerCase())
+			.build(true)
+			.toUri();
+		final List<Map<String, Object>> users = restClient.get()
+			.uri(uri)
+			.header("Authorization", "Bearer " + token)
+			.accept(MediaType.APPLICATION_JSON)
+			.retrieve()
+			.body(USER_LIST_TYPE);
+		if (users == null || users.isEmpty()) {
+			return Optional.empty();
+		}
+		final Object userId = users.get(0).get("user_id");
+		if (userId == null) {
+			return Optional.empty();
+		}
+		return Optional.of(userId.toString());
+	}
+
+	private String obtainManagementToken() {
+		final CachedToken current = cachedToken;
+		if (current != null && current.isValid()) {
+			return current.token();
+		}
+		synchronized (this) {
+			final CachedToken again = cachedToken;
+			if (again != null && again.isValid()) {
+				return again.token();
+			}
+			final Map<String, Object> response = restClient.post()
+				.uri("https://" + domain + "/oauth/token")
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(Map.of("client_id", clientId, "client_secret", clientSecret, "audience",
+						"https://" + domain + "/api/v2/", "grant_type", "client_credentials"))
+				.retrieve()
+				.body(new ParameterizedTypeReference<Map<String, Object>>() {
+				});
+			if (response == null || response.get("access_token") == null) {
+				throw new IllegalStateException("Auth0 Management API token request failed");
+			}
+			final String accessToken = response.get("access_token").toString();
+			final long expiresIn = response.get("expires_in") instanceof Number number ? number.longValue() : 3600L;
+			cachedToken = new CachedToken(accessToken, Instant.now().plusSeconds(Math.max(60L, expiresIn - 60L)));
+			if (log.isDebugEnabled()) {
+				log.debug("Obtained Auth0 Management API token for domain {}", domain);
+			}
+			return accessToken;
+		}
+	}
+
+	private static String normalizeDomain(final String rawDomain) {
+		if (!StringUtils.hasText(rawDomain)) {
+			return "";
+		}
+		String normalized = rawDomain.trim();
+		if (normalized.startsWith("https://")) {
+			normalized = normalized.substring("https://".length());
+		}
+		else if (normalized.startsWith("http://")) {
+			normalized = normalized.substring("http://".length());
+		}
+		while (normalized.endsWith("/")) {
+			normalized = normalized.substring(0, normalized.length() - 1);
+		}
+		return normalized;
+	}
+
+	private record CachedToken(String token, Instant expiresAt) {
+
+		boolean isValid() {
+			return Instant.now().isBefore(expiresAt);
+		}
+
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth0/NoOpAuth0UserLookup.java
+++ b/src/main/java/com/nutriconsultas/auth0/NoOpAuth0UserLookup.java
@@ -1,0 +1,22 @@
+package com.nutriconsultas.auth0;
+
+import java.util.Optional;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnMissingBean(Auth0UserLookupImpl.class)
+public class NoOpAuth0UserLookup implements Auth0UserLookup {
+
+	@Override
+	public boolean isConfigured() {
+		return false;
+	}
+
+	@Override
+	public Optional<String> findUserIdByEmail(final String email) {
+		return Optional.empty();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/calendar/CalendarEventRepository.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarEventRepository.java
@@ -2,6 +2,7 @@ package com.nutriconsultas.calendar;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +22,8 @@ public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Lo
 			+ "AND (:toDate IS NULL OR e.eventDateTime <= :toDate)")
 	Page<CalendarEvent> findPatientVisits(@Param("pacienteId") Long pacienteId, @Param("status") EventStatus status,
 			@Param("fromDate") Date fromDate, @Param("toDate") Date toDate, Pageable pageable);
+
+	Optional<CalendarEvent> findByIdAndPacienteId(Long id, Long pacienteId);
 
 	List<CalendarEvent> findByStatus(EventStatus status);
 

--- a/src/main/java/com/nutriconsultas/calendar/CalendarEventRepository.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarEventRepository.java
@@ -3,6 +3,8 @@ package com.nutriconsultas.calendar;
 import java.util.Date;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +14,13 @@ import org.springframework.stereotype.Repository;
 public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Long> {
 
 	List<CalendarEvent> findByPacienteId(Long pacienteId);
+
+	@Query("SELECT e FROM CalendarEvent e WHERE e.paciente.id = :pacienteId "
+			+ "AND (:status IS NULL OR e.status = :status) "
+			+ "AND (:fromDate IS NULL OR e.eventDateTime >= :fromDate) "
+			+ "AND (:toDate IS NULL OR e.eventDateTime <= :toDate)")
+	Page<CalendarEvent> findPatientVisits(@Param("pacienteId") Long pacienteId, @Param("status") EventStatus status,
+			@Param("fromDate") Date fromDate, @Param("toDate") Date toDate, Pageable pageable);
 
 	List<CalendarEvent> findByStatus(EventStatus status);
 

--- a/src/main/java/com/nutriconsultas/mobile/AbstractMobilePatientController.java
+++ b/src/main/java/com/nutriconsultas/mobile/AbstractMobilePatientController.java
@@ -1,7 +1,6 @@
 package com.nutriconsultas.mobile;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.oauth2.jwt.Jwt;
 
 import com.nutriconsultas.paciente.Paciente;
 
@@ -17,14 +16,11 @@ public abstract class AbstractMobilePatientController {
 		this.patientAuthService = patientAuthService;
 	}
 
-	protected Paciente getAuthenticatedPaciente(@AuthenticationPrincipal final JwtAuthenticationToken authentication) {
-		if (authentication == null) {
+	protected Paciente getAuthenticatedPaciente(final Jwt jwt) {
+		if (jwt == null) {
 			throw new PatientNotLinkedException();
 		}
-		if (authentication.getDetails() instanceof PatientPrincipal patientPrincipal) {
-			return patientAuthService.requirePacienteById(patientPrincipal.getPacienteId());
-		}
-		return patientAuthService.requirePacienteByJwt(authentication.getToken());
+		return patientAuthService.requirePacienteByJwt(jwt);
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/mobile/Auth0ManagementNotConfiguredException.java
+++ b/src/main/java/com/nutriconsultas/mobile/Auth0ManagementNotConfiguredException.java
@@ -1,0 +1,13 @@
+package com.nutriconsultas.mobile;
+
+/**
+ * Thrown when email-based Auth0 lookup is requested but Management API credentials are
+ * not configured.
+ */
+public class Auth0ManagementNotConfiguredException extends RuntimeException {
+
+	public Auth0ManagementNotConfiguredException() {
+		super("auth0_management_not_configured");
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/Auth0ManagementNotConfiguredException.java
+++ b/src/main/java/com/nutriconsultas/mobile/Auth0ManagementNotConfiguredException.java
@@ -6,6 +6,8 @@ package com.nutriconsultas.mobile;
  */
 public class Auth0ManagementNotConfiguredException extends RuntimeException {
 
+	private static final long serialVersionUID = 1L;
+
 	public Auth0ManagementNotConfiguredException() {
 		super("auth0_management_not_configured");
 	}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanController.java
@@ -1,0 +1,45 @@
+package com.nutriconsultas.mobile;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
+import com.nutriconsultas.mobile.dto.PagedResponse;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/mobile/patient/diet-plans")
+@Slf4j
+public class MobilePatientDietPlanController extends AbstractMobilePatientController {
+
+	private final MobilePatientDietPlanService mobilePatientDietPlanService;
+
+	public MobilePatientDietPlanController(final PatientAuthService patientAuthService,
+			final MobilePatientDietPlanService mobilePatientDietPlanService) {
+		super(patientAuthService);
+		this.mobilePatientDietPlanService = mobilePatientDietPlanService;
+	}
+
+	@GetMapping
+	public ApiResponse<PagedResponse<DietPlanSummaryDto>> listDietPlans(@AuthenticationPrincipal final Jwt jwt,
+			@RequestParam(defaultValue = "0") final int page, @RequestParam(defaultValue = "20") final int size,
+			@RequestParam(defaultValue = "false") final boolean activeOnly) {
+		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile list diet plans for patient {} activeOnly={}",
+					LogRedaction.redactPaciente(paciente.getId()), activeOnly);
+		}
+		final PagedResponse<DietPlanSummaryDto> plans = mobilePatientDietPlanService.listDietPlans(paciente.getId(),
+				page, size, activeOnly);
+		return ApiResponse.ok(plans);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanService.java
@@ -1,0 +1,48 @@
+package com.nutriconsultas.mobile;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
+import com.nutriconsultas.mobile.dto.PagedResponse;
+import com.nutriconsultas.paciente.PacienteDieta;
+import com.nutriconsultas.paciente.PacienteDietaRepository;
+import com.nutriconsultas.paciente.PacienteDietaStatus;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class MobilePatientDietPlanService {
+
+	private static final int MAX_PAGE_SIZE = 100;
+
+	private final PacienteDietaRepository pacienteDietaRepository;
+
+	public MobilePatientDietPlanService(final PacienteDietaRepository pacienteDietaRepository) {
+		this.pacienteDietaRepository = pacienteDietaRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public PagedResponse<DietPlanSummaryDto> listDietPlans(final Long pacienteId, final int page, final int size,
+			final boolean activeOnly) {
+		final int safePage = Math.max(page, 0);
+		final int safeSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+		final Pageable pageable = PageRequest.of(safePage, safeSize, Sort.by(Sort.Direction.DESC, "startDate"));
+		final Page<PacienteDieta> assignments = activeOnly
+				? pacienteDietaRepository.findByPacienteIdAndStatus(pacienteId, PacienteDietaStatus.ACTIVE, pageable)
+				: pacienteDietaRepository.findByPacienteId(pacienteId, pageable);
+		final Page<DietPlanSummaryDto> summaries = assignments.map(DietPlanSummaryDto::fromEntity);
+		if (log.isDebugEnabled()) {
+			log.debug("Listed mobile diet plans page={} size={} count={} activeOnly={} for patient {}", safePage,
+					safeSize, summaries.getNumberOfElements(), activeOnly, LogRedaction.redactPaciente(pacienteId));
+		}
+		return PagedResponse.of(summaries);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitController.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.nutriconsultas.calendar.EventStatus;
 import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.PagedResponse;
+import com.nutriconsultas.mobile.dto.VisitDetailDto;
 import com.nutriconsultas.mobile.dto.VisitSummaryDto;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.util.LogRedaction;
@@ -43,6 +45,17 @@ public class MobilePatientVisitController extends AbstractMobilePatientControlle
 		final PagedResponse<VisitSummaryDto> visits = mobilePatientVisitService.listVisits(paciente.getId(), page, size,
 				status, from, to);
 		return ApiResponse.ok(visits);
+	}
+
+	@GetMapping("/{visitId}")
+	public ApiResponse<VisitDetailDto> getVisitDetail(@AuthenticationPrincipal final Jwt jwt,
+			@PathVariable final Long visitId) {
+		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile get visit {} for patient {}", visitId, LogRedaction.redactPaciente(paciente.getId()));
+		}
+		final VisitDetailDto visit = mobilePatientVisitService.getVisitDetail(paciente.getId(), visitId);
+		return ApiResponse.ok(visit);
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitController.java
@@ -1,0 +1,48 @@
+package com.nutriconsultas.mobile;
+
+import java.time.Instant;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nutriconsultas.calendar.EventStatus;
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.PagedResponse;
+import com.nutriconsultas.mobile.dto.VisitSummaryDto;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/mobile/patient/visits")
+@Slf4j
+public class MobilePatientVisitController extends AbstractMobilePatientController {
+
+	private final MobilePatientVisitService mobilePatientVisitService;
+
+	public MobilePatientVisitController(final PatientAuthService patientAuthService,
+			final MobilePatientVisitService mobilePatientVisitService) {
+		super(patientAuthService);
+		this.mobilePatientVisitService = mobilePatientVisitService;
+	}
+
+	@GetMapping
+	public ApiResponse<PagedResponse<VisitSummaryDto>> listVisits(@AuthenticationPrincipal final Jwt jwt,
+			@RequestParam(defaultValue = "0") final int page, @RequestParam(defaultValue = "20") final int size,
+			@RequestParam(required = false) final EventStatus status,
+			@RequestParam(required = false) final Instant from, @RequestParam(required = false) final Instant to) {
+		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile list visits request for patient {}", LogRedaction.redactPaciente(paciente.getId()));
+		}
+		final PagedResponse<VisitSummaryDto> visits = mobilePatientVisitService.listVisits(paciente.getId(), page, size,
+				status, from, to);
+		return ApiResponse.ok(visits);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitService.java
@@ -1,0 +1,52 @@
+package com.nutriconsultas.mobile;
+
+import java.time.Instant;
+import java.util.Date;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.calendar.CalendarEventRepository;
+import com.nutriconsultas.calendar.EventStatus;
+import com.nutriconsultas.mobile.dto.PagedResponse;
+import com.nutriconsultas.mobile.dto.VisitSummaryDto;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class MobilePatientVisitService {
+
+	private static final int MAX_PAGE_SIZE = 100;
+
+	private final CalendarEventRepository calendarEventRepository;
+
+	public MobilePatientVisitService(final CalendarEventRepository calendarEventRepository) {
+		this.calendarEventRepository = calendarEventRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public PagedResponse<VisitSummaryDto> listVisits(final Long pacienteId, final int page, final int size,
+			final EventStatus status, final Instant from, final Instant to) {
+		final int safePage = Math.max(page, 0);
+		final int safeSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+		final Pageable pageable = PageRequest.of(safePage, safeSize, Sort.by(Sort.Direction.DESC, "eventDateTime"));
+		final Date fromDate = from != null ? Date.from(from) : null;
+		final Date toDate = to != null ? Date.from(to) : null;
+		final Page<CalendarEvent> events = calendarEventRepository.findPatientVisits(pacienteId, status, fromDate,
+				toDate, pageable);
+		final Page<VisitSummaryDto> summaries = events.map(VisitSummaryDto::fromEntity);
+		if (log.isDebugEnabled()) {
+			log.debug("Listed mobile visits page={} size={} count={} for patient {}", safePage, safeSize,
+					summaries.getNumberOfElements(), LogRedaction.redactPaciente(pacienteId));
+		}
+		return PagedResponse.of(summaries);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitService.java
@@ -7,13 +7,16 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.nutriconsultas.calendar.CalendarEvent;
 import com.nutriconsultas.calendar.CalendarEventRepository;
 import com.nutriconsultas.calendar.EventStatus;
 import com.nutriconsultas.mobile.dto.PagedResponse;
+import com.nutriconsultas.mobile.dto.VisitDetailDto;
 import com.nutriconsultas.mobile.dto.VisitSummaryDto;
 import com.nutriconsultas.util.LogRedaction;
 
@@ -47,6 +50,13 @@ public class MobilePatientVisitService {
 					summaries.getNumberOfElements(), LogRedaction.redactPaciente(pacienteId));
 		}
 		return PagedResponse.of(summaries);
+	}
+
+	@Transactional(readOnly = true)
+	public VisitDetailDto getVisitDetail(final Long pacienteId, final Long visitId) {
+		return calendarEventRepository.findByIdAndPacienteId(visitId, pacienteId)
+			.map(VisitDetailDto::fromEntity)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/mobile/PatientAuthLinkageService.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientAuthLinkageService.java
@@ -1,0 +1,88 @@
+package com.nutriconsultas.mobile;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.auth0.Auth0UserLookup;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class PatientAuthLinkageService {
+
+	private final PacienteRepository pacienteRepository;
+
+	private final Auth0UserLookup auth0UserLookup;
+
+	public PatientAuthLinkageService(final PacienteRepository pacienteRepository,
+			final Auth0UserLookup auth0UserLookup) {
+		this.pacienteRepository = pacienteRepository;
+		this.auth0UserLookup = auth0UserLookup;
+	}
+
+	@Transactional(readOnly = true)
+	public PatientMobileAuthStatus getStatus(final Long pacienteId, final String nutritionistUserId) {
+		final Paciente paciente = requireOwnedPaciente(pacienteId, nutritionistUserId);
+		return PatientMobileAuthStatus.of(paciente.getPatientAuthSub(), auth0UserLookup.isConfigured());
+	}
+
+	@Transactional
+	public Paciente linkByEmail(final Long pacienteId, final String nutritionistUserId) {
+		if (!auth0UserLookup.isConfigured()) {
+			throw new Auth0ManagementNotConfiguredException();
+		}
+		final Paciente paciente = requireOwnedPaciente(pacienteId, nutritionistUserId);
+		if (!StringUtils.hasText(paciente.getEmail())) {
+			throw new PatientEmailRequiredForLinkException();
+		}
+		final String patientAuthSub = auth0UserLookup.findUserIdByEmail(paciente.getEmail().trim())
+			.orElseThrow(PatientAuthUserNotFoundException::new);
+		return assignSub(paciente, patientAuthSub);
+	}
+
+	@Transactional
+	public Paciente linkBySub(final Long pacienteId, final String nutritionistUserId, final String patientAuthSub) {
+		if (!StringUtils.hasText(patientAuthSub)) {
+			throw new IllegalArgumentException("patientAuthSub is required");
+		}
+		final Paciente paciente = requireOwnedPaciente(pacienteId, nutritionistUserId);
+		return assignSub(paciente, patientAuthSub.trim());
+	}
+
+	@Transactional
+	public Paciente unlink(final Long pacienteId, final String nutritionistUserId) {
+		final Paciente paciente = requireOwnedPaciente(pacienteId, nutritionistUserId);
+		paciente.setPatientAuthSub(null);
+		final Paciente saved = pacienteRepository.save(paciente);
+		if (log.isInfoEnabled()) {
+			log.info("Unlinked mobile Auth0 account for patient {}", LogRedaction.redactPaciente(saved.getId()));
+		}
+		return saved;
+	}
+
+	private Paciente assignSub(final Paciente paciente, final String patientAuthSub) {
+		pacienteRepository.findByPatientAuthSub(patientAuthSub).ifPresent(existing -> {
+			if (!existing.getId().equals(paciente.getId())) {
+				throw new PatientAuthSubAlreadyLinkedException();
+			}
+		});
+		paciente.setPatientAuthSub(patientAuthSub);
+		final Paciente saved = pacienteRepository.save(paciente);
+		if (log.isInfoEnabled()) {
+			log.info("Linked mobile Auth0 account for patient {} sub={}", LogRedaction.redactPaciente(saved.getId()),
+					LogRedaction.redactUserId(patientAuthSub));
+		}
+		return saved;
+	}
+
+	private Paciente requireOwnedPaciente(final Long pacienteId, final String nutritionistUserId) {
+		return pacienteRepository.findByIdAndUserId(pacienteId, nutritionistUserId)
+			.orElseThrow(() -> new IllegalArgumentException("Paciente no encontrado"));
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/PatientAuthSubAlreadyLinkedException.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientAuthSubAlreadyLinkedException.java
@@ -1,0 +1,12 @@
+package com.nutriconsultas.mobile;
+
+/**
+ * Thrown when an Auth0 {@code sub} is already assigned to a different {@code Paciente}.
+ */
+public class PatientAuthSubAlreadyLinkedException extends RuntimeException {
+
+	public PatientAuthSubAlreadyLinkedException() {
+		super("patient_auth_sub_already_linked");
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/PatientAuthSubAlreadyLinkedException.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientAuthSubAlreadyLinkedException.java
@@ -5,6 +5,8 @@ package com.nutriconsultas.mobile;
  */
 public class PatientAuthSubAlreadyLinkedException extends RuntimeException {
 
+	private static final long serialVersionUID = 1L;
+
 	public PatientAuthSubAlreadyLinkedException() {
 		super("patient_auth_sub_already_linked");
 	}

--- a/src/main/java/com/nutriconsultas/mobile/PatientAuthUserNotFoundException.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientAuthUserNotFoundException.java
@@ -1,0 +1,12 @@
+package com.nutriconsultas.mobile;
+
+/**
+ * Thrown when Auth0 has no user for the patient email used in linkage.
+ */
+public class PatientAuthUserNotFoundException extends RuntimeException {
+
+	public PatientAuthUserNotFoundException() {
+		super("patient_auth_user_not_found");
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/PatientAuthUserNotFoundException.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientAuthUserNotFoundException.java
@@ -5,6 +5,8 @@ package com.nutriconsultas.mobile;
  */
 public class PatientAuthUserNotFoundException extends RuntimeException {
 
+	private static final long serialVersionUID = 1L;
+
 	public PatientAuthUserNotFoundException() {
 		super("patient_auth_user_not_found");
 	}

--- a/src/main/java/com/nutriconsultas/mobile/PatientEmailRequiredForLinkException.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientEmailRequiredForLinkException.java
@@ -5,6 +5,8 @@ package com.nutriconsultas.mobile;
  */
 public class PatientEmailRequiredForLinkException extends RuntimeException {
 
+	private static final long serialVersionUID = 1L;
+
 	public PatientEmailRequiredForLinkException() {
 		super("patient_email_required");
 	}

--- a/src/main/java/com/nutriconsultas/mobile/PatientEmailRequiredForLinkException.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientEmailRequiredForLinkException.java
@@ -1,0 +1,12 @@
+package com.nutriconsultas.mobile;
+
+/**
+ * Thrown when email-based linkage is requested but the patient record has no email.
+ */
+public class PatientEmailRequiredForLinkException extends RuntimeException {
+
+	public PatientEmailRequiredForLinkException() {
+		super("patient_email_required");
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/PatientMobileAuthStatus.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientMobileAuthStatus.java
@@ -20,6 +20,7 @@ public final class PatientMobileAuthStatus {
 		this.emailLookupAvailable = emailLookupAvailable;
 	}
 
+	@SuppressWarnings("PMD.ShortMethodName")
 	public static PatientMobileAuthStatus of(final String patientAuthSub, final boolean emailLookupAvailable) {
 		final boolean linked = patientAuthSub != null && !patientAuthSub.isBlank();
 		final String redacted = linked ? redactSub(patientAuthSub) : null;

--- a/src/main/java/com/nutriconsultas/mobile/PatientMobileAuthStatus.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientMobileAuthStatus.java
@@ -1,0 +1,54 @@
+package com.nutriconsultas.mobile;
+
+import java.util.Map;
+
+/**
+ * Status of patient mobile Auth0 linkage for admin UI and REST.
+ */
+public final class PatientMobileAuthStatus {
+
+	private final boolean linked;
+
+	private final String patientAuthSubRedacted;
+
+	private final boolean emailLookupAvailable;
+
+	private PatientMobileAuthStatus(final boolean linked, final String patientAuthSubRedacted,
+			final boolean emailLookupAvailable) {
+		this.linked = linked;
+		this.patientAuthSubRedacted = patientAuthSubRedacted;
+		this.emailLookupAvailable = emailLookupAvailable;
+	}
+
+	public static PatientMobileAuthStatus of(final String patientAuthSub, final boolean emailLookupAvailable) {
+		final boolean linked = patientAuthSub != null && !patientAuthSub.isBlank();
+		final String redacted = linked ? redactSub(patientAuthSub) : null;
+		return new PatientMobileAuthStatus(linked, redacted, emailLookupAvailable);
+	}
+
+	public Map<String, Object> toMap() {
+		return Map.of("linked", linked, "patientAuthSubRedacted",
+				patientAuthSubRedacted != null ? patientAuthSubRedacted : "", "emailLookupAvailable",
+				emailLookupAvailable);
+	}
+
+	public boolean isLinked() {
+		return linked;
+	}
+
+	public String getPatientAuthSubRedacted() {
+		return patientAuthSubRedacted;
+	}
+
+	public boolean isEmailLookupAvailable() {
+		return emailLookupAvailable;
+	}
+
+	private static String redactSub(final String sub) {
+		if (sub.length() <= 10) {
+			return sub.substring(0, Math.min(3, sub.length())) + "…";
+		}
+		return sub.substring(0, 8) + "…" + sub.substring(sub.length() - 4);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/ApiResponse.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/ApiResponse.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ApiResponse<T>(T data, String message, Instant timestamp) {
 
+	@SuppressWarnings("PMD.ShortMethodName")
 	public static <T> ApiResponse<T> ok(final T data) {
 		return new ApiResponse<>(data, null, Instant.now());
 	}

--- a/src/main/java/com/nutriconsultas/mobile/dto/ApiResponse.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/ApiResponse.java
@@ -1,0 +1,23 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Standard envelope for {@code /rest/mobile/**} JSON responses (#110).
+ *
+ * @param <T> payload type
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T>(T data, String message, Instant timestamp) {
+
+	public static <T> ApiResponse<T> ok(final T data) {
+		return new ApiResponse<>(data, null, Instant.now());
+	}
+
+	public static <T> ApiResponse<T> withMessage(final T data, final String message) {
+		return new ApiResponse<>(data, message, Instant.now());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/CursorPagedResponse.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/CursorPagedResponse.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CursorPagedResponse<T>(List<T> content, String nextCursor, boolean hasMore) {
 
+	@SuppressWarnings("PMD.ShortMethodName")
 	public static <T> CursorPagedResponse<T> of(final List<T> content, final String nextCursor) {
 		final boolean more = StringUtils.hasText(nextCursor);
 		return new CursorPagedResponse<>(content, more ? nextCursor : null, more);

--- a/src/main/java/com/nutriconsultas/mobile/dto/CursorPagedResponse.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/CursorPagedResponse.java
@@ -1,0 +1,22 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.util.List;
+
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Cursor-based page wrapper for mobile message threads (#96 / #110).
+ *
+ * @param <T> element type
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CursorPagedResponse<T>(List<T> content, String nextCursor, boolean hasMore) {
+
+	public static <T> CursorPagedResponse<T> of(final List<T> content, final String nextCursor) {
+		final boolean more = StringUtils.hasText(nextCursor);
+		return new CursorPagedResponse<>(content, more ? nextCursor : null, more);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/DietPlanSummaryDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DietPlanSummaryDto.java
@@ -1,0 +1,42 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.paciente.PacienteDieta;
+import com.nutriconsultas.paciente.PacienteDietaStatus;
+
+/**
+ * Assigned diet plan summary for {@code GET /rest/mobile/patient/diet-plans} (#93).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DietPlanSummaryDto(Long assignmentId, PacienteDietaStatus status, LocalDate startDate, LocalDate endDate,
+		String notes, String dietaName, Integer totalKcal, Double totalProteina, Double totalGrasas,
+		Double totalCarbohidratos) {
+
+	public static DietPlanSummaryDto fromEntity(final PacienteDieta assignment) {
+		if (assignment == null) {
+			return null;
+		}
+		final Dieta dieta = assignment.getDieta();
+		return new DietPlanSummaryDto(assignment.getId(), assignment.getStatus(),
+				toLocalDate(assignment.getStartDate()), toLocalDate(assignment.getEndDate()), assignment.getNotes(),
+				dieta != null ? dieta.getNombre() : null, dieta != null ? dieta.getEnergia() : null,
+				dieta != null ? dieta.getProteina() : null, dieta != null ? dieta.getLipidos() : null,
+				dieta != null ? dieta.getHidratosDeCarbono() : null);
+	}
+
+	private static LocalDate toLocalDate(final Date date) {
+		if (date == null) {
+			return null;
+		}
+		if (date instanceof java.sql.Date sqlDate) {
+			return sqlDate.toLocalDate();
+		}
+		return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/PagedResponse.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/PagedResponse.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record PagedResponse<T>(List<T> content, int page, int size, long totalElements, int totalPages, boolean last) {
 
+	@SuppressWarnings("PMD.ShortMethodName")
 	public static <T> PagedResponse<T> of(final Page<T> page) {
 		return new PagedResponse<>(page.getContent(), page.getNumber(), page.getSize(), page.getTotalElements(),
 				page.getTotalPages(), page.isLast());

--- a/src/main/java/com/nutriconsultas/mobile/dto/PagedResponse.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/PagedResponse.java
@@ -1,0 +1,22 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Offset-based page wrapper for mobile list endpoints (#110).
+ *
+ * @param <T> element type
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record PagedResponse<T>(List<T> content, int page, int size, long totalElements, int totalPages, boolean last) {
+
+	public static <T> PagedResponse<T> of(final Page<T> page) {
+		return new PagedResponse<>(page.getContent(), page.getNumber(), page.getSize(), page.getTotalElements(),
+				page.getTotalPages(), page.isLast());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/VisitDetailDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/VisitDetailDto.java
@@ -1,0 +1,31 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.calendar.EventStatus;
+import com.nutriconsultas.paciente.NivelPeso;
+
+/**
+ * Full consultation detail for {@code GET /rest/mobile/patient/visits/{visitId}} (#92).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record VisitDetailDto(Long id, Instant eventDateTime, String title, EventStatus status, Integer durationMinutes,
+		String summaryNotes, String description, Double peso, Double estatura, Double imc, Double indiceGrasaCorporal,
+		NivelPeso nivelPeso, Integer sistolica, Integer diastolica, Integer pulso, Integer indiceGlucemico, Double spo2,
+		Double temperatura) {
+
+	public static VisitDetailDto fromEntity(final CalendarEvent event) {
+		if (event == null) {
+			return null;
+		}
+		final Instant eventInstant = event.getEventDateTime() != null ? event.getEventDateTime().toInstant() : null;
+		return new VisitDetailDto(event.getId(), eventInstant, event.getTitle(), event.getStatus(),
+				event.getDurationMinutes(), event.getSummaryNotes(), event.getDescription(), event.getPeso(),
+				event.getEstatura(), event.getImc(), event.getIndiceGrasaCorporal(), event.getNivelPeso(),
+				event.getSistolica(), event.getDiastolica(), event.getPulso(), event.getIndiceGlucemico(),
+				event.getSpo2(), event.getTemperatura());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/VisitSummaryDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/VisitSummaryDto.java
@@ -1,0 +1,25 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.calendar.EventStatus;
+
+/**
+ * Lightweight consultation summary for {@code GET /rest/mobile/patient/visits} (#91).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record VisitSummaryDto(Long id, Instant eventDateTime, String title, EventStatus status, Integer durationMinutes,
+		String summaryNotes) {
+
+	public static VisitSummaryDto fromEntity(final CalendarEvent event) {
+		if (event == null) {
+			return null;
+		}
+		final Instant eventInstant = event.getEventDateTime() != null ? event.getEventDateTime().toInstant() : null;
+		return new VisitSummaryDto(event.getId(), eventInstant, event.getTitle(), event.getStatus(),
+				event.getDurationMinutes(), event.getSummaryNotes());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -28,7 +28,9 @@ import com.nutriconsultas.calendar.EventStatus;
 import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
 import com.nutriconsultas.clinical.exam.ClinicalExam;
 import com.nutriconsultas.clinical.exam.ClinicalExamService;
+import com.nutriconsultas.auth0.Auth0UserLookup;
 import com.nutriconsultas.controller.AbstractAuthorizedController;
+import com.nutriconsultas.mobile.PatientMobileAuthStatus;
 import com.nutriconsultas.dieta.DietaPdfService;
 import com.nutriconsultas.dieta.DietaRepository;
 import com.nutriconsultas.dieta.DietaService;
@@ -79,6 +81,9 @@ public class PacienteController extends AbstractAuthorizedController {
 
 	@Autowired
 	private PacienteDietaRepository pacienteDietaRepository;
+
+	@Autowired
+	private Auth0UserLookup auth0UserLookup;
 
 	/**
 	 * Gets the user ID from the OAuth2 principal.
@@ -248,6 +253,8 @@ public class PacienteController extends AbstractAuthorizedController {
 
 		model.addAttribute("activeMenu", "afiliacion");
 		model.addAttribute("paciente", paciente);
+		model.addAttribute("mobileAuth",
+				PatientMobileAuthStatus.of(paciente.getPatientAuthSub(), auth0UserLookup.isConfigured()));
 		return "sbadmin/pacientes/afiliacion";
 	}
 

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaRepository.java
@@ -3,6 +3,8 @@ package com.nutriconsultas.paciente;
 import java.util.Date;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,6 +18,10 @@ public interface PacienteDietaRepository extends JpaRepository<PacienteDieta, Lo
 	List<PacienteDieta> findByPacienteIdAndStatus(Long pacienteId, PacienteDietaStatus status);
 
 	List<PacienteDieta> findByPacienteIdOrderByStartDateDesc(Long pacienteId);
+
+	Page<PacienteDieta> findByPacienteId(Long pacienteId, Pageable pageable);
+
+	Page<PacienteDieta> findByPacienteIdAndStatus(Long pacienteId, PacienteDietaStatus status, Pageable pageable);
 
 	List<PacienteDieta> findByDietaId(Long dietaId);
 

--- a/src/main/java/com/nutriconsultas/paciente/PacienteMobileAuthRestController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteMobileAuthRestController.java
@@ -1,0 +1,130 @@
+package com.nutriconsultas.paciente;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nutriconsultas.mobile.Auth0ManagementNotConfiguredException;
+import com.nutriconsultas.mobile.PatientAuthLinkageService;
+import com.nutriconsultas.mobile.PatientAuthSubAlreadyLinkedException;
+import com.nutriconsultas.mobile.PatientAuthUserNotFoundException;
+import com.nutriconsultas.mobile.PatientEmailRequiredForLinkException;
+import com.nutriconsultas.mobile.PatientMobileAuthStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/pacientes/{pacienteId}/mobile-auth")
+@Slf4j
+public class PacienteMobileAuthRestController {
+
+	private final PatientAuthLinkageService patientAuthLinkageService;
+
+	public PacienteMobileAuthRestController(final PatientAuthLinkageService patientAuthLinkageService) {
+		this.patientAuthLinkageService = patientAuthLinkageService;
+	}
+
+	@GetMapping
+	public ResponseEntity<Map<String, Object>> getStatus(@PathVariable @NonNull final Long pacienteId,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = requireUserId(principal);
+		try {
+			final PatientMobileAuthStatus status = patientAuthLinkageService.getStatus(pacienteId, userId);
+			final Map<String, Object> body = new LinkedHashMap<>(status.toMap());
+			body.put("success", true);
+			return ResponseEntity.ok(body);
+		}
+		catch (IllegalArgumentException ex) {
+			return notFound(ex.getMessage());
+		}
+	}
+
+	@PostMapping
+	public ResponseEntity<Map<String, Object>> link(@PathVariable @NonNull final Long pacienteId,
+			@RequestBody(required = false) final Map<String, String> body,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = requireUserId(principal);
+		try {
+			final String patientAuthSub = body != null ? body.get("patientAuthSub") : null;
+			if (StringUtils.hasText(patientAuthSub)) {
+				patientAuthLinkageService.linkBySub(pacienteId, userId, patientAuthSub);
+			}
+			else {
+				patientAuthLinkageService.linkByEmail(pacienteId, userId);
+			}
+			final PatientMobileAuthStatus status = patientAuthLinkageService.getStatus(pacienteId, userId);
+			final Map<String, Object> response = new LinkedHashMap<>(status.toMap());
+			response.put("success", true);
+			return ResponseEntity.ok(response);
+		}
+		catch (IllegalArgumentException ex) {
+			return notFound(ex.getMessage());
+		}
+		catch (PatientAuthSubAlreadyLinkedException ex) {
+			return conflict("patient_auth_sub_already_linked", "Esta cuenta Auth0 ya está vinculada a otro paciente.");
+		}
+		catch (PatientAuthUserNotFoundException ex) {
+			return badRequest("patient_auth_user_not_found",
+					"No se encontró un usuario Auth0 con el correo del paciente.");
+		}
+		catch (PatientEmailRequiredForLinkException ex) {
+			return badRequest("patient_email_required", "El paciente debe tener un correo registrado.");
+		}
+		catch (Auth0ManagementNotConfiguredException ex) {
+			return badRequest("auth0_management_not_configured",
+					"Vinculación por correo no disponible. Use el identificador Auth0 (sub) o configure AUTH0_MGMT_*.");
+		}
+	}
+
+	@DeleteMapping
+	public ResponseEntity<Map<String, Object>> unlink(@PathVariable @NonNull final Long pacienteId,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = requireUserId(principal);
+		try {
+			patientAuthLinkageService.unlink(pacienteId, userId);
+			final PatientMobileAuthStatus status = patientAuthLinkageService.getStatus(pacienteId, userId);
+			final Map<String, Object> response = new LinkedHashMap<>(status.toMap());
+			response.put("success", true);
+			return ResponseEntity.ok(response);
+		}
+		catch (IllegalArgumentException ex) {
+			return notFound(ex.getMessage());
+		}
+	}
+
+	private static String requireUserId(final OidcUser principal) {
+		if (principal == null || !StringUtils.hasText(principal.getSubject())) {
+			throw new IllegalStateException("Not authenticated");
+		}
+		return principal.getSubject();
+	}
+
+	private static ResponseEntity<Map<String, Object>> notFound(final String message) {
+		return ResponseEntity.status(HttpStatus.NOT_FOUND)
+			.body(Map.of("success", false, "error", message != null ? message : "Paciente no encontrado"));
+	}
+
+	private static ResponseEntity<Map<String, Object>> badRequest(final String code, final String message) {
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(Map.of("success", false, "error", code, "message", message));
+	}
+
+	private static ResponseEntity<Map<String, Object>> conflict(final String code, final String message) {
+		return ResponseEntity.status(HttpStatus.CONFLICT)
+			.body(Map.of("success", false, "error", code, "message", message));
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
@@ -11,6 +11,7 @@ import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
 import com.nutriconsultas.clinical.exam.ClinicalExam;
 import com.nutriconsultas.dieta.Dieta;
 import com.nutriconsultas.validation.template.BaseTemplateValidator;
+import com.nutriconsultas.mobile.PatientMobileAuthStatus;
 
 /**
  * Validator for paciente (patient) templates. Provides mock variables for patient
@@ -29,6 +30,7 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 
 		final Paciente paciente = createMockPaciente();
 		variables.put("paciente", paciente);
+		variables.put("mobileAuth", PatientMobileAuthStatus.of(null, false));
 
 		variables.put("citaAnterior", "");
 		variables.put("citaSiguiente", "");

--- a/src/main/java/com/nutriconsultas/security/MobileJwtDecoderConfig.java
+++ b/src/main/java/com/nutriconsultas/security/MobileJwtDecoderConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -14,6 +15,7 @@ import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 
 @Configuration
+@Profile("!test")
 public class MobileJwtDecoderConfig {
 
 	@Bean

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,9 @@ server.error.include-stacktrace=always
 # Trust X-Forwarded-* from nginx (HTTP + HTTPS termination, OAuth redirect URLs).
 server.forward-headers-strategy=framework
 
+# Mobile API JSON: ISO-8601 dates, omit null fields on mobile DTO records (#110)
+spring.jackson.serialization.write-dates-as-timestamps=false
+
 spring.datasource.url=${JDBC_DATABASE_URL}
 spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,6 +32,10 @@ spring.security.oauth2.client.provider.auth0.issuer-uri=${AUTH_ISSUER}
 # Patient mobile API — JWT resource server (separate from nutritionist oauth2Login session)
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${AUTH_ISSUER}
 app.security.jwt.audience=${AUTH_AUDIENCE}
+# Auth0 Management API — optional; enables patient mobile linkage by email (#109)
+app.auth0.management.client-id=${AUTH0_MGMT_CLIENT_ID:}
+app.auth0.management.client-secret=${AUTH0_MGMT_CLIENT_SECRET:}
+app.auth0.management.domain=${AUTH0_MGMT_DOMAIN:${AUTH_ISSUER}}
 # reCAPTCHA configuration
 recaptcha.secret-key=${RECAPTCHA_SECRET_KEY}
 #logging.level.org.hibernate.SQL=debug

--- a/src/main/resources/templates/sbadmin/pacientes/afiliacion.html
+++ b/src/main/resources/templates/sbadmin/pacientes/afiliacion.html
@@ -96,6 +96,50 @@
                       <button type="submit" class="btn btn-success ">Listo!</button>
                     </form>
                   </div>
+
+                  <!-- Mobile app Auth0 linkage (#109) -->
+                  <div class="info-form p-5 border-top" th:if="${paciente != null and paciente.id != null}">
+                    <h5 class="text-gray-800 mb-3">App móvil del paciente</h5>
+                    <p class="text-muted small">
+                      Vincule la cuenta Auth0 del paciente para que pueda iniciar sesión en la app móvil.
+                      El identificador se guarda en <code>patientAuthSub</code> (distinto del nutricionista).
+                    </p>
+                    <div id="mobile-auth-alert" class="alert d-none" role="alert"></div>
+                    <div class="mb-3">
+                      <span class="font-weight-bold">Estado:</span>
+                      <span id="mobile-auth-status-badge" class="badge"
+                        th:classappend="${mobileAuth != null and mobileAuth.linked} ? 'badge-success' : 'badge-secondary'"
+                        th:text="${mobileAuth != null and mobileAuth.linked} ? 'Vinculado' : 'No vinculado'">No vinculado</span>
+                      <span id="mobile-auth-sub" class="text-muted small ml-2"
+                        th:if="${mobileAuth != null and mobileAuth.linked}"
+                        th:text="'(' + ${mobileAuth.patientAuthSubRedacted} + ')'"></span>
+                    </div>
+                    <div class="form-row align-items-end">
+                      <div class="form-group col-md-8" th:if="${mobileAuth == null or !mobileAuth.linked}">
+                        <label for="mobile-auth-sub-input">Identificador Auth0 (sub)</label>
+                        <input type="text" class="form-control" id="mobile-auth-sub-input"
+                          placeholder="auth0|… o google-oauth2|…">
+                        <small class="form-text text-muted">Opcional si usa vinculación por correo del paciente.</small>
+                      </div>
+                      <div class="form-group col-md-12">
+                        <button type="button" class="btn btn-primary btn-sm" id="mobile-auth-link-email-btn"
+                          th:if="${mobileAuth != null and mobileAuth.emailLookupAvailable and (mobileAuth == null or !mobileAuth.linked)}">
+                          Vincular por correo del paciente
+                        </button>
+                        <button type="button" class="btn btn-outline-primary btn-sm" id="mobile-auth-link-sub-btn"
+                          th:if="${mobileAuth == null or !mobileAuth.linked}">
+                          Vincular por identificador
+                        </button>
+                        <button type="button" class="btn btn-outline-danger btn-sm" id="mobile-auth-unlink-btn"
+                          th:if="${mobileAuth != null and mobileAuth.linked}">
+                          Desvincular
+                        </button>
+                      </div>
+                    </div>
+                    <p class="text-muted small mb-0" th:if="${mobileAuth != null and !mobileAuth.emailLookupAvailable}">
+                      Vinculación por correo no disponible (configure <code>AUTH0_MGMT_CLIENT_ID</code> en el servidor).
+                    </p>
+                  </div>
                   <br>
 
                   <a href="#nav-main" class="btn btn-secondary-outline btn-sm" role="button">↓</a>
@@ -126,6 +170,111 @@
 
     <!-- Custom scripts for all pages-->
     <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
+
+    <script th:inline="javascript">
+      (function () {
+        var pacienteId = /*[[${paciente != null ? paciente.id : null}]]*/ null;
+        if (!pacienteId) {
+          return;
+        }
+        var baseUrl = '/rest/pacientes/' + pacienteId + '/mobile-auth';
+        var alertEl = document.getElementById('mobile-auth-alert');
+        var badgeEl = document.getElementById('mobile-auth-status-badge');
+        var subEl = document.getElementById('mobile-auth-sub');
+
+        function showAlert(type, message) {
+          if (!alertEl) {
+            return;
+          }
+          alertEl.className = 'alert alert-' + type;
+          alertEl.textContent = message;
+          alertEl.classList.remove('d-none');
+        }
+
+        function refreshStatus(data) {
+          if (!data) {
+            return;
+          }
+          var linked = !!data.linked;
+          if (badgeEl) {
+            badgeEl.textContent = linked ? 'Vinculado' : 'No vinculado';
+            badgeEl.className = 'badge ' + (linked ? 'badge-success' : 'badge-secondary');
+          }
+          if (subEl) {
+            if (linked && data.patientAuthSubRedacted) {
+              subEl.textContent = '(' + data.patientAuthSubRedacted + ')';
+              subEl.classList.remove('d-none');
+            } else {
+              subEl.textContent = '';
+              subEl.classList.add('d-none');
+            }
+          }
+          if (linked) {
+            window.location.reload();
+          }
+        }
+
+        function postLink(body) {
+          return fetch(baseUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body || {})
+          }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, status: r.status, body: j }; }); });
+        }
+
+        var emailBtn = document.getElementById('mobile-auth-link-email-btn');
+        if (emailBtn) {
+          emailBtn.addEventListener('click', function () {
+            postLink({}).then(function (res) {
+              if (res.ok && res.body.success) {
+                showAlert('success', 'Cuenta móvil vinculada correctamente.');
+                refreshStatus(res.body);
+              } else {
+                showAlert('danger', res.body.message || res.body.error || 'No se pudo vincular.');
+              }
+            }).catch(function () { showAlert('danger', 'Error de red al vincular.'); });
+          });
+        }
+
+        var subBtn = document.getElementById('mobile-auth-link-sub-btn');
+        if (subBtn) {
+          subBtn.addEventListener('click', function () {
+            var input = document.getElementById('mobile-auth-sub-input');
+            var sub = input ? input.value.trim() : '';
+            if (!sub) {
+              showAlert('warning', 'Ingrese el identificador Auth0 (sub).');
+              return;
+            }
+            postLink({ patientAuthSub: sub }).then(function (res) {
+              if (res.ok && res.body.success) {
+                showAlert('success', 'Cuenta móvil vinculada correctamente.');
+                refreshStatus(res.body);
+              } else {
+                showAlert('danger', res.body.message || res.body.error || 'No se pudo vincular.');
+              }
+            }).catch(function () { showAlert('danger', 'Error de red al vincular.'); });
+          });
+        }
+
+        var unlinkBtn = document.getElementById('mobile-auth-unlink-btn');
+        if (unlinkBtn) {
+          unlinkBtn.addEventListener('click', function () {
+            if (!window.confirm('¿Desvincular la cuenta móvil de este paciente?')) {
+              return;
+            }
+            fetch(baseUrl, { method: 'DELETE' }).then(function (r) {
+              return r.json().then(function (j) { return { ok: r.ok, body: j }; });
+            }).then(function (res) {
+              if (res.ok && res.body.success) {
+                window.location.reload();
+              } else {
+                showAlert('danger', res.body.error || 'No se pudo desvincular.');
+              }
+            }).catch(function () { showAlert('danger', 'Error de red al desvincular.'); });
+          });
+        }
+      })();
+    </script>
 
 </body>
 

--- a/src/test/java/com/nutriconsultas/mobile/MobileIntegrationTestJwt.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileIntegrationTestJwt.java
@@ -1,0 +1,28 @@
+package com.nutriconsultas.mobile;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+
+import java.util.List;
+
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import com.nutriconsultas.security.TestMobileJwtDecoderConfig;
+
+public final class MobileIntegrationTestJwt {
+
+	private static final String TEST_ISSUER = "https://dev-imd1udg26uvzvfto.us.auth0.com/";
+
+	private static final String TEST_AUDIENCE = "https://api.nutriconsultas.test/mobile";
+
+	private MobileIntegrationTestJwt() {
+	}
+
+	public static RequestPostProcessor mobileJwt(final String subject) {
+		final String tokenValue = TestMobileJwtDecoderConfig.TOKEN_PREFIX + subject;
+		return jwt().jwt(j -> j.tokenValue(tokenValue)
+			.subject(subject)
+			.issuer(TEST_ISSUER)
+			.claim("aud", List.of(TEST_AUDIENCE)));
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanControllerTest.java
@@ -1,0 +1,64 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
+import com.nutriconsultas.mobile.dto.PagedResponse;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteDietaStatus;
+
+@ExtendWith(MockitoExtension.class)
+class MobilePatientDietPlanControllerTest {
+
+	private static final String PATIENT_SUB = "auth0|mobile-diet-plan-patient";
+
+	@InjectMocks
+	private MobilePatientDietPlanController controller;
+
+	@Mock
+	private PatientAuthService patientAuthService;
+
+	@Mock
+	private MobilePatientDietPlanService mobilePatientDietPlanService;
+
+	@Test
+	void listDietPlans_returnsApiResponseEnvelope() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(3L);
+		final DietPlanSummaryDto summary = new DietPlanSummaryDto(7L, PacienteDietaStatus.ACTIVE, null, null, null,
+				"Plan A", 2000, 100.0, 70.0, 250.0);
+		final PagedResponse<DietPlanSummaryDto> page = PagedResponse
+			.of(new PageImpl<>(List.of(summary), PageRequest.of(0, 20), 1));
+		final Jwt jwt = jwtWithSub(PATIENT_SUB);
+
+		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);
+		when(mobilePatientDietPlanService.listDietPlans(3L, 0, 20, true)).thenReturn(page);
+
+		final ApiResponse<PagedResponse<DietPlanSummaryDto>> response = controller.listDietPlans(jwt, 0, 20, true);
+
+		assertThat(response.data().content()).hasSize(1);
+		assertThat(response.data().content().get(0).dietaName()).isEqualTo("Plan A");
+		assertThat(response.timestamp()).isNotNull();
+		verify(mobilePatientDietPlanService).listDietPlans(3L, 0, 20, true);
+	}
+
+	private static Jwt jwtWithSub(final String subject) {
+		return Jwt.withTokenValue("token").header("alg", "none").subject(subject).build();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanIntegrationTest.java
@@ -1,0 +1,105 @@
+package com.nutriconsultas.mobile;
+
+import static com.nutriconsultas.mobile.MobileIntegrationTestJwt.mobileJwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.dieta.DietaRepository;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteDieta;
+import com.nutriconsultas.paciente.PacienteDietaRepository;
+import com.nutriconsultas.paciente.PacienteDietaStatus;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MobilePatientDietPlanIntegrationTest {
+
+	private static final String LINKED_SUB = "auth0|mobile-diet-plan-integration";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@Autowired
+	private DietaRepository dietaRepository;
+
+	@Autowired
+	private PacienteDietaRepository pacienteDietaRepository;
+
+	private Paciente linkedPaciente;
+
+	@BeforeEach
+	void seedData() {
+		linkedPaciente = pacienteRepository.findByPatientAuthSub(LINKED_SUB).orElseGet(() -> {
+			final Paciente paciente = samplePaciente(LINKED_SUB);
+			return pacienteRepository.saveAndFlush(paciente);
+		});
+		if (pacienteDietaRepository.findByPacienteId(linkedPaciente.getId()).isEmpty()) {
+			final Dieta dieta = new Dieta();
+			dieta.setNombre("Dieta integración");
+			dieta.setUserId("nutritionist-sub");
+			dieta.setEnergia(1900);
+			dieta.setProteina(95.0);
+			dieta.setLipidos(65.0);
+			dieta.setHidratosDeCarbono(210.0);
+			final Dieta savedDieta = dietaRepository.saveAndFlush(dieta);
+
+			final PacienteDieta assignment = new PacienteDieta();
+			assignment.setPaciente(linkedPaciente);
+			assignment.setDieta(savedDieta);
+			assignment.setStatus(PacienteDietaStatus.ACTIVE);
+			assignment
+				.setStartDate(Date.from(LocalDate.now().minusDays(7).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+			assignment.setNotes("Plan activo de prueba");
+			pacienteDietaRepository.saveAndFlush(assignment);
+		}
+	}
+
+	@Test
+	void listDietPlansWithLinkedJwtReturnsPagedSummaries() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/diet-plans").with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content").isArray())
+			.andExpect(jsonPath("$.data.content[0].dietaName").value("Dieta integración"))
+			.andExpect(jsonPath("$.data.content[0].status").value("ACTIVE"))
+			.andExpect(jsonPath("$.data.content[0].totalKcal").value(1900))
+			.andExpect(jsonPath("$.timestamp").exists());
+	}
+
+	@Test
+	void listDietPlansActiveOnlyFiltersResults() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/diet-plans").param("activeOnly", "true").with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content[0].status").value("ACTIVE"));
+	}
+
+	private static Paciente samplePaciente(final String patientAuthSub) {
+		final Paciente paciente = new Paciente();
+		paciente.setName("Mobile Diet Plan Patient");
+		paciente.setUserId("nutritionist-sub");
+		paciente.setPatientAuthSub(patientAuthSub);
+		final LocalDate dob = LocalDate.now().minusYears(28);
+		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		paciente.setGender("M");
+		return paciente;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanServiceTest.java
@@ -1,0 +1,101 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
+import com.nutriconsultas.mobile.dto.PagedResponse;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteDieta;
+import com.nutriconsultas.paciente.PacienteDietaRepository;
+import com.nutriconsultas.paciente.PacienteDietaStatus;
+
+@ExtendWith(MockitoExtension.class)
+class MobilePatientDietPlanServiceTest {
+
+	@InjectMocks
+	private MobilePatientDietPlanService service;
+
+	@Mock
+	private PacienteDietaRepository pacienteDietaRepository;
+
+	@Test
+	void listDietPlans_mapsAssignmentsToSummaryDtos() {
+		final PacienteDieta assignment = sampleAssignment(5L, PacienteDietaStatus.ACTIVE, "Plan semanal");
+		final Page<PacienteDieta> page = new PageImpl<>(List.of(assignment), PageRequest.of(0, 20), 1);
+		when(pacienteDietaRepository.findByPacienteId(eq(1L), any(Pageable.class))).thenReturn(page);
+
+		final PagedResponse<DietPlanSummaryDto> result = service.listDietPlans(1L, 0, 20, false);
+
+		assertThat(result.content()).hasSize(1);
+		assertThat(result.content().get(0).assignmentId()).isEqualTo(5L);
+		assertThat(result.content().get(0).dietaName()).isEqualTo("Plan semanal");
+		assertThat(result.content().get(0).status()).isEqualTo(PacienteDietaStatus.ACTIVE);
+		assertThat(result.content().get(0).totalKcal()).isEqualTo(1800);
+	}
+
+	@Test
+	void listDietPlans_activeOnlyQueriesActiveStatus() {
+		when(pacienteDietaRepository.findByPacienteIdAndStatus(eq(1L), eq(PacienteDietaStatus.ACTIVE),
+				any(Pageable.class)))
+			.thenReturn(Page.empty());
+
+		service.listDietPlans(1L, 0, 20, true);
+
+		verify(pacienteDietaRepository).findByPacienteIdAndStatus(eq(1L), eq(PacienteDietaStatus.ACTIVE),
+				any(Pageable.class));
+	}
+
+	@Test
+	void listDietPlans_capsPageSizeAt100() {
+		when(pacienteDietaRepository.findByPacienteId(eq(1L), any(Pageable.class))).thenReturn(Page.empty());
+
+		service.listDietPlans(1L, 0, 500, false);
+
+		final ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+		verify(pacienteDietaRepository).findByPacienteId(eq(1L), pageableCaptor.capture());
+		assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(100);
+		assertThat(pageableCaptor.getValue().getSort()).isEqualTo(Sort.by(Sort.Direction.DESC, "startDate"));
+	}
+
+	private static PacienteDieta sampleAssignment(final Long id, final PacienteDietaStatus status,
+			final String dietaName) {
+		final Paciente paciente = new Paciente();
+		paciente.setId(1L);
+		final Dieta dieta = new Dieta();
+		dieta.setId(10L);
+		dieta.setNombre(dietaName);
+		dieta.setEnergia(1800);
+		dieta.setProteina(90.0);
+		dieta.setLipidos(60.0);
+		dieta.setHidratosDeCarbono(200.0);
+		final PacienteDieta assignment = new PacienteDieta();
+		assignment.setId(id);
+		assignment.setPaciente(paciente);
+		assignment.setDieta(dieta);
+		assignment.setStatus(status);
+		assignment.setStartDate(new Date());
+		assignment.setNotes("Notas del plan");
+		return assignment;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitControllerTest.java
@@ -1,0 +1,65 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.nutriconsultas.calendar.EventStatus;
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.PagedResponse;
+import com.nutriconsultas.mobile.dto.VisitSummaryDto;
+import com.nutriconsultas.paciente.Paciente;
+
+@ExtendWith(MockitoExtension.class)
+class MobilePatientVisitControllerTest {
+
+	private static final String PATIENT_SUB = "auth0|mobile-visit-patient";
+
+	@InjectMocks
+	private MobilePatientVisitController controller;
+
+	@Mock
+	private PatientAuthService patientAuthService;
+
+	@Mock
+	private MobilePatientVisitService mobilePatientVisitService;
+
+	@Test
+	void listVisits_returnsApiResponseEnvelope() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(5L);
+		final VisitSummaryDto summary = new VisitSummaryDto(1L, null, "Consulta", EventStatus.SCHEDULED, 45, null);
+		final PagedResponse<VisitSummaryDto> page = PagedResponse
+			.of(new PageImpl<>(List.of(summary), PageRequest.of(0, 20), 1));
+		final Jwt jwt = jwtWithSub(PATIENT_SUB);
+
+		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);
+		when(mobilePatientVisitService.listVisits(eq(5L), eq(0), eq(20), eq(null), eq(null), eq(null)))
+			.thenReturn(page);
+
+		final ApiResponse<PagedResponse<VisitSummaryDto>> response = controller.listVisits(jwt, 0, 20, null, null,
+				null);
+
+		assertThat(response.data().content()).hasSize(1);
+		assertThat(response.message()).isNull();
+		assertThat(response.timestamp()).isNotNull();
+		verify(mobilePatientVisitService).listVisits(5L, 0, 20, null, null, null);
+	}
+
+	private static Jwt jwtWithSub(final String subject) {
+		return Jwt.withTokenValue("token").header("alg", "none").subject(subject).build();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import com.nutriconsultas.calendar.EventStatus;
 import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.PagedResponse;
+import com.nutriconsultas.mobile.dto.VisitDetailDto;
 import com.nutriconsultas.mobile.dto.VisitSummaryDto;
 import com.nutriconsultas.paciente.Paciente;
 
@@ -56,6 +57,25 @@ class MobilePatientVisitControllerTest {
 		assertThat(response.message()).isNull();
 		assertThat(response.timestamp()).isNotNull();
 		verify(mobilePatientVisitService).listVisits(5L, 0, 20, null, null, null);
+	}
+
+	@Test
+	void getVisitDetail_returnsApiResponseEnvelope() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(5L);
+		final VisitDetailDto detail = new VisitDetailDto(8L, null, "Consulta", EventStatus.SCHEDULED, 45, null,
+				"Descripción", null, null, null, null, null, null, null, null, null, null, null);
+		final Jwt jwt = jwtWithSub(PATIENT_SUB);
+
+		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);
+		when(mobilePatientVisitService.getVisitDetail(5L, 8L)).thenReturn(detail);
+
+		final ApiResponse<VisitDetailDto> response = controller.getVisitDetail(jwt, 8L);
+
+		assertThat(response.data().id()).isEqualTo(8L);
+		assertThat(response.data().description()).isEqualTo("Descripción");
+		assertThat(response.timestamp()).isNotNull();
+		verify(mobilePatientVisitService).getVisitDetail(5L, 8L);
 	}
 
 	private static Jwt jwtWithSub(final String subject) {

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitIntegrationTest.java
@@ -2,7 +2,6 @@ package com.nutriconsultas.mobile;
 
 import static com.nutriconsultas.mobile.MobileIntegrationTestJwt.mobileJwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -18,17 +17,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.calendar.CalendarEventRepository;
+import com.nutriconsultas.calendar.EventStatus;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-class MobileSecurityIntegrationTest {
+class MobilePatientVisitIntegrationTest {
 
-	private static final String LINKED_SUB = "auth0|mobile-security-linked";
-
-	private static final String UNLINKED_SUB = "auth0|mobile-security-unlinked";
+	private static final String LINKED_SUB = "auth0|mobile-visit-integration";
 
 	@Autowired
 	private MockMvc mockMvc;
@@ -36,40 +36,42 @@ class MobileSecurityIntegrationTest {
 	@Autowired
 	private PacienteRepository pacienteRepository;
 
+	@Autowired
+	private CalendarEventRepository calendarEventRepository;
+
+	private Paciente linkedPaciente;
+
 	@BeforeEach
-	void seedLinkedPatient() {
-		if (pacienteRepository.findByPatientAuthSub(LINKED_SUB).isEmpty()) {
-			pacienteRepository.saveAndFlush(samplePaciente(LINKED_SUB));
+	void seedData() {
+		linkedPaciente = pacienteRepository.findByPatientAuthSub(LINKED_SUB).orElseGet(() -> {
+			final Paciente paciente = samplePaciente(LINKED_SUB);
+			return pacienteRepository.saveAndFlush(paciente);
+		});
+		if (calendarEventRepository.findByPacienteId(linkedPaciente.getId()).isEmpty()) {
+			final CalendarEvent event = new CalendarEvent();
+			event.setPaciente(linkedPaciente);
+			event.setTitle("Consulta integración");
+			event.setStatus(EventStatus.SCHEDULED);
+			event.setDurationMinutes(60);
+			event.setEventDateTime(
+					Date.from(LocalDate.now().plusDays(3).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+			calendarEventRepository.saveAndFlush(event);
 		}
 	}
 
 	@Test
-	void patientEndpoint_withoutJwt_returnsUnauthorized() throws Exception {
-		mockMvc.perform(get("/rest/mobile/patient/visits")).andExpect(status().isUnauthorized());
-	}
-
-	@Test
-	void patientEndpoint_withUnlinkedJwt_returnsForbidden() throws Exception {
-		mockMvc.perform(get("/rest/mobile/patient/visits").with(mobileJwt(UNLINKED_SUB)))
-			.andExpect(status().isForbidden())
-			.andExpect(content().json("{\"error\":\"patient_not_linked\"}"));
-	}
-
-	@Test
-	void patientEndpoint_withLinkedJwt_passesLinkageFilter() throws Exception {
+	void listVisitsWithLinkedJwtReturnsPagedSummaries() throws Exception {
 		mockMvc.perform(get("/rest/mobile/patient/visits").with(mobileJwt(LINKED_SUB)))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data.content").isArray());
-	}
-
-	@Test
-	void nonPatientMobilePath_doesNotRequirePatientLinkage() throws Exception {
-		mockMvc.perform(get("/rest/mobile/status").with(mobileJwt(UNLINKED_SUB))).andExpect(status().isNotFound());
+			.andExpect(jsonPath("$.data.content").isArray())
+			.andExpect(jsonPath("$.data.content[0].title").value("Consulta integración"))
+			.andExpect(jsonPath("$.data.content[0].status").value("SCHEDULED"))
+			.andExpect(jsonPath("$.timestamp").exists());
 	}
 
 	private static Paciente samplePaciente(final String patientAuthSub) {
 		final Paciente paciente = new Paciente();
-		paciente.setName("Mobile Security Patient");
+		paciente.setName("Mobile Visit Patient");
 		paciente.setUserId("nutritionist-sub");
 		paciente.setPatientAuthSub(patientAuthSub);
 		final LocalDate dob = LocalDate.now().minusYears(28);

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitIntegrationTest.java
@@ -41,22 +41,28 @@ class MobilePatientVisitIntegrationTest {
 
 	private Paciente linkedPaciente;
 
+	private CalendarEvent linkedEvent;
+
 	@BeforeEach
 	void seedData() {
 		linkedPaciente = pacienteRepository.findByPatientAuthSub(LINKED_SUB).orElseGet(() -> {
 			final Paciente paciente = samplePaciente(LINKED_SUB);
 			return pacienteRepository.saveAndFlush(paciente);
 		});
-		if (calendarEventRepository.findByPacienteId(linkedPaciente.getId()).isEmpty()) {
-			final CalendarEvent event = new CalendarEvent();
-			event.setPaciente(linkedPaciente);
-			event.setTitle("Consulta integración");
-			event.setStatus(EventStatus.SCHEDULED);
-			event.setDurationMinutes(60);
-			event.setEventDateTime(
-					Date.from(LocalDate.now().plusDays(3).atStartOfDay(ZoneId.systemDefault()).toInstant()));
-			calendarEventRepository.saveAndFlush(event);
-		}
+		linkedEvent = calendarEventRepository.findByPacienteId(linkedPaciente.getId())
+			.stream()
+			.findFirst()
+			.orElseGet(() -> {
+				final CalendarEvent event = new CalendarEvent();
+				event.setPaciente(linkedPaciente);
+				event.setTitle("Consulta integración");
+				event.setDescription("Detalle de consulta");
+				event.setStatus(EventStatus.SCHEDULED);
+				event.setDurationMinutes(60);
+				event.setEventDateTime(
+						Date.from(LocalDate.now().plusDays(3).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+				return calendarEventRepository.saveAndFlush(event);
+			});
 	}
 
 	@Test
@@ -67,6 +73,47 @@ class MobilePatientVisitIntegrationTest {
 			.andExpect(jsonPath("$.data.content[0].title").value("Consulta integración"))
 			.andExpect(jsonPath("$.data.content[0].status").value("SCHEDULED"))
 			.andExpect(jsonPath("$.timestamp").exists());
+	}
+
+	@Test
+	void getVisitDetailWithLinkedJwtReturnsFullDetail() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/visits/" + linkedEvent.getId()).with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.id").value(linkedEvent.getId()))
+			.andExpect(jsonPath("$.data.title").value("Consulta integración"))
+			.andExpect(jsonPath("$.data.description").value("Detalle de consulta"))
+			.andExpect(jsonPath("$.timestamp").exists());
+	}
+
+	@Test
+	void getVisitDetailForOtherPatientsVisitReturnsNotFound() throws Exception {
+		final Paciente otherPatient = pacienteRepository.findByPatientAuthSub("auth0|mobile-visit-other")
+			.orElseGet(() -> {
+				final Paciente paciente = samplePaciente("auth0|mobile-visit-other");
+				return pacienteRepository.saveAndFlush(paciente);
+			});
+		final CalendarEvent otherEvent = calendarEventRepository.findByPacienteId(otherPatient.getId())
+			.stream()
+			.findFirst()
+			.orElseGet(() -> {
+				final CalendarEvent event = new CalendarEvent();
+				event.setPaciente(otherPatient);
+				event.setTitle("Consulta ajena");
+				event.setStatus(EventStatus.SCHEDULED);
+				event.setDurationMinutes(30);
+				event.setEventDateTime(
+						Date.from(LocalDate.now().plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+				return calendarEventRepository.saveAndFlush(event);
+			});
+
+		mockMvc.perform(get("/rest/mobile/patient/visits/" + otherEvent.getId()).with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void getVisitDetailForMissingVisitReturnsNotFound() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/visits/999999").with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isNotFound());
 	}
 
 	private static Paciente samplePaciente(final String patientAuthSub) {

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitServiceTest.java
@@ -1,6 +1,7 @@
 package com.nutriconsultas.mobile;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -9,6 +10,7 @@ import static org.mockito.Mockito.when;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,12 +23,16 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.nutriconsultas.calendar.CalendarEvent;
 import com.nutriconsultas.calendar.CalendarEventRepository;
 import com.nutriconsultas.calendar.EventStatus;
 import com.nutriconsultas.mobile.dto.PagedResponse;
+import com.nutriconsultas.mobile.dto.VisitDetailDto;
 import com.nutriconsultas.mobile.dto.VisitSummaryDto;
+import com.nutriconsultas.paciente.NivelPeso;
 import com.nutriconsultas.paciente.Paciente;
 
 @ExtendWith(MockitoExtension.class)
@@ -80,6 +86,31 @@ class MobilePatientVisitServiceTest {
 
 		verify(calendarEventRepository).findPatientVisits(eq(2L), eq(EventStatus.SCHEDULED), any(Date.class),
 				any(Date.class), any(Pageable.class));
+	}
+
+	@Test
+	void getVisitDetail_returnsDetailWhenOwnedByPatient() {
+		final CalendarEvent event = sampleEvent(10L, "Consulta inicial", EventStatus.COMPLETED);
+		event.setDescription("Notas de la consulta");
+		event.setPeso(72.5);
+		event.setNivelPeso(NivelPeso.NORMAL);
+		when(calendarEventRepository.findByIdAndPacienteId(10L, 1L)).thenReturn(Optional.of(event));
+
+		final VisitDetailDto result = service.getVisitDetail(1L, 10L);
+
+		assertThat(result.id()).isEqualTo(10L);
+		assertThat(result.description()).isEqualTo("Notas de la consulta");
+		assertThat(result.peso()).isEqualTo(72.5);
+		assertThat(result.nivelPeso()).isEqualTo(NivelPeso.NORMAL);
+	}
+
+	@Test
+	void getVisitDetail_throwsNotFoundWhenMissingOrNotOwned() {
+		when(calendarEventRepository.findByIdAndPacienteId(99L, 1L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.getVisitDetail(1L, 99L)).isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+			.isEqualTo(HttpStatus.NOT_FOUND);
 	}
 
 	private static CalendarEvent sampleEvent(final Long id, final String title, final EventStatus status) {

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitServiceTest.java
@@ -1,0 +1,99 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.calendar.CalendarEventRepository;
+import com.nutriconsultas.calendar.EventStatus;
+import com.nutriconsultas.mobile.dto.PagedResponse;
+import com.nutriconsultas.mobile.dto.VisitSummaryDto;
+import com.nutriconsultas.paciente.Paciente;
+
+@ExtendWith(MockitoExtension.class)
+class MobilePatientVisitServiceTest {
+
+	@InjectMocks
+	private MobilePatientVisitService service;
+
+	@Mock
+	private CalendarEventRepository calendarEventRepository;
+
+	@Test
+	void listVisits_mapsEventsToSummaryDtos() {
+		final CalendarEvent event = sampleEvent(10L, "Consulta inicial", EventStatus.COMPLETED);
+		final Page<CalendarEvent> page = new PageImpl<>(List.of(event), PageRequest.of(0, 20), 1);
+		when(calendarEventRepository.findPatientVisits(eq(1L), eq(null), eq(null), eq(null), any(Pageable.class)))
+			.thenReturn(page);
+
+		final PagedResponse<VisitSummaryDto> result = service.listVisits(1L, 0, 20, null, null, null);
+
+		assertThat(result.content()).hasSize(1);
+		assertThat(result.content().get(0).id()).isEqualTo(10L);
+		assertThat(result.content().get(0).title()).isEqualTo("Consulta inicial");
+		assertThat(result.content().get(0).status()).isEqualTo(EventStatus.COMPLETED);
+		assertThat(result.totalElements()).isEqualTo(1);
+	}
+
+	@Test
+	void listVisits_capsPageSizeAt100() {
+		when(calendarEventRepository.findPatientVisits(eq(1L), eq(null), eq(null), eq(null), any(Pageable.class)))
+			.thenReturn(Page.empty());
+
+		service.listVisits(1L, 0, 500, null, null, null);
+
+		final ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+		verify(calendarEventRepository).findPatientVisits(eq(1L), eq(null), eq(null), eq(null),
+				pageableCaptor.capture());
+		assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(100);
+		assertThat(pageableCaptor.getValue().getSort()).isEqualTo(Sort.by(Sort.Direction.DESC, "eventDateTime"));
+	}
+
+	@Test
+	void listVisits_passesStatusAndDateFilters() {
+		final Instant from = Instant.parse("2026-01-01T00:00:00Z");
+		final Instant to = Instant.parse("2026-06-01T00:00:00Z");
+		when(calendarEventRepository.findPatientVisits(eq(2L), eq(EventStatus.SCHEDULED), any(Date.class),
+				any(Date.class), any(Pageable.class)))
+			.thenReturn(Page.empty());
+
+		service.listVisits(2L, 1, 10, EventStatus.SCHEDULED, from, to);
+
+		verify(calendarEventRepository).findPatientVisits(eq(2L), eq(EventStatus.SCHEDULED), any(Date.class),
+				any(Date.class), any(Pageable.class));
+	}
+
+	private static CalendarEvent sampleEvent(final Long id, final String title, final EventStatus status) {
+		final Paciente paciente = new Paciente();
+		paciente.setId(1L);
+		final CalendarEvent event = new CalendarEvent();
+		event.setId(id);
+		event.setPaciente(paciente);
+		event.setTitle(title);
+		event.setStatus(status);
+		event.setDurationMinutes(60);
+		event.setEventDateTime(Date.from(Instant.parse("2026-03-15T14:30:00Z")));
+		event.setSummaryNotes("Seguimiento nutricional");
+		return event;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/PatientAuthLinkageServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/PatientAuthLinkageServiceTest.java
@@ -1,0 +1,160 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.auth0.Auth0UserLookup;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PatientAuthLinkageServiceTest {
+
+	private static final String NUTRITIONIST_SUB = "auth0|nutritionist-1";
+
+	private static final String PATIENT_SUB = "auth0|patient-mobile-1";
+
+	private static final String OTHER_SUB = "auth0|patient-mobile-other";
+
+	@InjectMocks
+	private PatientAuthLinkageService service;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Mock
+	private Auth0UserLookup auth0UserLookup;
+
+	private Paciente paciente;
+
+	@BeforeEach
+	void setUp() {
+		paciente = samplePaciente(1L, "patient@example.com");
+		lenient().when(pacienteRepository.findByIdAndUserId(1L, NUTRITIONIST_SUB)).thenReturn(Optional.of(paciente));
+	}
+
+	@Test
+	void getStatus_whenUnlinked_reportsNotLinked() {
+		when(auth0UserLookup.isConfigured()).thenReturn(true);
+
+		final PatientMobileAuthStatus status = service.getStatus(1L, NUTRITIONIST_SUB);
+
+		assertThat(status.isLinked()).isFalse();
+		assertThat(status.isEmailLookupAvailable()).isTrue();
+	}
+
+	@Test
+	void linkBySub_setsPatientAuthSub() {
+		when(pacienteRepository.findByPatientAuthSub(PATIENT_SUB)).thenReturn(Optional.empty());
+		when(pacienteRepository.save(any(Paciente.class))).thenAnswer(inv -> inv.getArgument(0));
+
+		final Paciente linked = service.linkBySub(1L, NUTRITIONIST_SUB, PATIENT_SUB);
+
+		assertThat(linked.getPatientAuthSub()).isEqualTo(PATIENT_SUB);
+		verify(pacienteRepository).save(paciente);
+	}
+
+	@Test
+	void linkBySub_whenSubAlreadyUsedByOtherPatient_throws() {
+		final Paciente other = samplePaciente(99L, "other@example.com");
+		other.setPatientAuthSub(PATIENT_SUB);
+		when(pacienteRepository.findByPatientAuthSub(PATIENT_SUB)).thenReturn(Optional.of(other));
+
+		assertThatThrownBy(() -> service.linkBySub(1L, NUTRITIONIST_SUB, PATIENT_SUB))
+			.isInstanceOf(PatientAuthSubAlreadyLinkedException.class);
+		verify(pacienteRepository, never()).save(any());
+	}
+
+	@Test
+	void linkByEmail_usesAuth0Lookup() {
+		when(auth0UserLookup.isConfigured()).thenReturn(true);
+		when(auth0UserLookup.findUserIdByEmail("patient@example.com")).thenReturn(Optional.of(PATIENT_SUB));
+		when(pacienteRepository.findByPatientAuthSub(PATIENT_SUB)).thenReturn(Optional.empty());
+		when(pacienteRepository.save(any(Paciente.class))).thenAnswer(inv -> inv.getArgument(0));
+
+		final Paciente linked = service.linkByEmail(1L, NUTRITIONIST_SUB);
+
+		assertThat(linked.getPatientAuthSub()).isEqualTo(PATIENT_SUB);
+		verify(auth0UserLookup).findUserIdByEmail("patient@example.com");
+	}
+
+	@Test
+	void linkByEmail_whenMgmtNotConfigured_throws() {
+		when(auth0UserLookup.isConfigured()).thenReturn(false);
+
+		assertThatThrownBy(() -> service.linkByEmail(1L, NUTRITIONIST_SUB))
+			.isInstanceOf(Auth0ManagementNotConfiguredException.class);
+	}
+
+	@Test
+	void linkByEmail_whenPatientHasNoEmail_throws() {
+		paciente.setEmail(null);
+		when(auth0UserLookup.isConfigured()).thenReturn(true);
+
+		assertThatThrownBy(() -> service.linkByEmail(1L, NUTRITIONIST_SUB))
+			.isInstanceOf(PatientEmailRequiredForLinkException.class);
+	}
+
+	@Test
+	void linkByEmail_whenAuth0UserMissing_throws() {
+		when(auth0UserLookup.isConfigured()).thenReturn(true);
+		when(auth0UserLookup.findUserIdByEmail("patient@example.com")).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.linkByEmail(1L, NUTRITIONIST_SUB))
+			.isInstanceOf(PatientAuthUserNotFoundException.class);
+	}
+
+	@Test
+	void unlink_clearsPatientAuthSub() {
+		paciente.setPatientAuthSub(PATIENT_SUB);
+		when(pacienteRepository.save(any(Paciente.class))).thenAnswer(inv -> inv.getArgument(0));
+
+		final Paciente unlinked = service.unlink(1L, NUTRITIONIST_SUB);
+
+		assertThat(unlinked.getPatientAuthSub()).isNull();
+		verify(pacienteRepository).save(paciente);
+	}
+
+	@Test
+	void getStatus_whenLinked_redactsSub() {
+		paciente.setPatientAuthSub(PATIENT_SUB);
+		when(auth0UserLookup.isConfigured()).thenReturn(false);
+
+		final PatientMobileAuthStatus status = service.getStatus(1L, NUTRITIONIST_SUB);
+
+		assertThat(status.isLinked()).isTrue();
+		assertThat(status.getPatientAuthSubRedacted()).contains("…");
+		assertThat(status.getPatientAuthSubRedacted()).doesNotContain(PATIENT_SUB);
+	}
+
+	private static Paciente samplePaciente(final Long id, final String email) {
+		final Paciente entity = new Paciente();
+		entity.setId(id);
+		entity.setName("Test Patient");
+		entity.setUserId(NUTRITIONIST_SUB);
+		entity.setEmail(email);
+		final LocalDate dob = LocalDate.now().minusYears(30);
+		entity.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		entity.setGender("F");
+		return entity;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/dto/MobileDtoSerializationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/dto/MobileDtoSerializationTest.java
@@ -1,0 +1,74 @@
+package com.nutriconsultas.mobile.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+class MobileDtoSerializationTest {
+
+	private ObjectMapper objectMapper;
+
+	@BeforeEach
+	void setUp() {
+		objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+	}
+
+	@Test
+	void apiResponse_ok_omitsNullMessageAndUsesIso8601Timestamp() throws Exception {
+		final ApiResponse<String> response = ApiResponse.ok("payload");
+		final JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
+
+		assertThat(json.get("data").asText()).isEqualTo("payload");
+		assertThat(json.has("message")).isFalse();
+		assertThat(json.get("timestamp").asText()).matches("\\d{4}-\\d{2}-\\d{2}T.*");
+	}
+
+	@Test
+	void pagedResponse_of_mapsSpringPage() throws Exception {
+		final Page<String> page = new PageImpl<>(List.of("a", "b"), PageRequest.of(1, 2), 5);
+		final PagedResponse<String> response = PagedResponse.of(page);
+		final JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
+
+		assertThat(json.get("content")).hasSize(2);
+		assertThat(json.get("page").asInt()).isEqualTo(1);
+		assertThat(json.get("size").asInt()).isEqualTo(2);
+		assertThat(json.get("totalElements").asLong()).isEqualTo(5);
+		assertThat(json.get("totalPages").asInt()).isEqualTo(3);
+		assertThat(json.get("last").asBoolean()).isFalse();
+	}
+
+	@Test
+	void cursorPagedResponse_of_omitsBlankCursor() throws Exception {
+		final CursorPagedResponse<Instant> lastPage = CursorPagedResponse
+			.of(List.of(Instant.parse("2026-01-01T00:00:00Z")), null);
+		final JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(lastPage));
+
+		assertThat(json.get("hasMore").asBoolean()).isFalse();
+		assertThat(json.has("nextCursor")).isFalse();
+	}
+
+	@Test
+	void cursorPagedResponse_of_includesNextCursorWhenPresent() throws Exception {
+		final CursorPagedResponse<LocalDateTime> page = CursorPagedResponse.of(List.of(), "cursor-abc");
+		final JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(page));
+
+		assertThat(json.get("nextCursor").asText()).isEqualTo("cursor-abc");
+		assertThat(json.get("hasMore").asBoolean()).isTrue();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/PacienteMobileAuthRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteMobileAuthRestControllerTest.java
@@ -1,0 +1,78 @@
+package com.nutriconsultas.paciente;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import com.nutriconsultas.mobile.PatientAuthLinkageService;
+import com.nutriconsultas.mobile.PatientMobileAuthStatus;
+
+@ExtendWith(MockitoExtension.class)
+class PacienteMobileAuthRestControllerTest {
+
+	private static final String NUTRITIONIST_SUB = "auth0|nutritionist-rest";
+
+	@InjectMocks
+	private PacienteMobileAuthRestController controller;
+
+	@Mock
+	private PatientAuthLinkageService patientAuthLinkageService;
+
+	@Test
+	void getStatus_returnsLinkageInfo() {
+		when(patientAuthLinkageService.getStatus(eq(1L), eq(NUTRITIONIST_SUB)))
+			.thenReturn(PatientMobileAuthStatus.of("auth0|linked-patient", true));
+
+		final ResponseEntity<Map<String, Object>> response = controller.getStatus(1L, principal());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("success", true).containsEntry("linked", true);
+	}
+
+	@Test
+	void linkBySub_delegatesToService() {
+		when(patientAuthLinkageService.getStatus(eq(2L), eq(NUTRITIONIST_SUB)))
+			.thenReturn(PatientMobileAuthStatus.of("auth0|new-patient", false));
+
+		final ResponseEntity<Map<String, Object>> response = controller.link(2L,
+				Map.of("patientAuthSub", "auth0|new-patient"), principal());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		verify(patientAuthLinkageService).linkBySub(2L, NUTRITIONIST_SUB, "auth0|new-patient");
+	}
+
+	@Test
+	void unlink_delegatesToService() {
+		when(patientAuthLinkageService.getStatus(eq(3L), eq(NUTRITIONIST_SUB)))
+			.thenReturn(PatientMobileAuthStatus.of(null, false));
+
+		final ResponseEntity<Map<String, Object>> response = controller.unlink(3L, principal());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("linked", false);
+		verify(patientAuthLinkageService).unlink(3L, NUTRITIONIST_SUB);
+	}
+
+	private static OidcUser principal() {
+		final Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject(NUTRITIONIST_SUB).build();
+		final OidcIdToken idToken = new OidcIdToken("token", jwt.getIssuedAt(), jwt.getExpiresAt(),
+				Map.of("sub", NUTRITIONIST_SUB));
+		return new DefaultOidcUser(null, idToken);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/security/TestMobileJwtDecoderConfig.java
+++ b/src/test/java/com/nutriconsultas/security/TestMobileJwtDecoderConfig.java
@@ -1,0 +1,37 @@
+package com.nutriconsultas.security;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+
+@Configuration
+@Profile("test")
+public class TestMobileJwtDecoderConfig {
+
+	public static final String TOKEN_PREFIX = "test-jwt:";
+
+	@Bean
+	JwtDecoder mobileJwtDecoder(
+			@Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}") final String issuerUri,
+			@Value("${app.security.jwt.audience}") final String expectedAudience) {
+		return token -> {
+			if (token == null || !token.startsWith(TOKEN_PREFIX)) {
+				throw new JwtException("Unsupported test JWT token");
+			}
+			final String subject = token.substring(TOKEN_PREFIX.length());
+			return Jwt.withTokenValue(token)
+				.header("alg", "none")
+				.subject(subject)
+				.issuer(issuerUri)
+				.claim("aud", List.of(expectedAudience))
+				.build();
+		};
+	}
+
+}


### PR DESCRIPTION
## Summary

Stacked mobile API work for the patient app:

- **#109** — Patient Auth0 linkage admin flow (base of stack)
- **#110** — `ApiResponse`, `PagedResponse`, `CursorPagedResponse` + Jackson ISO-8601
- **#91** — `GET /rest/mobile/patient/visits` (paged summaries, filters)
- **#92** — `GET /rest/mobile/patient/visits/{visitId}` (detail; 404 on IDOR)
- **#93** — `GET /rest/mobile/patient/diet-plans` (paged assignments, `activeOnly`)

## Commits (oldest → newest)

1. `165be2b` — #109 patient Auth0 linkage
2. `a80f99b` — #110 DTO envelope wrappers
3. `67fd2b6` — #91 patient visits list
4. `fbb0bd2` — #92 patient visit detail
5. `f3ab945` — #93 patient diet plans list

## Test plan

- [ ] `mvn test -Dtest=MobileDtoSerializationTest,MobilePatientVisit*Test,MobilePatientDietPlan*Test`
- [ ] `mvn test -Dtest=MobileSecurityIntegrationTest,MobilePatientVisitIntegrationTest,MobilePatientDietPlanIntegrationTest`
- [ ] Linked JWT → visits & diet-plans endpoints return 200 with `ApiResponse` envelope
- [ ] Foreign/missing visit id → **404**
- [ ] Unlinked JWT → 403 `patient_not_linked`
- [ ] `activeOnly=true` → only `ACTIVE` diet assignments