### PR TITLE
feat(mobile-api): add POST /rest/mobile/patient/messages (#97)

### DIFF
--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-14 — **#96 done** (in progress on branch). Contact form persisted; platform admin inbox at `/admin/contact-inquiries`.
+**Last updated:** 2026-06-14 — **#97 in progress** on branch `mobile-api/97-patient-send-message`. **#96 done** on `main`.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116) plus the directly-related `[Dashboard]` IMC gauge (#106). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -98,8 +98,8 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 
 | # | Endpoint | URL | State | Backend source |
 |---|----------|-----|-------|----------------|
-| 96 | `GET /rest/mobile/patient/messages` — list thread | https://github.com/diego-torres/nutriconsultas/issues/96 | **done** (branch) | NEW entity/repo/service; **cursor** pagination; contact form → `ContactInquiry`; admin inbox |
-| 97 | `POST /rest/mobile/patient/messages` — send to nutritionist | https://github.com/diego-torres/nutriconsultas/issues/97 | open | `senderRole=PATIENT` from JWT only; `@Valid @Size(max=2000)`; rate limit via #113 |
+| 96 | `GET /rest/mobile/patient/messages` — list thread | https://github.com/diego-torres/nutriconsultas/issues/96 | **done** | Merged PR #146: cursor pagination; contact form → `ContactInquiry`; admin inbox |
+| 97 | `POST /rest/mobile/patient/messages` — send to nutritionist | https://github.com/diego-torres/nutriconsultas/issues/97 | **in-progress** | `senderRole=PATIENT` from JWT only; `@Valid @Size(max=2000)`; rate limit deferred to #113 |
 
 ### Progress — `AnthropometricMeasurement` / `Paciente`
 

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageController.java
@@ -3,6 +3,8 @@ package com.nutriconsultas.mobile;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,9 +12,11 @@ import org.springframework.web.bind.annotation.RestController;
 import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.CursorPagedResponse;
 import com.nutriconsultas.mobile.dto.PatientMessageSummaryDto;
+import com.nutriconsultas.mobile.dto.SendPatientMessageRequest;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.util.LogRedaction;
 
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
@@ -39,6 +43,17 @@ public class MobilePatientMessageController extends AbstractMobilePatientControl
 		final CursorPagedResponse<PatientMessageSummaryDto> messages = mobilePatientMessageService
 			.listMessages(paciente.getId(), cursor, size);
 		return ApiResponse.ok(messages);
+	}
+
+	@PostMapping
+	public ApiResponse<PatientMessageSummaryDto> sendMessage(@AuthenticationPrincipal final Jwt jwt,
+			@Valid @RequestBody final SendPatientMessageRequest request) {
+		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile send message request for patient {}", LogRedaction.redactPaciente(paciente.getId()));
+		}
+		final PatientMessageSummaryDto sent = mobilePatientMessageService.sendMessage(paciente, request.body());
+		return ApiResponse.ok(sent);
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageService.java
@@ -7,10 +7,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import com.nutriconsultas.message.MessageSenderRole;
 import com.nutriconsultas.message.PatientMessage;
 import com.nutriconsultas.message.PatientMessageRepository;
 import com.nutriconsultas.mobile.dto.CursorPagedResponse;
 import com.nutriconsultas.mobile.dto.PatientMessageSummaryDto;
+import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.util.LogRedaction;
 
 import lombok.extern.slf4j.Slf4j;
@@ -47,6 +49,18 @@ public class MobilePatientMessageService {
 					LogRedaction.redactPaciente(pacienteId));
 		}
 		return CursorPagedResponse.of(summaries, nextCursor);
