### PR TITLE
feat(mobile-api): patient diet plan PDF endpoint (#95)

### DIFF
--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-13 — **#94 in-progress** on branch `mobile-api/94-patient-diet-plan-detail`.
+**Last updated:** 2026-06-13 — **#95 in-progress** on branch `mobile-api/95-patient-diet-plan-pdf`.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116) plus the directly-related `[Dashboard]` IMC gauge (#106). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -58,7 +58,7 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 |---|-------|-----|-------|-----------|-------|
 | **107** | Phase 0 — Auth0 JWT resource server + patient Auth0 linkage | https://github.com/diego-torres/nutriconsultas/issues/107 | **done** | — | Merged `aa4db72`: `MobileSecurityConfig` `@Order(1)` on `/rest/mobile/**`; `Paciente.patientAuthSub` + `PatientAuthService` / `PatientLinkageFilter`. |
 | 108 | Auth0 API resource + audience + scopes setup | https://github.com/diego-torres/nutriconsultas/issues/108 | open | 107 | Auth0-tenant config: API identifier `https://api.nutriconsultas.minutriporcion.com`, scopes; prod `AUTH_AUDIENCE` deployed via #118. |
-| **109** | Patient-Auth0 account linkage (admin invite/assign flow) | https://github.com/diego-torres/nutriconsultas/issues/109 | **in-progress** | 107 | Branch `mobile-api/109-patient-auth0-linkage` (pushed): admin Afiliación UI + `POST/DELETE /rest/pacientes/{id}/mobile-auth`. Option A: email lookup via Auth0 Management API. |
+| **109** | Patient-Auth0 account linkage (admin invite/assign flow) | https://github.com/diego-torres/nutriconsultas/issues/109 | **done** | 107 | Merged PR #142: admin Afiliación UI + `POST/DELETE /rest/pacientes/{id}/mobile-auth`. Option A: email lookup via Auth0 Management API. |
 | **110** | DTO conventions + `ApiResponse`/`PagedResponse` wrappers | https://github.com/diego-torres/nutriconsultas/issues/110 | **done** | — | Merged on branch `mobile-api/110-dto-wrappers`: `com.nutriconsultas.mobile.dto` records + Jackson ISO-8601. |
 
 ### Infra (mobile JWT)
@@ -91,8 +91,8 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 | # | Endpoint | URL | State | Backend source |
 |---|----------|-----|-------|----------------|
 | **93** | `GET /rest/mobile/patient/diet-plans` — list assigned plans | https://github.com/diego-torres/nutriconsultas/issues/93 | **done** | 110 | Merged PR #142: paged `DietPlanSummaryDto`, `activeOnly` filter, macro aliases per §F8. |
-| **94** | `GET /rest/mobile/patient/diet-plans/{assignmentId}` — structured meal JSON | https://github.com/diego-torres/nutriconsultas/issues/94 | **in-progress** | 93 | Branch `mobile-api/94-patient-diet-plan-detail`: `DietPlanDetailDto` + ingesta/platillo/alimento tree; `findByIdAndPacienteId` IDOR guard → 404. |
-| 95 | `GET /rest/mobile/patient/diet-plans/{assignmentId}/pdf` — printable PDF | https://github.com/diego-torres/nutriconsultas/issues/95 | open | Reuses existing PDF export (#14) + `NutritionistProfile` branding (#101 ✓); `Content-Disposition`; ownership check |
+| **94** | `GET /rest/mobile/patient/diet-plans/{assignmentId}` — structured meal JSON | https://github.com/diego-torres/nutriconsultas/issues/94 | **done** | 93 | Merged PR #143: `DietPlanDetailDto` + ingesta/platillo/alimento tree; `findByIdAndPacienteId` IDOR guard → 404. |
+| **95** | `GET /rest/mobile/patient/diet-plans/{assignmentId}/pdf` — printable PDF | https://github.com/diego-torres/nutriconsultas/issues/95 | **in-progress** | 94 | Branch `mobile-api/95-patient-diet-plan-pdf`: reuses `DietaPdfService.generatePdfForAssignment`, `Content-Disposition`, ownership → 404. |
 
 ### Messages — **greenfield** (no entity exists)
 

--- a/src/main/java/com/nutriconsultas/dieta/DietaPdfService.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaPdfService.java
@@ -155,13 +155,40 @@ public class DietaPdfService {
 				.orElse(null);
 		}
 
+		return buildPdf(dieta, activeAssignment);
+	}
+
+	/**
+	 * Generates a patient-specific PDF for an explicit {@link PacienteDieta} assignment.
+	 *
+	 * <p>
+	 * Used by the mobile API so the PDF reflects the requested assignment (notes, dates,
+	 * patient context) rather than the first active assignment on the dieta.
+	 * @param assignment the patient diet assignment; must reference a persisted dieta
+	 * @return PDF document as byte array
+	 * @throws IllegalArgumentException if the assignment has no dieta or the dieta is
+	 * missing
+	 */
+	public byte[] generatePdfForAssignment(@NonNull final PacienteDieta assignment) {
+		if (assignment.getDieta() == null || assignment.getDieta().getId() == null) {
+			throw new IllegalArgumentException("Assignment has no dieta");
+		}
+		final Long dietaId = assignment.getDieta().getId();
+		log.info("Generating PDF for assignment id: {} dieta id: {}", assignment.getId(), dietaId);
+		final Dieta dieta = dietaService.getDieta(dietaId);
+		if (dieta == null) {
+			throw new IllegalArgumentException("Dieta with id " + dietaId + " not found");
+		}
+		return buildPdf(dieta, assignment);
+	}
+
+	private byte[] buildPdf(final Dieta dieta, final PacienteDieta assignment) {
 		// Prepare context for Thymeleaf template
 		// Template will conditionally render patient info based on these variables
 		final Context context = new Context();
 		context.setVariable("dieta", dieta);
-		// null if unassigned or if includePatientInfo is false
-		context.setVariable("pacienteDieta", activeAssignment);
-		context.setVariable("paciente", activeAssignment != null ? activeAssignment.getPaciente() : null);
+		context.setVariable("pacienteDieta", assignment);
+		context.setVariable("paciente", assignment != null ? assignment.getPaciente() : null);
 
 		// Sort ingestas by id
 		final List<Ingesta> sortedIngestas = dieta.getIngestas()

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanController.java
@@ -1,5 +1,8 @@
 package com.nutriconsultas.mobile;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
+import com.nutriconsultas.mobile.dto.DietPlanPdfResult;
 import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
 import com.nutriconsultas.mobile.dto.PagedResponse;
 import com.nutriconsultas.paciente.Paciente;
@@ -54,6 +58,21 @@ public class MobilePatientDietPlanController extends AbstractMobilePatientContro
 		}
 		final DietPlanDetailDto plan = mobilePatientDietPlanService.getDietPlanDetail(paciente.getId(), assignmentId);
 		return ApiResponse.ok(plan);
