### PR TITLE
docs(mobile-api): E2E status doc and Auth0 setup script

### DIFF
--- a/docs/mobile-api/MOBILE-E2E-STATUS.md
+++ b/docs/mobile-api/MOBILE-E2E-STATUS.md
@@ -1,0 +1,211 @@
+# Mobile E2E — Backend & Auth0 status
+
+**Date:** 2026-06-14  
+**Audience:** [nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) team  
+**Backend:** https://minutriporcion.com  
+**Auth0 tenant:** `dev-imd1udg26uvzvfto.us.auth0.com`
+
+This document summarizes what the backend team verified after Auth0 CLI authentication and production checks. Use it to resume live E2E testing with `MOCK_AUTH=false`.
+
+---
+
+## Quick verdict
+
+| Area | Status | Action for mobile team |
+|------|--------|------------------------|
+| Auth0 API + audience | ✅ Ready | Keep `AUTH0_AUDIENCE=https://api.nutriconsultas.minutriporcion.com` |
+| Native client + client grant | ✅ Ready | Use `CmZdUaMZ3Oqs4JSbUBdYZYmKoqDUiLBk` |
+| Google login | ✅ Ready | `connection=google-oauth2` |
+| Apple login | ✅ Ready (dev keys) | Connection `apple` enabled on `minutriporcion-native` — uses Auth0 dev keys until Apple Developer creds are added |
+| JWT validation on prod (`AUTH_AUDIENCE`) | ✅ Ready | Valid token should **not** return 401 |
+| Patient linkage (prod test user) | ✅ Ready | Paciente linked to Google account below |
+| Visits / diet-plans / messages API | ✅ Deployed | Expect **200** after login + linkage |
+| Progress API (#98) | ⚠️ Pending deploy | Merged in backend `main`; prod JAR may lag |
+
+---
+
+## Auth0 configuration (verified 2026-06-14)
+
+### Tenant & API (#108)
+
+| Setting | Value |
+|---------|-------|
+| API name | `nutriconsultas-mobile-api` |
+| API identifier (audience) | `https://api.nutriconsultas.minutriporcion.com` |
+| Signing algorithm | RS256 |
+| Scopes | `read:visits`, `read:diet-plans`, `read:progress`, `read:messages`, `write:messages` |
+
+Mobile `.env` **must** use the same audience on `login()`:
+
+```env
+AUTH0_AUDIENCE=https://api.nutriconsultas.minutriporcion.com
+```
+
+### Native application
+
+| Setting | Value |
+|---------|-------|
+| Name | `minutriporcion-native` |
+| Client ID | `CmZdUaMZ3Oqs4JSbUBdYZYmKoqDUiLBk` |
+| Type | Native |
+| Client grant | ✅ Authorized for `nutriconsultas-mobile-api` with all scopes above |
+
+**Connections enabled on native app:**
+
+| Connection | Enabled | Notes |
+|------------|---------|-------|
+| `google-oauth2` | ✅ | Use for Android + iOS Google button |
+| `Username-Password-Authentication` | ✅ | Email/password flow |
+| `apple` | ✅ | Enabled on native app; **Auth0 dev keys** (blank Client ID) — OK for E2E, not for production |
+
+### Callback URLs (Auth0 dashboard)
+
+Currently registered:
+
+```
+com.example.mobile://dev-imd1udg26uvzvfto.us.auth0.com/ios/com.example.mobile/callback
+com.example.mobile://dev-imd1udg26uvzvfto.us.auth0.com/android/com.example.mobile/callback
+```
+
+Confirm these match your **production bundle ID / application ID** in `auth0.properties` / `Info.plist`. If the app uses a different scheme (e.g. `com.minutriporcion.app`), update Auth0 callbacks or you'll see callback mismatch errors.
+
+---
+
+## Production backend
+
+### Environment
+
+| Variable | Prod value |
+|----------|------------|
+| `AUTH_ISSUER` | `https://dev-imd1udg26uvzvfto.us.auth0.com/` |
+| `AUTH_AUDIENCE` | `https://api.nutriconsultas.minutriporcion.com` |
+| `AUTH0_MGMT_*` | Not configured (admin email lookup unavailable; manual `sub` linkage only) |
+
+### Anonymous requests (no Bearer)
+
+All return **401** as expected:
+
+```
+GET /rest/mobile/patient/visits      → 401
+GET /rest/mobile/patient/diet-plans  → 401
+GET /rest/mobile/patient/messages    → 401
+GET /rest/mobile/patient/progress    → 401
+GET /actuator/health                 → 200
+```
+
+### HTTP codes after login
+
+| Code | Meaning |
+|------|---------|
+| **401** | Missing/invalid JWT, wrong issuer, or wrong `aud` |
+| **403** `patient_not_linked` | JWT valid but `sub` not linked to any `Paciente.patientAuthSub` |
+| **200** | Auth + linkage OK; endpoint implemented |
+| **404** | Auth + linkage OK but resource not found (or endpoint not deployed yet) |
+
+---
+
+## Test patient linked for E2E
+
+A production patient record is linked for live testing:
+
+| Field | Value |
+|-------|-------|
+| Paciente ID | `1` |
+| Name | Diego Torres |
+| Email | `diego.torres.fuerte@gmail.com` |
+| Auth0 `sub` (must match JWT) | `google-oauth2\|105777036752849735533` |
+
+**Important:** Linkage uses the **patient's mobile Auth0 `sub`**, not the nutritionist's web-admin `sub`. The first linkage attempt used the nutritionist sub by mistake; it was corrected on 2026-06-14.
+
+### Who can test?
+
+Log in on the mobile app with Google account **`diego.torres.fuerte@gmail.com`**. After login, API calls should pass linkage and return data (1 visit and 1 diet assignment exist in prod for this patient).
+
+To link another tester, ask the nutritionist to use **Admin → Pacientes → Afiliación → Vincular** with the patient's Auth0 `sub`, or contact the backend team.
+
+---
+
+## Blockers
+
+### A1 — Apple Sign-In (Auth0) — resolved 2026-06-14
+
+| Item | Detail |
+|------|--------|
+| Connection | `apple` (`con_DsJCAz8WVvd2Atp3`) |
+| Native app | ✅ `CmZdUaMZ3Oqs4JSbUBdYZYmKoqDUiLBk` enabled |
+| Credentials | **Auth0 development keys** (Client ID / signing key left blank) — sufficient for simulator E2E |
+| Production | Replace with Apple Developer **Services ID**, **Team ID**, **Key ID**, and **.p8 signing key** in Auth0 → Authentication → Social → apple → Settings |
+| App-side | No change needed — `connection=apple` is correct |
+
+### B3 — Progress endpoint deploy lag
+
+| Item | Detail |
+|------|--------|
+| Backend PR | [#148](https://github.com/diego-torres/nutriconsultas/pull/148) **merged** (`GET /rest/mobile/patient/progress`) |
+| Prod | May still run an older JAR until CodePipeline deploys |
+| Symptom | Linked JWT → **404** on `/progress` until redeploy |
+| Action | Backend will trigger deploy; retest progress after deploy |
+
+---
+
+## Recommended test matrix (update as you go)
+
+Run with `MOCK_AUTH=false` against **https://minutriporcion.com**.
+
+### Welcome — social login
+
+| Step | iOS | Android | Expected |
+|------|-----|---------|----------|
+| Tap **Google** | [ ] | [ ] | Google account picker → return to app |
+| Tap **Apple** | [ ] | n/a | Should open Apple sign-in (Auth0 dev keys) |
+| Callback returns to app | [ ] | [ ] | No URL mismatch |
+| Lands on home tabs | [ ] | [ ] | |
+
+### Post-login API (Google account above)
+
+| Endpoint | Expected | Actual | Notes |
+|----------|----------|--------|-------|
+| `GET /rest/mobile/patient/visits` | 200 + paged data | [ ] | |
+| `GET /rest/mobile/patient/diet-plans` | 200 + paged data | [ ] | |
+| `GET /rest/mobile/patient/messages` | 200 (may be empty) | [ ] | |
+| `POST /rest/mobile/patient/messages` | 201/200 | [ ] | |
+| `GET /rest/mobile/patient/progress` | 200 after deploy | [ ] | 404 until prod redeploy |
+
+### Token sanity check
+
+After login, decode the access token (or use app logs):
+
+- `iss` = `https://dev-imd1udg26uvzvfto.us.auth0.com/`
+- `aud` includes `https://api.nutriconsultas.minutriporcion.com`
+- `sub` = `google-oauth2|105777036752849735533` (for the linked test account)
+
+Optional backend script (requires access token from the app):
+
+```bash
+./scripts/mobile-auth0-e2e-setup.sh verify-token '<access_token>'
+```
+
+---
+
+## Mobile app checklist (unchanged)
+
+| Item | Status |
+|------|--------|
+| Native `AUTH_CLIENT` (`CmZdUaMZ…`) | ✅ |
+| `AUTH0_AUDIENCE` on `login()` | ✅ |
+| Google → `connection=google-oauth2` | ✅ |
+| Apple → `connection=apple` (iOS) | ✅ wired + Auth0 connection enabled |
+| `MOCK_AUTH=false` for live test | Required |
+
+---
+
+## Backend contacts & references
+
+- Mobile API registry: [`ISSUE.md`](../../ISSUE.md)
+- Alignment spec: [`docs/mobile-api/ALIGNMENT-SPEC.md`](ALIGNMENT-SPEC.md) (if present)
+- E2E setup script: [`scripts/mobile-auth0-e2e-setup.sh`](../../scripts/mobile-auth0-e2e-setup.sh)
+- Related mobile issues: [#22](https://github.com/Escanor4323/nutriconsultas-mobile/issues/22), PR [#61](https://github.com/Escanor4323/nutriconsultas-mobile/pull/61)
+
+---
+
+*Updated 2026-06-14: Apple connection created and enabled on `minutriporcion-native` (Auth0 dev keys).*

--- a/scripts/mobile-auth0-e2e-setup.sh
+++ b/scripts/mobile-auth0-e2e-setup.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Auth0 + prod mobile E2E setup for patient app testing.
+#
+# Prerequisites:
+#   - auth0 CLI logged in: auth0 login  (tenant dev-imd1udg26uvzvfto.us.auth0.com)
+#   - AWS_PROFILE=minutriporcion (or set AWS_REGION / credentials)
+#
+# Usage:
+#   ./scripts/mobile-auth0-e2e-setup.sh audit
+#   ./scripts/mobile-auth0-e2e-setup.sh link --paciente-id 1 --sub 'google-oauth2|…' [--email user@example.com]
+#   ./scripts/mobile-auth0-e2e-setup.sh link-by-email --paciente-id 1 --email user@example.com
+#   ./scripts/mobile-auth0-e2e-setup.sh verify-token <access_token>
+#
+set -euo pipefail
+
+TENANT_DOMAIN="${AUTH0_TENANT_DOMAIN:-dev-imd1udg26uvzvfto.us.auth0.com}"
+NATIVE_CLIENT_ID="${AUTH0_NATIVE_CLIENT_ID:-CmZdUaMZ3Oqs4JSbUBdYZYmKoqDUiLBk}"
+API_IDENTIFIER="${AUTH0_API_IDENTIFIER:-https://api.nutriconsultas.minutriporcion.com}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+AWS_PROFILE="${AWS_PROFILE:-minutriporcion}"
+PROD_BASE_URL="${PROD_BASE_URL:-https://minutriporcion.com}"
+
+require_auth0() {
+	if ! auth0 tenants list >/dev/null 2>&1; then
+		echo "Auth0 CLI is not authenticated. Run: auth0 login" >&2
+		exit 1
+	fi
+}
+
+ssm_instance_id() {
+	aws ssm get-parameter --region "${AWS_REGION}" --profile "${AWS_PROFILE}" \
+		--name /nutriconsultas/deploy/app_instance_id --query Parameter.Value --output text
+}
+
+run_prod_sql() {
+	local sql="$1"
+	local instance_id b64_sql tmp_json cmd_id
+	instance_id="$(ssm_instance_id)"
+	b64_sql="$(printf '%s' "${sql}" | base64 | tr -d '\n')"
+	tmp_json="$(mktemp)"
+	jq -n --arg b64 "${b64_sql}" \
+		'{commands: ["set -eu", "set -a; source /opt/nutriconsultas/app.env; set +a", ("echo " + ($b64 | @sh) + " | base64 -d | PGPASSWORD=$JDBC_DATABASE_PASSWORD psql -h 172.31.14.201 -U $JDBC_DATABASE_USERNAME -d nutriconsultas -v ON_ERROR_STOP=1 -f -")]}' \
+		>"${tmp_json}"
+	cmd_id="$(aws ssm send-command --region "${AWS_REGION}" --profile "${AWS_PROFILE}" \
+		--instance-ids "${instance_id}" \
+		--document-name "AWS-RunShellScript" \
+		--parameters "file://${tmp_json}" \
+		--query Command.CommandId --output text)"
+	rm -f "${tmp_json}"
+	sleep 10
+	aws ssm get-command-invocation --region "${AWS_REGION}" --profile "${AWS_PROFILE}" \
+		--command-id "${cmd_id}" --instance-id "${instance_id}" \
+		--query '{Status:Status,Stdout:StandardOutputContent,Stderr:StandardErrorContent}' --output json
+}
+
+cmd_audit() {
+	require_auth0
+	echo "=== Auth0 tenant audit (${TENANT_DOMAIN}) ==="
+	echo
+	echo "-- API resource (issue #108) --"
+	auth0 apis list --json 2>/dev/null | python3 -c "
+import json, sys
+target = '${API_IDENTIFIER}'
+apis = json.load(sys.stdin)
+found = [a for a in apis if a.get('identifier') == target]
+if found:
+    a = found[0]
+    print('OK  API identifier:', a.get('identifier'))
+    print('    name:', a.get('name'))
+    print('    signing_alg:', a.get('signing_alg'))
+else:
+    print('MISSING  API with identifier', target)
+    print('Create: auth0 apis create --name \"Nutriconsultas Mobile API\" --identifier \"' + target + '\"')
+"
+	echo
+	echo "-- Native app (${NATIVE_CLIENT_ID}) --"
+	auth0 apps show "${NATIVE_CLIENT_ID}" --json 2>/dev/null | python3 -c "
+import json, sys
+a = json.load(sys.stdin)
+print('name:', a.get('name'))
+print('app_type:', a.get('app_type'))
+print('callbacks:', len(a.get('callbacks') or []), 'configured')
+"
+	echo
+	echo "-- Native app connections (Google / Apple / DB) --"
+	auth0 api get "clients/${NATIVE_CLIENT_ID}/connections" 2>/dev/null | python3 -c "
+import json, sys
+raw = json.load(sys.stdin)
+conns = raw.get('connections', raw if isinstance(raw, list) else [])
+names = sorted(c.get('name', c.get('connection_id', '?')) for c in conns)
+for n in names:
+    print(' -', n)
+if not any('apple' in str(n).lower() for n in names):
+    print('WARN  Apple (A1) not enabled on minutriporcion-native — enable in Auth0 Dashboard')
+"
+	echo
+	echo "-- Prod backend (no Bearer → expect 401) --"
+	for path in visits diet-plans messages progress; do
+		code="$(curl -s -o /dev/null -w '%{http_code}' "${PROD_BASE_URL}/rest/mobile/patient/${path}")"
+		echo "GET /rest/mobile/patient/${path} → ${code}"
+	done
+	echo
+	echo "-- Prod app.env Auth0 keys --"
+	instance_id="$(ssm_instance_id)"
+	cmd_id="$(aws ssm send-command --region "${AWS_REGION}" --profile "${AWS_PROFILE}" \
+		--instance-ids "${instance_id}" \
+		--document-name "AWS-RunShellScript" \
+		--parameters 'commands=["grep -E \"^(AUTH_ISSUER|AUTH_AUDIENCE|AUTH0_MGMT_)\" /opt/nutriconsultas/app.env | sed \"s/=.*SECRET.*/=***REDACTED***/; s/CLIENT_SECRET=.*/CLIENT_SECRET=***REDACTED***/\""]' \
+		--query Command.CommandId --output text)"
+	sleep 8
+	aws ssm get-command-invocation --region "${AWS_REGION}" --profile "${AWS_PROFILE}" \
+		--command-id "${cmd_id}" --instance-id "${instance_id}" \
+		--query StandardOutputContent --output text
+	echo
+	echo "-- Paciente linkage (prod DB) --"
+	run_prod_sql "SELECT id, name, COALESCE(email,''), COALESCE(patient_auth_sub,'(unlinked)') FROM paciente ORDER BY id;"
+}
+
+cmd_link() {
+	local paciente_id="" patient_sub="" patient_email=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--paciente-id) paciente_id="$2"; shift 2 ;;
+			--sub) patient_sub="$2"; shift 2 ;;
+			--email) patient_email="$2"; shift 2 ;;
+			*) echo "Unknown arg: $1" >&2; exit 1 ;;
+		esac
+	done
+	if [[ -z "${paciente_id}" || -z "${patient_sub}" ]]; then
+		echo "Usage: $0 link --paciente-id ID --sub 'auth0|…' [--email user@example.com]" >&2
+		exit 1
+	fi
+	local sql="UPDATE paciente SET patient_auth_sub = '${patient_sub}'"
+	if [[ -n "${patient_email}" ]]; then
+		sql="${sql}, email = '${patient_email}'"
+	fi
+	sql="${sql} WHERE id = ${paciente_id} RETURNING id, name, email, patient_auth_sub;"
+	echo "Linking paciente ${paciente_id} → sub ${patient_sub}"
+	run_prod_sql "${sql}"
+}
+
+cmd_link_by_email() {
+	require_auth0
+	local paciente_id="" email=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--paciente-id) paciente_id="$2"; shift 2 ;;
+			--email) email="$2"; shift 2 ;;
+			*) echo "Unknown arg: $1" >&2; exit 1 ;;
+		esac
+	done
+	if [[ -z "${paciente_id}" || -z "${email}" ]]; then
+		echo "Usage: $0 link-by-email --paciente-id ID --email user@example.com" >&2
+		exit 1
+	fi
+	local sub
+	sub="$(auth0 users search-by-email "${email}" --json 2>/dev/null | python3 -c "
+import json, sys
+users = json.load(sys.stdin)
+if not users:
+    sys.exit('No Auth0 user for email')
+print(users[0].get('user_id',''))
+")"
+	cmd_link --paciente-id "${paciente_id}" --sub "${sub}" --email "${email}"
+}
+
+cmd_verify_token() {
+	local token="${1:-}"
+	if [[ -z "${token}" ]]; then
+		echo "Usage: $0 verify-token <access_token>" >&2
+		exit 1
+	fi
+	echo "Testing mobile endpoints with Bearer token..."
+	for path in visits diet-plans messages progress; do
+		code="$(curl -s -o /tmp/mobile-e2e-body.json -w '%{http_code}' \
+			-H "Authorization: Bearer ${token}" \
+			"${PROD_BASE_URL}/rest/mobile/patient/${path}")"
+		echo "GET /rest/mobile/patient/${path} → ${code}"
+		if [[ "${code}" == "403" ]]; then
+			echo "  (403 = patient_not_linked — run link or link-by-email)"
+		elif [[ "${code}" == "401" ]]; then
+			echo "  (401 = invalid JWT or wrong aud — check AUTH0_AUDIENCE on mobile)"
+		elif [[ "${code}" == "200" ]]; then
+			head -c 120 /tmp/mobile-e2e-body.json; echo
+		fi
+	done
+	rm -f /tmp/mobile-e2e-body.json
+}
+
+main() {
+	local cmd="${1:-audit}"
+	shift || true
+	case "${cmd}" in
+		audit) cmd_audit ;;
+		link) cmd_link "$@" ;;
+		link-by-email) cmd_link_by_email "$@" ;;
+		verify-token) cmd_verify_token "$@" ;;
+		*) echo "Unknown command: ${cmd}" >&2; exit 1 ;;
+	esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Adds `docs/mobile-api/MOBILE-E2E-STATUS.md` as a handoff for the mobile team: Auth0 tenant config, test user linkage, endpoint verification matrix, and known blockers.
- Adds `scripts/mobile-auth0-e2e-setup.sh` to audit the Auth0 tenant, link a prod patient to an Auth0 `sub` via SSM, and smoke-test mobile API endpoints with a bearer token.

## Test plan
- [ ] Review `MOBILE-E2E-STATUS.md` for accuracy against current Auth0 tenant and prod backend
- [ ] Run `./scripts/mobile-auth0-e2e-setup.sh audit` (requires Auth0 CLI login)
- [ ] Optionally run `./scripts/mobile-auth0-e2e-setup.sh verify <token>` against prod endpoints


Made with [Cursor](https://cursor.com)