### PR TITLE
feat(mobile-api): patient messages API and contact inquiry inbox (#96)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ JDBC_DATABASE_URL=jdbc:postgresql://localhost:5432/nutriconsultas
 JDBC_DATABASE_USERNAME=nutriconsultas
 JDBC_DATABASE_PASSWORD=nutriconsultas
 RECAPTCHA_SECRET_KEY=secretkey
+# Google reCAPTCHA v2 site key (public; pair with RECAPTCHA_SECRET_KEY)
+RECAPTCHA_SITE_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 
 # Optional: Maps API Key (if using maps functionality)
 # MAPS_KEY=your_maps_key_here

--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,6 @@ RECAPTCHA_SECRET_KEY=secretkey
 # AUTH0_MGMT_CLIENT_ID=your_m2m_client_id
 # AUTH0_MGMT_CLIENT_SECRET=your_m2m_client_secret
 # AUTH0_MGMT_DOMAIN=https://your-domain.auth0.com/   # defaults to AUTH_ISSUER when omitted
+
+# Platform admins (OAuth login email → contact inquiries inbox at /admin/contact-inquiries)
+PLATFORM_ADMIN_EMAILS=diego.torres.fuerte@gmail.com,esperanza.romero.salinas@gmail.com,mjoel4318@gmail.com

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-13 — **#95 in-progress** on branch `mobile-api/95-patient-diet-plan-pdf`.
+**Last updated:** 2026-06-14 — **#96 done** (in progress on branch). Contact form persisted; platform admin inbox at `/admin/contact-inquiries`.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116) plus the directly-related `[Dashboard]` IMC gauge (#106). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -46,7 +46,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 JWT (#107) and DTO wrappers (#110) are **done** on stacked branches. Patient linkage (#109) is **pushed**. Visits (#91–#92) and diet plan list (#93) land on `mobile-api/93-patient-diet-plans`.
+Phase 0 JWT (#107) and DTO wrappers (#110) are **done**. Patient linkage (#109) is **done**. Visits (#91–#92) and diet plans (#93–#95) are **done** on `main`.
 
 ---
 
@@ -92,13 +92,13 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 |---|----------|-----|-------|----------------|
 | **93** | `GET /rest/mobile/patient/diet-plans` — list assigned plans | https://github.com/diego-torres/nutriconsultas/issues/93 | **done** | 110 | Merged PR #142: paged `DietPlanSummaryDto`, `activeOnly` filter, macro aliases per §F8. |
 | **94** | `GET /rest/mobile/patient/diet-plans/{assignmentId}` — structured meal JSON | https://github.com/diego-torres/nutriconsultas/issues/94 | **done** | 93 | Merged PR #143: `DietPlanDetailDto` + ingesta/platillo/alimento tree; `findByIdAndPacienteId` IDOR guard → 404. |
-| **95** | `GET /rest/mobile/patient/diet-plans/{assignmentId}/pdf` — printable PDF | https://github.com/diego-torres/nutriconsultas/issues/95 | **in-progress** | 94 | Branch `mobile-api/95-patient-diet-plan-pdf`: reuses `DietaPdfService.generatePdfForAssignment`, `Content-Disposition`, ownership → 404. |
+| **95** | `GET /rest/mobile/patient/diet-plans/{assignmentId}/pdf` — printable PDF | https://github.com/diego-torres/nutriconsultas/issues/95 | **done** | 94 | Merged PR #144: `DietaPdfService.generatePdfForAssignment`, `Content-Disposition`, ownership → 404. |
 
 ### Messages — **greenfield** (no entity exists)
 
 | # | Endpoint | URL | State | Backend source |
 |---|----------|-----|-------|----------------|
-| 96 | `GET /rest/mobile/patient/messages` — list thread | https://github.com/diego-torres/nutriconsultas/issues/96 | open | NEW entity/repo/service; **cursor** pagination (not offset); never log body; optional `senderDisplayName` (#116) |
+| 96 | `GET /rest/mobile/patient/messages` — list thread | https://github.com/diego-torres/nutriconsultas/issues/96 | **done** (branch) | NEW entity/repo/service; **cursor** pagination; contact form → `ContactInquiry`; admin inbox |
 | 97 | `POST /rest/mobile/patient/messages` — send to nutritionist | https://github.com/diego-torres/nutriconsultas/issues/97 | open | `senderRole=PATIENT` from JWT only; `@Valid @Size(max=2000)`; rate limit via #113 |
 
 ### Progress — `AnthropometricMeasurement` / `Paciente`

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -122,7 +122,7 @@ Preferred: the GitHub Action on `main` (see below) or [scripts/deploy-jar-to-ec2
 
 ### OAuth2 and app secrets on the server
 
-Set `AUTH_*` (including `AUTH_AUDIENCE` for `/rest/mobile/**` JWT validation), `AWS_*`, and any other required environment variables. Edit `/opt/nutriconsultas/app.env` in an SSM session (or a systemd `EnvironmentFile` drop-in). On instances already running, add `AUTH_AUDIENCE` manually and restart the app — `user_data` only runs at first boot. Never commit real secrets to git.
+Set `AUTH_*` (including `AUTH_AUDIENCE` for `/rest/mobile/**` JWT validation), `AWS_*`, and optional `PLATFORM_ADMIN_EMAILS` (comma-separated OAuth login emails for the contact-inquiries admin inbox; set via `platform_admin_emails` in gitignored `terraform.tfvars`). Edit `/opt/nutriconsultas/app.env` in an SSM session (or a systemd `EnvironmentFile` drop-in). On instances already running, add missing keys manually and restart the app — `user_data` only runs at first boot. Never commit real secrets to git.
 
 ## Outputs
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -252,6 +252,7 @@ resource "aws_instance" "app" {
         aws_secret_b64           = base64encode(var.aws_secret)
         maps_key_b64             = base64encode(var.maps_key)
         recaptcha_secret_key_b64 = base64encode(var.recaptcha_secret_key)
+        recaptcha_site_key_b64   = base64encode(var.recaptcha_site_key)
         platform_admin_emails_b64 = base64encode(join(",", var.platform_admin_emails))
         nginx_config = templatefile("${path.module}/templates/nutriconsultas-nginx.conf.tpl", {
           nginx_server_names = local.app_nginx_server_names

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -252,6 +252,7 @@ resource "aws_instance" "app" {
         aws_secret_b64           = base64encode(var.aws_secret)
         maps_key_b64             = base64encode(var.maps_key)
         recaptcha_secret_key_b64 = base64encode(var.recaptcha_secret_key)
+        platform_admin_emails_b64 = base64encode(join(",", var.platform_admin_emails))
         nginx_config = templatefile("${path.module}/templates/nutriconsultas-nginx.conf.tpl", {
           nginx_server_names = local.app_nginx_server_names
         })

--- a/infrastructure/templates/app.user_data.sh
+++ b/infrastructure/templates/app.user_data.sh
@@ -49,6 +49,9 @@ install -d -o root -g nutri -m 750 /opt/nutriconsultas
   echo -n "RECAPTCHA_SECRET_KEY="
   printf '%s' '${recaptcha_secret_key_b64}' | base64 -d
   echo
+  echo -n "PLATFORM_ADMIN_EMAILS="
+  printf '%s' '${platform_admin_emails_b64}' | base64 -d
+  echo
 } > /opt/nutriconsultas/app.env
 chown root:nutri /opt/nutriconsultas/app.env
 chmod 640 /opt/nutriconsultas/app.env

--- a/infrastructure/templates/app.user_data.sh
+++ b/infrastructure/templates/app.user_data.sh
@@ -49,6 +49,9 @@ install -d -o root -g nutri -m 750 /opt/nutriconsultas
   echo -n "RECAPTCHA_SECRET_KEY="
   printf '%s' '${recaptcha_secret_key_b64}' | base64 -d
   echo
+  echo -n "RECAPTCHA_SITE_KEY="
+  printf '%s' '${recaptcha_site_key_b64}' | base64 -d
+  echo
   echo -n "PLATFORM_ADMIN_EMAILS="
   printf '%s' '${platform_admin_emails_b64}' | base64 -d
   echo

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -21,7 +21,7 @@ ebs_root_volume_size_gb = 30
 #   export TF_VAR_auth_audience='https://api.example.com/mobile'
 #   export TF_VAR_aws_bucket='...' TF_VAR_aws_key='...' TF_VAR_aws_secret='...'
 # Optional (empty string ok if unused):
-#   export TF_VAR_maps_key='' TF_VAR_recaptcha_secret_key=''
+#   export TF_VAR_maps_key='' TF_VAR_recaptcha_secret_key='' TF_VAR_recaptcha_site_key=''
 # auth_client            = "from-auth0-application"
 # auth_secret            = "from-auth0-application"
 # auth_issuer            = "https://YOUR_TENANT.auth0.com/"
@@ -31,6 +31,7 @@ ebs_root_volume_size_gb = 30
 # aws_secret             = "..."
 # maps_key               = ""
 # recaptcha_secret_key   = ""
+# recaptcha_site_key     = ""   # reCAPTCHA v2 checkbox (public site key)
 #
 # Platform admins (OAuth login emails; contact inquiries inbox). Gitignored tfvars only:
 # platform_admin_emails = ["you@example.com", "colleague@example.com"]

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -32,6 +32,9 @@ ebs_root_volume_size_gb = 30
 # maps_key               = ""
 # recaptcha_secret_key   = ""
 #
+# Platform admins (OAuth login emails; contact inquiries inbox). Gitignored tfvars only:
+# platform_admin_emails = ["you@example.com", "colleague@example.com"]
+#
 # Security: EC2 user_data is readable via DescribeInstances; Terraform state also holds
 # these values. For production, consider SSM SecureString / Secrets Manager instead.
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -125,6 +125,13 @@ variable "recaptcha_secret_key" {
   sensitive   = true
 }
 
+variable "recaptcha_site_key" {
+  type        = string
+  description = "reCAPTCHA v2 site key (recaptcha.site-key / RECAPTCHA_SITE_KEY). Public widget key paired with recaptcha_secret_key."
+  default     = ""
+  sensitive   = false
+}
+
 variable "platform_admin_emails" {
   type        = list(string)
   description = "OAuth login emails granted platform admin (contact inquiries inbox). Written to app.env as PLATFORM_ADMIN_EMAILS (comma-separated)."

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -125,6 +125,13 @@ variable "recaptcha_secret_key" {
   sensitive   = true
 }
 
+variable "platform_admin_emails" {
+  type        = list(string)
+  description = "OAuth login emails granted platform admin (contact inquiries inbox). Written to app.env as PLATFORM_ADMIN_EMAILS (comma-separated)."
+  default     = []
+  sensitive   = true
+}
+
 # -----------------------------------------------------------------------------
 # HTTPS (Let's Encrypt Certbot on the app EC2; DNS must point apex/aliases to the app EIP first)
 # -----------------------------------------------------------------------------

--- a/scripts/seed-patient-messages.sh
+++ b/scripts/seed-patient-messages.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Seeds sample patient messages in the local PostgreSQL database for manual UI testing.
+# Requires the nutriconsultas-db container (see dev-start.sh).
+
+set -euo pipefail
+
+CONTAINER_NAME="${CONTAINER_NAME:-nutriconsultas-db}"
+POSTGRES_USER="${POSTGRES_USER:-nutriconsultas}"
+POSTGRES_DB="${POSTGRES_DB:-nutriconsultas}"
+
+if ! command -v podman >/dev/null 2>&1; then
+  echo "podman is required to run this script." >&2
+  exit 1
+fi
+
+if ! podman ps --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
+  echo "Database container '${CONTAINER_NAME}' is not running. Start it with ./dev-start.sh first." >&2
+  exit 1
+fi
+
+echo "Seeding patient messages for the first two patients in the database..."
+
+podman exec -i "${CONTAINER_NAME}" psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" <<'SQL'
+WITH target_patients AS (
+  SELECT id, user_id, name
+  FROM paciente
+  ORDER BY id
+  LIMIT 2
+),
+inserted AS (
+  INSERT INTO patient_message (
+    paciente_id,
+    nutritionist_user_id,
+    sender_role,
+    body,
+    sent_at,
+    read_by_patient,
+    read_by_nutritionist
+  )
+  SELECT
+    p.id,
+    p.user_id,
+    v.sender_role,
+    v.body,
+    NOW() - (v.minutes_ago || ' minutes')::interval,
+    v.read_by_patient,
+    v.read_by_nutritionist
+  FROM target_patients p
+  CROSS JOIN (
+    VALUES
+      ('PATIENT', 'Hola doctor, ¿puedo sustituir el pollo del almuerzo?', 180, true, false),
+      ('NUTRITIONIST', 'Sí, puedes usar pescado blanco o tofu en la misma porción.', 150, false, true),
+      ('PATIENT', 'Perfecto, gracias. ¿Y el snack de la tarde?', 45, true, false)
+  ) AS v(sender_role, body, minutes_ago, read_by_patient, read_by_nutritionist)
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM patient_message m
+    WHERE m.paciente_id = p.id
+      AND m.body = v.body
+  )
+  RETURNING paciente_id
+)
+SELECT COUNT(*) AS inserted_messages FROM inserted;
+SQL
+
+echo "Done. Open /admin and /admin/pacientes/{id} to test the chat widget."

--- a/src/main/java/com/nutriconsultas/admin/ContactInquiryAdminController.java
+++ b/src/main/java/com/nutriconsultas/admin/ContactInquiryAdminController.java
@@ -6,6 +6,8 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -33,6 +35,20 @@ public class ContactInquiryAdminController extends AbstractAuthorizedController 
 		model.addAttribute("inquiries", contactInquiryService.findAllNewestFirst());
 		model.addAttribute("activeMenu", "contact-inquiries");
 		return "sbadmin/contact-inquiries/listado";
+	}
+
+	@PostMapping("/{id}/read")
+	public String markAsRead(@AuthenticationPrincipal final OidcUser principal, @PathVariable final Long id) {
+		requirePlatformAdmin(principal);
+		contactInquiryService.markAsRead(id);
+		return "redirect:/admin/contact-inquiries";
+	}
+
+	@PostMapping("/{id}/delete")
+	public String delete(@AuthenticationPrincipal final OidcUser principal, @PathVariable final Long id) {
+		requirePlatformAdmin(principal);
+		contactInquiryService.deleteById(id);
+		return "redirect:/admin/contact-inquiries";
 	}
 
 	private void requirePlatformAdmin(final OidcUser principal) {

--- a/src/main/java/com/nutriconsultas/admin/ContactInquiryAdminController.java
+++ b/src/main/java/com/nutriconsultas/admin/ContactInquiryAdminController.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.admin;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nutriconsultas.contact.ContactInquiryService;
+import com.nutriconsultas.controller.AbstractAuthorizedController;
+import com.nutriconsultas.platform.PlatformAdminService;
+
+@Controller
+@RequestMapping("/admin/contact-inquiries")
+public class ContactInquiryAdminController extends AbstractAuthorizedController {
+
+	private final ContactInquiryService contactInquiryService;
+
+	private final PlatformAdminService platformAdminService;
+
+	public ContactInquiryAdminController(final ContactInquiryService contactInquiryService,
+			final PlatformAdminService platformAdminService) {
+		this.contactInquiryService = contactInquiryService;
+		this.platformAdminService = platformAdminService;
+	}
+
+	@GetMapping
+	public String list(@AuthenticationPrincipal final OidcUser principal, final Model model) {
+		requirePlatformAdmin(principal);
+		model.addAttribute("inquiries", contactInquiryService.findAllNewestFirst());
+		model.addAttribute("activeMenu", "contact-inquiries");
+		return "sbadmin/contact-inquiries/listado";
+	}
+
+	private void requirePlatformAdmin(final OidcUser principal) {
+		if (!platformAdminService.isPlatformAdmin(principal)) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/contact/ContactInquiry.java
+++ b/src/main/java/com/nutriconsultas/contact/ContactInquiry.java
@@ -1,0 +1,50 @@
+package com.nutriconsultas.contact;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContactInquiry {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, length = 100)
+	private String name;
+
+	@Column(nullable = false, length = 255)
+	private String email;
+
+	@Column(nullable = false, length = 200)
+	private String subject;
+
+	@Column(nullable = false, length = 2000)
+	private String message;
+
+	@Column(nullable = false)
+	private Instant createdAt;
+
+	@Column(nullable = false)
+	private boolean readByAdmin;
+
+	@PrePersist
+	void onCreate() {
+		if (createdAt == null) {
+			createdAt = Instant.now();
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/contact/ContactInquiryRepository.java
+++ b/src/main/java/com/nutriconsultas/contact/ContactInquiryRepository.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.contact;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContactInquiryRepository extends JpaRepository<ContactInquiry, Long> {
+
+	List<ContactInquiry> findAllByOrderByCreatedAtDesc();
+
+}

--- a/src/main/java/com/nutriconsultas/contact/ContactInquiryService.java
+++ b/src/main/java/com/nutriconsultas/contact/ContactInquiryService.java
@@ -1,0 +1,39 @@
+package com.nutriconsultas.contact;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nutriconsultas.controller.ContactForm;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class ContactInquiryService {
+
+	private final ContactInquiryRepository contactInquiryRepository;
+
+	public ContactInquiryService(final ContactInquiryRepository contactInquiryRepository) {
+		this.contactInquiryRepository = contactInquiryRepository;
+	}
+
+	@Transactional
+	public ContactInquiry saveFromForm(final ContactForm contactForm) {
+		final ContactInquiry inquiry = new ContactInquiry();
+		inquiry.setName(contactForm.getName());
+		inquiry.setEmail(contactForm.getEmail());
+		inquiry.setSubject(contactForm.getSubject());
+		inquiry.setMessage(contactForm.getMessage());
+		inquiry.setReadByAdmin(false);
+		final ContactInquiry saved = contactInquiryRepository.save(inquiry);
+		log.info("Contact inquiry saved: {}", LogRedaction.redactContactInquiry(saved.getId()));
+		return saved;
+	}
+
+	@Transactional(readOnly = true)
+	public java.util.List<ContactInquiry> findAllNewestFirst() {
+		return contactInquiryRepository.findAllByOrderByCreatedAtDesc();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/contact/ContactInquiryService.java
+++ b/src/main/java/com/nutriconsultas/contact/ContactInquiryService.java
@@ -1,7 +1,9 @@
 package com.nutriconsultas.contact;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.nutriconsultas.controller.ContactForm;
 import com.nutriconsultas.util.LogRedaction;
@@ -34,6 +36,26 @@ public class ContactInquiryService {
 	@Transactional(readOnly = true)
 	public java.util.List<ContactInquiry> findAllNewestFirst() {
 		return contactInquiryRepository.findAllByOrderByCreatedAtDesc();
+	}
+
+	@Transactional
+	public void markAsRead(final Long id) {
+		final ContactInquiry inquiry = contactInquiryRepository.findById(id)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+		if (!inquiry.isReadByAdmin()) {
+			inquiry.setReadByAdmin(true);
+			contactInquiryRepository.save(inquiry);
+			log.info("Contact inquiry marked read: {}", LogRedaction.redactContactInquiry(id));
+		}
+	}
+
+	@Transactional
+	public void deleteById(final Long id) {
+		if (!contactInquiryRepository.existsById(id)) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+		}
+		contactInquiryRepository.deleteById(id);
+		log.info("Contact inquiry deleted: {}", LogRedaction.redactContactInquiry(id));
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/contact/ContactInquiryTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/contact/ContactInquiryTemplateValidator.java
@@ -1,6 +1,7 @@
 package com.nutriconsultas.contact;
 
-import java.util.ArrayList;
+import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
 import com.nutriconsultas.validation.template.BaseTemplateValidator;
@@ -15,7 +16,25 @@ public class ContactInquiryTemplateValidator extends BaseTemplateValidator {
 	@Override
 	public Map<String, Object> createMockModelVariables() {
 		final Map<String, Object> variables = super.createMockModelVariables();
-		variables.put("inquiries", new ArrayList<>());
+		final ContactInquiry unread = new ContactInquiry();
+		unread.setId(1L);
+		unread.setName("Ana López");
+		unread.setEmail("ana@example.com");
+		unread.setSubject("Consulta");
+		unread.setMessage("Mensaje de prueba");
+		unread.setReadByAdmin(false);
+		unread.setCreatedAt(Instant.parse("2026-01-15T10:30:00Z"));
+
+		final ContactInquiry read = new ContactInquiry();
+		read.setId(2L);
+		read.setName("Carlos Ruiz");
+		read.setEmail("carlos@example.com");
+		read.setSubject("Acceso");
+		read.setMessage("Ya atendido");
+		read.setReadByAdmin(true);
+		read.setCreatedAt(Instant.parse("2026-01-10T09:00:00Z"));
+
+		variables.put("inquiries", List.of(unread, read));
 		variables.put("platformAdmin", true);
 		return variables;
 	}

--- a/src/main/java/com/nutriconsultas/contact/ContactInquiryTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/contact/ContactInquiryTemplateValidator.java
@@ -1,0 +1,23 @@
+package com.nutriconsultas.contact;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import com.nutriconsultas.validation.template.BaseTemplateValidator;
+
+public class ContactInquiryTemplateValidator extends BaseTemplateValidator {
+
+	@Override
+	public String getTemplatePathPattern() {
+		return "sbadmin/contact-inquiries/*";
+	}
+
+	@Override
+	public Map<String, Object> createMockModelVariables() {
+		final Map<String, Object> variables = super.createMockModelVariables();
+		variables.put("inquiries", new ArrayList<>());
+		variables.put("platformAdmin", true);
+		return variables;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/controller/PlatformAdminModelAdvice.java
+++ b/src/main/java/com/nutriconsultas/controller/PlatformAdminModelAdvice.java
@@ -1,0 +1,28 @@
+package com.nutriconsultas.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Component;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+import com.nutriconsultas.platform.PlatformAdminService;
+
+@Component
+@ControllerAdvice
+public class PlatformAdminModelAdvice {
+
+	private final PlatformAdminService platformAdminService;
+
+	public PlatformAdminModelAdvice(final PlatformAdminService platformAdminService) {
+		this.platformAdminService = platformAdminService;
+	}
+
+	@ModelAttribute
+	public void addPlatformAdminFlag(@AuthenticationPrincipal final OidcUser principal, final Model model) {
+		final boolean platformAdmin = platformAdminService.isPlatformAdmin(principal);
+		model.addAttribute("platformAdmin", platformAdmin);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/controller/WebController.java
+++ b/src/main/java/com/nutriconsultas/controller/WebController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.client.RestClient;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.nutriconsultas.contact.ContactInquiry;
 import com.nutriconsultas.contact.ContactInquiryService;
 import com.nutriconsultas.util.LogRedaction;
 
@@ -76,7 +77,7 @@ public class WebController {
 			return ResponseEntity.badRequest().body("La verificación reCAPTCHA falló. Por favor, intenta nuevamente.");
 		}
 
-		final var saved = contactInquiryService.saveFromForm(contactForm);
+		final ContactInquiry saved = contactInquiryService.saveFromForm(contactForm);
 		log.info("Contact form submitted successfully: {}", LogRedaction.redactContactInquiry(saved.getId()));
 
 		return ResponseEntity.ok("OK");

--- a/src/main/java/com/nutriconsultas/controller/WebController.java
+++ b/src/main/java/com/nutriconsultas/controller/WebController.java
@@ -3,8 +3,10 @@ package com.nutriconsultas.controller;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.client.RestClient;
@@ -29,9 +31,17 @@ public class WebController {
 	@Value("${recaptcha.secret-key:6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe}")
 	private String recaptchaSecretKey;
 
+	@Value("${recaptcha.site-key:6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI}")
+	private String recaptchaSiteKey;
+
 	public WebController(final ContactInquiryService contactInquiryService) {
 		this.restClient = RestClient.create();
 		this.contactInquiryService = contactInquiryService;
+	}
+
+	@ModelAttribute
+	public void addPublicPageAttributes(final Model model) {
+		model.addAttribute("recaptchaSiteKey", recaptchaSiteKey);
 	}
 
 	@GetMapping(path = "/")

--- a/src/main/java/com/nutriconsultas/controller/WebController.java
+++ b/src/main/java/com/nutriconsultas/controller/WebController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.client.RestClient;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.nutriconsultas.contact.ContactInquiryService;
+import com.nutriconsultas.util.LogRedaction;
 
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
@@ -22,17 +24,26 @@ public class WebController {
 
 	private final RestClient restClient;
 
+	private final ContactInquiryService contactInquiryService;
+
 	@Value("${recaptcha.secret-key:6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe}")
 	private String recaptchaSecretKey;
 
-	public WebController() {
+	public WebController(final ContactInquiryService contactInquiryService) {
 		this.restClient = RestClient.create();
+		this.contactInquiryService = contactInquiryService;
 	}
 
 	@GetMapping(path = "/")
 	public String index() {
 		log.debug("Resolving index");
 		return "eterna/index";
+	}
+
+	@GetMapping(path = "/contact")
+	public String contactPage() {
+		log.debug("Resolving contact page");
+		return "eterna/contact";
 	}
 
 	@PostMapping(path = "/contact")
@@ -55,9 +66,8 @@ public class WebController {
 			return ResponseEntity.badRequest().body("La verificación reCAPTCHA falló. Por favor, intenta nuevamente.");
 		}
 
-		log.info("Contact form submitted successfully from: {}", contactForm.getEmail());
-		// TODO: Send email notification or save to database
-		// For now, we just log and return success
+		final var saved = contactInquiryService.saveFromForm(contactForm);
+		log.info("Contact form submitted successfully: {}", LogRedaction.redactContactInquiry(saved.getId()));
 
 		return ResponseEntity.ok("OK");
 	}

--- a/src/main/java/com/nutriconsultas/message/MessageSenderRole.java
+++ b/src/main/java/com/nutriconsultas/message/MessageSenderRole.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.message;
+
+public enum MessageSenderRole {
+
+	PATIENT, NUTRITIONIST
+
+}

--- a/src/main/java/com/nutriconsultas/message/PatientMessage.java
+++ b/src/main/java/com/nutriconsultas/message/PatientMessage.java
@@ -1,0 +1,58 @@
+package com.nutriconsultas.message;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import com.nutriconsultas.paciente.Paciente;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PatientMessage {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "paciente_id", nullable = false)
+	private Paciente paciente;
+
+	@Column(nullable = false, length = 255)
+	private String nutritionistUserId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private MessageSenderRole senderRole;
+
+	@Column(nullable = false, length = 2000)
+	private String body;
+
+	@Column(nullable = false)
+	private Instant sentAt;
+
+	@Column(nullable = false)
+	private boolean readByPatient;
+
+	@PrePersist
+	void onCreate() {
+		if (sentAt == null) {
+			sentAt = Instant.now();
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/message/PatientMessage.java
+++ b/src/main/java/com/nutriconsultas/message/PatientMessage.java
@@ -48,10 +48,21 @@ public class PatientMessage {
 	@Column(nullable = false)
 	private boolean readByPatient;
 
+	@Column(nullable = false)
+	private boolean readByNutritionist;
+
 	@PrePersist
 	void onCreate() {
 		if (sentAt == null) {
 			sentAt = Instant.now();
+		}
+		if (senderRole == MessageSenderRole.NUTRITIONIST) {
+			readByNutritionist = true;
+			readByPatient = false;
+		}
+		else if (senderRole == MessageSenderRole.PATIENT) {
+			readByPatient = true;
+			readByNutritionist = false;
 		}
 	}
 

--- a/src/main/java/com/nutriconsultas/message/PatientMessageRepository.java
+++ b/src/main/java/com/nutriconsultas/message/PatientMessageRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -17,5 +18,41 @@ public interface PatientMessageRepository extends JpaRepository<PatientMessage, 
 			""")
 	List<PatientMessage> findThreadForPatient(@Param("pacienteId") Long pacienteId, @Param("cursorId") Long cursorId,
 			Pageable pageable);
+
+	@Query("""
+			SELECT m FROM PatientMessage m
+			WHERE m.paciente.id = :pacienteId
+			AND m.nutritionistUserId = :userId
+			ORDER BY m.sentAt ASC, m.id ASC
+			""")
+	List<PatientMessage> findThreadAscending(@Param("pacienteId") Long pacienteId, @Param("userId") String userId);
+
+	@Query("""
+			SELECT m FROM PatientMessage m
+			JOIN FETCH m.paciente p
+			WHERE m.nutritionistUserId = :userId
+			AND m.senderRole = com.nutriconsultas.message.MessageSenderRole.PATIENT
+			AND m.readByNutritionist = false
+			ORDER BY m.sentAt DESC, m.id DESC
+			""")
+	List<PatientMessage> findUnreadFromPatientsByNutritionist(@Param("userId") String userId);
+
+	@Query("""
+			SELECT COUNT(m) FROM PatientMessage m
+			WHERE m.nutritionistUserId = :userId
+			AND m.senderRole = com.nutriconsultas.message.MessageSenderRole.PATIENT
+			AND m.readByNutritionist = false
+			""")
+	long countUnreadFromPatientsByNutritionist(@Param("userId") String userId);
+
+	@Modifying
+	@Query("""
+			UPDATE PatientMessage m SET m.readByNutritionist = true
+			WHERE m.paciente.id = :pacienteId
+			AND m.nutritionistUserId = :userId
+			AND m.senderRole = com.nutriconsultas.message.MessageSenderRole.PATIENT
+			AND m.readByNutritionist = false
+			""")
+	int markReadByNutritionist(@Param("pacienteId") Long pacienteId, @Param("userId") String userId);
 
 }

--- a/src/main/java/com/nutriconsultas/message/PatientMessageRepository.java
+++ b/src/main/java/com/nutriconsultas/message/PatientMessageRepository.java
@@ -1,0 +1,21 @@
+package com.nutriconsultas.message;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PatientMessageRepository extends JpaRepository<PatientMessage, Long> {
+
+	@Query("""
+			SELECT m FROM PatientMessage m
+			WHERE m.paciente.id = :pacienteId
+			AND (:cursorId IS NULL OR m.id < :cursorId)
+			ORDER BY m.id DESC
+			""")
+	List<PatientMessage> findThreadForPatient(@Param("pacienteId") Long pacienteId, @Param("cursorId") Long cursorId,
+			Pageable pageable);
+
+}

--- a/src/main/java/com/nutriconsultas/message/PatientMessageRestController.java
+++ b/src/main/java/com/nutriconsultas/message/PatientMessageRestController.java
@@ -1,0 +1,78 @@
+package com.nutriconsultas.message;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nutriconsultas.message.dto.PatientMessageThreadItemDto;
+import com.nutriconsultas.message.dto.PatientUnreadMessageDto;
+import com.nutriconsultas.message.dto.SendPatientMessageRequest;
+
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/patient-messages")
+@Slf4j
+@Validated
+public class PatientMessageRestController {
+
+	private final PatientMessageService patientMessageService;
+
+	public PatientMessageRestController(final PatientMessageService patientMessageService) {
+		this.patientMessageService = patientMessageService;
+	}
+
+	@GetMapping("/unread")
+	public List<PatientUnreadMessageDto> listUnread(@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = requireUserId(principal);
+		return patientMessageService.listUnreadSummaries(userId);
+	}
+
+	@GetMapping("/unread/count")
+	public Map<String, Long> countUnread(@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = requireUserId(principal);
+		return Map.of("count", patientMessageService.countUnread(userId));
+	}
+
+	@GetMapping("/thread/{pacienteId}")
+	public List<PatientMessageThreadItemDto> listThread(@AuthenticationPrincipal final OidcUser principal,
+			@PathVariable final Long pacienteId) {
+		final String userId = requireUserId(principal);
+		return patientMessageService.listThread(pacienteId, userId);
+	}
+
+	@PostMapping("/thread/{pacienteId}")
+	public PatientMessageThreadItemDto sendMessage(@AuthenticationPrincipal final OidcUser principal,
+			@PathVariable final Long pacienteId, @Valid @RequestBody final SendPatientMessageRequest request) {
+		final String userId = requireUserId(principal);
+		return patientMessageService.sendAsNutritionist(pacienteId, userId, request.body());
+	}
+
+	@PostMapping("/thread/{pacienteId}/read")
+	public Map<String, String> markRead(@AuthenticationPrincipal final OidcUser principal,
+			@PathVariable final Long pacienteId) {
+		final String userId = requireUserId(principal);
+		patientMessageService.markThreadReadByNutritionist(pacienteId, userId);
+		return Map.of("status", "ok");
+	}
+
+	private String requireUserId(final OidcUser principal) {
+		if (principal == null || principal.getSubject() == null) {
+			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+		}
+		return principal.getSubject();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/message/PatientMessageService.java
+++ b/src/main/java/com/nutriconsultas/message/PatientMessageService.java
@@ -1,0 +1,113 @@
+package com.nutriconsultas.message;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nutriconsultas.message.dto.PatientMessageThreadItemDto;
+import com.nutriconsultas.message.dto.PatientUnreadMessageDto;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class PatientMessageService {
+
+	private static final int MAX_BODY_LENGTH = 2000;
+
+	private final PatientMessageRepository patientMessageRepository;
+
+	private final PacienteRepository pacienteRepository;
+
+	public PatientMessageService(final PatientMessageRepository patientMessageRepository,
+			final PacienteRepository pacienteRepository) {
+		this.patientMessageRepository = patientMessageRepository;
+		this.pacienteRepository = pacienteRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public List<PatientMessageThreadItemDto> listThread(final Long pacienteId, final String userId) {
+		final Paciente paciente = requireOwnedPaciente(pacienteId, userId);
+		return patientMessageRepository.findThreadAscending(paciente.getId(), userId)
+			.stream()
+			.map(PatientMessageThreadItemDto::fromEntity)
+			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public List<PatientUnreadMessageDto> listUnreadSummaries(final String userId) {
+		final List<PatientMessage> unreadMessages = patientMessageRepository
+			.findUnreadFromPatientsByNutritionist(userId);
+		final Map<Long, PatientUnreadMessageDto> summaries = new LinkedHashMap<>();
+		for (final PatientMessage message : unreadMessages) {
+			final Long pacienteId = message.getPaciente().getId();
+			final PatientUnreadMessageDto existing = summaries.get(pacienteId);
+			if (existing == null) {
+				summaries.put(pacienteId, PatientUnreadMessageDto.fromLatest(message, 1));
+			}
+			else {
+				summaries.put(pacienteId, existing.withIncrementedCount());
+			}
+		}
+		return new ArrayList<>(summaries.values());
+	}
+
+	@Transactional(readOnly = true)
+	public long countUnread(final String userId) {
+		return patientMessageRepository.countUnreadFromPatientsByNutritionist(userId);
+	}
+
+	@Transactional
+	public PatientMessageThreadItemDto sendAsNutritionist(final Long pacienteId, final String userId,
+			final String body) {
+		final Paciente paciente = requireOwnedPaciente(pacienteId, userId);
+		final String trimmedBody = requireBody(body);
+		final PatientMessage message = new PatientMessage();
+		message.setPaciente(paciente);
+		message.setNutritionistUserId(userId);
+		message.setSenderRole(MessageSenderRole.NUTRITIONIST);
+		message.setBody(trimmedBody);
+		message.setReadByPatient(false);
+		message.setReadByNutritionist(true);
+		final PatientMessage saved = patientMessageRepository.save(message);
+		log.info("Nutritionist sent patient message: {}", LogRedaction.redactPatientMessage(saved.getId()));
+		return PatientMessageThreadItemDto.fromEntity(saved);
+	}
+
+	@Transactional
+	public void markThreadReadByNutritionist(final Long pacienteId, final String userId) {
+		requireOwnedPaciente(pacienteId, userId);
+		final int updated = patientMessageRepository.markReadByNutritionist(pacienteId, userId);
+		if (updated > 0) {
+			log.info("Marked {} patient messages read for patient {}", updated,
+					LogRedaction.redactPaciente(pacienteId));
+		}
+	}
+
+	private Paciente requireOwnedPaciente(final Long pacienteId, final String userId) {
+		return pacienteRepository.findByIdAndUserId(pacienteId, userId)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Patient not found"));
+	}
+
+	private String requireBody(final String body) {
+		if (!StringUtils.hasText(body)) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Message body is required");
+		}
+		final String trimmed = body.trim();
+		if (trimmed.length() > MAX_BODY_LENGTH) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Message body is too long");
+		}
+		return trimmed;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/message/dto/PatientMessageThreadItemDto.java
+++ b/src/main/java/com/nutriconsultas/message/dto/PatientMessageThreadItemDto.java
@@ -1,0 +1,15 @@
+package com.nutriconsultas.message.dto;
+
+import java.time.Instant;
+
+import com.nutriconsultas.message.MessageSenderRole;
+import com.nutriconsultas.message.PatientMessage;
+
+public record PatientMessageThreadItemDto(Long id, Instant sentAt, MessageSenderRole senderRole, String body) {
+
+	public static PatientMessageThreadItemDto fromEntity(final PatientMessage message) {
+		return new PatientMessageThreadItemDto(message.getId(), message.getSentAt(), message.getSenderRole(),
+				message.getBody());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/message/dto/PatientUnreadMessageDto.java
+++ b/src/main/java/com/nutriconsultas/message/dto/PatientUnreadMessageDto.java
@@ -1,0 +1,19 @@
+package com.nutriconsultas.message.dto;
+
+import java.time.Instant;
+
+import com.nutriconsultas.message.PatientMessage;
+
+public record PatientUnreadMessageDto(Long pacienteId, String pacienteName, String preview, Instant sentAt,
+		long unreadCount) {
+
+	public static PatientUnreadMessageDto fromLatest(final PatientMessage message, final long unreadCount) {
+		return new PatientUnreadMessageDto(message.getPaciente().getId(), message.getPaciente().getName(),
+				message.getBody(), message.getSentAt(), unreadCount);
+	}
+
+	public PatientUnreadMessageDto withIncrementedCount() {
+		return new PatientUnreadMessageDto(pacienteId, pacienteName, preview, sentAt, unreadCount + 1);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/message/dto/SendPatientMessageRequest.java
+++ b/src/main/java/com/nutriconsultas/message/dto/SendPatientMessageRequest.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.message.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SendPatientMessageRequest(@NotBlank @Size(max = 2000) String body) {
+}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
@@ -88,10 +89,10 @@ public class MobilePatientDietPlanService {
 		}
 		for (final Ingesta ingesta : dieta.getIngestas()) {
 			if (ingesta.getPlatillos() != null) {
-				ingesta.getPlatillos().size();
+				Hibernate.initialize(ingesta.getPlatillos());
 			}
 			if (ingesta.getAlimentos() != null) {
-				ingesta.getAlimentos().size();
+				Hibernate.initialize(ingesta.getAlimentos());
 			}
 		}
 	}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageController.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.mobile;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.CursorPagedResponse;
+import com.nutriconsultas.mobile.dto.PatientMessageSummaryDto;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/mobile/patient/messages")
+@Slf4j
+public class MobilePatientMessageController extends AbstractMobilePatientController {
+
+	private final MobilePatientMessageService mobilePatientMessageService;
+
+	public MobilePatientMessageController(final PatientAuthService patientAuthService,
+			final MobilePatientMessageService mobilePatientMessageService) {
+		super(patientAuthService);
+		this.mobilePatientMessageService = mobilePatientMessageService;
+	}
+
+	@GetMapping
+	public ApiResponse<CursorPagedResponse<PatientMessageSummaryDto>> listMessages(
+			@AuthenticationPrincipal final Jwt jwt, @RequestParam(required = false) final String cursor,
+			@RequestParam(defaultValue = "20") final int size) {
+		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile list messages request for patient {}", LogRedaction.redactPaciente(paciente.getId()));
+		}
+		final CursorPagedResponse<PatientMessageSummaryDto> messages = mobilePatientMessageService
+			.listMessages(paciente.getId(), cursor, size);
+		return ApiResponse.ok(messages);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageService.java
@@ -1,0 +1,64 @@
+package com.nutriconsultas.mobile;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.message.PatientMessage;
+import com.nutriconsultas.message.PatientMessageRepository;
+import com.nutriconsultas.mobile.dto.CursorPagedResponse;
+import com.nutriconsultas.mobile.dto.PatientMessageSummaryDto;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class MobilePatientMessageService {
+
+	private static final int DEFAULT_PAGE_SIZE = 20;
+
+	private static final int MAX_PAGE_SIZE = 100;
+
+	private final PatientMessageRepository patientMessageRepository;
+
+	public MobilePatientMessageService(final PatientMessageRepository patientMessageRepository) {
+		this.patientMessageRepository = patientMessageRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public CursorPagedResponse<PatientMessageSummaryDto> listMessages(final Long pacienteId, final String cursor,
+			final int size) {
+		final int safeSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+		final Long cursorId = parseCursor(cursor);
+		final List<PatientMessage> fetched = patientMessageRepository.findThreadForPatient(pacienteId, cursorId,
+				PageRequest.of(0, safeSize + 1));
+		final boolean hasMore = fetched.size() > safeSize;
+		final List<PatientMessage> page = hasMore ? fetched.subList(0, safeSize) : fetched;
+		final List<PatientMessageSummaryDto> summaries = page.stream()
+			.map(PatientMessageSummaryDto::fromEntity)
+			.toList();
+		final String nextCursor = hasMore && !page.isEmpty() ? String.valueOf(page.get(page.size() - 1).getId()) : null;
+		if (log.isDebugEnabled()) {
+			log.debug("Listed mobile messages count={} hasMore={} for patient {}", summaries.size(), hasMore,
+					LogRedaction.redactPaciente(pacienteId));
+		}
+		return CursorPagedResponse.of(summaries, nextCursor);
+	}
+
+	private Long parseCursor(final String cursor) {
+		if (!StringUtils.hasText(cursor)) {
+			return null;
+		}
+		try {
+			return Long.valueOf(cursor.trim());
+		}
+		catch (NumberFormatException ex) {
+			return null;
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/PatientMessageSummaryDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/PatientMessageSummaryDto.java
@@ -1,0 +1,16 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.time.Instant;
+
+import com.nutriconsultas.message.MessageSenderRole;
+import com.nutriconsultas.message.PatientMessage;
+
+public record PatientMessageSummaryDto(Long id, Instant sentAt, MessageSenderRole senderRole, String body,
+		boolean read) {
+
+	public static PatientMessageSummaryDto fromEntity(final PatientMessage message) {
+		return new PatientMessageSummaryDto(message.getId(), message.getSentAt(), message.getSenderRole(),
+				message.getBody(), message.isReadByPatient());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/platform/PlatformAdminConfig.java
+++ b/src/main/java/com/nutriconsultas/platform/PlatformAdminConfig.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.platform;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(PlatformAdminProperties.class)
+public class PlatformAdminConfig {
+
+}

--- a/src/main/java/com/nutriconsultas/platform/PlatformAdminProperties.java
+++ b/src/main/java/com/nutriconsultas/platform/PlatformAdminProperties.java
@@ -1,0 +1,40 @@
+package com.nutriconsultas.platform;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+@ConfigurationProperties(prefix = "nutriconsultas.platform")
+public class PlatformAdminProperties {
+
+	private List<String> adminUserIds = new ArrayList<>();
+
+	private List<String> adminEmails = new ArrayList<>();
+
+	public List<String> getAdminUserIds() {
+		return adminUserIds;
+	}
+
+	public void setAdminUserIds(final List<String> adminUserIds) {
+		this.adminUserIds = adminUserIds != null ? adminUserIds : new ArrayList<>();
+	}
+
+	public List<String> getAdminEmails() {
+		return adminEmails;
+	}
+
+	public void setAdminEmails(final List<String> adminEmails) {
+		if (adminEmails == null) {
+			this.adminEmails = new ArrayList<>();
+			return;
+		}
+		this.adminEmails = adminEmails.stream()
+			.filter(StringUtils::hasText)
+			.map(email -> email.trim().toLowerCase(Locale.ROOT))
+			.toList();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/platform/PlatformAdminService.java
+++ b/src/main/java/com/nutriconsultas/platform/PlatformAdminService.java
@@ -1,0 +1,43 @@
+package com.nutriconsultas.platform;
+
+import java.util.Locale;
+
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+public class PlatformAdminService {
+
+	private final PlatformAdminProperties platformAdminProperties;
+
+	public PlatformAdminService(final PlatformAdminProperties platformAdminProperties) {
+		this.platformAdminProperties = platformAdminProperties;
+	}
+
+	public boolean isPlatformAdmin(final OidcUser principal) {
+		if (principal == null) {
+			return false;
+		}
+		if (isPlatformAdminByUserId(principal.getSubject())) {
+			return true;
+		}
+		return isPlatformAdminByEmail(principal.getEmail());
+	}
+
+	public boolean isPlatformAdminByUserId(final String userId) {
+		if (!StringUtils.hasText(userId)) {
+			return false;
+		}
+		return platformAdminProperties.getAdminUserIds().contains(userId);
+	}
+
+	private boolean isPlatformAdminByEmail(final String email) {
+		if (!StringUtils.hasText(email)) {
+			return false;
+		}
+		final String normalized = email.trim().toLowerCase(Locale.ROOT);
+		return platformAdminProperties.getAdminEmails().contains(normalized);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/platform/PlatformAdminService.java
+++ b/src/main/java/com/nutriconsultas/platform/PlatformAdminService.java
@@ -19,17 +19,11 @@ public class PlatformAdminService {
 		if (principal == null) {
 			return false;
 		}
-		if (isPlatformAdminByUserId(principal.getSubject())) {
-			return true;
-		}
-		return isPlatformAdminByEmail(principal.getEmail());
+		return isPlatformAdminByUserId(principal.getSubject()) || isPlatformAdminByEmail(principal.getEmail());
 	}
 
 	public boolean isPlatformAdminByUserId(final String userId) {
-		if (!StringUtils.hasText(userId)) {
-			return false;
-		}
-		return platformAdminProperties.getAdminUserIds().contains(userId);
+		return StringUtils.hasText(userId) && platformAdminProperties.getAdminUserIds().contains(userId);
 	}
 
 	private boolean isPlatformAdminByEmail(final String email) {

--- a/src/main/java/com/nutriconsultas/util/LogRedaction.java
+++ b/src/main/java/com/nutriconsultas/util/LogRedaction.java
@@ -228,4 +228,16 @@ public final class LogRedaction {
 		return "ContactInquiry[id=" + inquiryId + "]";
 	}
 
+	/**
+	 * Redacts a patient message ID for logging purposes.
+	 * @param messageId the message ID
+	 * @return a safe string representation (e.g., "PatientMessage[id=123]")
+	 */
+	public static String redactPatientMessage(final Long messageId) {
+		if (messageId == null) {
+			return "PatientMessage[id=null]";
+		}
+		return "PatientMessage[id=" + messageId + "]";
+	}
+
 }

--- a/src/main/java/com/nutriconsultas/util/LogRedaction.java
+++ b/src/main/java/com/nutriconsultas/util/LogRedaction.java
@@ -216,4 +216,16 @@ public final class LogRedaction {
 		return "NutritionistProfile[id=" + profileId + "]";
 	}
 
+	/**
+	 * Redacts a contact inquiry for logging purposes. Returns only the inquiry ID.
+	 * @param inquiryId the contact inquiry ID
+	 * @return a safe string representation (e.g., "ContactInquiry[id=1]")
+	 */
+	public static String redactContactInquiry(final Long inquiryId) {
+		if (inquiryId == null) {
+			return "ContactInquiry[id=null]";
+		}
+		return "ContactInquiry[id=" + inquiryId + "]";
+	}
+
 }

--- a/src/main/java/com/nutriconsultas/validation/template/EternaTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/validation/template/EternaTemplateValidator.java
@@ -15,9 +15,9 @@ public class EternaTemplateValidator extends BaseTemplateValidator {
 
 	@Override
 	public Map<String, Object> createMockModelVariables() {
-		// Public templates may not need username/user_picture, but we include them
-		// for consistency
-		return super.createMockModelVariables();
+		final Map<String, Object> variables = super.createMockModelVariables();
+		variables.put("recaptchaSiteKey", "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI");
+		return variables;
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/validation/template/TemplateValidatorRegistry.java
+++ b/src/main/java/com/nutriconsultas/validation/template/TemplateValidatorRegistry.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.nutriconsultas.alimentos.AlimentoTemplateValidator;
 import com.nutriconsultas.calendar.CalendarTemplateValidator;
+import com.nutriconsultas.contact.ContactInquiryTemplateValidator;
 import com.nutriconsultas.dieta.DietaTemplateValidator;
 import com.nutriconsultas.paciente.PacienteTemplateValidator;
 import com.nutriconsultas.platillos.PlatilloTemplateValidator;
@@ -33,6 +34,7 @@ public class TemplateValidatorRegistry {
 		register(new ReportTemplateValidator());
 		register(new SearchTemplateValidator());
 		register(new ProfileTemplateValidator());
+		register(new ContactInquiryTemplateValidator());
 		register(new EternaTemplateValidator());
 		// Default validator should be last (handles "*")
 		register(new DefaultTemplateValidator());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,6 +40,7 @@ app.auth0.management.client-id=${AUTH0_MGMT_CLIENT_ID:}
 app.auth0.management.client-secret=${AUTH0_MGMT_CLIENT_SECRET:}
 app.auth0.management.domain=${AUTH0_MGMT_DOMAIN:${AUTH_ISSUER}}
 # reCAPTCHA configuration
+recaptcha.site-key=${RECAPTCHA_SITE_KEY:6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI}
 recaptcha.secret-key=${RECAPTCHA_SECRET_KEY}
 # Platform administrators (Auth0 sub claims or OAuth login emails, comma-separated)
 nutriconsultas.platform.admin-user-ids=${PLATFORM_ADMIN_USER_IDS:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,5 +41,8 @@ app.auth0.management.client-secret=${AUTH0_MGMT_CLIENT_SECRET:}
 app.auth0.management.domain=${AUTH0_MGMT_DOMAIN:${AUTH_ISSUER}}
 # reCAPTCHA configuration
 recaptcha.secret-key=${RECAPTCHA_SECRET_KEY}
+# Platform administrators (Auth0 sub claims or OAuth login emails, comma-separated)
+nutriconsultas.platform.admin-user-ids=${PLATFORM_ADMIN_USER_IDS:}
+nutriconsultas.platform.admin-emails=${PLATFORM_ADMIN_EMAILS:}
 #logging.level.org.hibernate.SQL=debug
 #logging.level.org.hibernate.type.descriptor.sql=trace

--- a/src/main/resources/static/eterna/assets/vendor/php-email-form/validate.js
+++ b/src/main/resources/static/eterna/assets/vendor/php-email-form/validate.js
@@ -1,84 +1,119 @@
 /**
-* PHP Email Form Validation - v3.4
+* PHP Email Form Validation - v3.4 (Minutriporcion: reCAPTCHA v2 checkbox + v3 fallback)
 * URL: https://bootstrapmade.com/php-email-form/
-* Author: BootstrapMade.com
 */
 (function () {
   "use strict";
 
+  const RECAPTCHA_MISSING_MSG = "Por favor, completa la verificación reCAPTCHA.";
+  const RECAPTCHA_API_MSG = "No se pudo cargar reCAPTCHA. Recarga la página e inténtalo de nuevo.";
+
   let forms = document.querySelectorAll('.php-email-form');
 
-  forms.forEach( function(e) {
-    e.addEventListener('submit', function(event) {
+  forms.forEach(function (form) {
+    form.addEventListener('submit', function (event) {
       event.preventDefault();
 
-      let thisForm = this;
+      const thisForm = this;
+      const action = thisForm.getAttribute('action');
 
-      let action = thisForm.getAttribute('action');
-      let recaptcha = thisForm.getAttribute('data-recaptcha-site-key');
-      
-      if( ! action ) {
-        displayError(thisForm, 'The form action property is not set!')
+      if (!action) {
+        displayError(thisForm, 'The form action property is not set!');
         return;
       }
+
       thisForm.querySelector('.loading').classList.add('d-block');
       thisForm.querySelector('.error-message').classList.remove('d-block');
       thisForm.querySelector('.sent-message').classList.remove('d-block');
 
-      let formData = new FormData( thisForm );
+      const formData = new FormData(thisForm);
+      const recaptchaWidget = thisForm.querySelector('.g-recaptcha');
+      const recaptchaSiteKey = thisForm.getAttribute('data-recaptcha-site-key');
 
-      if ( recaptcha ) {
-        if(typeof grecaptcha !== "undefined" ) {
-          grecaptcha.ready(function() {
-            try {
-              grecaptcha.execute(recaptcha, {action: 'php_email_form_submit'})
-              .then(token => {
-                formData.set('recaptcha-response', token);
-                php_email_form_submit(thisForm, action, formData);
-              })
-            } catch(error) {
-              displayError(thisForm, error)
-            }
-          });
-        } else {
-          displayError(thisForm, 'The reCaptcha javascript API url is not loaded!')
-        }
+      if (recaptchaWidget) {
+        submitWithRecaptchaV2(thisForm, action, formData, recaptchaWidget);
+      } else if (recaptchaSiteKey) {
+        submitWithRecaptchaV3(thisForm, action, formData, recaptchaSiteKey);
       } else {
-        php_email_form_submit(thisForm, action, formData);
+        phpEmailFormSubmit(thisForm, action, formData);
       }
     });
   });
 
-  function php_email_form_submit(thisForm, action, formData) {
+  function submitWithRecaptchaV2(thisForm, action, formData, recaptchaWidget) {
+    if (typeof grecaptcha === "undefined") {
+      displayError(thisForm, RECAPTCHA_API_MSG);
+      return;
+    }
+    const token = grecaptcha.getResponse();
+    if (!token) {
+      thisForm.querySelector('.loading').classList.remove('d-block');
+      displayError(thisForm, RECAPTCHA_MISSING_MSG);
+      return;
+    }
+    formData.set('recaptcha-response', token);
+    phpEmailFormSubmit(thisForm, action, formData, true);
+  }
+
+  function submitWithRecaptchaV3(thisForm, action, formData, recaptchaSiteKey) {
+    if (typeof grecaptcha === "undefined") {
+      displayError(thisForm, RECAPTCHA_API_MSG);
+      return;
+    }
+    grecaptcha.ready(function () {
+      try {
+        grecaptcha.execute(recaptchaSiteKey, { action: 'php_email_form_submit' })
+          .then(function (token) {
+            formData.set('recaptcha-response', token);
+            phpEmailFormSubmit(thisForm, action, formData);
+          });
+      } catch (error) {
+        displayError(thisForm, error);
+      }
+    });
+  }
+
+  function phpEmailFormSubmit(thisForm, action, formData, resetCaptchaOnComplete) {
     fetch(action, {
       method: 'POST',
       body: formData,
-      headers: {'X-Requested-With': 'XMLHttpRequest'}
+      headers: { 'X-Requested-With': 'XMLHttpRequest' }
     })
-    .then(response => {
-      if( response.ok ) {
-        return response.text()
-      } else {
-        throw new Error(`${response.status} ${response.statusText} ${response.url}`); 
-      }
-    })
-    .then(data => {
-      thisForm.querySelector('.loading').classList.remove('d-block');
-      if (data.trim() == 'OK') {
-        thisForm.querySelector('.sent-message').classList.add('d-block');
-        thisForm.reset(); 
-      } else {
-        throw new Error(data ? data : 'Form submission failed and no error message returned from: ' + action); 
-      }
-    })
-    .catch((error) => {
-      displayError(thisForm, error);
-    });
+      .then(function (response) {
+        return response.text().then(function (text) {
+          if (response.ok) {
+            return text;
+          }
+          throw new Error(text && text.trim() ? text.trim()
+            : response.status + ' ' + response.statusText);
+        });
+      })
+      .then(function (data) {
+        thisForm.querySelector('.loading').classList.remove('d-block');
+        if (data.trim() === 'OK') {
+          thisForm.querySelector('.sent-message').classList.add('d-block');
+          thisForm.reset();
+          resetRecaptcha(resetCaptchaOnComplete);
+        } else {
+          throw new Error(data ? data : 'Form submission failed and no error message returned from: ' + action);
+        }
+      })
+      .catch(function (error) {
+        resetRecaptcha(resetCaptchaOnComplete);
+        displayError(thisForm, error);
+      });
+  }
+
+  function resetRecaptcha(shouldReset) {
+    if (shouldReset && typeof grecaptcha !== "undefined") {
+      grecaptcha.reset();
+    }
   }
 
   function displayError(thisForm, error) {
     thisForm.querySelector('.loading').classList.remove('d-block');
-    thisForm.querySelector('.error-message').innerHTML = error;
+    const message = error && error.message ? error.message : String(error);
+    thisForm.querySelector('.error-message').textContent = message;
     thisForm.querySelector('.error-message').classList.add('d-block');
   }
 

--- a/src/main/resources/static/sbadmin/css/patient-messages-widget.css
+++ b/src/main/resources/static/sbadmin/css/patient-messages-widget.css
@@ -1,0 +1,230 @@
+#patientChatRoot {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 1050;
+  font-family: Nunito, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+#patientChatToggle {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  border: none;
+  background: #4e73df;
+  color: #fff;
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  cursor: pointer;
+  position: relative;
+}
+
+#patientChatToggle:hover {
+  background: #2e59d9;
+}
+
+#patientChatBadge {
+  position: absolute;
+  top: -0.25rem;
+  right: -0.25rem;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 0.35rem;
+  border-radius: 999px;
+  background: #e74a3b;
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1.25rem;
+  text-align: center;
+}
+
+#patientChatPanel {
+  position: absolute;
+  right: 0;
+  bottom: 4.25rem;
+  width: 22rem;
+  max-width: calc(100vw - 2rem);
+  height: 28rem;
+  max-height: calc(100vh - 6rem);
+  background: #fff;
+  border-radius: 0.75rem;
+  box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+#patientChatHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: #4e73df;
+  color: #fff;
+}
+
+#patientChatTitle {
+  flex: 1;
+  font-weight: 700;
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.patient-chat-icon-btn {
+  border: none;
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+  padding: 0.15rem 0.35rem;
+}
+
+#patientChatBody {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: #f8f9fc;
+}
+
+#patientChatGlobalView,
+#patientChatThreadView {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+#patientChatUnreadList {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem;
+}
+
+.patient-chat-unread-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: 1px solid #e3e6f0;
+  border-radius: 0.5rem;
+  background: #fff;
+  padding: 0.75rem;
+  margin-bottom: 0.5rem;
+  cursor: pointer;
+}
+
+.patient-chat-unread-item:hover {
+  border-color: #4e73df;
+}
+
+.patient-chat-unread-item strong {
+  display: block;
+  color: #3a3b45;
+  margin-bottom: 0.25rem;
+}
+
+.patient-chat-unread-preview {
+  display: block;
+  color: #5a5c69;
+  font-size: 0.85rem;
+}
+
+.patient-chat-unread-meta {
+  display: block;
+  color: #858796;
+  font-size: 0.75rem;
+  margin-top: 0.35rem;
+}
+
+#patientChatMessages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem;
+}
+
+.patient-chat-message {
+  margin-bottom: 0.75rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.patient-chat-message.incoming {
+  align-items: flex-start;
+}
+
+.patient-chat-message.outgoing {
+  align-items: flex-end;
+}
+
+.patient-chat-bubble {
+  max-width: 85%;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.75rem;
+  font-size: 0.9rem;
+  line-height: 1.35;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.patient-chat-message.incoming .patient-chat-bubble {
+  background: #fff;
+  border: 1px solid #e3e6f0;
+  color: #3a3b45;
+}
+
+.patient-chat-message.outgoing .patient-chat-bubble {
+  background: #4e73df;
+  color: #fff;
+}
+
+.patient-chat-time {
+  font-size: 0.7rem;
+  color: #858796;
+  margin-top: 0.2rem;
+}
+
+#patientChatComposer {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border-top: 1px solid #e3e6f0;
+  background: #fff;
+}
+
+#patientChatInput {
+  flex: 1;
+  resize: none;
+  min-height: 2.5rem;
+  max-height: 5rem;
+  border: 1px solid #d1d3e2;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.65rem;
+  font-size: 0.9rem;
+}
+
+#patientChatSendBtn {
+  border: none;
+  border-radius: 0.5rem;
+  background: #1cc88a;
+  color: #fff;
+  padding: 0 0.85rem;
+  cursor: pointer;
+}
+
+#patientChatSendBtn:hover {
+  background: #17a673;
+}
+
+.patient-chat-empty {
+  color: #858796;
+  font-size: 0.9rem;
+  text-align: center;
+  margin: 1rem 0;
+}
+
+#patientChatProfileHint {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8rem;
+  color: #5a5c69;
+  background: #eef2ff;
+  border-bottom: 1px solid #e3e6f0;
+}

--- a/src/main/resources/static/sbadmin/js/patient-messages-widget.js
+++ b/src/main/resources/static/sbadmin/js/patient-messages-widget.js
@@ -1,0 +1,285 @@
+/* Floating patient messages chat widget for admin pages */
+
+(function () {
+  'use strict';
+
+  var POLL_INTERVAL_MS = 60000;
+  var state = {
+    open: false,
+    unreadCount: 0,
+    unreadSummaries: [],
+    thread: [],
+    activePacienteId: null,
+    activePacienteName: null,
+    profileMode: false,
+    pollTimer: null
+  };
+
+  function $(selector) {
+    return document.querySelector(selector);
+  }
+
+  function escapeHtml(text) {
+    var div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  function formatTime(iso) {
+    if (!iso) {
+      return '';
+    }
+    try {
+      return new Date(iso).toLocaleString('es-MX', {
+        day: '2-digit',
+        month: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit'
+      });
+    } catch (e) {
+      return iso;
+    }
+  }
+
+  function truncate(text, max) {
+    if (!text || text.length <= max) {
+      return text || '';
+    }
+    return text.substring(0, max - 1) + '…';
+  }
+
+  function fetchJson(url, options) {
+    return fetch(url, options || {}).then(function (response) {
+      if (!response.ok) {
+        throw new Error('Request failed: ' + response.status);
+      }
+      return response.json();
+    });
+  }
+
+  function initContext() {
+    if (window.PATIENT_CHAT_CONTEXT && window.PATIENT_CHAT_CONTEXT.pacienteId) {
+      state.profileMode = true;
+      state.activePacienteId = window.PATIENT_CHAT_CONTEXT.pacienteId;
+      state.activePacienteName = window.PATIENT_CHAT_CONTEXT.pacienteName || 'Paciente';
+    }
+  }
+
+  function updateBadge() {
+    var badge = $('#patientChatBadge');
+    if (!badge) {
+      return;
+    }
+    if (state.unreadCount > 0) {
+      badge.textContent = state.unreadCount > 99 ? '99+' : String(state.unreadCount);
+      badge.hidden = false;
+    } else {
+      badge.hidden = true;
+    }
+  }
+
+  function renderUnreadList() {
+    var container = $('#patientChatUnreadList');
+    if (!container) {
+      return;
+    }
+    if (state.unreadSummaries.length === 0) {
+      container.innerHTML = '<p class="patient-chat-empty">No hay mensajes nuevos de pacientes.</p>';
+      return;
+    }
+    container.innerHTML = state.unreadSummaries.map(function (item) {
+      return '<button type="button" class="patient-chat-unread-item" data-paciente-id="' + item.pacienteId + '" data-paciente-name="' + escapeHtml(item.pacienteName) + '">' +
+        '<strong>' + escapeHtml(item.pacienteName) + '</strong>' +
+        '<span class="patient-chat-unread-preview">' + escapeHtml(truncate(item.preview, 80)) + '</span>' +
+        '<span class="patient-chat-unread-meta">' + formatTime(item.sentAt) +
+        (item.unreadCount > 1 ? ' · ' + item.unreadCount + ' nuevos' : '') + '</span>' +
+        '</button>';
+    }).join('');
+
+    container.querySelectorAll('.patient-chat-unread-item').forEach(function (button) {
+      button.addEventListener('click', function () {
+        openThread(Number(button.getAttribute('data-paciente-id')), button.getAttribute('data-paciente-name'));
+      });
+    });
+  }
+
+  function renderThread() {
+    var container = $('#patientChatMessages');
+    if (!container) {
+      return;
+    }
+    if (state.thread.length === 0) {
+      container.innerHTML = '<p class="patient-chat-empty">Aún no hay mensajes en esta conversación.</p>';
+      return;
+    }
+    container.innerHTML = state.thread.map(function (message) {
+      var roleClass = message.senderRole === 'NUTRITIONIST' ? 'outgoing' : 'incoming';
+      return '<div class="patient-chat-message ' + roleClass + '">' +
+        '<div class="patient-chat-bubble">' + escapeHtml(message.body) + '</div>' +
+        '<div class="patient-chat-time">' + formatTime(message.sentAt) + '</div>' +
+        '</div>';
+    }).join('');
+    container.scrollTop = container.scrollHeight;
+  }
+
+  function setPanelTitle(title) {
+    var titleEl = $('#patientChatTitle');
+    if (titleEl) {
+      titleEl.textContent = title;
+    }
+  }
+
+  function showGlobalView() {
+    $('#patientChatGlobalView').hidden = false;
+    $('#patientChatThreadView').hidden = true;
+    $('#patientChatBackBtn').hidden = true;
+    setPanelTitle('Mensajes de pacientes');
+    renderUnreadList();
+  }
+
+  function showThreadView() {
+    $('#patientChatGlobalView').hidden = true;
+    $('#patientChatThreadView').hidden = false;
+    $('#patientChatBackBtn').hidden = state.profileMode;
+    setPanelTitle(state.activePacienteName || 'Conversación');
+    renderThread();
+  }
+
+  function loadUnread() {
+    return fetchJson('/rest/patient-messages/unread').then(function (summaries) {
+      state.unreadSummaries = summaries || [];
+      return fetchJson('/rest/patient-messages/unread/count');
+    }).then(function (payload) {
+      state.unreadCount = payload.count || 0;
+      updateBadge();
+      if (state.open && !state.profileMode && $('#patientChatThreadView').hidden) {
+        renderUnreadList();
+      }
+    }).catch(function (err) {
+      console.warn('Could not load unread patient messages', err);
+    });
+  }
+
+  function openThread(pacienteId, pacienteName) {
+    state.activePacienteId = pacienteId;
+    state.activePacienteName = pacienteName;
+    return fetchJson('/rest/patient-messages/thread/' + pacienteId).then(function (messages) {
+      state.thread = messages || [];
+      showThreadView();
+      return fetchJson('/rest/patient-messages/thread/' + pacienteId + '/read', { method: 'POST' });
+    }).then(function () {
+      return loadUnread();
+    }).catch(function (err) {
+      console.warn('Could not open patient message thread', err);
+    });
+  }
+
+  function sendMessage() {
+    var input = $('#patientChatInput');
+    if (!input || !state.activePacienteId) {
+      return;
+    }
+    var body = input.value.trim();
+    if (!body) {
+      return;
+    }
+    input.disabled = true;
+    fetchJson('/rest/patient-messages/thread/' + state.activePacienteId, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body: body })
+    }).then(function (message) {
+      state.thread.push(message);
+      input.value = '';
+      renderThread();
+    }).catch(function (err) {
+      console.warn('Could not send patient message', err);
+      alert('No se pudo enviar el mensaje. Intenta de nuevo.');
+    }).finally(function () {
+      input.disabled = false;
+      input.focus();
+    });
+  }
+
+  function togglePanel(forceOpen) {
+    var panel = $('#patientChatPanel');
+    if (!panel) {
+      return;
+    }
+    state.open = forceOpen !== undefined ? forceOpen : !state.open;
+    panel.hidden = !state.open;
+    if (state.open) {
+      if (state.profileMode && state.activePacienteId) {
+        openThread(state.activePacienteId, state.activePacienteName);
+      } else {
+        showGlobalView();
+        loadUnread();
+      }
+    }
+  }
+
+  function bindEvents() {
+    var toggleBtn = $('#patientChatToggle');
+    var closeBtn = $('#patientChatClose');
+    var backBtn = $('#patientChatBackBtn');
+    var sendBtn = $('#patientChatSendBtn');
+    var input = $('#patientChatInput');
+
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', function () {
+        togglePanel();
+      });
+    }
+    if (closeBtn) {
+      closeBtn.addEventListener('click', function () {
+        togglePanel(false);
+      });
+    }
+    if (backBtn) {
+      backBtn.addEventListener('click', function () {
+        state.activePacienteId = null;
+        state.activePacienteName = null;
+        state.thread = [];
+        showGlobalView();
+        loadUnread();
+      });
+    }
+    if (sendBtn) {
+      sendBtn.addEventListener('click', sendMessage);
+    }
+    if (input) {
+      input.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter' && !event.shiftKey) {
+          event.preventDefault();
+          sendMessage();
+        }
+      });
+    }
+  }
+
+  function startPolling() {
+    if (state.pollTimer) {
+      clearInterval(state.pollTimer);
+    }
+    state.pollTimer = setInterval(loadUnread, POLL_INTERVAL_MS);
+  }
+
+  function init() {
+    initContext();
+    bindEvents();
+    loadUnread();
+    startPolling();
+    if (state.profileMode && state.activePacienteId) {
+      var hint = $('#patientChatProfileHint');
+      if (hint) {
+        hint.hidden = false;
+      }
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/src/main/resources/templates/eterna/contact.html
+++ b/src/main/resources/templates/eterna/contact.html
@@ -1,31 +1,40 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 
 <head>
   <meta charset="utf-8">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-  <title>Contact - Eterna Bootstrap Template</title>
-  <meta content="" name="description">
-  <meta content="" name="keywords">
+  <title>Contacto - Minutriporcion</title>
+  <meta content="Solicita acceso a Minutriporcion o envíanos tus preguntas." name="description">
+  <meta content="nutriólogo, nutricionista, contacto, Minutriporcion" name="keywords">
 
   <!-- Favicons -->
-  <link href="assets/img/favicon.png" rel="icon">
-  <link href="assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+  <link th:href="@{/eterna/assets/img/favicon.png}" rel="icon">
+  <link th:href="@{/eterna/assets/img/apple-touch-icon.png}" rel="apple-touch-icon">
 
   <!-- Google Fonts -->
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Raleway:300,300i,400,400i,500,500i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
 
   <!-- Vendor CSS Files -->
-  <link href="assets/vendor/animate.css/animate.min.css" rel="stylesheet">
-  <link href="assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-  <link href="assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
-  <link href="assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
-  <link href="assets/vendor/glightbox/css/glightbox.min.css" rel="stylesheet">
-  <link href="assets/vendor/swiper/swiper-bundle.min.css" rel="stylesheet">
+  <link th:href="@{/eterna/assets/vendor/animate.css/animate.min.css}" rel="stylesheet">
+  <link th:href="@{/eterna/assets/vendor/bootstrap/css/bootstrap.min.css}" rel="stylesheet">
+  <link th:href="@{/eterna/assets/vendor/bootstrap-icons/bootstrap-icons.css}" rel="stylesheet">
+  <link th:href="@{/eterna/assets/vendor/boxicons/css/boxicons.min.css}" rel="stylesheet">
+  <link th:href="@{/eterna/assets/vendor/glightbox/css/glightbox.min.css}" rel="stylesheet">
+  <link th:href="@{/eterna/assets/vendor/swiper/swiper-bundle.min.css}" rel="stylesheet">
 
   <!-- Template Main CSS File -->
-  <link href="assets/css/style.css" rel="stylesheet">
+  <link th:href="@{/eterna/assets/css/style.css}" rel="stylesheet">
+
+  <!-- Google reCAPTCHA -->
+  <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+
+  <style>
+  #main {
+    padding-top: 150px;
+  }
+  </style>
 
   <!-- =======================================================
   * Template Name: Eterna - v4.8.1
@@ -41,14 +50,11 @@
   <section id="topbar" class="d-flex align-items-center">
     <div class="container d-flex justify-content-center justify-content-md-between">
       <div class="contact-info d-flex align-items-center">
-        <i class="bi bi-envelope d-flex align-items-center"><a href="mailto:contact@example.com">contact@example.com</a></i>
-        <i class="bi bi-phone d-flex align-items-center ms-4"><span>+1 5589 55488 55</span></i>
+        <i class="bi bi-envelope d-flex align-items-center"><a href="mailto:contacto@minutriporcion.com">contacto@minutriporcion.com</a></i>
       </div>
       <div class="social-links d-none d-md-flex align-items-center">
-        <a href="#" class="twitter"><i class="bi bi-twitter"></i></a>
-        <a href="#" class="facebook"><i class="bi bi-facebook"></i></a>
-        <a href="#" class="instagram"><i class="bi bi-instagram"></i></a>
-        <a href="#" class="linkedin"><i class="bi bi-linkedin"></i></i></a>
+        <a href="https://www.facebook.com/minutriporcion" target="_blank" rel="noopener noreferrer" class="facebook"><i class="bi bi-facebook"></i></a>
+        <a href="https://www.instagram.com/minutriporcion" target="_blank" rel="noopener noreferrer" class="instagram"><i class="bi bi-instagram"></i></a>
       </div>
     </div>
   </section>
@@ -58,38 +64,20 @@
     <div class="container d-flex justify-content-between align-items-center">
 
       <div class="logo">
-        <h1><a href="index.html">Eterna</a></h1>
-        <!-- Uncomment below if you prefer to use an image logo -->
-        <!-- <a href="index.html"><img src="assets/img/logo.png" alt="" class="img-fluid"></a>-->
+        <a th:href="@{/}" class="d-flex align-items-center">
+          <img th:src="@{/eterna/assets/img/favicon.png}" alt="Minutriporcion" style="height: 40px; margin-right: 10px;">
+          <h1 class="mb-0">Minutriporcion</h1>
+        </a>
       </div>
 
       <nav id="navbar" class="navbar">
         <ul>
-          <li><a href="index.html">Home</a></li>
-          <li><a href="about.html">About</a></li>
-          <li><a href="services.html">Services</a></li>
-          <li><a href="portfolio.html">Portfolio</a></li>
-          <li><a href="team.html">Team</a></li>
-          <li><a href="pricing.html">Pricing</a></li>
-          <li><a href="blog.html">Blog</a></li>
-          <li class="dropdown"><a href="#"><span>Drop Down</span> <i class="bi bi-chevron-down"></i></a>
-            <ul>
-              <li><a href="#">Drop Down 1</a></li>
-              <li class="dropdown"><a href="#"><span>Deep Drop Down</span> <i class="bi bi-chevron-right"></i></a>
-                <ul>
-                  <li><a href="#">Deep Drop Down 1</a></li>
-                  <li><a href="#">Deep Drop Down 2</a></li>
-                  <li><a href="#">Deep Drop Down 3</a></li>
-                  <li><a href="#">Deep Drop Down 4</a></li>
-                  <li><a href="#">Deep Drop Down 5</a></li>
-                </ul>
-              </li>
-              <li><a href="#">Drop Down 2</a></li>
-              <li><a href="#">Drop Down 3</a></li>
-              <li><a href="#">Drop Down 4</a></li>
-            </ul>
-          </li>
-          <li><a class="active" href="contact.html">Contact</a></li>
+          <li><a th:href="@{/}">Inicio</a></li>
+          <li><a th:href="@{/#about}">Acerca de</a></li>
+          <li><a th:href="@{/#services}">Servicios</a></li>
+          <li><a th:href="@{/#pricing}">Planes</a></li>
+          <li><a class="active" th:href="@{/contact}">Contacto</a></li>
+          <li><a th:href="@{/admin}">Ingresar</a></li>
         </ul>
         <i class="bi bi-list mobile-nav-toggle"></i>
       </nav><!-- .navbar -->
@@ -104,10 +92,10 @@
       <div class="container">
 
         <ol>
-          <li><a href="index.html">Home</a></li>
-          <li>Contact</li>
+          <li><a th:href="@{/}">Inicio</a></li>
+          <li>Contacto</li>
         </ol>
-        <h2>Contact</h2>
+        <h2>Contacto</h2>
 
       </div>
     </section><!-- End Breadcrumbs -->
@@ -119,61 +107,49 @@
         <div class="row">
           <div class="col-lg-6">
             <div class="info-box mb-4">
-              <i class="bx bx-map"></i>
-              <h3>Our Address</h3>
-              <p>A108 Adam Street, New York, NY 535022</p>
-            </div>
-          </div>
-
-          <div class="col-lg-3 col-md-6">
-            <div class="info-box  mb-4">
               <i class="bx bx-envelope"></i>
-              <h3>Email Us</h3>
-              <p>contact@example.com</p>
+              <h3>Email</h3>
+              <p>contacto@minutriporcion.com</p>
             </div>
-          </div>
-
-          <div class="col-lg-3 col-md-6">
-            <div class="info-box  mb-4">
-              <i class="bx bx-phone-call"></i>
-              <h3>Call Us</h3>
-              <p>+1 5589 55488 55</p>
-            </div>
-          </div>
-
-        </div>
-
-        <div class="row">
-
-          <div class="col-lg-6 ">
-            <iframe class="mb-4 mb-lg-0" src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d12097.433213460943!2d-74.0062269!3d40.7101282!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0xb89d1fe6bc499443!2sDowntown+Conference+Center!5e0!3m2!1smk!2sbg!4v1539943755621" frameborder="0" style="border:0; width: 100%; height: 384px;" allowfullscreen></iframe>
           </div>
 
           <div class="col-lg-6">
-            <form action="forms/contact.php" method="post" role="form" class="php-email-form">
+            <div class="info-box mb-4">
+              <i class="bx bx-share-alt"></i>
+              <h3>Redes Sociales</h3>
+              <div class="social-links">
+                <a href="https://www.facebook.com/minutriporcion" target="_blank" rel="noopener noreferrer" class="facebook"><i class="bx bxl-facebook"></i></a>
+                <a href="https://www.instagram.com/minutriporcion" target="_blank" rel="noopener noreferrer" class="instagram"><i class="bx bxl-instagram"></i></a>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-lg-12">
+            <form th:action="@{/contact}" method="post" role="form" class="php-email-form" data-recaptcha-site-key="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI">
               <div class="row">
                 <div class="col-md-6 form-group">
-                  <input type="text" name="name" class="form-control" id="name" placeholder="Your Name" required>
+                  <input type="text" name="name" class="form-control" id="name" placeholder="Tu Nombre" required>
                 </div>
                 <div class="col-md-6 form-group mt-3 mt-md-0">
-                  <input type="email" class="form-control" name="email" id="email" placeholder="Your Email" required>
+                  <input type="email" class="form-control" name="email" id="email" placeholder="Tu Email" required>
                 </div>
               </div>
               <div class="form-group mt-3">
-                <input type="text" class="form-control" name="subject" id="subject" placeholder="Subject" required>
+                <input type="text" class="form-control" name="subject" id="subject" placeholder="Asunto" required>
               </div>
               <div class="form-group mt-3">
-                <textarea class="form-control" name="message" rows="5" placeholder="Message" required></textarea>
+                <textarea class="form-control" name="message" rows="5" placeholder="Mensaje" required></textarea>
               </div>
               <div class="my-3">
-                <div class="loading">Loading</div>
+                <div class="loading">Enviando...</div>
                 <div class="error-message"></div>
-                <div class="sent-message">Your message has been sent. Thank you!</div>
+                <div class="sent-message">Tu mensaje ha sido enviado. ¡Gracias!</div>
               </div>
-              <div class="text-center"><button type="submit">Send Message</button></div>
+              <div class="text-center"><button type="submit">Enviar Mensaje</button></div>
             </form>
           </div>
-
         </div>
 
       </div>
@@ -271,16 +247,16 @@
   <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="bi bi-arrow-up-short"></i></a>
 
   <!-- Vendor JS Files -->
-  <script src="assets/vendor/purecounter/purecounter_vanilla.js"></script>
-  <script src="assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
-  <script src="assets/vendor/glightbox/js/glightbox.min.js"></script>
-  <script src="assets/vendor/isotope-layout/isotope.pkgd.min.js"></script>
-  <script src="assets/vendor/swiper/swiper-bundle.min.js"></script>
-  <script src="assets/vendor/waypoints/noframework.waypoints.js"></script>
-  <script src="assets/vendor/php-email-form/validate.js"></script>
+  <script th:src="@{/eterna/assets/vendor/purecounter/purecounter_vanilla.js}"></script>
+  <script th:src="@{/eterna/assets/vendor/bootstrap/js/bootstrap.bundle.min.js}"></script>
+  <script th:src="@{/eterna/assets/vendor/glightbox/js/glightbox.min.js}"></script>
+  <script th:src="@{/eterna/assets/vendor/isotope-layout/isotope.pkgd.min.js}"></script>
+  <script th:src="@{/eterna/assets/vendor/swiper/swiper-bundle.min.js}"></script>
+  <script th:src="@{/eterna/assets/vendor/waypoints/noframework.waypoints.js}"></script>
+  <script th:src="@{/eterna/assets/vendor/php-email-form/validate.js}"></script>
 
   <!-- Template Main JS File -->
-  <script src="assets/js/main.js"></script>
+  <script th:src="@{/eterna/assets/js/main.js}"></script>
 
 </body>
 

--- a/src/main/resources/templates/eterna/contact.html
+++ b/src/main/resources/templates/eterna/contact.html
@@ -127,28 +127,7 @@
 
         <div class="row">
           <div class="col-lg-12">
-            <form th:action="@{/contact}" method="post" role="form" class="php-email-form" data-recaptcha-site-key="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI">
-              <div class="row">
-                <div class="col-md-6 form-group">
-                  <input type="text" name="name" class="form-control" id="name" placeholder="Tu Nombre" required>
-                </div>
-                <div class="col-md-6 form-group mt-3 mt-md-0">
-                  <input type="email" class="form-control" name="email" id="email" placeholder="Tu Email" required>
-                </div>
-              </div>
-              <div class="form-group mt-3">
-                <input type="text" class="form-control" name="subject" id="subject" placeholder="Asunto" required>
-              </div>
-              <div class="form-group mt-3">
-                <textarea class="form-control" name="message" rows="5" placeholder="Mensaje" required></textarea>
-              </div>
-              <div class="my-3">
-                <div class="loading">Enviando...</div>
-                <div class="error-message"></div>
-                <div class="sent-message">Tu mensaje ha sido enviado. ¡Gracias!</div>
-              </div>
-              <div class="text-center"><button type="submit">Enviar Mensaje</button></div>
-            </form>
+            <div th:replace="~{eterna/fragments/contact-form :: contactForm}"></div>
           </div>
         </div>
 

--- a/src/main/resources/templates/eterna/fragments/contact-form.html
+++ b/src/main/resources/templates/eterna/fragments/contact-form.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+
+<body>
+  <form th:fragment="contactForm" th:action="@{/contact}" method="post" role="form" class="php-email-form">
+    <div class="row">
+      <div class="col-md-6 form-group">
+        <input type="text" name="name" class="form-control" id="name" placeholder="Tu Nombre" required>
+      </div>
+      <div class="col-md-6 form-group mt-3 mt-md-0">
+        <input type="email" class="form-control" name="email" id="email" placeholder="Tu Email" required>
+      </div>
+    </div>
+    <div class="form-group mt-3">
+      <input type="text" class="form-control" name="subject" id="subject" placeholder="Asunto" required>
+    </div>
+    <div class="form-group mt-3">
+      <textarea class="form-control" name="message" rows="5" placeholder="Mensaje" required></textarea>
+    </div>
+    <div class="form-group mt-3 d-flex justify-content-center">
+      <div class="g-recaptcha" th:attr="data-sitekey=${recaptchaSiteKey}"></div>
+    </div>
+    <div class="my-3">
+      <div class="loading">Enviando...</div>
+      <div class="error-message"></div>
+      <div class="sent-message">Tu mensaje ha sido enviado. ¡Gracias!</div>
+    </div>
+    <div class="text-center"><button type="submit">Enviar Mensaje</button></div>
+  </form>
+</body>
+
+</html>

--- a/src/main/resources/templates/eterna/index.html
+++ b/src/main/resources/templates/eterna/index.html
@@ -445,28 +445,7 @@
 
         <div class="row">
           <div class="col-lg-12">
-            <form th:action="@{/contact}" method="post" role="form" class="php-email-form" data-recaptcha-site-key="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI">
-              <div class="row">
-                <div class="col-md-6 form-group">
-                  <input type="text" name="name" class="form-control" id="name" placeholder="Tu Nombre" required>
-                </div>
-                <div class="col-md-6 form-group mt-3 mt-md-0">
-                  <input type="email" class="form-control" name="email" id="email" placeholder="Tu Email" required>
-                </div>
-              </div>
-              <div class="form-group mt-3">
-                <input type="text" class="form-control" name="subject" id="subject" placeholder="Asunto" required>
-              </div>
-              <div class="form-group mt-3">
-                <textarea class="form-control" name="message" rows="5" placeholder="Mensaje" required></textarea>
-              </div>
-              <div class="my-3">
-                <div class="loading">Enviando...</div>
-                <div class="error-message"></div>
-                <div class="sent-message">Tu mensaje ha sido enviado. ¡Gracias!</div>
-              </div>
-              <div class="text-center"><button type="submit">Enviar Mensaje</button></div>
-            </form>
+            <div th:replace="~{eterna/fragments/contact-form :: contactForm}"></div>
           </div>
         </div>
 

--- a/src/main/resources/templates/sbadmin/contact-inquiries/listado.html
+++ b/src/main/resources/templates/sbadmin/contact-inquiries/listado.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <link th:href="@{/eterna/assets/img/favicon.png}" rel="icon">
+  <title>Minutriporcion - Mensajes de contacto</title>
+  <link th:href="@{/sbadmin/vendor/fontawesome-free/css/all.min.css}" rel="stylesheet" type="text/css">
+  <link th:href="@{/sbadmin/vendor/datatables/dataTables.bootstrap4.min.css}" rel="stylesheet">
+  <link
+    href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
+    rel="stylesheet">
+  <link th:href="@{/sbadmin/css/sb-admin-2.min.css}" rel="stylesheet">
+</head>
+
+<body id="page-top">
+  <div id="wrapper">
+    <div th:insert="~{sbadmin/sidebar :: sidebar}"></div>
+    <div id="content-wrapper" class="d-flex flex-column">
+      <div id="content">
+        <div th:insert="~{sbadmin/topbar :: topbar}"></div>
+        <div class="container-fluid">
+          <div class="d-sm-flex align-items-center justify-content-between mb-4">
+            <h1 class="h3 mb-0 text-gray-800">Mensajes de contacto</h1>
+          </div>
+          <div class="card shadow mb-4">
+            <div class="card-header py-3">
+              <h6 class="m-0 font-weight-bold text-primary">Solicitudes enviadas desde el sitio público</h6>
+            </div>
+            <div class="card-body">
+              <div class="table-responsive">
+                <table class="table table-bordered" id="contactInquiriesTable" width="100%" cellspacing="0">
+                  <thead>
+                    <tr>
+                      <th>Fecha</th>
+                      <th>Nombre</th>
+                      <th>Email</th>
+                      <th>Asunto</th>
+                      <th>Mensaje</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr th:each="inquiry : ${inquiries}">
+                      <td th:text="${#temporals.format(inquiry.createdAt, 'dd/MM/yyyy HH:mm')}">01/01/2026</td>
+                      <td th:text="${inquiry.name}">Nombre</td>
+                      <td th:text="${inquiry.email}">email@example.com</td>
+                      <td th:text="${inquiry.subject}">Asunto</td>
+                      <td th:text="${inquiry.message}">Mensaje</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <p th:if="${#lists.isEmpty(inquiries)}" class="text-muted mb-0">No hay mensajes de contacto todavía.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div th:insert="~{sbadmin/footer :: footer}"></div>
+    </div>
+  </div>
+  <script th:src="@{/sbadmin/vendor/jquery/jquery.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/bootstrap/js/bootstrap.bundle.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/jquery-easing/jquery.easing.min.js}"></script>
+  <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/datatables/jquery.dataTables.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/datatables/dataTables.bootstrap4.min.js}"></script>
+  <script th:inline="javascript">
+    $(document).ready(function () {
+      $('#contactInquiriesTable').DataTable({
+        order: [[0, 'desc']],
+        language: {
+          url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/es-ES.json'
+        }
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/src/main/resources/templates/sbadmin/contact-inquiries/listado.html
+++ b/src/main/resources/templates/sbadmin/contact-inquiries/listado.html
@@ -34,20 +34,42 @@
                 <table class="table table-bordered" id="contactInquiriesTable" width="100%" cellspacing="0">
                   <thead>
                     <tr>
+                      <th>Estado</th>
                       <th>Fecha</th>
                       <th>Nombre</th>
                       <th>Email</th>
                       <th>Asunto</th>
                       <th>Mensaje</th>
+                      <th>Acciones</th>
                     </tr>
                   </thead>
                   <tbody>
-                    <tr th:each="inquiry : ${inquiries}">
+                    <tr th:each="inquiry : ${inquiries}"
+                      th:classappend="${!inquiry.readByAdmin} ? 'table-warning' : ''">
+                      <td>
+                        <span th:if="${inquiry.readByAdmin}" class="badge badge-secondary">Leído</span>
+                        <span th:unless="${inquiry.readByAdmin}" class="badge badge-primary">Nuevo</span>
+                      </td>
                       <td th:text="${#temporals.format(inquiry.createdAt, 'dd/MM/yyyy HH:mm')}">01/01/2026</td>
                       <td th:text="${inquiry.name}">Nombre</td>
                       <td th:text="${inquiry.email}">email@example.com</td>
                       <td th:text="${inquiry.subject}">Asunto</td>
                       <td th:text="${inquiry.message}">Mensaje</td>
+                      <td class="text-nowrap">
+                        <form th:if="${!inquiry.readByAdmin}"
+                          th:action="@{/admin/contact-inquiries/{id}/read(id=${inquiry.id})}" method="post"
+                          class="d-inline">
+                          <button type="submit" class="btn btn-sm btn-success" title="Marcar como leído">
+                            <i class="fas fa-check"></i>
+                          </button>
+                        </form>
+                        <form th:action="@{/admin/contact-inquiries/{id}/delete(id=${inquiry.id})}" method="post"
+                          class="d-inline" onsubmit="return confirm('¿Eliminar este mensaje de contacto?');">
+                          <button type="submit" class="btn btn-sm btn-danger" title="Eliminar">
+                            <i class="fas fa-trash"></i>
+                          </button>
+                        </form>
+                      </td>
                     </tr>
                   </tbody>
                 </table>
@@ -69,10 +91,13 @@
   <script th:inline="javascript">
     $(document).ready(function () {
       $('#contactInquiriesTable').DataTable({
-        order: [[0, 'desc']],
+        order: [[1, 'desc']],
         language: {
           url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/es-ES.json'
-        }
+        },
+        columnDefs: [
+          { orderable: false, targets: [6] }
+        ]
       });
     });
   </script>

--- a/src/main/resources/templates/sbadmin/footer.html
+++ b/src/main/resources/templates/sbadmin/footer.html
@@ -8,4 +8,5 @@
     </div>
   </footer>
   <!-- End of Footer -->
+  <div th:insert="~{sbadmin/fragments/patient-messages-widget :: widget}"></div>
 </div>

--- a/src/main/resources/templates/sbadmin/fragments/patient-messages-widget.html
+++ b/src/main/resources/templates/sbadmin/fragments/patient-messages-widget.html
@@ -1,0 +1,38 @@
+<div th:fragment="widget">
+  <link rel="stylesheet" th:href="@{/sbadmin/css/patient-messages-widget.css}" />
+  <div id="patientChatRoot" aria-live="polite">
+    <div id="patientChatPanel" hidden>
+      <div id="patientChatHeader">
+        <button type="button" id="patientChatBackBtn" class="patient-chat-icon-btn" title="Volver" hidden>
+          <i class="fas fa-arrow-left"></i>
+        </button>
+        <h2 id="patientChatTitle">Mensajes de pacientes</h2>
+        <button type="button" id="patientChatClose" class="patient-chat-icon-btn" title="Cerrar">
+          <i class="fas fa-times"></i>
+        </button>
+      </div>
+      <div id="patientChatBody">
+        <p id="patientChatProfileHint" hidden>Conversación con el paciente de este perfil.</p>
+        <div id="patientChatGlobalView">
+          <div id="patientChatUnreadList">
+            <p class="patient-chat-empty">Cargando mensajes…</p>
+          </div>
+        </div>
+        <div id="patientChatThreadView" hidden>
+          <div id="patientChatMessages"></div>
+          <div id="patientChatComposer">
+            <textarea id="patientChatInput" rows="2" maxlength="2000" placeholder="Escribe un mensaje…"></textarea>
+            <button type="button" id="patientChatSendBtn" title="Enviar">
+              <i class="fas fa-paper-plane"></i>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <button type="button" id="patientChatToggle" title="Mensajes de pacientes" aria-label="Mensajes de pacientes">
+      <i class="fas fa-comments fa-lg"></i>
+      <span id="patientChatBadge" hidden>0</span>
+    </button>
+  </div>
+  <script th:src="@{/sbadmin/js/patient-messages-widget.js}" defer></script>
+</div>

--- a/src/main/resources/templates/sbadmin/pacientes/perfil.html
+++ b/src/main/resources/templates/sbadmin/pacientes/perfil.html
@@ -242,6 +242,13 @@
   </div>
   <!-- End of Page Wrapper -->
 
+  <script th:inline="javascript">
+    window.PATIENT_CHAT_CONTEXT = {
+      pacienteId: /*[[${paciente.id}]]*/ 0,
+      pacienteName: /*[[${paciente.name}]]*/ ''
+    };
+  </script>
+
   <!-- Bootstrap core JavaScript-->
   <script th:src="@{/sbadmin/vendor/jquery/jquery.min.js}"></script>
   <script th:src="@{/sbadmin/vendor/bootstrap/js/bootstrap.bundle.min.js}"></script>

--- a/src/main/resources/templates/sbadmin/sidebar.html
+++ b/src/main/resources/templates/sbadmin/sidebar.html
@@ -58,6 +58,11 @@
         <i class="fas fa-fw fa-user-md"></i>
         <span>Mi Perfil</span></a>
     </li>
+    <li class="nav-item" th:if="${platformAdmin}" th:classappend="${activeMenu == 'contact-inquiries' ? 'active' : ''}">
+      <a class="nav-link" th:href="@{/admin/contact-inquiries}">
+        <i class="fas fa-fw fa-envelope"></i>
+        <span>Mensajes de contacto</span></a>
+    </li>
 
     <!-- Divider -->
     <hr class="sidebar-divider d-none d-md-block">

--- a/src/test/java/com/nutriconsultas/admin/ContactInquiryAdminControllerTest.java
+++ b/src/test/java/com/nutriconsultas/admin/ContactInquiryAdminControllerTest.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.admin;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nutriconsultas.contact.ContactInquiryService;
+import com.nutriconsultas.platform.PlatformAdminService;
+
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+@ExtendWith(MockitoExtension.class)
+class ContactInquiryAdminControllerTest {
+
+	@InjectMocks
+	private ContactInquiryAdminController controller;
+
+	@Mock
+	private ContactInquiryService contactInquiryService;
+
+	@Mock
+	private PlatformAdminService platformAdminService;
+
+	@Mock
+	private OidcUser principal;
+
+	@Test
+	void list_whenNotPlatformAdmin_throwsForbidden() {
+		when(platformAdminService.isPlatformAdmin(principal)).thenReturn(false);
+
+		assertThatThrownBy(() -> controller.list(principal, new ExtendedModelMap()))
+			.isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode().value())
+			.isEqualTo(403);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/admin/ContactInquiryAdminControllerTest.java
+++ b/src/test/java/com/nutriconsultas/admin/ContactInquiryAdminControllerTest.java
@@ -1,6 +1,8 @@
 package com.nutriconsultas.admin;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
@@ -39,6 +41,44 @@ class ContactInquiryAdminControllerTest {
 			.isInstanceOf(ResponseStatusException.class)
 			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode().value())
 			.isEqualTo(403);
+	}
+
+	@Test
+	void markAsRead_whenNotPlatformAdmin_throwsForbidden() {
+		when(platformAdminService.isPlatformAdmin(principal)).thenReturn(false);
+
+		assertThatThrownBy(() -> controller.markAsRead(principal, 1L)).isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode().value())
+			.isEqualTo(403);
+	}
+
+	@Test
+	void markAsRead_whenPlatformAdmin_redirectsToList() {
+		when(platformAdminService.isPlatformAdmin(principal)).thenReturn(true);
+
+		final String view = controller.markAsRead(principal, 1L);
+
+		verify(contactInquiryService).markAsRead(1L);
+		assertThat(view).isEqualTo("redirect:/admin/contact-inquiries");
+	}
+
+	@Test
+	void delete_whenNotPlatformAdmin_throwsForbidden() {
+		when(platformAdminService.isPlatformAdmin(principal)).thenReturn(false);
+
+		assertThatThrownBy(() -> controller.delete(principal, 1L)).isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode().value())
+			.isEqualTo(403);
+	}
+
+	@Test
+	void delete_whenPlatformAdmin_redirectsToList() {
+		when(platformAdminService.isPlatformAdmin(principal)).thenReturn(true);
+
+		final String view = controller.delete(principal, 1L);
+
+		verify(contactInquiryService).deleteById(1L);
+		assertThat(view).isEqualTo("redirect:/admin/contact-inquiries");
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/contact/ContactInquiryServiceTest.java
+++ b/src/test/java/com/nutriconsultas/contact/ContactInquiryServiceTest.java
@@ -1,9 +1,13 @@
 package com.nutriconsultas.contact;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,6 +15,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.nutriconsultas.controller.ContactForm;
 
@@ -47,6 +53,60 @@ class ContactInquiryServiceTest {
 		assertThat(captor.getValue().getSubject()).isEqualTo("Acceso");
 		assertThat(captor.getValue().getMessage()).isEqualTo("Quiero solicitar acceso");
 		assertThat(captor.getValue().isReadByAdmin()).isFalse();
+	}
+
+	@Test
+	void markAsRead_setsReadByAdminTrue() {
+		final ContactInquiry inquiry = new ContactInquiry();
+		inquiry.setId(5L);
+		inquiry.setReadByAdmin(false);
+		when(contactInquiryRepository.findById(5L)).thenReturn(Optional.of(inquiry));
+		when(contactInquiryRepository.save(any(ContactInquiry.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		contactInquiryService.markAsRead(5L);
+
+		assertThat(inquiry.isReadByAdmin()).isTrue();
+		verify(contactInquiryRepository).save(inquiry);
+	}
+
+	@Test
+	void markAsRead_whenAlreadyRead_doesNotSave() {
+		final ContactInquiry inquiry = new ContactInquiry();
+		inquiry.setId(5L);
+		inquiry.setReadByAdmin(true);
+		when(contactInquiryRepository.findById(5L)).thenReturn(Optional.of(inquiry));
+
+		contactInquiryService.markAsRead(5L);
+
+		verify(contactInquiryRepository, never()).save(any(ContactInquiry.class));
+	}
+
+	@Test
+	void markAsRead_whenNotFound_throwsNotFound() {
+		when(contactInquiryRepository.findById(99L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> contactInquiryService.markAsRead(99L)).isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+			.isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	void deleteById_removesInquiry() {
+		when(contactInquiryRepository.existsById(7L)).thenReturn(true);
+
+		contactInquiryService.deleteById(7L);
+
+		verify(contactInquiryRepository).deleteById(7L);
+	}
+
+	@Test
+	void deleteById_whenNotFound_throwsNotFound() {
+		when(contactInquiryRepository.existsById(99L)).thenReturn(false);
+
+		assertThatThrownBy(() -> contactInquiryService.deleteById(99L)).isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+			.isEqualTo(HttpStatus.NOT_FOUND);
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/contact/ContactInquiryServiceTest.java
+++ b/src/test/java/com/nutriconsultas/contact/ContactInquiryServiceTest.java
@@ -1,0 +1,52 @@
+package com.nutriconsultas.contact;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.controller.ContactForm;
+
+@ExtendWith(MockitoExtension.class)
+class ContactInquiryServiceTest {
+
+	@InjectMocks
+	private ContactInquiryService contactInquiryService;
+
+	@Mock
+	private ContactInquiryRepository contactInquiryRepository;
+
+	@Test
+	void saveFromForm_persistsInquiry() {
+		final ContactForm form = new ContactForm();
+		form.setName("Ana López");
+		form.setEmail("ana@example.com");
+		form.setSubject("Acceso");
+		form.setMessage("Quiero solicitar acceso");
+
+		when(contactInquiryRepository.save(any(ContactInquiry.class))).thenAnswer(invocation -> {
+			final ContactInquiry inquiry = invocation.getArgument(0);
+			inquiry.setId(10L);
+			return inquiry;
+		});
+
+		final ContactInquiry saved = contactInquiryService.saveFromForm(form);
+
+		final ArgumentCaptor<ContactInquiry> captor = ArgumentCaptor.forClass(ContactInquiry.class);
+		verify(contactInquiryRepository).save(captor.capture());
+		assertThat(saved.getId()).isEqualTo(10L);
+		assertThat(captor.getValue().getName()).isEqualTo("Ana López");
+		assertThat(captor.getValue().getEmail()).isEqualTo("ana@example.com");
+		assertThat(captor.getValue().getSubject()).isEqualTo("Acceso");
+		assertThat(captor.getValue().getMessage()).isEqualTo("Quiero solicitar acceso");
+		assertThat(captor.getValue().isReadByAdmin()).isFalse();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/controller/WebControllerTest.java
+++ b/src/test/java/com/nutriconsultas/controller/WebControllerTest.java
@@ -1,5 +1,6 @@
 package com.nutriconsultas.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -15,6 +16,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import com.nutriconsultas.contact.ContactInquiryRepository;
+
 import lombok.extern.slf4j.Slf4j;
 
 @SpringBootTest
@@ -25,6 +28,9 @@ public class WebControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;
+
+	@Autowired
+	private ContactInquiryRepository contactInquiryRepository;
 
 	@Test
 	public void testIndex() throws Exception {
@@ -42,6 +48,29 @@ public class WebControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(MockMvcResultMatchers.view().name("eterna/index"));
 		log.info("Finishing testIndexWithTrailingSlash");
+	}
+
+	@Test
+	public void testContactPage() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.get("/contact"))
+			.andExpect(status().isOk())
+			.andExpect(MockMvcResultMatchers.view().name("eterna/contact"));
+	}
+
+	@Test
+	public void testContactFormSuccess() throws Exception {
+		final long before = contactInquiryRepository.count();
+		mockMvc
+			.perform(MockMvcRequestBuilders.post("/contact")
+				.contentType(Objects.requireNonNull(MediaType.APPLICATION_FORM_URLENCODED))
+				.param("name", "Test User")
+				.param("email", "test@example.com")
+				.param("subject", "Test Subject")
+				.param("message", "Test message")
+				.param("recaptcha-response", "test-token"))
+			.andExpect(status().isOk())
+			.andExpect(content().string("OK"));
+		assertThat(contactInquiryRepository.count()).isEqualTo(before + 1);
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/message/PatientMessageRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/message/PatientMessageRestControllerTest.java
@@ -1,0 +1,94 @@
+package com.nutriconsultas.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+
+import com.nutriconsultas.message.dto.PatientMessageThreadItemDto;
+import com.nutriconsultas.message.dto.PatientUnreadMessageDto;
+import com.nutriconsultas.message.dto.SendPatientMessageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class PatientMessageRestControllerTest {
+
+	private static final String USER_ID = "auth0|nutritionist";
+
+	@InjectMocks
+	private PatientMessageRestController controller;
+
+	@Mock
+	private PatientMessageService patientMessageService;
+
+	@Test
+	void listUnread_returnsSummaries() {
+		when(patientMessageService.listUnreadSummaries(USER_ID)).thenReturn(List
+			.of(new PatientUnreadMessageDto(1L, "Ana López", "Hola doctor", Instant.parse("2026-06-01T10:00:00Z"), 1)));
+
+		final List<PatientUnreadMessageDto> result = controller.listUnread(oidcUser());
+
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).pacienteName()).isEqualTo("Ana López");
+	}
+
+	@Test
+	void listThread_returnsMessages() {
+		when(patientMessageService.listThread(eq(1L), eq(USER_ID)))
+			.thenReturn(List.of(new PatientMessageThreadItemDto(5L, Instant.parse("2026-06-01T10:00:00Z"),
+					MessageSenderRole.PATIENT, "Hola")));
+
+		final List<PatientMessageThreadItemDto> result = controller.listThread(oidcUser(), 1L);
+
+		assertThat(result.get(0).body()).isEqualTo("Hola");
+	}
+
+	@Test
+	void sendMessage_returnsCreatedMessage() {
+		when(patientMessageService.sendAsNutritionist(eq(1L), eq(USER_ID), eq("Respuesta")))
+			.thenReturn(new PatientMessageThreadItemDto(9L, Instant.parse("2026-06-01T11:00:00Z"),
+					MessageSenderRole.NUTRITIONIST, "Respuesta"));
+
+		final PatientMessageThreadItemDto result = controller.sendMessage(oidcUser(), 1L,
+				new SendPatientMessageRequest("Respuesta"));
+
+		assertThat(result.body()).isEqualTo("Respuesta");
+	}
+
+	@Test
+	void markRead_returnsOk() {
+		final Map<String, String> result = controller.markRead(oidcUser(), 1L);
+
+		verify(patientMessageService).markThreadReadByNutritionist(1L, USER_ID);
+		assertThat(result.get("status")).isEqualTo("ok");
+	}
+
+	@Test
+	void countUnread_returnsCount() {
+		when(patientMessageService.countUnread(USER_ID)).thenReturn(3L);
+
+		final Map<String, Long> result = controller.countUnread(oidcUser());
+
+		assertThat(result.get("count")).isEqualTo(3L);
+	}
+
+	private static DefaultOidcUser oidcUser() {
+		final OidcIdToken token = OidcIdToken.withTokenValue("token")
+			.claim("sub", USER_ID)
+			.claim("name", "Nutritionist")
+			.build();
+		return new DefaultOidcUser(List.of(), token);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/message/PatientMessageServiceTest.java
+++ b/src/test/java/com/nutriconsultas/message/PatientMessageServiceTest.java
@@ -1,0 +1,139 @@
+package com.nutriconsultas.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nutriconsultas.message.dto.PatientMessageThreadItemDto;
+import com.nutriconsultas.message.dto.PatientUnreadMessageDto;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PatientMessageServiceTest {
+
+	private static final String USER_ID = "auth0|nutritionist";
+
+	@InjectMocks
+	private PatientMessageService patientMessageService;
+
+	@Mock
+	private PatientMessageRepository patientMessageRepository;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Test
+	void listThread_returnsAscendingMessages() {
+		final Paciente paciente = samplePaciente(1L);
+		final PatientMessage message = sampleMessage(paciente, MessageSenderRole.PATIENT, "Hola");
+		when(pacienteRepository.findByIdAndUserId(1L, USER_ID)).thenReturn(Optional.of(paciente));
+		when(patientMessageRepository.findThreadAscending(1L, USER_ID)).thenReturn(List.of(message));
+
+		final List<PatientMessageThreadItemDto> thread = patientMessageService.listThread(1L, USER_ID);
+
+		assertThat(thread).hasSize(1);
+		assertThat(thread.get(0).body()).isEqualTo("Hola");
+	}
+
+	@Test
+	void listUnreadSummaries_groupsByPatient() {
+		final Paciente paciente = samplePaciente(1L);
+		final PatientMessage first = sampleMessage(paciente, MessageSenderRole.PATIENT, "Uno");
+		first.setReadByNutritionist(false);
+		final PatientMessage second = sampleMessage(paciente, MessageSenderRole.PATIENT, "Dos");
+		second.setReadByNutritionist(false);
+		when(patientMessageRepository.findUnreadFromPatientsByNutritionist(USER_ID)).thenReturn(List.of(first, second));
+
+		final List<PatientUnreadMessageDto> summaries = patientMessageService.listUnreadSummaries(USER_ID);
+
+		assertThat(summaries).hasSize(1);
+		assertThat(summaries.get(0).pacienteId()).isEqualTo(1L);
+		assertThat(summaries.get(0).unreadCount()).isEqualTo(2);
+	}
+
+	@Test
+	void sendAsNutritionist_persistsMessage() {
+		final Paciente paciente = samplePaciente(1L);
+		when(pacienteRepository.findByIdAndUserId(1L, USER_ID)).thenReturn(Optional.of(paciente));
+		when(patientMessageRepository.save(any(PatientMessage.class))).thenAnswer(invocation -> {
+			final PatientMessage saved = invocation.getArgument(0);
+			saved.setId(99L);
+			saved.setSentAt(Instant.parse("2026-06-01T12:00:00Z"));
+			return saved;
+		});
+
+		final PatientMessageThreadItemDto sent = patientMessageService.sendAsNutritionist(1L, USER_ID, "Respuesta");
+
+		assertThat(sent.id()).isEqualTo(99L);
+		assertThat(sent.senderRole()).isEqualTo(MessageSenderRole.NUTRITIONIST);
+		final ArgumentCaptor<PatientMessage> captor = ArgumentCaptor.forClass(PatientMessage.class);
+		verify(patientMessageRepository).save(captor.capture());
+		assertThat(captor.getValue().getBody()).isEqualTo("Respuesta");
+		assertThat(captor.getValue().isReadByNutritionist()).isTrue();
+		assertThat(captor.getValue().isReadByPatient()).isFalse();
+	}
+
+	@Test
+	void sendAsNutritionist_whenBodyBlank_throwsBadRequest() {
+		final Paciente paciente = samplePaciente(1L);
+		when(pacienteRepository.findByIdAndUserId(1L, USER_ID)).thenReturn(Optional.of(paciente));
+
+		assertThatThrownBy(() -> patientMessageService.sendAsNutritionist(1L, USER_ID, "   "))
+			.isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+			.isEqualTo(HttpStatus.BAD_REQUEST);
+
+		verify(patientMessageRepository, never()).save(any(PatientMessage.class));
+	}
+
+	@Test
+	void markThreadReadByNutritionist_delegatesToRepository() {
+		final Paciente paciente = samplePaciente(1L);
+		when(pacienteRepository.findByIdAndUserId(1L, USER_ID)).thenReturn(Optional.of(paciente));
+		when(patientMessageRepository.markReadByNutritionist(1L, USER_ID)).thenReturn(2);
+
+		patientMessageService.markThreadReadByNutritionist(1L, USER_ID);
+
+		verify(patientMessageRepository).markReadByNutritionist(1L, USER_ID);
+	}
+
+	private static Paciente samplePaciente(final Long id) {
+		final Paciente paciente = new Paciente();
+		paciente.setId(id);
+		paciente.setName("Ana López");
+		paciente.setUserId(USER_ID);
+		paciente.setDob(new java.util.Date());
+		paciente.setGender("F");
+		return paciente;
+	}
+
+	private static PatientMessage sampleMessage(final Paciente paciente, final MessageSenderRole role,
+			final String body) {
+		final PatientMessage message = new PatientMessage();
+		message.setId(10L);
+		message.setPaciente(paciente);
+		message.setNutritionistUserId(USER_ID);
+		message.setSenderRole(role);
+		message.setBody(body);
+		message.setSentAt(Instant.parse("2026-06-01T10:00:00Z"));
+		return message;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageControllerTest.java
@@ -1,0 +1,63 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.nutriconsultas.message.MessageSenderRole;
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.CursorPagedResponse;
+import com.nutriconsultas.mobile.dto.PatientMessageSummaryDto;
+import com.nutriconsultas.paciente.Paciente;
+
+@ExtendWith(MockitoExtension.class)
+class MobilePatientMessageControllerTest {
+
+	private static final String PATIENT_SUB = "auth0|mobile-message-patient";
+
+	@InjectMocks
+	private MobilePatientMessageController controller;
+
+	@Mock
+	private PatientAuthService patientAuthService;
+
+	@Mock
+	private MobilePatientMessageService mobilePatientMessageService;
+
+	@Test
+	void listMessages_returnsApiResponseEnvelope() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(5L);
+		final PatientMessageSummaryDto summary = new PatientMessageSummaryDto(1L, Instant.parse("2026-06-01T12:00:00Z"),
+				MessageSenderRole.PATIENT, "Hola", true);
+		final CursorPagedResponse<PatientMessageSummaryDto> page = CursorPagedResponse.of(List.of(summary), null);
+		final Jwt jwt = jwtWithSub(PATIENT_SUB);
+
+		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);
+		when(mobilePatientMessageService.listMessages(eq(5L), eq(null), eq(20))).thenReturn(page);
+
+		final ApiResponse<CursorPagedResponse<PatientMessageSummaryDto>> response = controller.listMessages(jwt, null,
+				20);
+
+		assertThat(response.data().content()).hasSize(1);
+		assertThat(response.data().content().get(0).body()).isEqualTo("Hola");
+		assertThat(response.timestamp()).isNotNull();
+		verify(mobilePatientMessageService).listMessages(5L, null, 20);
+	}
+
+	private static Jwt jwtWithSub(final String subject) {
+		return Jwt.withTokenValue("token").header("alg", "none").subject(subject).build();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageIntegrationTest.java
@@ -57,6 +57,7 @@ class MobilePatientMessageIntegrationTest {
 				message.setBody("Bienvenido a tu consultorio digital");
 				message.setSentAt(Instant.parse("2026-06-01T10:00:00Z"));
 				message.setReadByPatient(false);
+				message.setReadByNutritionist(true);
 				return patientMessageRepository.saveAndFlush(message);
 			});
 	}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.nutriconsultas.mobile;
+
+import static com.nutriconsultas.mobile.MobileIntegrationTestJwt.mobileJwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.nutriconsultas.message.MessageSenderRole;
+import com.nutriconsultas.message.PatientMessage;
+import com.nutriconsultas.message.PatientMessageRepository;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MobilePatientMessageIntegrationTest {
+
+	private static final String LINKED_SUB = "auth0|mobile-message-integration";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@Autowired
+	private PatientMessageRepository patientMessageRepository;
+
+	private Paciente linkedPaciente;
+
+	@BeforeEach
+	void seedData() {
+		linkedPaciente = pacienteRepository.findByPatientAuthSub(LINKED_SUB).orElseGet(() -> {
+			final Paciente paciente = samplePaciente(LINKED_SUB);
+			return pacienteRepository.saveAndFlush(paciente);
+		});
+		patientMessageRepository
+			.findThreadForPatient(linkedPaciente.getId(), null, org.springframework.data.domain.PageRequest.of(0, 1))
+			.stream()
+			.findFirst()
+			.orElseGet(() -> {
+				final PatientMessage message = new PatientMessage();
+				message.setPaciente(linkedPaciente);
+				message.setNutritionistUserId(linkedPaciente.getUserId());
+				message.setSenderRole(MessageSenderRole.NUTRITIONIST);
+				message.setBody("Bienvenido a tu consultorio digital");
+				message.setSentAt(Instant.parse("2026-06-01T10:00:00Z"));
+				message.setReadByPatient(false);
+				return patientMessageRepository.saveAndFlush(message);
+			});
+	}
+
+	@Test
+	void listMessagesWithLinkedJwtReturnsCursorPage() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/messages").with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content").isArray())
+			.andExpect(jsonPath("$.data.content[0].senderRole").value("NUTRITIONIST"))
+			.andExpect(jsonPath("$.data.content[0].body").value("Bienvenido a tu consultorio digital"))
+			.andExpect(jsonPath("$.data.content[0].read").value(false))
+			.andExpect(jsonPath("$.timestamp").exists());
+	}
+
+	@Test
+	void listMessagesForUnlinkedJwtReturnsForbidden() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/messages").with(mobileJwt("auth0|mobile-message-unlinked")))
+			.andExpect(status().isForbidden());
+	}
+
+	private static Paciente samplePaciente(final String patientAuthSub) {
+		final Paciente paciente = new Paciente();
+		paciente.setName("Paciente mensajes");
+		paciente.setUserId("auth0|nutritionist-owner");
+		paciente.setPatientAuthSub(patientAuthSub);
+		paciente.setDob(new java.util.Date());
+		paciente.setGender("F");
+		return paciente;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageServiceTest.java
@@ -1,0 +1,83 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import com.nutriconsultas.message.MessageSenderRole;
+import com.nutriconsultas.message.PatientMessage;
+import com.nutriconsultas.message.PatientMessageRepository;
+import com.nutriconsultas.mobile.dto.CursorPagedResponse;
+import com.nutriconsultas.mobile.dto.PatientMessageSummaryDto;
+import com.nutriconsultas.paciente.Paciente;
+
+@ExtendWith(MockitoExtension.class)
+class MobilePatientMessageServiceTest {
+
+	@InjectMocks
+	private MobilePatientMessageService service;
+
+	@Mock
+	private PatientMessageRepository patientMessageRepository;
+
+	@Test
+	void listMessages_returnsCursorPageWithoutNextWhenNoMore() {
+		final PatientMessage message = sampleMessage(42L, "Hola nutrióloga");
+		when(patientMessageRepository.findThreadForPatient(eq(5L), isNull(), org.mockito.ArgumentMatchers.any()))
+			.thenReturn(List.of(message));
+
+		final CursorPagedResponse<PatientMessageSummaryDto> page = service.listMessages(5L, null, 20);
+
+		assertThat(page.content()).hasSize(1);
+		assertThat(page.content().get(0).id()).isEqualTo(42L);
+		assertThat(page.content().get(0).body()).isEqualTo("Hola nutrióloga");
+		assertThat(page.content().get(0).senderRole()).isEqualTo(MessageSenderRole.NUTRITIONIST);
+		assertThat(page.hasMore()).isFalse();
+		assertThat(page.nextCursor()).isNull();
+	}
+
+	@Test
+	void listMessages_returnsNextCursorWhenMoreResultsExist() {
+		final PatientMessage first = sampleMessage(100L, "Mensaje 1");
+		final PatientMessage second = sampleMessage(99L, "Mensaje 2");
+		final PatientMessage extra = sampleMessage(98L, "Mensaje 3");
+		when(patientMessageRepository.findThreadForPatient(eq(5L), isNull(), org.mockito.ArgumentMatchers.any()))
+			.thenAnswer(invocation -> {
+				final Pageable pageable = invocation.getArgument(2);
+				assertThat(pageable.getPageSize()).isEqualTo(3);
+				return List.of(first, second, extra);
+			});
+
+		final CursorPagedResponse<PatientMessageSummaryDto> page = service.listMessages(5L, null, 2);
+
+		assertThat(page.content()).hasSize(2);
+		assertThat(page.hasMore()).isTrue();
+		assertThat(page.nextCursor()).isEqualTo("99");
+	}
+
+	private static PatientMessage sampleMessage(final Long id, final String body) {
+		final Paciente paciente = new Paciente();
+		paciente.setId(5L);
+		final PatientMessage message = new PatientMessage();
+		message.setId(id);
+		message.setPaciente(paciente);
+		message.setNutritionistUserId("auth0|nutritionist");
+		message.setSenderRole(MessageSenderRole.NUTRITIONIST);
+		message.setBody(body);
+		message.setSentAt(Instant.parse("2026-06-01T12:00:00Z"));
+		message.setReadByPatient(false);
+		return message;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/platform/PlatformAdminServiceTest.java
+++ b/src/test/java/com/nutriconsultas/platform/PlatformAdminServiceTest.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.platform;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+class PlatformAdminServiceTest {
+
+	@Test
+	void isPlatformAdmin_returnsTrueForConfiguredUserId() {
+		final PlatformAdminProperties properties = new PlatformAdminProperties();
+		properties.setAdminUserIds(java.util.List.of("auth0|admin-one", "auth0|admin-two"));
+		final PlatformAdminService service = new PlatformAdminService(properties);
+
+		assertThat(service.isPlatformAdminByUserId("auth0|admin-one")).isTrue();
+		assertThat(service.isPlatformAdminByUserId("auth0|admin-two")).isTrue();
+		assertThat(service.isPlatformAdminByUserId("auth0|regular-user")).isFalse();
+		assertThat(service.isPlatformAdminByUserId(null)).isFalse();
+		assertThat(service.isPlatformAdminByUserId("")).isFalse();
+	}
+
+	@Test
+	void isPlatformAdmin_returnsTrueForConfiguredEmail() {
+		final PlatformAdminProperties properties = new PlatformAdminProperties();
+		properties.setAdminEmails(java.util.List.of("Admin@Example.com"));
+		final PlatformAdminService service = new PlatformAdminService(properties);
+		final OidcUser principal = mock(OidcUser.class);
+		when(principal.getSubject()).thenReturn("auth0|regular-user");
+		when(principal.getEmail()).thenReturn("admin@example.com");
+
+		assertThat(service.isPlatformAdmin(principal)).isTrue();
+	}
+
+	@Test
+	void isPlatformAdmin_returnsFalseWhenPrincipalIsNull() {
+		final PlatformAdminService service = new PlatformAdminService(new PlatformAdminProperties());
+
+		assertThat(service.isPlatformAdmin(null)).isFalse();
+	}
+
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -19,6 +19,7 @@ amazon.s3.bucket=${AWS_BUCKET:noval}
 amazon.s3.key=${AWS_KEY:noval}
 amazon.s3.secret=${AWS_SECRET:noval}
 amazon.s3.region=us-east-1
-# reCAPTCHA configuration (using Google test key for testing)
+# reCAPTCHA configuration (Google test keys for testing)
+recaptcha.site-key=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 recaptcha.secret-key=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
 nutriconsultas.platform.admin-user-ids=auth0|platform-admin-test

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -21,3 +21,4 @@ amazon.s3.secret=${AWS_SECRET:noval}
 amazon.s3.region=us-east-1
 # reCAPTCHA configuration (using Google test key for testing)
 recaptcha.secret-key=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+nutriconsultas.platform.admin-user-ids=auth0|platform-admin-test


### PR DESCRIPTION
## Summary
- Adds `GET /rest/mobile/patient/messages` with cursor-based pagination for the patient–nutritionist thread (#96).
- Persists public contact form submissions (`ContactInquiry`) and exposes them to platform admins at `/admin/contact-inquiries`.
- Wires `contact.html` to `POST /contact`, configures platform admins via `PLATFORM_ADMIN_EMAILS` (Terraform `platform_admin_emails` + local `.env.example`).

Closes #96

## Test plan
- [ ] `mvn test` passes locally
- [ ] Submit contact form on `/` or `/contact` and verify row in DB / admin inbox
- [ ] Log in as a configured platform admin email and open `/admin/contact-inquiries`
- [ ] Call `GET /rest/mobile/patient/messages` with a linked patient JWT and verify cursor pagination
- [ ] After merge: set `platform_admin_emails` in gitignored `terraform.tfvars` (or `PLATFORM_ADMIN_EMAILS` on EC2) and restart app if needed


Made with [Cursor](https://cursor.com)