+	}
+
+	@GetMapping(value = "/{assignmentId}/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+	public ResponseEntity<byte[]> getDietPlanPdf(@AuthenticationPrincipal final Jwt jwt,
+			@PathVariable final Long assignmentId) {
+		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile get diet plan PDF {} for patient {}", assignmentId,
+					LogRedaction.redactPaciente(paciente.getId()));
+		}
+		final DietPlanPdfResult pdf = mobilePatientDietPlanService.generateDietPlanPdf(paciente.getId(), assignmentId);
+		return ResponseEntity.ok()
+			.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + pdf.filename() + "\"")
+			.contentType(MediaType.APPLICATION_PDF)
+			.body(pdf.content());
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanService.java
@@ -10,8 +10,10 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.dieta.DietaPdfService;
 import com.nutriconsultas.dieta.Ingesta;
 import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
+import com.nutriconsultas.mobile.dto.DietPlanPdfResult;
 import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
 import com.nutriconsultas.mobile.dto.PagedResponse;
 import com.nutriconsultas.paciente.PacienteDieta;
@@ -29,8 +31,12 @@ public class MobilePatientDietPlanService {
 
 	private final PacienteDietaRepository pacienteDietaRepository;
 
-	public MobilePatientDietPlanService(final PacienteDietaRepository pacienteDietaRepository) {
+	private final DietaPdfService dietaPdfService;
+
+	public MobilePatientDietPlanService(final PacienteDietaRepository pacienteDietaRepository,
+			final DietaPdfService dietaPdfService) {
 		this.pacienteDietaRepository = pacienteDietaRepository;
+		this.dietaPdfService = dietaPdfService;
 	}
 
 	@Transactional(readOnly = true)
@@ -60,6 +66,20 @@ public class MobilePatientDietPlanService {
 					LogRedaction.redactPaciente(pacienteId));
 		}
 		return DietPlanDetailDto.fromEntity(assignment);
+	}
+
+	@Transactional(readOnly = true)
+	public DietPlanPdfResult generateDietPlanPdf(final Long pacienteId, final Long assignmentId) {
+		final PacienteDieta assignment = pacienteDietaRepository.findByIdAndPacienteId(assignmentId, pacienteId)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+		final byte[] pdfBytes = dietaPdfService.generatePdfForAssignment(assignment);
+		final Dieta dieta = assignment.getDieta();
+		final String filename = (dieta != null && dieta.getNombre() != null ? dieta.getNombre() : "dieta") + ".pdf";
+		if (log.isDebugEnabled()) {
+			log.debug("Generated mobile diet plan PDF assignmentId={} for patient {}", assignmentId,
+					LogRedaction.redactPaciente(pacienteId));
+		}
+		return new DietPlanPdfResult(pdfBytes, filename);
 	}
 
 	private static void initializeDietaTree(final Dieta dieta) {

--- a/src/main/java/com/nutriconsultas/mobile/dto/DietPlanPdfResult.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DietPlanPdfResult.java
@@ -1,0 +1,9 @@
+package com.nutriconsultas.mobile.dto;
+
+/**
+ * Binary PDF payload for {@code GET /rest/mobile/patient/diet-plans/{assignmentId}/pdf}
+ * (#95).
+ */
+public record DietPlanPdfResult(byte[] content, String filename) {
+
+}

--- a/src/test/java/com/nutriconsultas/dieta/DietaPdfServiceTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaPdfServiceTest.java
@@ -174,4 +174,30 @@ public class DietaPdfServiceTest {
 		// This is verified implicitly - if it were called, we'd need to mock it
 	}
 
+	@Test
+	public void testGeneratePdfForAssignmentUsesProvidedAssignment() {
+		final PacienteDieta pacienteDieta = new PacienteDieta();
+		pacienteDieta.setId(5L);
+		pacienteDieta.setStatus(PacienteDietaStatus.ACTIVE);
+		pacienteDieta.setDieta(dieta);
+
+		when(dietaService.getDieta(1L)).thenReturn(dieta);
+		when(templateEngine.process(eq("sbadmin/dietas/printable"), any(Context.class)))
+			.thenReturn("<html><body>Test</body></html>");
+
+		final byte[] pdfBytes = dietaPdfService.generatePdfForAssignment(pacienteDieta);
+
+		assertThat(pdfBytes).isNotNull();
+		assertThat(pdfBytes.length).isGreaterThan(0);
+	}
+
+	@Test
+	public void testGeneratePdfForAssignmentWithoutDietaThrows() {
+		final PacienteDieta pacienteDieta = new PacienteDieta();
+
+		assertThatThrownBy(() -> dietaPdfService.generatePdfForAssignment(pacienteDieta))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("no dieta");
+	}
+
 }

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanControllerTest.java
@@ -14,9 +14,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.jwt.Jwt;
 
 import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.DietPlanPdfResult;
 import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
 import com.nutriconsultas.mobile.dto.PagedResponse;
 import com.nutriconsultas.paciente.Paciente;
