### PR TITLE
feat(mobile-api): add GET /rest/mobile/patient/progress snapshot (#98)

### DIFF
--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-14 — **#98 in progress** on branch `mobile-api/98-patient-progress-snapshot`. **#97 done** on `main`.
+**Last updated:** 2026-06-14 — **#98 done** (PR #148). **#97 done** on `main`.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116) plus the directly-related `[Dashboard]` IMC gauge (#106). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -105,7 +105,7 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 
 | # | Endpoint | URL | State | Backend source |
 |---|----------|-----|-------|----------------|
-| 98 | `GET /rest/mobile/patient/progress` — BMI/indicator snapshot | https://github.com/diego-torres/nutriconsultas/issues/98 | **in-progress** | Aggregate in service; `deltaPeso`/`deltaImc` vs prior measurement; `NivelPeso`→`imcLabel`; BMI/BMR on `Paciente` |
+| 98 | `GET /rest/mobile/patient/progress` — BMI/indicator snapshot | https://github.com/diego-torres/nutriconsultas/issues/98 | **done** | PR #148: `deltaPeso`/`deltaImc`, `imcLabel`, BMR, optional circumferences |
 | 99 | `GET /rest/mobile/patient/progress/measurements` — time series | https://github.com/diego-torres/nutriconsultas/issues/99 | open | `from`/`to` ISO-8601; cap `maxRows=365`; ASC order; prefer `porcentajeGrasaCorporal` |
 
 ---

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-14 — **#97 in progress** on branch `mobile-api/97-patient-send-message`. **#96 done** on `main`.
+**Last updated:** 2026-06-14 — **#98 in progress** on branch `mobile-api/98-patient-progress-snapshot`. **#97 done** on `main`.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116) plus the directly-related `[Dashboard]` IMC gauge (#106). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -99,13 +99,13 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 | # | Endpoint | URL | State | Backend source |
 |---|----------|-----|-------|----------------|
 | 96 | `GET /rest/mobile/patient/messages` — list thread | https://github.com/diego-torres/nutriconsultas/issues/96 | **done** | Merged PR #146: cursor pagination; contact form → `ContactInquiry`; admin inbox |
-| 97 | `POST /rest/mobile/patient/messages` — send to nutritionist | https://github.com/diego-torres/nutriconsultas/issues/97 | **in-progress** | `senderRole=PATIENT` from JWT only; `@Valid @Size(max=2000)`; rate limit deferred to #113 |
+| 97 | `POST /rest/mobile/patient/messages` — send to nutritionist | https://github.com/diego-torres/nutriconsultas/issues/97 | **done** | Merged PR #147: `senderRole=PATIENT` from JWT; `@Valid @Size(max=2000)`; rate limit deferred to #113 |
 
 ### Progress — `AnthropometricMeasurement` / `Paciente`
 
 | # | Endpoint | URL | State | Backend source |
 |---|----------|-----|-------|----------------|
-| 98 | `GET /rest/mobile/patient/progress` — BMI/indicator snapshot | https://github.com/diego-torres/nutriconsultas/issues/98 | open | Aggregate in service; `deltaPeso`/`deltaImc` vs prior measurement; `NivelPeso`→`imcLabel`; BMI/BMR on `Paciente` |
+| 98 | `GET /rest/mobile/patient/progress` — BMI/indicator snapshot | https://github.com/diego-torres/nutriconsultas/issues/98 | **in-progress** | Aggregate in service; `deltaPeso`/`deltaImc` vs prior measurement; `NivelPeso`→`imcLabel`; BMI/BMR on `Paciente` |
 | 99 | `GET /rest/mobile/patient/progress/measurements` — time series | https://github.com/diego-torres/nutriconsultas/issues/99 | open | `from`/`to` ISO-8601; cap `maxRows=365`; ASC order; prefer `porcentajeGrasaCorporal` |
 
 ---

--- a/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurementRepository.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurementRepository.java
@@ -13,6 +13,9 @@ public interface AnthropometricMeasurementRepository extends JpaRepository<Anthr
 
 	List<AnthropometricMeasurement> findByPacienteId(Long pacienteId);
 
+	java.util.Optional<AnthropometricMeasurement> findFirstByPacienteIdOrderByMeasurementDateTimeDescIdDesc(
+			Long pacienteId);
+
 	@Query("SELECT COUNT(m) FROM AnthropometricMeasurement m WHERE m.paciente.userId = :userId")
 	long countByUserId(@Param("userId") String userId);
 

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressController.java
@@ -1,0 +1,39 @@
+package com.nutriconsultas.mobile;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.PatientProgressSnapshotDto;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/mobile/patient/progress")
+@Slf4j
+public class MobilePatientProgressController extends AbstractMobilePatientController {
+
+	private final MobilePatientProgressService mobilePatientProgressService;
+
+	public MobilePatientProgressController(final PatientAuthService patientAuthService,
+			final MobilePatientProgressService mobilePatientProgressService) {
+		super(patientAuthService);
+		this.mobilePatientProgressService = mobilePatientProgressService;
+	}
+
+	@GetMapping
+	public ApiResponse<PatientProgressSnapshotDto> getProgress(@AuthenticationPrincipal final Jwt jwt) {
+		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile progress snapshot request for patient {}", LogRedaction.redactPaciente(paciente.getId()));
+		}
+		final PatientProgressSnapshotDto snapshot = mobilePatientProgressService.getSnapshot(paciente.getId());
+		return ApiResponse.ok(snapshot);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressService.java
@@ -1,0 +1,127 @@
+package com.nutriconsultas.mobile;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
+import com.nutriconsultas.clinical.exam.AnthropometricMeasurementRepository;
+import com.nutriconsultas.mobile.dto.PatientProgressSnapshotDto;
+import com.nutriconsultas.mobile.dto.ProgressCircumferenceDto;
+import com.nutriconsultas.paciente.NivelPeso;
+import com.nutriconsultas.paciente.NivelPesoLabels;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.metrics.BodyMetricRecord;
+import com.nutriconsultas.paciente.metrics.BodyMetricRecordService;
+import com.nutriconsultas.util.ImcGaugeUtils;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class MobilePatientProgressService {
+
+	private final BodyMetricRecordService bodyMetricRecordService;
+
+	private final com.nutriconsultas.paciente.metrics.BodyMetricRecordRepository bodyMetricRecordRepository;
+
+	private final AnthropometricMeasurementRepository anthropometricMeasurementRepository;
+
+	private final PacienteRepository pacienteRepository;
+
+	public MobilePatientProgressService(final BodyMetricRecordService bodyMetricRecordService,
+			final com.nutriconsultas.paciente.metrics.BodyMetricRecordRepository bodyMetricRecordRepository,
+			final AnthropometricMeasurementRepository anthropometricMeasurementRepository,
+			final PacienteRepository pacienteRepository) {
+		this.bodyMetricRecordService = bodyMetricRecordService;
+		this.bodyMetricRecordRepository = bodyMetricRecordRepository;
+		this.anthropometricMeasurementRepository = anthropometricMeasurementRepository;
+		this.pacienteRepository = pacienteRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public PatientProgressSnapshotDto getSnapshot(final Long pacienteId) {
+		final Paciente paciente = pacienteRepository.findById(pacienteId)
+			.orElseThrow(() -> new IllegalArgumentException("Patient not found"));
+		bodyMetricRecordService.ensureBackfilled(pacienteId);
+		final List<BodyMetricRecord> recentRecords = bodyMetricRecordRepository
+			.findTop2ByPacienteIdOrderByRecordedAtDescIdDesc(pacienteId);
+		final Optional<BodyMetricRecord> latestRecord = recentRecords.stream().findFirst();
+		final Optional<BodyMetricRecord> previousRecord = recentRecords.size() > 1 ? Optional.of(recentRecords.get(1))
+				: Optional.empty();
+
+		final Double weightKg = firstNonNull(latestRecord.map(BodyMetricRecord::getWeight).orElse(null),
+				paciente.getPeso());
+		final Double heightM = firstNonNull(latestRecord.map(BodyMetricRecord::getHeight).orElse(null),
+				paciente.getEstatura());
+		final Double bmi = firstNonNull(latestRecord.map(BodyMetricRecord::getImc).orElse(null), paciente.getImc());
+		final NivelPeso nivelPeso = ImcGaugeUtils.resolveNivelPeso(bmi,
+				firstNonNull(latestRecord.map(BodyMetricRecord::getNivelPeso).orElse(null), paciente.getNivelPeso()));
+		final Double bodyFatPercentage = latestRecord.map(this::resolveBodyFatPercentage).orElse(null);
+		final Double deltaPeso = computeDelta(latestRecord.map(BodyMetricRecord::getWeight).orElse(null),
+				previousRecord.map(BodyMetricRecord::getWeight).orElse(null));
+		final Double deltaImc = computeDelta(latestRecord.map(BodyMetricRecord::getImc).orElse(null),
+				previousRecord.map(BodyMetricRecord::getImc).orElse(null));
+
+		if (log.isDebugEnabled()) {
+			log.debug("Built mobile progress snapshot for patient {}", LogRedaction.redactPaciente(pacienteId));
+		}
+
+		return new PatientProgressSnapshotDto(toInstant(latestRecord.map(BodyMetricRecord::getRecordedAt).orElse(null)),
+				toInstant(previousRecord.map(BodyMetricRecord::getRecordedAt).orElse(null)), weightKg, heightM, bmi,
+				nivelPeso, NivelPesoLabels.toImcLabel(nivelPeso), paciente.getBmr(), bodyFatPercentage, deltaPeso,
+				deltaImc, loadCircumferences(pacienteId));
+	}
+
+	private ProgressCircumferenceDto loadCircumferences(final Long pacienteId) {
+		return anthropometricMeasurementRepository.findFirstByPacienteIdOrderByMeasurementDateTimeDescIdDesc(pacienteId)
+			.map(this::toCircumferenceDto)
+			.orElse(null);
+	}
+
+	private ProgressCircumferenceDto toCircumferenceDto(final AnthropometricMeasurement measurement) {
+		final Double waist = measurement.getCintura();
+		final Double hip = measurement.getCadera();
+		if (waist == null && hip == null) {
+			return null;
+		}
+		return new ProgressCircumferenceDto(waist, hip);
+	}
+
+	private Double resolveBodyFatPercentage(final BodyMetricRecord record) {
+		if (record.getBodyFatPercentage() != null) {
+			return record.getBodyFatPercentage();
+		}
+		return record.getBodyFatIndex();
+	}
+
+	private static Double computeDelta(final Double latest, final Double previous) {
+		if (latest == null || previous == null) {
+			return null;
+		}
+		return latest - previous;
+	}
+
+	private static Instant toInstant(final java.util.Date date) {
+		if (date == null) {
+			return null;
+		}
+		return date.toInstant();
+	}
+
+	@SafeVarargs
+	private static <T> T firstNonNull(final T... values) {
+		for (final T value : values) {
+			if (value != null) {
+				return value;
+			}
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/PatientProgressSnapshotDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/PatientProgressSnapshotDto.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.time.Instant;
+
+import com.nutriconsultas.paciente.NivelPeso;
+
+public record PatientProgressSnapshotDto(Instant latestMeasurementAt, Instant previousMeasurementAt, Double weightKg,
+		Double heightM, Double bmi, NivelPeso nivelPeso, String imcLabel, Double bmr, Double bodyFatPercentage,
+		Double deltaPeso, Double deltaImc, ProgressCircumferenceDto circumferences) {
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/ProgressCircumferenceDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/ProgressCircumferenceDto.java
@@ -1,0 +1,4 @@
+package com.nutriconsultas.mobile.dto;
+
+public record ProgressCircumferenceDto(Double waistCm, Double hipCm) {
+}

--- a/src/main/java/com/nutriconsultas/paciente/NivelPesoLabels.java
+++ b/src/main/java/com/nutriconsultas/paciente/NivelPesoLabels.java
@@ -1,0 +1,23 @@
+package com.nutriconsultas.paciente;
+
+/**
+ * Patient-facing display labels for {@link NivelPeso} (mobile progress snapshot).
+ */
+public final class NivelPesoLabels {
+
+	private NivelPesoLabels() {
+	}
+
+	public static String toImcLabel(final NivelPeso nivelPeso) {
+		if (nivelPeso == null) {
+			return null;
+		}
+		return switch (nivelPeso) {
+			case BAJO -> "Bajo peso";
+			case NORMAL -> "Normal";
+			case ALTO -> "Sobrepeso";
+			case SOBREPESO -> "Obesidad";
+		};
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordRepository.java
@@ -13,6 +13,8 @@ public interface BodyMetricRecordRepository extends JpaRepository<BodyMetricReco
 
 	Optional<BodyMetricRecord> findFirstByPacienteIdOrderByRecordedAtDescIdDesc(Long pacienteId);
 
+	List<BodyMetricRecord> findTop2ByPacienteIdOrderByRecordedAtDescIdDesc(Long pacienteId);
+
 	Optional<BodyMetricRecord> findBySourceAndSourceId(BodyMetricSource source, Long sourceId);
 
 	boolean existsByPacienteId(Long pacienteId);

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientProgressControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientProgressControllerTest.java
@@ -1,0 +1,55 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.PatientProgressSnapshotDto;
+import com.nutriconsultas.paciente.NivelPeso;
+import com.nutriconsultas.paciente.Paciente;
+
+@ExtendWith(MockitoExtension.class)
+class MobilePatientProgressControllerTest {
+
+	private static final String PATIENT_SUB = "auth0|mobile-progress-patient";
+
+	@InjectMocks
+	private MobilePatientProgressController controller;
+
+	@Mock
+	private PatientAuthService patientAuthService;
+
+	@Mock
+	private MobilePatientProgressService mobilePatientProgressService;
+
+	@Test
+	void getProgress_returnsApiResponseEnvelope() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(5L);
+		final PatientProgressSnapshotDto snapshot = new PatientProgressSnapshotDto(
+				Instant.parse("2026-06-01T10:00:00Z"), null, 70.0, 1.70, 24.2, NivelPeso.NORMAL, "Normal", 1500.0, 22.0,
+				null, null, null);
+		final Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject(PATIENT_SUB).build();
+
+		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);
+		when(mobilePatientProgressService.getSnapshot(5L)).thenReturn(snapshot);
+
+		final ApiResponse<PatientProgressSnapshotDto> response = controller.getProgress(jwt);
+
+		assertThat(response.data().bmi()).isEqualTo(24.2);
+		assertThat(response.data().imcLabel()).isEqualTo("Normal");
+		assertThat(response.timestamp()).isNotNull();
+		verify(mobilePatientProgressService).getSnapshot(5L);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientProgressIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientProgressIntegrationTest.java
@@ -1,0 +1,106 @@
+package com.nutriconsultas.mobile;
+
+import static com.nutriconsultas.mobile.MobileIntegrationTestJwt.mobileJwt;
+import static org.hamcrest.Matchers.closeTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.nutriconsultas.paciente.NivelPeso;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.metrics.BodyMetricRecord;
+import com.nutriconsultas.paciente.metrics.BodyMetricRecordRepository;
+import com.nutriconsultas.paciente.metrics.BodyMetricSource;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MobilePatientProgressIntegrationTest {
+
+	private static final String LINKED_SUB = "auth0|mobile-progress-integration";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@Autowired
+	private BodyMetricRecordRepository bodyMetricRecordRepository;
+
+	private Paciente linkedPaciente;
+
+	@BeforeEach
+	void seedData() {
+		linkedPaciente = pacienteRepository.findByPatientAuthSub(LINKED_SUB).orElseGet(() -> {
+			final Paciente paciente = samplePaciente(LINKED_SUB);
+			return pacienteRepository.saveAndFlush(paciente);
+		});
+		bodyMetricRecordRepository.findByPacienteIdOrderByRecordedAtAsc(linkedPaciente.getId())
+			.forEach(bodyMetricRecordRepository::delete);
+		linkedPaciente.setPeso(70.0);
+		linkedPaciente.setEstatura(1.70);
+		linkedPaciente.setImc(24.2);
+		linkedPaciente.setNivelPeso(NivelPeso.NORMAL);
+		linkedPaciente.setBmr(1500.0);
+		pacienteRepository.saveAndFlush(linkedPaciente);
+
+		saveMetric(linkedPaciente, 1L, 72.0, 24.9, Date.from(Instant.parse("2026-05-01T10:00:00Z")));
+		saveMetric(linkedPaciente, 2L, 70.0, 24.2, Date.from(Instant.parse("2026-06-01T10:00:00Z")));
+	}
+
+	@Test
+	void getProgressWithLinkedJwtReturnsSnapshot() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/progress").with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.weightKg").value(70.0))
+			.andExpect(jsonPath("$.data.bmi").value(closeTo(24.2, 0.01)))
+			.andExpect(jsonPath("$.data.imcLabel").value("Normal"))
+			.andExpect(jsonPath("$.data.bmr").value(1500.0))
+			.andExpect(jsonPath("$.data.deltaPeso").value(-2.0))
+			.andExpect(jsonPath("$.timestamp").exists());
+	}
+
+	@Test
+	void getProgressForUnlinkedJwtReturnsForbidden() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/progress").with(mobileJwt("auth0|mobile-progress-unlinked")))
+			.andExpect(status().isForbidden());
+	}
+
+	private static Paciente samplePaciente(final String patientAuthSub) {
+		final Paciente paciente = new Paciente();
+		paciente.setName("Paciente progreso");
+		paciente.setUserId("auth0|nutritionist-owner");
+		paciente.setPatientAuthSub(patientAuthSub);
+		paciente.setDob(new Date());
+		paciente.setGender("F");
+		return paciente;
+	}
+
+	private void saveMetric(final Paciente paciente, final Long sourceId, final Double weight, final Double imc,
+			final Date recordedAt) {
+		final BodyMetricRecord record = new BodyMetricRecord();
+		record.setPaciente(paciente);
+		record.setSource(BodyMetricSource.ANTHROPOMETRIC);
+		record.setSourceId(sourceId);
+		record.setWeight(weight);
+		record.setHeight(1.70);
+		record.setImc(imc);
+		record.setNivelPeso(NivelPeso.NORMAL);
+		record.setRecordedAt(recordedAt);
+		bodyMetricRecordRepository.saveAndFlush(record);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientProgressServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientProgressServiceTest.java
@@ -1,0 +1,123 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
+import com.nutriconsultas.clinical.exam.AnthropometricMeasurementRepository;
+import com.nutriconsultas.clinical.exam.anthropometric.Circumferences;
+import com.nutriconsultas.mobile.dto.PatientProgressSnapshotDto;
+import com.nutriconsultas.paciente.NivelPeso;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.metrics.BodyMetricRecord;
+import com.nutriconsultas.paciente.metrics.BodyMetricRecordRepository;
+import com.nutriconsultas.paciente.metrics.BodyMetricRecordService;
+import com.nutriconsultas.paciente.metrics.BodyMetricSource;
+
+@ExtendWith(MockitoExtension.class)
+class MobilePatientProgressServiceTest {
+
+	@InjectMocks
+	private MobilePatientProgressService service;
+
+	@Mock
+	private BodyMetricRecordService bodyMetricRecordService;
+
+	@Mock
+	private BodyMetricRecordRepository bodyMetricRecordRepository;
+
+	@Mock
+	private AnthropometricMeasurementRepository anthropometricMeasurementRepository;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Test
+	void getSnapshot_computesDeltasAndLabelsFromRecentRecords() {
+		final Paciente paciente = samplePaciente();
+		final BodyMetricRecord latest = metricRecord(2L, 70.0, 1.70, 24.2, NivelPeso.NORMAL, 22.0, null,
+				Date.from(Instant.parse("2026-06-01T10:00:00Z")));
+		final BodyMetricRecord previous = metricRecord(1L, 72.0, 1.70, 24.9, NivelPeso.ALTO, 23.0, null,
+				Date.from(Instant.parse("2026-05-01T10:00:00Z")));
+		final AnthropometricMeasurement measurement = new AnthropometricMeasurement();
+		measurement.setCircumferences(new Circumferences());
+		measurement.getCircumferences().setWaistCircumference(82.0);
+		measurement.getCircumferences().setHipCircumference(98.0);
+
+		when(pacienteRepository.findById(5L)).thenReturn(Optional.of(paciente));
+		when(bodyMetricRecordRepository.findTop2ByPacienteIdOrderByRecordedAtDescIdDesc(5L))
+			.thenReturn(List.of(latest, previous));
+		when(anthropometricMeasurementRepository.findFirstByPacienteIdOrderByMeasurementDateTimeDescIdDesc(5L))
+			.thenReturn(Optional.of(measurement));
+
+		final PatientProgressSnapshotDto snapshot = service.getSnapshot(5L);
+
+		verify(bodyMetricRecordService).ensureBackfilled(5L);
+		assertThat(snapshot.weightKg()).isEqualTo(70.0);
+		assertThat(snapshot.bmi()).isEqualTo(24.2);
+		assertThat(snapshot.nivelPeso()).isEqualTo(NivelPeso.NORMAL);
+		assertThat(snapshot.imcLabel()).isEqualTo("Normal");
+		assertThat(snapshot.bmr()).isEqualTo(1500.0);
+		assertThat(snapshot.bodyFatPercentage()).isEqualTo(22.0);
+		assertThat(snapshot.deltaPeso()).isEqualTo(-2.0);
+		assertThat(snapshot.deltaImc()).isCloseTo(-0.7, org.assertj.core.data.Offset.offset(0.0001));
+		assertThat(snapshot.circumferences().waistCm()).isEqualTo(82.0);
+		assertThat(snapshot.circumferences().hipCm()).isEqualTo(98.0);
+	}
+
+	@Test
+	void getSnapshot_prefersBodyFatPercentageOverIndex() {
+		final Paciente paciente = samplePaciente();
+		final BodyMetricRecord latest = metricRecord(2L, 70.0, 1.70, 24.2, NivelPeso.NORMAL, 19.0, 21.5,
+				Date.from(Instant.parse("2026-06-01T10:00:00Z")));
+
+		when(pacienteRepository.findById(5L)).thenReturn(Optional.of(paciente));
+		when(bodyMetricRecordRepository.findTop2ByPacienteIdOrderByRecordedAtDescIdDesc(5L))
+			.thenReturn(List.of(latest));
+		when(anthropometricMeasurementRepository.findFirstByPacienteIdOrderByMeasurementDateTimeDescIdDesc(5L))
+			.thenReturn(Optional.empty());
+
+		final PatientProgressSnapshotDto snapshot = service.getSnapshot(5L);
+
+		assertThat(snapshot.bodyFatPercentage()).isEqualTo(21.5);
+		assertThat(snapshot.deltaPeso()).isNull();
+	}
+
+	private static Paciente samplePaciente() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(5L);
+		paciente.setBmr(1500.0);
+		return paciente;
+	}
+
+	private static BodyMetricRecord metricRecord(final Long id, final Double weight, final Double height,
+			final Double imc, final NivelPeso nivelPeso, final Double bodyFatIndex, final Double bodyFatPercentage,
+			final Date recordedAt) {
+		final BodyMetricRecord record = new BodyMetricRecord();
+		record.setId(id);
+		record.setSource(BodyMetricSource.ANTHROPOMETRIC);
+		record.setSourceId(id);
+		record.setWeight(weight);
+		record.setHeight(height);
+		record.setImc(imc);
+		record.setNivelPeso(nivelPeso);
+		record.setBodyFatIndex(bodyFatIndex);
+		record.setBodyFatPercentage(bodyFatPercentage);
+		record.setRecordedAt(recordedAt);
+		return record;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/NivelPesoLabelsTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/NivelPesoLabelsTest.java
@@ -1,0 +1,18 @@
+package com.nutriconsultas.paciente;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class NivelPesoLabelsTest {
+
+	@Test
+	void toImcLabel_mapsAllLevels() {
+		assertThat(NivelPesoLabels.toImcLabel(NivelPeso.BAJO)).isEqualTo("Bajo peso");
+		assertThat(NivelPesoLabels.toImcLabel(NivelPeso.NORMAL)).isEqualTo("Normal");
+		assertThat(NivelPesoLabels.toImcLabel(NivelPeso.ALTO)).isEqualTo("Sobrepeso");
+		assertThat(NivelPesoLabels.toImcLabel(NivelPeso.SOBREPESO)).isEqualTo("Obesidad");
+		assertThat(NivelPesoLabels.toImcLabel(null)).isNull();
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds `GET /rest/mobile/patient/progress` for linked patients to view a BMI and body-metrics snapshot
- Computes `deltaPeso` and `deltaImc` vs the prior measurement from the unified `BodyMetricRecord` timeline
- Maps `NivelPeso` to Spanish `imcLabel`, includes BMR from `Paciente`, and optional waist/hip circumferences from the latest anthropometric record
- Updates `ISSUE.md`: marks #97 done and #98 in progress

Closes #98

## Test plan
- [ ] Call `GET /rest/mobile/patient/progress` with a linked patient JWT → 200 with `bmi`, `imcLabel`, `bmr`
- [ ] Verify `deltaPeso` / `deltaImc` when at least two body metric records exist
- [ ] Call with unlinked JWT → 403 `patient_not_linked`
- [ ] Confirm `bodyFatPercentage` prefers `porcentajeGrasaCorporal` when available


Made with [Cursor](https://cursor.com)