### PR TITLE
feat(mobile-api): patient diet plan detail endpoint (#94)

### DIFF
--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-13 — **#93 done** on branch `mobile-api/93-patient-diet-plans` (PR #142).
+**Last updated:** 2026-06-13 — **#94 in-progress** on branch `mobile-api/94-patient-diet-plan-detail`.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116) plus the directly-related `[Dashboard]` IMC gauge (#106). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -90,8 +90,8 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 
 | # | Endpoint | URL | State | Backend source |
 |---|----------|-----|-------|----------------|
-| **93** | `GET /rest/mobile/patient/diet-plans` — list assigned plans | https://github.com/diego-torres/nutriconsultas/issues/93 | **done** | 110 | Branch `mobile-api/93-patient-diet-plans`: paged `DietPlanSummaryDto`, `activeOnly` filter, macro aliases per §F8. |
-| 94 | `GET /rest/mobile/patient/diet-plans/{assignmentId}` — structured meal JSON | https://github.com/diego-torres/nutriconsultas/issues/94 | open | `Dieta`→`Ingesta`→`PlatilloIngesta`/`AlimentoIngesta` tree; strip nutritionist-internal fields; field map per §F8 |
+| **93** | `GET /rest/mobile/patient/diet-plans` — list assigned plans | https://github.com/diego-torres/nutriconsultas/issues/93 | **done** | 110 | Merged PR #142: paged `DietPlanSummaryDto`, `activeOnly` filter, macro aliases per §F8. |
+| **94** | `GET /rest/mobile/patient/diet-plans/{assignmentId}` — structured meal JSON | https://github.com/diego-torres/nutriconsultas/issues/94 | **in-progress** | 93 | Branch `mobile-api/94-patient-diet-plan-detail`: `DietPlanDetailDto` + ingesta/platillo/alimento tree; `findByIdAndPacienteId` IDOR guard → 404. |
 | 95 | `GET /rest/mobile/patient/diet-plans/{assignmentId}/pdf` — printable PDF | https://github.com/diego-torres/nutriconsultas/issues/95 | open | Reuses existing PDF export (#14) + `NutritionistProfile` branding (#101 ✓); `Content-Disposition`; ownership check |
 
 ### Messages — **greenfield** (no entity exists)

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanController.java
@@ -3,11 +3,13 @@ package com.nutriconsultas.mobile;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
 import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
 import com.nutriconsultas.mobile.dto.PagedResponse;
 import com.nutriconsultas.paciente.Paciente;
@@ -40,6 +42,18 @@ public class MobilePatientDietPlanController extends AbstractMobilePatientContro
 		final PagedResponse<DietPlanSummaryDto> plans = mobilePatientDietPlanService.listDietPlans(paciente.getId(),
 				page, size, activeOnly);
 		return ApiResponse.ok(plans);
+	}
+
+	@GetMapping("/{assignmentId}")
+	public ApiResponse<DietPlanDetailDto> getDietPlanDetail(@AuthenticationPrincipal final Jwt jwt,
+			@PathVariable final Long assignmentId) {
+		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile get diet plan {} for patient {}", assignmentId,
+					LogRedaction.redactPaciente(paciente.getId()));
+		}
+		final DietPlanDetailDto plan = mobilePatientDietPlanService.getDietPlanDetail(paciente.getId(), assignmentId);
+		return ApiResponse.ok(plan);
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanService.java
@@ -4,9 +4,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.dieta.Ingesta;
+import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
 import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
 import com.nutriconsultas.mobile.dto.PagedResponse;
 import com.nutriconsultas.paciente.PacienteDieta;
@@ -43,6 +48,32 @@ public class MobilePatientDietPlanService {
 					safeSize, summaries.getNumberOfElements(), activeOnly, LogRedaction.redactPaciente(pacienteId));
 		}
 		return PagedResponse.of(summaries);