@@ -55,6 +59,27 @@ class MobilePatientDietPlanControllerTest {
 		assertThat(response.data().content().get(0).dietaName()).isEqualTo("Plan A");
 		assertThat(response.timestamp()).isNotNull();
 		verify(mobilePatientDietPlanService).listDietPlans(3L, 0, 20, true);
+	}
+
+	@Test
+	void getDietPlanPdf_returnsPdfResponseWithContentDisposition() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(3L);
+		final Jwt jwt = jwtWithSub(PATIENT_SUB);
+		final byte[] pdfBytes = new byte[] { 37, 80, 68, 70 };
+		final DietPlanPdfResult pdf = new DietPlanPdfResult(pdfBytes, "Plan A.pdf");
+
+		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);
+		when(mobilePatientDietPlanService.generateDietPlanPdf(3L, 7L)).thenReturn(pdf);
+
+		final ResponseEntity<byte[]> response = controller.getDietPlanPdf(jwt, 7L);
+
+		assertThat(response.getStatusCode().value()).isEqualTo(200);
+		assertThat(response.getHeaders().getFirst(HttpHeaders.CONTENT_DISPOSITION))
+			.isEqualTo("attachment; filename=\"Plan A.pdf\"");
+		assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_PDF);
+		assertThat(response.getBody()).isEqualTo(pdfBytes);
+		verify(mobilePatientDietPlanService).generateDietPlanPdf(3L, 7L);
 	}
 
 	private static Jwt jwtWithSub(final String subject) {

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanIntegrationTest.java
@@ -1,7 +1,11 @@
 package com.nutriconsultas.mobile;
 
 import static com.nutriconsultas.mobile.MobileIntegrationTestJwt.mobileJwt;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -15,11 +19,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.nutriconsultas.dieta.AlimentoIngesta;
 import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.dieta.DietaPdfService;
 import com.nutriconsultas.dieta.DietaRepository;
 import com.nutriconsultas.dieta.Ingesta;
 import com.nutriconsultas.dieta.PlatilloIngesta;
@@ -47,6 +55,9 @@ class MobilePatientDietPlanIntegrationTest {
 
 	@Autowired
 	private PacienteDietaRepository pacienteDietaRepository;
+
+	@MockBean
+	private DietaPdfService dietaPdfService;
 
 	private Paciente linkedPaciente;
 
@@ -181,6 +192,58 @@ class MobilePatientDietPlanIntegrationTest {
 	@Test
 	void getDietPlanDetailForMissingAssignmentReturnsNotFound() throws Exception {
 		mockMvc.perform(get("/rest/mobile/patient/diet-plans/999999").with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void getDietPlanPdfForMissingAssignmentReturnsNotFound() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/diet-plans/999999/pdf").with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void getDietPlanPdfWithLinkedJwtReturnsPdfAttachment() throws Exception {
+		when(dietaPdfService.generatePdfForAssignment(any(PacienteDieta.class)))
+			.thenReturn(new byte[] { 37, 80, 68, 70 });
+
+		mockMvc
+			.perform(get("/rest/mobile/patient/diet-plans/" + linkedAssignment.getId() + "/pdf")
+				.with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_PDF))
+			.andExpect(
+					header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"Dieta integración.pdf\""));
+	}
+
+	@Test
+	void getDietPlanPdfForOtherPatientsAssignmentReturnsNotFound() throws Exception {
+		final Paciente otherPatient = pacienteRepository.findByPatientAuthSub("auth0|mobile-diet-plan-other")
+			.orElseGet(() -> {
+				final Paciente paciente = samplePaciente("auth0|mobile-diet-plan-other");
+				return pacienteRepository.saveAndFlush(paciente);
+			});
+		final PacienteDieta otherAssignment = pacienteDietaRepository.findByPacienteId(otherPatient.getId())
+			.stream()
+			.findFirst()
+			.orElseGet(() -> {
+				final Dieta dieta = new Dieta();
+				dieta.setNombre("Dieta ajena");
+				dieta.setUserId("nutritionist-sub");
+				dieta.setEnergia(1500);
+				final Dieta savedDieta = dietaRepository.saveAndFlush(dieta);
+
+				final PacienteDieta assignment = new PacienteDieta();
+				assignment.setPaciente(otherPatient);
+				assignment.setDieta(savedDieta);
+				assignment.setStatus(PacienteDietaStatus.ACTIVE);
+				assignment.setStartDate(
+						Date.from(LocalDate.now().minusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+				return pacienteDietaRepository.saveAndFlush(assignment);
+			});
+
+		mockMvc
+			.perform(get("/rest/mobile/patient/diet-plans/" + otherAssignment.getId() + "/pdf")
+				.with(mobileJwt(LINKED_SUB)))
 			.andExpect(status().isNotFound());
 	}
 

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanServiceTest.java
@@ -2,6 +2,7 @@ package com.nutriconsultas.mobile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
@@ -20,9 +21,11 @@ import org.springframework.web.server.ResponseStatusException;
 
 import com.nutriconsultas.dieta.AlimentoIngesta;
 import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.dieta.DietaPdfService;
 import com.nutriconsultas.dieta.Ingesta;
 import com.nutriconsultas.dieta.PlatilloIngesta;
 import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
+import com.nutriconsultas.mobile.dto.DietPlanPdfResult;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
@@ -36,6 +39,9 @@ class MobilePatientDietPlanServiceTest {
 
 	@Mock
 	private PacienteDietaRepository pacienteDietaRepository;
+
+	@Mock
+	private DietaPdfService dietaPdfService;
 
 	@Test
 	void getDietPlanDetail_returnsStructuredMealTreeWhenOwnedByPatient() {
@@ -63,6 +69,29 @@ class MobilePatientDietPlanServiceTest {
 		when(pacienteDietaRepository.findByIdAndPacienteId(99L, 1L)).thenReturn(Optional.empty());
 
 		assertThatThrownBy(() -> service.getDietPlanDetail(1L, 99L)).isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+			.isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	void generateDietPlanPdf_returnsPdfWithFilenameWhenOwnedByPatient() {
+		final PacienteDieta assignment = sampleAssignment(5L, 1L);
+		final byte[] pdfBytes = new byte[] { 37, 80, 68, 70 };
+		when(pacienteDietaRepository.findByIdAndPacienteId(5L, 1L)).thenReturn(Optional.of(assignment));
+		when(dietaPdfService.generatePdfForAssignment(assignment)).thenReturn(pdfBytes);
+
+		final DietPlanPdfResult result = service.generateDietPlanPdf(1L, 5L);
+
+		assertThat(result.content()).isEqualTo(pdfBytes);
+		assertThat(result.filename()).isEqualTo("Plan hipocalórico.pdf");
+		verify(dietaPdfService).generatePdfForAssignment(assignment);
+	}
+
+	@Test
+	void generateDietPlanPdf_throwsNotFoundWhenMissingOrNotOwned() {
+		when(pacienteDietaRepository.findByIdAndPacienteId(99L, 1L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.generateDietPlanPdf(1L, 99L)).isInstanceOf(ResponseStatusException.class)
 			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
 			.isEqualTo(HttpStatus.NOT_FOUND);
 	}


### PR DESCRIPTION
## Summary
- Adds `GET /rest/mobile/patient/diet-plans/{assignmentId}/pdf` returning a printable PDF for the authenticated patient's owned diet assignment.
- Introduces `DietaPdfService.generatePdfForAssignment()` so the PDF reflects the specific assignment (patient context, notes, dates) with existing nutritionist branding.
- Returns `Content-Disposition: attachment` and enforces ownership via `findByIdAndPacienteId` → 404 on foreign or missing assignments.

## Test plan
- [x] `DietaPdfServiceTest` — assignment-specific PDF + error without dieta
- [x] `MobilePatientDietPlanServiceTest` — happy path + 404
- [x] `MobilePatientDietPlanControllerTest` — PDF headers and body
- [x] `MobilePatientDietPlanIntegrationTest` — 200 with PDF content-type, 404 for other patient / missing ID
- [x] `mvn checkstyle:check` + `mvn pmd:check`
- [ ] Manual: linked patient JWT → download PDF opens correctly on mobile


Made with [Cursor](https://cursor.com)