+	}
+
+	@Transactional
+	public PatientMessageSummaryDto sendMessage(final Paciente paciente, final String body) {
+		final PatientMessage message = new PatientMessage();
+		message.setPaciente(paciente);
+		message.setNutritionistUserId(paciente.getUserId());
+		message.setSenderRole(MessageSenderRole.PATIENT);
+		message.setBody(body.trim());
+		final PatientMessage saved = patientMessageRepository.save(message);
+		log.info("Patient sent message: {}", LogRedaction.redactPatientMessage(saved.getId()));
+		return PatientMessageSummaryDto.fromEntity(saved);
 	}
 
 	private Long parseCursor(final String cursor) {

--- a/src/main/java/com/nutriconsultas/mobile/dto/SendPatientMessageRequest.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/SendPatientMessageRequest.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.mobile.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SendPatientMessageRequest(@NotBlank @Size(max = 2000) String body) {
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageControllerTest.java
@@ -19,6 +19,7 @@ import com.nutriconsultas.message.MessageSenderRole;
 import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.CursorPagedResponse;
 import com.nutriconsultas.mobile.dto.PatientMessageSummaryDto;
+import com.nutriconsultas.mobile.dto.SendPatientMessageRequest;
 import com.nutriconsultas.paciente.Paciente;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,6 +55,26 @@ class MobilePatientMessageControllerTest {
 		assertThat(response.data().content().get(0).body()).isEqualTo("Hola");
 		assertThat(response.timestamp()).isNotNull();
 		verify(mobilePatientMessageService).listMessages(5L, null, 20);
+	}
+
+	@Test
+	void sendMessage_returnsCreatedMessageInApiResponseEnvelope() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(5L);
+		final PatientMessageSummaryDto sent = new PatientMessageSummaryDto(9L, Instant.parse("2026-06-01T12:00:00Z"),
+				MessageSenderRole.PATIENT, "Hola doctor", true);
+		final Jwt jwt = jwtWithSub(PATIENT_SUB);
+
+		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);
+		when(mobilePatientMessageService.sendMessage(paciente, "Hola doctor")).thenReturn(sent);
+
+		final ApiResponse<PatientMessageSummaryDto> response = controller.sendMessage(jwt,
+				new SendPatientMessageRequest("Hola doctor"));
+
+		assertThat(response.data().id()).isEqualTo(9L);
+		assertThat(response.data().senderRole()).isEqualTo(MessageSenderRole.PATIENT);
+		assertThat(response.data().body()).isEqualTo("Hola doctor");
+		verify(mobilePatientMessageService).sendMessage(paciente, "Hola doctor");
 	}
 
 	private static Jwt jwtWithSub(final String subject) {

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageIntegrationTest.java
@@ -2,6 +2,7 @@ package com.nutriconsultas.mobile;
 
 import static com.nutriconsultas.mobile.MobileIntegrationTestJwt.mobileJwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -12,6 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -45,21 +48,17 @@ class MobilePatientMessageIntegrationTest {
 			final Paciente paciente = samplePaciente(LINKED_SUB);
 			return pacienteRepository.saveAndFlush(paciente);
 		});
-		patientMessageRepository
-			.findThreadForPatient(linkedPaciente.getId(), null, org.springframework.data.domain.PageRequest.of(0, 1))
-			.stream()
-			.findFirst()
-			.orElseGet(() -> {
-				final PatientMessage message = new PatientMessage();
-				message.setPaciente(linkedPaciente);
-				message.setNutritionistUserId(linkedPaciente.getUserId());
-				message.setSenderRole(MessageSenderRole.NUTRITIONIST);
-				message.setBody("Bienvenido a tu consultorio digital");
-				message.setSentAt(Instant.parse("2026-06-01T10:00:00Z"));
-				message.setReadByPatient(false);
-				message.setReadByNutritionist(true);
-				return patientMessageRepository.saveAndFlush(message);
-			});
+		patientMessageRepository.findThreadForPatient(linkedPaciente.getId(), null, PageRequest.of(0, 500))
+			.forEach(patientMessageRepository::delete);
+		final PatientMessage message = new PatientMessage();
+		message.setPaciente(linkedPaciente);
+		message.setNutritionistUserId(linkedPaciente.getUserId());
+		message.setSenderRole(MessageSenderRole.NUTRITIONIST);
+		message.setBody("Bienvenido a tu consultorio digital");
+		message.setSentAt(Instant.parse("2026-06-01T10:00:00Z"));
+		message.setReadByPatient(false);
+		message.setReadByNutritionist(true);
+		patientMessageRepository.saveAndFlush(message);
 	}
 
 	@Test