+	}
+
+	@Transactional(readOnly = true)
+	public DietPlanDetailDto getDietPlanDetail(final Long pacienteId, final Long assignmentId) {
+		final PacienteDieta assignment = pacienteDietaRepository.findByIdAndPacienteId(assignmentId, pacienteId)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+		initializeDietaTree(assignment.getDieta());
+		if (log.isDebugEnabled()) {
+			log.debug("Loaded mobile diet plan detail assignmentId={} for patient {}", assignmentId,
+					LogRedaction.redactPaciente(pacienteId));
+		}
+		return DietPlanDetailDto.fromEntity(assignment);
+	}
+
+	private static void initializeDietaTree(final Dieta dieta) {
+		if (dieta == null || dieta.getIngestas() == null) {
+			return;
+		}
+		for (final Ingesta ingesta : dieta.getIngestas()) {
+			if (ingesta.getPlatillos() != null) {
+				ingesta.getPlatillos().size();
+			}
+			if (ingesta.getAlimentos() != null) {
+				ingesta.getAlimentos().size();
+			}
+		}
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/mobile/dto/DietAlimentoDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DietAlimentoDto.java
@@ -1,0 +1,20 @@
+package com.nutriconsultas.mobile.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.nutriconsultas.dieta.AlimentoIngesta;
+
+/**
+ * Patient-facing food item within a meal slot for mobile diet plan detail (#94).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DietAlimentoDto(String nombre, Integer porciones, Integer kcal, String unidad) {
+
+	public static DietAlimentoDto fromEntity(final AlimentoIngesta alimento) {
+		if (alimento == null) {
+			return null;
+		}
+		return new DietAlimentoDto(alimento.getName(), alimento.getPortions(), alimento.getEnergia(),
+				alimento.getUnidad());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/DietIngestaDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DietIngestaDto.java
@@ -1,0 +1,36 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.util.Comparator;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.nutriconsultas.dieta.AlimentoIngesta;
+import com.nutriconsultas.dieta.Ingesta;
+import com.nutriconsultas.dieta.PlatilloIngesta;
+
+/**
+ * Meal slot within a diet plan for mobile diet plan detail (#94).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DietIngestaDto(String tipo, Integer totalKcal, Double totalProteina, Double totalGrasas,
+		Double totalCarbohidratos, List<DietPlatilloDto> platillos, List<DietAlimentoDto> alimentos) {
+
+	public static DietIngestaDto fromEntity(final Ingesta ingesta) {
+		if (ingesta == null) {
+			return null;
+		}
+		final List<DietPlatilloDto> platillos = ingesta.getPlatillos()
+			.stream()
+			.sorted(Comparator.comparingLong(PlatilloIngesta::getId))
+			.map(DietPlatilloDto::fromEntity)
+			.toList();
+		final List<DietAlimentoDto> alimentos = ingesta.getAlimentos()
+			.stream()
+			.sorted(Comparator.comparingLong(AlimentoIngesta::getId))
+			.map(DietAlimentoDto::fromEntity)
+			.toList();
+		return new DietIngestaDto(ingesta.getNombre(), ingesta.getEnergia(), ingesta.getProteina(),
+				ingesta.getLipidos(), ingesta.getHidratosDeCarbono(), platillos, alimentos);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/DietPlanDetailDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DietPlanDetailDto.java
@@ -1,0 +1,51 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.dieta.Ingesta;
+import com.nutriconsultas.paciente.PacienteDieta;
+import com.nutriconsultas.paciente.PacienteDietaStatus;
+
+/**
+ * Full assigned diet plan with meal tree for {@code GET
+ * /rest/mobile/patient/diet-plans/{assignmentId}} (#94).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DietPlanDetailDto(Long assignmentId, PacienteDietaStatus status, LocalDate startDate, LocalDate endDate,
+		String notes, String dietaName, Integer totalKcal, Double totalProteina, Double totalGrasas,
+		Double totalCarbohidratos, List<DietIngestaDto> ingestas) {
+
+	public static DietPlanDetailDto fromEntity(final PacienteDieta assignment) {
+		if (assignment == null) {
+			return null;
+		}
+		final Dieta dieta = assignment.getDieta();
+		final List<DietIngestaDto> ingestas = dieta != null && dieta.getIngestas() != null ? dieta.getIngestas()
+			.stream()
+			.sorted(Comparator.comparingLong(Ingesta::getId))
+			.map(DietIngestaDto::fromEntity)
+			.toList() : List.of();
+		return new DietPlanDetailDto(assignment.getId(), assignment.getStatus(), toLocalDate(assignment.getStartDate()),
+				toLocalDate(assignment.getEndDate()), assignment.getNotes(), dieta != null ? dieta.getNombre() : null,
+				dieta != null ? dieta.getEnergia() : null, dieta != null ? dieta.getProteina() : null,
+				dieta != null ? dieta.getLipidos() : null, dieta != null ? dieta.getHidratosDeCarbono() : null,
+				ingestas);
+	}
+
+	private static LocalDate toLocalDate(final Date date) {
+		if (date == null) {
+			return null;
+		}
+		if (date instanceof java.sql.Date sqlDate) {
+			return sqlDate.toLocalDate();
+		}
+		return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/DietPlatilloDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DietPlatilloDto.java
@@ -1,0 +1,20 @@
+package com.nutriconsultas.mobile.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.nutriconsultas.dieta.PlatilloIngesta;
+
+/**
+ * Patient-facing dish within a meal slot for mobile diet plan detail (#94).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DietPlatilloDto(String nombre, Integer porciones, Integer kcal, String recommendations, String imageUrl) {
+
+	public static DietPlatilloDto fromEntity(final PlatilloIngesta platillo) {
+		if (platillo == null) {
+			return null;
+		}
+		return new DietPlatilloDto(platillo.getName(), platillo.getPortions(), platillo.getEnergia(),
+				platillo.getRecommendations(), platillo.getImageUrl());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaRepository.java
@@ -2,6 +2,7 @@ package com.nutriconsultas.paciente;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,6 +13,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PacienteDietaRepository extends JpaRepository<PacienteDieta, Long> {
+
+	Optional<PacienteDieta> findByIdAndPacienteId(Long id, Long pacienteId);
 
 	List<PacienteDieta> findByPacienteId(Long pacienteId);
 

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,8 +18,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.nutriconsultas.dieta.AlimentoIngesta;
 import com.nutriconsultas.dieta.Dieta;
 import com.nutriconsultas.dieta.DietaRepository;
+import com.nutriconsultas.dieta.Ingesta;
+import com.nutriconsultas.dieta.PlatilloIngesta;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
@@ -46,31 +50,70 @@ class MobilePatientDietPlanIntegrationTest {
 
 	private Paciente linkedPaciente;
 
+	private PacienteDieta linkedAssignment;
+
 	@BeforeEach
 	void seedData() {
 		linkedPaciente = pacienteRepository.findByPatientAuthSub(LINKED_SUB).orElseGet(() -> {
 			final Paciente paciente = samplePaciente(LINKED_SUB);
 			return pacienteRepository.saveAndFlush(paciente);
 		});
-		if (pacienteDietaRepository.findByPacienteId(linkedPaciente.getId()).isEmpty()) {
-			final Dieta dieta = new Dieta();
-			dieta.setNombre("Dieta integración");
-			dieta.setUserId("nutritionist-sub");
-			dieta.setEnergia(1900);
-			dieta.setProteina(95.0);
-			dieta.setLipidos(65.0);
-			dieta.setHidratosDeCarbono(210.0);
-			final Dieta savedDieta = dietaRepository.saveAndFlush(dieta);
+		linkedAssignment = ensureAssignmentWithMealTree();
+	}
 
-			final PacienteDieta assignment = new PacienteDieta();
-			assignment.setPaciente(linkedPaciente);
-			assignment.setDieta(savedDieta);
-			assignment.setStatus(PacienteDietaStatus.ACTIVE);
-			assignment
-				.setStartDate(Date.from(LocalDate.now().minusDays(7).atStartOfDay(ZoneId.systemDefault()).toInstant()));
-			assignment.setNotes("Plan activo de prueba");
-			pacienteDietaRepository.saveAndFlush(assignment);
+	private PacienteDieta ensureAssignmentWithMealTree() {
+		for (final PacienteDieta assignment : pacienteDietaRepository.findByPacienteId(linkedPaciente.getId())) {
+			if ("Plan activo de prueba con arbol".equals(assignment.getNotes())) {
+				return assignment;
+			}
 		}
+		return createAssignmentWithMealTree();
+	}
+
+	private PacienteDieta createAssignmentWithMealTree() {
+		final Dieta dieta = new Dieta();
+		dieta.setNombre("Dieta integración");
+		dieta.setUserId("nutritionist-sub");
+		dieta.setEnergia(1900);
+		dieta.setProteina(95.0);
+		dieta.setLipidos(65.0);
+		dieta.setHidratosDeCarbono(210.0);
+
+		final Ingesta ingesta = new Ingesta("Desayuno");
+		ingesta.setDieta(dieta);
+		ingesta.setEnergia(400);
+		ingesta.setProteina(18.0);
+		ingesta.setLipidos(10.0);
+		ingesta.setHidratosDeCarbono(50.0);
+
+		final PlatilloIngesta platillo = new PlatilloIngesta();
+		platillo.setName("Huevos revueltos");
+		platillo.setPortions(1);
+		platillo.setEnergia(280);
+		platillo.setRecommendations("Con verduras");
+		platillo.setIngesta(ingesta);
+
+		final AlimentoIngesta alimento = new AlimentoIngesta();
+		alimento.setName("Pan integral");
+		alimento.setPortions(2);
+		alimento.setEnergia(120);
+		alimento.setUnidad("rebanada");
+		alimento.setIngesta(ingesta);
+
+		ingesta.setPlatillos(List.of(platillo));
+		ingesta.setAlimentos(List.of(alimento));
+		dieta.setIngestas(List.of(ingesta));
+
+		final Dieta savedDieta = dietaRepository.saveAndFlush(dieta);
+
+		final PacienteDieta assignment = new PacienteDieta();
+		assignment.setPaciente(linkedPaciente);
+		assignment.setDieta(savedDieta);
+		assignment.setStatus(PacienteDietaStatus.ACTIVE);
+		assignment
+			.setStartDate(Date.from(LocalDate.now().minusDays(7).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		assignment.setNotes("Plan activo de prueba con arbol");
+		return pacienteDietaRepository.saveAndFlush(assignment);
 	}
 
 	@Test
@@ -89,6 +132,56 @@ class MobilePatientDietPlanIntegrationTest {
 		mockMvc.perform(get("/rest/mobile/patient/diet-plans").param("activeOnly", "true").with(mobileJwt(LINKED_SUB)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.content[0].status").value("ACTIVE"));
+	}
+
+	@Test
+	void getDietPlanDetailWithLinkedJwtReturnsStructuredMealTree() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/diet-plans/" + linkedAssignment.getId()).with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.assignmentId").value(linkedAssignment.getId()))
+			.andExpect(jsonPath("$.data.dietaName").value("Dieta integración"))
+			.andExpect(jsonPath("$.data.totalKcal").value(1900))
+			.andExpect(jsonPath("$.data.ingestas[0].tipo").value("Desayuno"))
+			.andExpect(jsonPath("$.data.ingestas[0].platillos[0].nombre").value("Huevos revueltos"))
+			.andExpect(jsonPath("$.data.ingestas[0].platillos[0].porciones").value(1))
+			.andExpect(jsonPath("$.data.ingestas[0].alimentos[0].nombre").value("Pan integral"))
+			.andExpect(jsonPath("$.timestamp").exists());
+	}
+
+	@Test
+	void getDietPlanDetailForOtherPatientsAssignmentReturnsNotFound() throws Exception {
+		final Paciente otherPatient = pacienteRepository.findByPatientAuthSub("auth0|mobile-diet-plan-other")
+			.orElseGet(() -> {
+				final Paciente paciente = samplePaciente("auth0|mobile-diet-plan-other");
+				return pacienteRepository.saveAndFlush(paciente);
+			});
+		final PacienteDieta otherAssignment = pacienteDietaRepository.findByPacienteId(otherPatient.getId())
+			.stream()
+			.findFirst()
+			.orElseGet(() -> {
+				final Dieta dieta = new Dieta();
+				dieta.setNombre("Dieta ajena");
+				dieta.setUserId("nutritionist-sub");
+				dieta.setEnergia(1500);
+				final Dieta savedDieta = dietaRepository.saveAndFlush(dieta);
+
+				final PacienteDieta assignment = new PacienteDieta();
+				assignment.setPaciente(otherPatient);
+				assignment.setDieta(savedDieta);
+				assignment.setStatus(PacienteDietaStatus.ACTIVE);
+				assignment.setStartDate(
+						Date.from(LocalDate.now().minusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+				return pacienteDietaRepository.saveAndFlush(assignment);
+			});
+
+		mockMvc.perform(get("/rest/mobile/patient/diet-plans/" + otherAssignment.getId()).with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void getDietPlanDetailForMissingAssignmentReturnsNotFound() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/diet-plans/999999").with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isNotFound());
 	}
 
 	private static Paciente samplePaciente(final String patientAuthSub) {

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanServiceTest.java
@@ -1,29 +1,28 @@
 package com.nutriconsultas.mobile;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
+import com.nutriconsultas.dieta.AlimentoIngesta;
 import com.nutriconsultas.dieta.Dieta;
-import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
-import com.nutriconsultas.mobile.dto.PagedResponse;
+import com.nutriconsultas.dieta.Ingesta;
+import com.nutriconsultas.dieta.PlatilloIngesta;
+import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
@@ -39,62 +38,84 @@ class MobilePatientDietPlanServiceTest {
 	private PacienteDietaRepository pacienteDietaRepository;
 
 	@Test
-	void listDietPlans_mapsAssignmentsToSummaryDtos() {
-		final PacienteDieta assignment = sampleAssignment(5L, PacienteDietaStatus.ACTIVE, "Plan semanal");
-		final Page<PacienteDieta> page = new PageImpl<>(List.of(assignment), PageRequest.of(0, 20), 1);
-		when(pacienteDietaRepository.findByPacienteId(eq(1L), any(Pageable.class))).thenReturn(page);
+	void getDietPlanDetail_returnsStructuredMealTreeWhenOwnedByPatient() {
+		final PacienteDieta assignment = sampleAssignment(5L, 1L);
+		when(pacienteDietaRepository.findByIdAndPacienteId(5L, 1L)).thenReturn(Optional.of(assignment));
 
-		final PagedResponse<DietPlanSummaryDto> result = service.listDietPlans(1L, 0, 20, false);
+		final DietPlanDetailDto result = service.getDietPlanDetail(1L, 5L);
 
-		assertThat(result.content()).hasSize(1);
-		assertThat(result.content().get(0).assignmentId()).isEqualTo(5L);
-		assertThat(result.content().get(0).dietaName()).isEqualTo("Plan semanal");
-		assertThat(result.content().get(0).status()).isEqualTo(PacienteDietaStatus.ACTIVE);
-		assertThat(result.content().get(0).totalKcal()).isEqualTo(1800);
+		assertThat(result.assignmentId()).isEqualTo(5L);
+		assertThat(result.dietaName()).isEqualTo("Plan hipocalórico");
+		assertThat(result.totalKcal()).isEqualTo(1800);
+		assertThat(result.ingestas()).hasSize(1);
+		assertThat(result.ingestas().get(0).tipo()).isEqualTo("Desayuno");
+		assertThat(result.ingestas().get(0).platillos()).hasSize(1);
+		assertThat(result.ingestas().get(0).platillos().get(0).nombre()).isEqualTo("Avena con fruta");
+		assertThat(result.ingestas().get(0).platillos().get(0).porciones()).isEqualTo(2);
+		assertThat(result.ingestas().get(0).platillos().get(0).kcal()).isEqualTo(320);
+		assertThat(result.ingestas().get(0).alimentos()).hasSize(1);
+		assertThat(result.ingestas().get(0).alimentos().get(0).nombre()).isEqualTo("Manzana");
+		assertThat(result.ingestas().get(0).alimentos().get(0).unidad()).isEqualTo("pieza");
 	}
 
 	@Test
-	void listDietPlans_activeOnlyQueriesActiveStatus() {
-		when(pacienteDietaRepository.findByPacienteIdAndStatus(eq(1L), eq(PacienteDietaStatus.ACTIVE),
-				any(Pageable.class)))
-			.thenReturn(Page.empty());
+	void getDietPlanDetail_throwsNotFoundWhenMissingOrNotOwned() {
+		when(pacienteDietaRepository.findByIdAndPacienteId(99L, 1L)).thenReturn(Optional.empty());
 
-		service.listDietPlans(1L, 0, 20, true);
-
-		verify(pacienteDietaRepository).findByPacienteIdAndStatus(eq(1L), eq(PacienteDietaStatus.ACTIVE),
-				any(Pageable.class));
+		assertThatThrownBy(() -> service.getDietPlanDetail(1L, 99L)).isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+			.isEqualTo(HttpStatus.NOT_FOUND);
 	}
 
-	@Test
-	void listDietPlans_capsPageSizeAt100() {
-		when(pacienteDietaRepository.findByPacienteId(eq(1L), any(Pageable.class))).thenReturn(Page.empty());
-
-		service.listDietPlans(1L, 0, 500, false);
-
-		final ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-		verify(pacienteDietaRepository).findByPacienteId(eq(1L), pageableCaptor.capture());
-		assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(100);
-		assertThat(pageableCaptor.getValue().getSort()).isEqualTo(Sort.by(Sort.Direction.DESC, "startDate"));
-	}
-
-	private static PacienteDieta sampleAssignment(final Long id, final PacienteDietaStatus status,
-			final String dietaName) {
+	private static PacienteDieta sampleAssignment(final Long assignmentId, final Long pacienteId) {
 		final Paciente paciente = new Paciente();
-		paciente.setId(1L);
+		paciente.setId(pacienteId);
+
 		final Dieta dieta = new Dieta();
 		dieta.setId(10L);
-		dieta.setNombre(dietaName);
+		dieta.setNombre("Plan hipocalórico");
+		dieta.setUserId("nutritionist-sub");
 		dieta.setEnergia(1800);
 		dieta.setProteina(90.0);
 		dieta.setLipidos(60.0);
 		dieta.setHidratosDeCarbono(200.0);
+
+		final Ingesta ingesta = new Ingesta("Desayuno");
+		ingesta.setId(20L);
+		ingesta.setDieta(dieta);
+		ingesta.setEnergia(450);
+		ingesta.setProteina(20.0);
+		ingesta.setLipidos(12.0);
+		ingesta.setHidratosDeCarbono(55.0);
+
+		final PlatilloIngesta platillo = new PlatilloIngesta();
+		platillo.setId(30L);
+		platillo.setName("Avena con fruta");
+		platillo.setPortions(2);
+		platillo.setEnergia(320);
+		platillo.setRecommendations("Servir tibia");
+		platillo.setIngesta(ingesta);
+
+		final AlimentoIngesta alimento = new AlimentoIngesta();
+		alimento.setId(40L);
+		alimento.setName("Manzana");
+		alimento.setPortions(1);
+		alimento.setEnergia(52);
+		alimento.setUnidad("pieza");
+		alimento.setIngesta(ingesta);
+
+		ingesta.setPlatillos(List.of(platillo));
+		ingesta.setAlimentos(List.of(alimento));
+		dieta.setIngestas(List.of(ingesta));
+
 		final PacienteDieta assignment = new PacienteDieta();
-		assignment.setId(id);
+		assignment.setId(assignmentId);
 		assignment.setPaciente(paciente);
 		assignment.setDieta(dieta);
-		assignment.setStatus(status);
-		assignment.setStartDate(new Date());
-		assignment.setNotes("Notas del plan");
+		assignment.setStatus(PacienteDietaStatus.ACTIVE);
+		assignment
+			.setStartDate(Date.from(LocalDate.now().minusDays(3).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		assignment.setNotes("Seguimiento semanal");
 		return assignment;
 	}
 


### PR DESCRIPTION
## Summary
- Adds `GET /rest/mobile/patient/diet-plans/{assignmentId}` returning structured meal JSON for the authenticated patient's assigned diet plan.
- Introduces `DietPlanDetailDto` and nested DTOs with §F8 field aliases (`tipo`, `nombre`, `porciones`, `kcal`, macro totals) while omitting nutritionist-internal fields.
- Enforces ownership via `findByIdAndPacienteId` with 404 on foreign or missing assignments (IDOR-safe, same pattern as #92).

## Test plan
- [x] `MobilePatientDietPlanServiceTest` — happy path + 404 on foreign assignment
- [x] `MobilePatientDietPlanIntegrationTest` — detail tree JSON, 404 for other patient's assignment and missing ID
- [x] `mvn checkstyle:check` + `mvn pmd:check`
- [ ] Manual: linked patient JWT → `GET /rest/mobile/patient/diet-plans/{assignmentId}` returns ingestas/platillos/alimentos


Made with [Cursor](https://cursor.com)