### PR TITLE
fix(infra): extend SSM deploy timeouts and systemd start limits

### DIFF
--- a/infrastructure/codepipeline.tf
+++ b/infrastructure/codepipeline.tf
@@ -230,7 +230,8 @@ resource "aws_codebuild_project" "app_deploy" {
   count         = local.codepipeline_enabled ? 1 : 0
   name          = "${var.project}-app-deploy"
   description   = "S3 + SSM deploy to app EC2"
-  build_timeout = 30
+  # Must exceed deploy-jar-to-ec2-ssm.sh SSM poll window (~35m) plus apt/jq/setup.
+  build_timeout = 45
   service_role  = aws_iam_role.codebuild_deploy[0].arn
   tags          = local.common_tags
 

--- a/infrastructure/scripts/deploy-jar-to-ec2-ssm.sh
+++ b/infrastructure/scripts/deploy-jar-to-ec2-ssm.sh
@@ -24,6 +24,7 @@ UNIT_B64=$(base64 < "$UNIT_FILE" | tr -d '\n')
 BUCKET="$(aws ssm get-parameter --name "$P/s3_bucket" --query "Parameter.Value" --output text)"
 KEY="$(aws ssm get-parameter --name "$P/s3_key" --query "Parameter.Value" --output text)"
 INSTANCE_ID="$(aws ssm get-parameter --name "$P/app_instance_id" --query "Parameter.Value" --output text)"
+DEPLOY_REGION="$(aws ssm get-parameter --name "$P/aws_region" --query "Parameter.Value" --output text)"
 S3URI="s3://$BUCKET/$KEY"
 aws s3 cp "$JAR_FILE" "$S3URI" --no-progress
 
@@ -31,6 +32,7 @@ JSON="$(jq -n \
   --arg s3 "$S3URI" \
   --arg ub "$UNIT_B64" \
   --arg iid "$INSTANCE_ID" \
+  --arg rg "$DEPLOY_REGION" \
   '{
      DocumentName: "AWS-RunShellScript",
      InstanceIds: [$iid],
@@ -38,10 +40,11 @@ JSON="$(jq -n \
      Parameters: {
        commands: [
          "set -euo pipefail",
-         "command -v aws || sudo dnf -y -q install awscli",
+         ("export AWS_DEFAULT_REGION=" + ($rg | @sh)),
+         "[ -x /usr/bin/aws ] || timeout 300 sudo dnf -y -q install awscli",
          ("printf %s " + ($ub | @sh) + " | base64 -d | sudo tee /etc/systemd/system/nutriconsultas.service > /dev/null"),
          "sudo systemctl daemon-reload",
-         ("sudo /usr/bin/aws s3 cp " + $s3 + " /opt/nutriconsultas/app.new.jar --no-progress"),
+         ("timeout 600 sudo /usr/bin/aws s3 cp " + $s3 + " /opt/nutriconsultas/app.new.jar --no-progress"),
          "sudo chown nutri:nutri /opt/nutriconsultas/app.new.jar",
          "sudo mv -f /opt/nutriconsultas/app.new.jar /opt/nutriconsultas/app.jar",
          "sudo systemctl daemon-reload",
@@ -54,9 +57,12 @@ JSON="$(jq -n \
    }')"
 
 CMD_ID="$(aws ssm send-command --cli-input-json "$JSON" --query "Command.CommandId" --output text)"
-echo "SSM CommandId=$CMD_ID instance=$INSTANCE_ID (waiting up to ~20m for completion)"
-# Poll: 240 * 5s = 20m (JAR copy + JVM start can exceed the old 6m cap).
-for _ in $(seq 1 240); do
+# Poll must outlive SendCommand TimeoutSeconds (1800s): 420 * 5s = 35m + margin vs stuck InProgress.
+POLL_MAX=420
+echo "SSM CommandId=$CMD_ID instance=$INSTANCE_ID region=$DEPLOY_REGION (waiting up to ~$((POLL_MAX * 5 / 60))m for completion)"
+poll=0
+while [ "$poll" -lt "$POLL_MAX" ]; do
+  poll=$((poll + 1))
   ST=$(aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" --query "Status" --output text 2>/dev/null) || true
   ST="${ST:-InProgress}"
   case "$ST" in
@@ -70,10 +76,13 @@ for _ in $(seq 1 240); do
       exit 1
       ;;
     *)
+      if [ $((poll % 12)) -eq 0 ]; then
+        echo "SSM still $ST after $((poll * 5 / 60))m (command $CMD_ID)…"
+      fi
       sleep 5
       ;;
   esac
 done
-echo "Timeout waiting for SSM (still not Success after ~20m)." >&2
+echo "Timeout waiting for SSM (still not Success after ~$((POLL_MAX * 5 / 60))m)." >&2
 aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" || true
 exit 1

--- a/infrastructure/scripts/nutriconsultas-app.service
+++ b/infrastructure/scripts/nutriconsultas-app.service
@@ -10,6 +10,8 @@ User=nutri
 Group=nutri
 WorkingDirectory=/opt/nutriconsultas
 EnvironmentFile=-/opt/nutriconsultas/app.env
+TimeoutStartSec=300
+TimeoutStopSec=120
 ExecStart=/usr/bin/java -Dserver.port=3000 -Djava.net.preferIPv4Stack=true -Xms256m -Xmx512m -XX:+UseG1GC -jar /opt/nutriconsultas/app.jar
 Restart=on-failure
 RestartSec=5

--- a/infrastructure/templates/app.user_data.sh
+++ b/infrastructure/templates/app.user_data.sh
@@ -78,6 +78,8 @@ User=nutri
 Group=nutri
 WorkingDirectory=/opt/nutriconsultas
 EnvironmentFile=-/opt/nutriconsultas/app.env
+TimeoutStartSec=300
+TimeoutStopSec=120
 ExecStart=/usr/bin/java -Dserver.port=3000 -Djava.net.preferIPv4Stack=true -Xms256m -Xmx512m -XX:+UseG1GC -jar /opt/nutriconsultas/app.jar
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
## Summary
- Increase CodeBuild `app-deploy` timeout from 30 to 45 minutes so it outlives the SSM poll window.
- Extend SSM deploy script polling to ~35 minutes, export `AWS_DEFAULT_REGION` on EC2, and add explicit timeouts for `dnf`/S3 copy.
- Add `TimeoutStartSec=300` and `TimeoutStopSec=120` to the systemd unit (deploy artifact + user_data template) so Spring Boot has time to start after deploy.

## Motivation
Deploys were failing in CodeBuild/SSM polling before the EC2 instance finished copying the JAR and starting the app, especially on slow boots or first-time `awscli` install.

## Test plan
- [ ] Merge and run CodePipeline deploy to prod/staging EC2
- [ ] Confirm CodeBuild completes with SSM `Success`
- [ ] Confirm `nutriconsultas.service` reaches active state within 5 minutes
- [ ] Verify app responds on port 3000 after deploy


Made with [Cursor](https://cursor.com)