@@ -76,6 +75,37 @@ class MobilePatientMessageIntegrationTest {
 	@Test
 	void listMessagesForUnlinkedJwtReturnsForbidden() throws Exception {
 		mockMvc.perform(get("/rest/mobile/patient/messages").with(mobileJwt("auth0|mobile-message-unlinked")))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	void sendMessageWithLinkedJwtPersistsPatientMessage() throws Exception {
+		mockMvc
+			.perform(post("/rest/mobile/patient/messages").with(mobileJwt(LINKED_SUB))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"body\":\"Tengo una duda sobre mi dieta\"}"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.senderRole").value("PATIENT"))
+			.andExpect(jsonPath("$.data.body").value("Tengo una duda sobre mi dieta"))
+			.andExpect(jsonPath("$.data.read").value(true))
+			.andExpect(jsonPath("$.timestamp").exists());
+	}
+
+	@Test
+	void sendMessageWithBlankBodyReturnsBadRequest() throws Exception {
+		mockMvc
+			.perform(post("/rest/mobile/patient/messages").with(mobileJwt(LINKED_SUB))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"body\":\"   \"}"))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void sendMessageForUnlinkedJwtReturnsForbidden() throws Exception {
+		mockMvc
+			.perform(post("/rest/mobile/patient/messages").with(mobileJwt("auth0|mobile-message-unlinked"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"body\":\"Hola\"}"))
 			.andExpect(status().isForbidden());
 	}
 

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageServiceTest.java
@@ -1,8 +1,10 @@
 package com.nutriconsultas.mobile;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
@@ -10,6 +12,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -64,6 +67,33 @@ class MobilePatientMessageServiceTest {
 		assertThat(page.content()).hasSize(2);
 		assertThat(page.hasMore()).isTrue();
 		assertThat(page.nextCursor()).isEqualTo("99");
+	}
+
+	@Test
+	void sendMessage_persistsPatientMessageWithNutritionistTenant() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(5L);
+		paciente.setUserId("auth0|nutritionist-owner");
+		when(patientMessageRepository.save(any(PatientMessage.class))).thenAnswer(invocation -> {
+			final PatientMessage saved = invocation.getArgument(0);
+			saved.setId(77L);
+			saved.setSentAt(Instant.parse("2026-06-01T13:00:00Z"));
+			saved.setReadByPatient(true);
+			saved.setReadByNutritionist(false);
+			return saved;
+		});
+
+		final PatientMessageSummaryDto sent = service.sendMessage(paciente, "  Hola doctor  ");
+
+		assertThat(sent.id()).isEqualTo(77L);
+		assertThat(sent.senderRole()).isEqualTo(MessageSenderRole.PATIENT);
+		assertThat(sent.body()).isEqualTo("Hola doctor");
+		assertThat(sent.read()).isTrue();
+		final ArgumentCaptor<PatientMessage> captor = ArgumentCaptor.forClass(PatientMessage.class);
+		verify(patientMessageRepository).save(captor.capture());
+		assertThat(captor.getValue().getSenderRole()).isEqualTo(MessageSenderRole.PATIENT);
+		assertThat(captor.getValue().getNutritionistUserId()).isEqualTo("auth0|nutritionist-owner");
+		assertThat(captor.getValue().getPaciente()).isSameAs(paciente);
 	}
 
 	private static PatientMessage sampleMessage(final Long id, final String body) {


### PR DESCRIPTION
## Summary
- Adds `POST /rest/mobile/patient/messages` so linked patients can send messages to their nutritionist
- Enforces `senderRole=PATIENT` server-side from JWT identity; validates body with `@NotBlank` and `@Size(max=2000)`
- Returns `ApiResponse<PatientMessageSummaryDto>` consistent with the existing GET thread endpoint

Closes #97

## Test plan
- [ ] Send message with a linked patient JWT → 200 and `senderRole=PATIENT` in response
- [ ] Send with blank body → 400
- [ ] Send with unlinked JWT → 403 `patient_not_linked`
- [ ] Confirm new message appears in `GET /rest/mobile/patient/messages` and admin chat widget unread list


Made with [Cursor](https://cursor.com)