### PR TITLE
Gasto energético: incorporar TEF/ETA (#122)

### DIFF
--- a/src/main/java/com/nutriconsultas/calendar/CalendarEvent.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarEvent.java
@@ -117,4 +117,10 @@ public class CalendarEvent {
 	@Column(precision = 7)
 	private Double getKcal;
 
+	@Column(precision = 7)
+	private Double tefKcal;
+
+	@Column(precision = 7)
+	private Double totalAdjustedKcal;
+
 }

--- a/src/main/java/com/nutriconsultas/calendar/CalendarEventRestController.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarEventRestController.java
@@ -183,6 +183,24 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 			if (event.getPaciente().getPreferredBmrFormula() != null) {
 				extendedProps.put("patientPreferredBmrFormula", event.getPaciente().getPreferredBmrFormula().name());
 			}
+			if (event.getPaciente().getTefMethod() != null) {
+				extendedProps.put("patientTefMethod", event.getPaciente().getTefMethod().name());
+			}
+			if (event.getPaciente().getTefBase() != null) {
+				extendedProps.put("patientTefBase", event.getPaciente().getTefBase().name());
+			}
+			if (event.getPaciente().getTefFixedPercent() != null) {
+				extendedProps.put("patientTefFixedPercent", event.getPaciente().getTefFixedPercent());
+			}
+			if (event.getPaciente().getTefMacroProteinPercent() != null) {
+				extendedProps.put("patientTefMacroProteinPercent", event.getPaciente().getTefMacroProteinPercent());
+			}
+			if (event.getPaciente().getTefMacroCarbsPercent() != null) {
+				extendedProps.put("patientTefMacroCarbsPercent", event.getPaciente().getTefMacroCarbsPercent());
+			}
+			if (event.getPaciente().getTefMacroFatPercent() != null) {
+				extendedProps.put("patientTefMacroFatPercent", event.getPaciente().getTefMacroFatPercent());
+			}
 		}
 		if (event.getStatus() != null) {
 			extendedProps.put("status", event.getStatus().name());
@@ -241,6 +259,12 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 		}
 		if (event.getGetKcal() != null) {
 			extendedProps.put("getKcal", event.getGetKcal());
+		}
+		if (event.getTefKcal() != null) {
+			extendedProps.put("tefKcal", event.getTefKcal());
+		}
+		if (event.getTotalAdjustedKcal() != null) {
+			extendedProps.put("totalAdjustedKcal", event.getTotalAdjustedKcal());
 		}
 		eventMap.put("extendedProps", extendedProps);
 		eventMap.put("url", "/admin/calendario/" + event.getId());
@@ -690,10 +714,11 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 			changed = true;
 		}
 		if (event.getGetKcal() != null) {
-			EnergyExpenditureResolver.applyToPatient(paciente,
-					new EnergyExpenditureResolver.EnergyResult(event.getBmrUsed(), event.getActivityFactor(),
-							event.getGetKcal()),
-					event.getPhysicalActivityLevel());
+			final EnergyExpenditureResolver.EnergyResult tefResult = EnergyExpenditureResolver.applyTef(paciente,
+					event.getBmrUsed(), event.getActivityFactor(), event.getGetKcal());
+			event.setTefKcal(tefResult.tefKcal());
+			event.setTotalAdjustedKcal(tefResult.totalAdjustedKcal());
+			EnergyExpenditureResolver.applyToPatient(paciente, tefResult, event.getPhysicalActivityLevel());
 			changed = true;
 		}
 		else if (event.getPeso() != null && event.getEstatura() != null) {
@@ -705,14 +730,16 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 				event.setBmrUsed(result.bmr());
 				event.setActivityFactor(result.activityFactor());
 				event.setGetKcal(result.getKcal());
+				event.setTefKcal(result.tefKcal());
+				event.setTotalAdjustedKcal(result.totalAdjustedKcal());
 				EnergyExpenditureResolver.applyToPatient(paciente, result, event.getPhysicalActivityLevel());
 				changed = true;
 			}
 		}
 		if (changed) {
 			pacienteRepository.save(paciente);
-			log.debug("Updated patient {} snapshot: imc={}, bmr={}, get={}", paciente.getId(), paciente.getImc(),
-					paciente.getBmr(), paciente.getGetKcal());
+			log.debug("Updated patient {} snapshot: imc={}, bmr={}, get={}, total={}", paciente.getId(),
+					paciente.getImc(), paciente.getBmr(), paciente.getGetKcal(), paciente.getTotalAdjustedKcal());
 		}
 	}
 
@@ -744,6 +771,8 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 		event.setBmrUsed(result.bmr());
 		event.setActivityFactor(result.activityFactor());
 		event.setGetKcal(result.getKcal());
+		event.setTefKcal(result.tefKcal());
+		event.setTotalAdjustedKcal(result.totalAdjustedKcal());
 	}
 
 	/**

--- a/src/main/java/com/nutriconsultas/calendar/CalendarEventRestController.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarEventRestController.java
@@ -173,102 +173,65 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 			eventMap.put("backgroundColor", getEventColor(event.getStatus()));
 			eventMap.put("borderColor", getEventColor(event.getStatus()));
 		}
-		final Map<String, Object> extendedProps = new HashMap<>();
-		if (event.getPaciente() != null) {
-			extendedProps.put("paciente", event.getPaciente().getName());
-			extendedProps.put("pacienteId", event.getPaciente().getId());
-			if (event.getPaciente().getActivityFactorScale() != null) {
-				extendedProps.put("patientActivityFactorScale", event.getPaciente().getActivityFactorScale().name());
-			}
-			if (event.getPaciente().getPreferredBmrFormula() != null) {
-				extendedProps.put("patientPreferredBmrFormula", event.getPaciente().getPreferredBmrFormula().name());
-			}
-			if (event.getPaciente().getTefMethod() != null) {
-				extendedProps.put("patientTefMethod", event.getPaciente().getTefMethod().name());
-			}
-			if (event.getPaciente().getTefBase() != null) {
-				extendedProps.put("patientTefBase", event.getPaciente().getTefBase().name());
-			}
-			if (event.getPaciente().getTefFixedPercent() != null) {
-				extendedProps.put("patientTefFixedPercent", event.getPaciente().getTefFixedPercent());
-			}
-			if (event.getPaciente().getTefMacroProteinPercent() != null) {
-				extendedProps.put("patientTefMacroProteinPercent", event.getPaciente().getTefMacroProteinPercent());
-			}
-			if (event.getPaciente().getTefMacroCarbsPercent() != null) {
-				extendedProps.put("patientTefMacroCarbsPercent", event.getPaciente().getTefMacroCarbsPercent());
-			}
-			if (event.getPaciente().getTefMacroFatPercent() != null) {
-				extendedProps.put("patientTefMacroFatPercent", event.getPaciente().getTefMacroFatPercent());
-			}
-		}
-		if (event.getStatus() != null) {
-			extendedProps.put("status", event.getStatus().name());
-		}
-		if (event.getDescription() != null) {
-			extendedProps.put("description", event.getDescription());
-		}
-		if (event.getSummaryNotes() != null) {
-			extendedProps.put("summaryNotes", event.getSummaryNotes());
-		}
-		extendedProps.put("durationMinutes", event.getDurationMinutes());
-		if (event.getPeso() != null) {
-			extendedProps.put("peso", event.getPeso());
-		}
-		if (event.getEstatura() != null) {
-			extendedProps.put("estatura", event.getEstatura());
-		}
-		if (event.getImc() != null) {
-			extendedProps.put("imc", event.getImc());
-		}
-		if (event.getIndiceGrasaCorporal() != null) {
-			extendedProps.put("indiceGrasaCorporal", event.getIndiceGrasaCorporal());
-		}
-		if (event.getNivelPeso() != null) {
-			extendedProps.put("nivelPeso", event.getNivelPeso().name());
-		}
-		if (event.getSistolica() != null) {
-			extendedProps.put("sistolica", event.getSistolica());
-		}
-		if (event.getDiastolica() != null) {
-			extendedProps.put("diastolica", event.getDiastolica());
-		}
-		if (event.getPulso() != null) {
-			extendedProps.put("pulso", event.getPulso());
-		}
-		if (event.getIndiceGlucemico() != null) {
-			extendedProps.put("indiceGlucemico", event.getIndiceGlucemico());
-		}
-		if (event.getSpo2() != null) {
-			extendedProps.put("spo2", event.getSpo2());
-		}
-		if (event.getTemperatura() != null) {
-			extendedProps.put("temperatura", event.getTemperatura());
-		}
-		if (event.getPhysicalActivityLevel() != null) {
-			extendedProps.put("physicalActivityLevel", event.getPhysicalActivityLevel().name());
-		}
-		if (event.getActivityFactor() != null) {
-			extendedProps.put("activityFactor", event.getActivityFactor());
-		}
-		if (event.getBmrFormula() != null) {
-			extendedProps.put("bmrFormula", event.getBmrFormula().name());
-		}
-		if (event.getBmrUsed() != null) {
-			extendedProps.put("bmrUsed", event.getBmrUsed());
-		}
-		if (event.getGetKcal() != null) {
-			extendedProps.put("getKcal", event.getGetKcal());
-		}
-		if (event.getTefKcal() != null) {
-			extendedProps.put("tefKcal", event.getTefKcal());
-		}
-		if (event.getTotalAdjustedKcal() != null) {
-			extendedProps.put("totalAdjustedKcal", event.getTotalAdjustedKcal());
-		}
+		final Map<String, Object> extendedProps = buildExtendedProps(event);
 		eventMap.put("extendedProps", extendedProps);
 		eventMap.put("url", "/admin/calendario/" + event.getId());
 		return eventMap;
+	}
+
+	private Map<String, Object> buildExtendedProps(final CalendarEvent event) {
+		final Map<String, Object> extendedProps = new HashMap<>();
+		if (event.getPaciente() != null) {
+			appendPatientExtendedProps(extendedProps, event.getPaciente());
+		}
+		putEnumNameIfPresent(extendedProps, "status", event.getStatus());
+		putIfPresent(extendedProps, "description", event.getDescription());
+		putIfPresent(extendedProps, "summaryNotes", event.getSummaryNotes());
+		extendedProps.put("durationMinutes", event.getDurationMinutes());
+		putIfPresent(extendedProps, "peso", event.getPeso());
+		putIfPresent(extendedProps, "estatura", event.getEstatura());
+		putIfPresent(extendedProps, "imc", event.getImc());
+		putIfPresent(extendedProps, "indiceGrasaCorporal", event.getIndiceGrasaCorporal());
+		putEnumNameIfPresent(extendedProps, "nivelPeso", event.getNivelPeso());
+		putIfPresent(extendedProps, "sistolica", event.getSistolica());
+		putIfPresent(extendedProps, "diastolica", event.getDiastolica());
+		putIfPresent(extendedProps, "pulso", event.getPulso());
+		putIfPresent(extendedProps, "indiceGlucemico", event.getIndiceGlucemico());
+		putIfPresent(extendedProps, "spo2", event.getSpo2());
+		putIfPresent(extendedProps, "temperatura", event.getTemperatura());
+		putEnumNameIfPresent(extendedProps, "physicalActivityLevel", event.getPhysicalActivityLevel());
+		putIfPresent(extendedProps, "activityFactor", event.getActivityFactor());
+		putEnumNameIfPresent(extendedProps, "bmrFormula", event.getBmrFormula());
+		putIfPresent(extendedProps, "bmrUsed", event.getBmrUsed());
+		putIfPresent(extendedProps, "getKcal", event.getGetKcal());
+		putIfPresent(extendedProps, "tefKcal", event.getTefKcal());
+		putIfPresent(extendedProps, "totalAdjustedKcal", event.getTotalAdjustedKcal());
+		return extendedProps;
+	}
+
+	private void appendPatientExtendedProps(final Map<String, Object> extendedProps, final Paciente paciente) {
+		extendedProps.put("paciente", paciente.getName());
+		extendedProps.put("pacienteId", paciente.getId());
+		putEnumNameIfPresent(extendedProps, "patientActivityFactorScale", paciente.getActivityFactorScale());
+		putEnumNameIfPresent(extendedProps, "patientPreferredBmrFormula", paciente.getPreferredBmrFormula());
+		putEnumNameIfPresent(extendedProps, "patientTefMethod", paciente.getTefMethod());
+		putEnumNameIfPresent(extendedProps, "patientTefBase", paciente.getTefBase());
+		putIfPresent(extendedProps, "patientTefFixedPercent", paciente.getTefFixedPercent());
+		putIfPresent(extendedProps, "patientTefMacroProteinPercent", paciente.getTefMacroProteinPercent());
+		putIfPresent(extendedProps, "patientTefMacroCarbsPercent", paciente.getTefMacroCarbsPercent());
+		putIfPresent(extendedProps, "patientTefMacroFatPercent", paciente.getTefMacroFatPercent());
+	}
+
+	private static void putIfPresent(final Map<String, Object> target, final String key, final Object value) {
+		if (value != null) {
+			target.put(key, value);
+		}
+	}
+
+	private static void putEnumNameIfPresent(final Map<String, Object> target, final String key, final Enum<?> value) {
+		if (value != null) {
+			target.put(key, value.name());
+		}
 	}
 
 	private String getEventColor(final EventStatus status) {

--- a/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurement.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurement.java
@@ -106,6 +106,12 @@ public class AnthropometricMeasurement {
 	@Column(precision = 7)
 	private Double getKcal;
 
+	@Column(precision = 7)
+	private Double tefKcal;
+
+	@Column(precision = 7)
+	private Double totalAdjustedKcal;
+
 	// Convenience methods for backward compatibility
 	public Double getPeso() {
 		return bodyMass != null ? bodyMass.getWeight() : null;

--- a/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurementServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurementServiceImpl.java
@@ -77,6 +77,8 @@ public class AnthropometricMeasurementServiceImpl implements AnthropometricMeasu
 		measurement.setBmrUsed(result.bmr());
 		measurement.setActivityFactor(result.activityFactor());
 		measurement.setGetKcal(result.getKcal());
+		measurement.setTefKcal(result.tefKcal());
+		measurement.setTotalAdjustedKcal(result.totalAdjustedKcal());
 	}
 
 	private void syncPatientEnergySnapshot(final AnthropometricMeasurement measurement) {
@@ -84,9 +86,9 @@ public class AnthropometricMeasurementServiceImpl implements AnthropometricMeasu
 			return;
 		}
 		final Paciente paciente = measurement.getPaciente();
-		EnergyExpenditureResolver.applyToPatient(
-				paciente, new EnergyExpenditureResolver.EnergyResult(measurement.getBmrUsed(),
-						measurement.getActivityFactor(), measurement.getGetKcal()),
+		EnergyExpenditureResolver.applyToPatient(paciente,
+				new EnergyExpenditureResolver.EnergyResult(measurement.getBmrUsed(), measurement.getActivityFactor(),
+						measurement.getGetKcal(), null, measurement.getTefKcal(), measurement.getTotalAdjustedKcal()),
 				measurement.getPhysicalActivityLevel());
 		pacienteRepository.save(paciente);
 	}

--- a/src/main/java/com/nutriconsultas/dieta/DietaNutritionCalculator.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaNutritionCalculator.java
@@ -1,0 +1,96 @@
+package com.nutriconsultas.dieta;
+
+/**
+ * Calculates dieta totals from ingestas (platillos and alimentos). Same formula as
+ * {@code /admin/dietas} grid: protein × 4 + lipids × 9 + carbohydrates × 4.
+ */
+public final class DietaNutritionCalculator {
+
+	private DietaNutritionCalculator() {
+	}
+
+	public static Double calculateTotalProteina(final Dieta dieta) {
+		if (dieta == null || dieta.getIngestas() == null) {
+			return 0.0;
+		}
+		return dieta.getIngestas().stream().mapToDouble(ingesta -> {
+			final double platillos = ingesta.getPlatillos() != null
+					? ingesta.getPlatillos()
+						.stream()
+						.mapToDouble(p -> p.getProteina() != null ? p.getProteina() : 0.0)
+						.sum()
+					: 0.0;
+			final double alimentos = ingesta.getAlimentos() != null
+					? ingesta.getAlimentos()
+						.stream()
+						.mapToDouble(a -> a.getProteina() != null ? a.getProteina() : 0.0)
+						.sum()
+					: 0.0;
+			return platillos + alimentos;
+		}).sum();
+	}
+
+	public static Double calculateTotalLipidos(final Dieta dieta) {
+		if (dieta == null || dieta.getIngestas() == null) {
+			return 0.0;
+		}
+		return dieta.getIngestas().stream().mapToDouble(ingesta -> {
+			final double platillos = ingesta.getPlatillos() != null
+					? ingesta.getPlatillos()
+						.stream()
+						.mapToDouble(p -> p.getLipidos() != null ? p.getLipidos() : 0.0)
+						.sum()
+					: 0.0;
+			final double alimentos = ingesta.getAlimentos() != null
+					? ingesta.getAlimentos()
+						.stream()
+						.mapToDouble(a -> a.getLipidos() != null ? a.getLipidos() : 0.0)
+						.sum()
+					: 0.0;
+			return platillos + alimentos;
+		}).sum();
+	}
+
+	public static Double calculateTotalHidratosDeCarbono(final Dieta dieta) {
+		if (dieta == null || dieta.getIngestas() == null) {
+			return 0.0;
+		}
+		return dieta.getIngestas().stream().mapToDouble(ingesta -> {
+			final double platillos = ingesta.getPlatillos() != null
+					? ingesta.getPlatillos()
+						.stream()
+						.mapToDouble(p -> p.getHidratosDeCarbono() != null ? p.getHidratosDeCarbono() : 0.0)
+						.sum()
+					: 0.0;
+			final double alimentos = ingesta.getAlimentos() != null
+					? ingesta.getAlimentos()
+						.stream()
+						.mapToDouble(a -> a.getHidratosDeCarbono() != null ? a.getHidratosDeCarbono() : 0.0)
+						.sum()
+					: 0.0;
+			return platillos + alimentos;
+		}).sum();
+	}
+
+	public static Double calculateTotalKcal(final Dieta dieta) {
+		if (dieta == null) {
+			return 0.0;
+		}
+		final Double proteina = calculateTotalProteina(dieta);
+		final Double lipidos = calculateTotalLipidos(dieta);
+		final Double hidratos = calculateTotalHidratosDeCarbono(dieta);
+		return proteina * 4 + lipidos * 9 + hidratos * 4;
+	}
+
+	public static void applyCalculatedNutrients(final Dieta dieta) {
+		if (dieta == null) {
+			return;
+		}
+		dieta.setProteina(calculateTotalProteina(dieta));
+		dieta.setLipidos(calculateTotalLipidos(dieta));
+		dieta.setHidratosDeCarbono(calculateTotalHidratosDeCarbono(dieta));
+		final Double kcal = calculateTotalKcal(dieta);
+		dieta.setEnergia(kcal != null ? kcal.intValue() : 0);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/dieta/DietaPickerItemDto.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaPickerItemDto.java
@@ -1,0 +1,18 @@
+package com.nutriconsultas.dieta;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DietaPickerItemDto {
+
+	private Long id;
+
+	private String nombre;
+
+	private Integer energiaKcal;
+
+}

--- a/src/main/java/com/nutriconsultas/dieta/DietaPickerPageDto.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaPickerPageDto.java
@@ -1,0 +1,25 @@
+package com.nutriconsultas.dieta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DietaPickerPageDto {
+
+	private List<DietaPickerItemDto> items = new ArrayList<>();
+
+	private int page;
+
+	private int size;
+
+	private long totalElements;
+
+	private boolean hasNext;
+
+}

--- a/src/main/java/com/nutriconsultas/dieta/DietaService.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaService.java
@@ -18,6 +18,8 @@ public interface DietaService {
 
 	List<Dieta> getDietas();
 
+	DietaPickerPageDto findPickerPage(String search, int page, int size, Double requerimientoKcal);
+
 	void addIngesta(@NonNull Long id, String nombreIngesta);
 
 	void renameIngesta(@NonNull Long id, @NonNull Long ingestaId, String nombreIngesta);

--- a/src/main/java/com/nutriconsultas/dieta/DietaServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaServiceImpl.java
@@ -1,9 +1,11 @@
 package com.nutriconsultas.dieta;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,6 +56,92 @@ public class DietaServiceImpl implements DietaService {
 	public List<Dieta> getDietas() {
 		log.info("Getting all dietas");
 		return dietaRepository.findAll();
+	}
+
+	private static final int PICKER_MAX_PAGE_SIZE = 50;
+
+	@Override
+	@Transactional(readOnly = true)
+	public DietaPickerPageDto findPickerPage(final String search, final int page, final int size,
+			final Double requerimientoKcal) {
+		final String term = search == null ? "" : search.trim().toLowerCase();
+		final int safeSize = Math.min(Math.max(size, 1), PICKER_MAX_PAGE_SIZE);
+		final int safePage = Math.max(page, 0);
+
+		final List<DietaPickerItemDto> filtered = dietaRepository.findAll(Sort.by("nombre"))
+			.stream()
+			.filter(dieta -> matchesPickerSearch(dieta, term))
+			.map(this::toPickerItem)
+			.sorted(pickerComparator(requerimientoKcal))
+			.toList();
+
+		final int total = filtered.size();
+		final int fromIndex = safePage * safeSize;
+		final List<DietaPickerItemDto> pageItems;
+		if (fromIndex >= total) {
+			pageItems = List.of();
+		}
+		else {
+			final int toIndex = Math.min(fromIndex + safeSize, total);
+			pageItems = filtered.subList(fromIndex, toIndex);
+		}
+
+		final DietaPickerPageDto result = new DietaPickerPageDto();
+		result.setItems(new ArrayList<>(pageItems));
+		result.setPage(safePage);
+		result.setSize(safeSize);
+		result.setTotalElements(total);
+		result.setHasNext(fromIndex + safeSize < total);
+		return result;
+	}
+
+	private DietaPickerItemDto toPickerItem(final Dieta dieta) {
+		final Double kcal = DietaNutritionCalculator.calculateTotalKcal(dieta);
+		return new DietaPickerItemDto(dieta.getId(), dieta.getNombre(), kcal != null ? kcal.intValue() : 0);
+	}
+
+	private boolean matchesPickerSearch(final Dieta dieta, final String term) {
+		if (term.isEmpty()) {
+			return true;
+		}
+		if (dieta.getNombre() != null && dieta.getNombre().toLowerCase().contains(term)) {
+			return true;
+		}
+		final int kcal = DietaNutritionCalculator.calculateTotalKcal(dieta).intValue();
+		if (String.valueOf(kcal).contains(term)) {
+			return true;
+		}
+		if (dieta.getIngestas() != null) {
+			return dieta.getIngestas()
+				.stream()
+				.anyMatch(ingesta -> ingesta.getNombre() != null
+						&& ingesta.getNombre().toLowerCase().contains(term));
+		}
+		return false;
+	}
+
+	private Comparator<DietaPickerItemDto> pickerComparator(final Double requerimientoKcal) {
+		if (requerimientoKcal == null) {
+			return Comparator.comparing(DietaPickerItemDto::getNombre, String.CASE_INSENSITIVE_ORDER);
+		}
+		return Comparator.comparingInt((DietaPickerItemDto item) -> caloricFitRank(item.getEnergiaKcal(), requerimientoKcal))
+			.thenComparingInt(item -> Math.abs(item.getEnergiaKcal() - requerimientoKcal.intValue()))
+			.thenComparing(DietaPickerItemDto::getNombre, String.CASE_INSENSITIVE_ORDER);
+	}
+
+	private int caloricFitRank(final Integer energiaKcal, final Double requerimientoKcal) {
+		if (requerimientoKcal == null || energiaKcal == null || energiaKcal <= 0) {
+			return 3;
+		}
+		final double tolerance = Math.max(50, requerimientoKcal * 0.05);
+		final double diff = energiaKcal - requerimientoKcal;
+		if (Math.abs(diff) <= tolerance) {
+			return 0;
+		}
+		if (diff < 0) {
+			return 1;
+		}
+		return 2;
 	}
 
 	@Override

--- a/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
@@ -13,6 +13,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -35,6 +36,14 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 
 	@Autowired
 	private DietaService dietaService;
+
+	@GetMapping("picker")
+	public DietaPickerPageDto getPickerPage(@RequestParam(required = false) final String q,
+			@RequestParam(defaultValue = "0") final int page, @RequestParam(defaultValue = "20") final int size,
+			@RequestParam(required = false) final Double requerimientoKcal) {
+		log.debug("Dieta picker page={}, size={}, q={}", page, size, q);
+		return dietaService.findPickerPage(q, page, size, requerimientoKcal);
+	}
 
 	@PostMapping("add")
 	public Dieta addDieta(@RequestBody final Dieta dieta, @AuthenticationPrincipal final OidcUser principal) {

--- a/src/main/java/com/nutriconsultas/paciente/Paciente.java
+++ b/src/main/java/com/nutriconsultas/paciente/Paciente.java
@@ -21,6 +21,9 @@ import org.springframework.format.annotation.DateTimeFormat.ISO;
 import com.nutriconsultas.paciente.calculation.ActivityFactorScale;
 import com.nutriconsultas.paciente.calculation.BmrFormulaType;
 import com.nutriconsultas.paciente.calculation.PhysicalActivityLevel;
+import com.nutriconsultas.paciente.calculation.TefBase;
+import com.nutriconsultas.paciente.calculation.TefCalculationService;
+import com.nutriconsultas.paciente.calculation.TefMethod;
 import com.nutriconsultas.paciente.validation.ValidPregnancy;
 
 import jakarta.persistence.EnumType;
@@ -96,6 +99,38 @@ public class Paciente {
 	 */
 	@Column(precision = 7)
 	private Double getKcal;
+
+	/**
+	 * Thermic effect of food (TEF / ETA) in kcal/day.
+	 */
+	@Column(precision = 7)
+	private Double tefKcal;
+
+	/**
+	 * Total adjusted daily energy requirement (GET + TEF) in kcal/day.
+	 */
+	@Column(precision = 7)
+	private Double totalAdjustedKcal;
+
+	@Enumerated(EnumType.STRING)
+	@Column(length = 30)
+	private TefMethod tefMethod = TefMethod.FIXED;
+
+	@Enumerated(EnumType.STRING)
+	@Column(length = 30)
+	private TefBase tefBase = TefBase.GET;
+
+	@Column(precision = 5)
+	private Double tefFixedPercent = TefCalculationService.DEFAULT_FIXED_TEF_PERCENT;
+
+	@Column(precision = 5)
+	private Double tefMacroProteinPercent;
+
+	@Column(precision = 5)
+	private Double tefMacroCarbsPercent;
+
+	@Column(precision = 5)
+	private Double tefMacroFatPercent;
 
 	@Enumerated(EnumType.STRING)
 	@Column(length = 30)

--- a/src/main/java/com/nutriconsultas/paciente/Paciente.java
+++ b/src/main/java/com/nutriconsultas/paciente/Paciente.java
@@ -33,6 +33,7 @@ import jakarta.persistence.Enumerated;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@SuppressWarnings("PMD.TooManyFields")
 public class Paciente {
 
 	@Id

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -31,6 +31,7 @@ import com.nutriconsultas.clinical.exam.ClinicalExamService;
 import com.nutriconsultas.auth0.Auth0UserLookup;
 import com.nutriconsultas.controller.AbstractAuthorizedController;
 import com.nutriconsultas.mobile.PatientMobileAuthStatus;
+import com.nutriconsultas.dieta.DietaNutritionCalculator;
 import com.nutriconsultas.dieta.DietaPdfService;
 import com.nutriconsultas.dieta.DietaRepository;
 import com.nutriconsultas.dieta.DietaService;
@@ -106,6 +107,13 @@ public class PacienteController extends AbstractAuthorizedController {
 	 * @param userId the current user's ID
 	 * @throws IllegalArgumentException if the patient does not belong to the user
 	 */
+	private Double resolveRequerimientoKcal(final Paciente paciente) {
+		if (paciente.getTotalAdjustedKcal() != null) {
+			return paciente.getTotalAdjustedKcal();
+		}
+		return paciente.getGetKcal();
+	}
+
 	private void verifyPatientOwnership(final Paciente paciente, final String userId) {
 		if (paciente == null) {
 			throw new IllegalArgumentException("Paciente no encontrado");
@@ -415,14 +423,7 @@ public class PacienteController extends AbstractAuthorizedController {
 				if (dietaId != null) {
 					final com.nutriconsultas.dieta.Dieta dieta = dietaService.getDieta(dietaId);
 					if (dieta != null) {
-						// Calculate and set macronutrientes
-						dieta.setProteina(getTotalProteina(dieta));
-						dieta.setLipidos(getTotalLipidos(dieta));
-						dieta.setHidratosDeCarbono(getTotalHidratosDeCarbono(dieta));
-						// Calculate and set kilocalorías
-						final Double kCal = getTotalKCal(dieta);
-						dieta.setEnergia(kCal != null ? kCal.intValue() : 0);
-						// Update the dieta in pacienteDieta
+						DietaNutritionCalculator.applyCalculatedNutrients(dieta);
 						pacienteDieta.setDieta(dieta);
 					}
 				}
@@ -437,22 +438,15 @@ public class PacienteController extends AbstractAuthorizedController {
 				if (dietaId != null) {
 					final com.nutriconsultas.dieta.Dieta dieta = dietaService.getDieta(dietaId);
 					if (dieta != null) {
-						// Calculate and set macronutrientes
-						dieta.setProteina(getTotalProteina(dieta));
-						dieta.setLipidos(getTotalLipidos(dieta));
-						dieta.setHidratosDeCarbono(getTotalHidratosDeCarbono(dieta));
-						// Calculate and set kilocalorías
-						final Double kCal = getTotalKCal(dieta);
-						dieta.setEnergia(kCal != null ? kCal.intValue() : 0);
-						// Update the dieta in pacienteDieta
+						DietaNutritionCalculator.applyCalculatedNutrients(dieta);
 						pacienteDieta.setDieta(dieta);
 					}
 				}
 			}
 		}
 		model.addAttribute("dietasActivas", dietasActivas);
-		// obtener todas las dietas disponibles para asignar
-		model.addAttribute("dietasDisponibles", dietaService.getDietas());
+		// obtener todas las dietas disponibles para asignar (legacy attribute for dietas template)
+		model.addAttribute("dietasDisponibles", getDietasDisponiblesWithCalculatedNutrients());
 		return "sbadmin/pacientes/dietas";
 	}
 
@@ -705,7 +699,7 @@ public class PacienteController extends AbstractAuthorizedController {
 
 		model.addAttribute("activeMenu", "perfil");
 		model.addAttribute("paciente", paciente);
-		model.addAttribute("dietasDisponibles", dietaService.getDietas());
+		model.addAttribute("requerimientoKcal", resolveRequerimientoKcal(paciente));
 		model.addAttribute("pacienteDieta", new PacienteDieta());
 		return "sbadmin/pacientes/asignar-dieta";
 	}
@@ -765,7 +759,7 @@ public class PacienteController extends AbstractAuthorizedController {
 				.forEach(error -> log.error("Error: {} - {}", error.getObjectName(), error.getDefaultMessage()));
 			model.addAttribute("activeMenu", "perfil");
 			model.addAttribute("paciente", paciente);
-			model.addAttribute("dietasDisponibles", dietaService.getDietas());
+			model.addAttribute("requerimientoKcal", resolveRequerimientoKcal(paciente));
 			return "sbadmin/pacientes/asignar-dieta";
 		}
 		final PacienteDieta saved = pacienteDietaService.assignDieta(id, dietaId, pacienteDieta, userId);
@@ -968,81 +962,27 @@ public class PacienteController extends AbstractAuthorizedController {
 	}
 
 	/**
-	 * Calculates total protein from a dieta.
-	 * @param dieta the dieta to calculate protein from
-	 * @return total protein in grams
+	 * Loads available dietas with kcal/macros calculated from ingestas (same formula as
+	 * {@code /admin/dietas} grid), not the persisted {@code energia} column.
 	 */
-	private Double getTotalProteina(final com.nutriconsultas.dieta.Dieta dieta) {
-		if (dieta == null || dieta.getIngestas() == null) {
-			return 0.0;
-		}
-		return dieta.getIngestas().stream().mapToDouble(i -> {
-			double platillosProteina = i.getPlatillos() != null
-					? i.getPlatillos().stream().mapToDouble(p -> p.getProteina() != null ? p.getProteina() : 0.0).sum()
-					: 0.0;
-			double alimentosProteina = i.getAlimentos() != null
-					? i.getAlimentos().stream().mapToDouble(a -> a.getProteina() != null ? a.getProteina() : 0.0).sum()
-					: 0.0;
-			return platillosProteina + alimentosProteina;
-		}).sum();
+	private List<com.nutriconsultas.dieta.Dieta> getDietasDisponiblesWithCalculatedNutrients() {
+		return dietaService.getDietas()
+			.stream()
+			.map(this::enrichDietaWithCalculatedNutrients)
+			.collect(Collectors.toList());
 	}
 
-	/**
-	 * Calculates total lipids from a dieta.
-	 * @param dieta the dieta to calculate lipids from
-	 * @return total lipids in grams
-	 */
-	private Double getTotalLipidos(final com.nutriconsultas.dieta.Dieta dieta) {
-		if (dieta == null || dieta.getIngestas() == null) {
-			return 0.0;
+	private com.nutriconsultas.dieta.Dieta enrichDietaWithCalculatedNutrients(
+			final com.nutriconsultas.dieta.Dieta dieta) {
+		if (dieta == null || dieta.getId() == null) {
+			return dieta;
 		}
-		return dieta.getIngestas().stream().mapToDouble(i -> {
-			double platillosLipidos = i.getPlatillos() != null
-					? i.getPlatillos().stream().mapToDouble(p -> p.getLipidos() != null ? p.getLipidos() : 0.0).sum()
-					: 0.0;
-			double alimentosLipidos = i.getAlimentos() != null
-					? i.getAlimentos().stream().mapToDouble(a -> a.getLipidos() != null ? a.getLipidos() : 0.0).sum()
-					: 0.0;
-			return platillosLipidos + alimentosLipidos;
-		}).sum();
-	}
-
-	/**
-	 * Calculates total carbohydrates from a dieta.
-	 * @param dieta the dieta to calculate carbohydrates from
-	 * @return total carbohydrates in grams
-	 */
-	private Double getTotalHidratosDeCarbono(final com.nutriconsultas.dieta.Dieta dieta) {
-		if (dieta == null || dieta.getIngestas() == null) {
-			return 0.0;
+		final com.nutriconsultas.dieta.Dieta fullDieta = dietaService.getDieta(dieta.getId());
+		if (fullDieta == null) {
+			return dieta;
 		}
-		return dieta.getIngestas().stream().mapToDouble(i -> {
-			double platillosHidratos = i.getPlatillos() != null ? i.getPlatillos()
-				.stream()
-				.mapToDouble(p -> p.getHidratosDeCarbono() != null ? p.getHidratosDeCarbono() : 0.0)
-				.sum() : 0.0;
-			double alimentosHidratos = i.getAlimentos() != null ? i.getAlimentos()
-				.stream()
-				.mapToDouble(a -> a.getHidratosDeCarbono() != null ? a.getHidratosDeCarbono() : 0.0)
-				.sum() : 0.0;
-			return platillosHidratos + alimentosHidratos;
-		}).sum();
-	}
-
-	/**
-	 * Calculates total kilocalories from a dieta. Formula: protein * 4 + lipids * 9 +
-	 * carbohydrates * 4
-	 * @param dieta the dieta to calculate kilocalories from
-	 * @return total kilocalories
-	 */
-	private Double getTotalKCal(final com.nutriconsultas.dieta.Dieta dieta) {
-		if (dieta == null) {
-			return 0.0;
-		}
-		final Double proteina = getTotalProteina(dieta);
-		final Double lipidos = getTotalLipidos(dieta);
-		final Double hidratosDeCarbono = getTotalHidratosDeCarbono(dieta);
-		return proteina * 4 + lipidos * 9 + hidratosDeCarbono * 4;
+		DietaNutritionCalculator.applyCalculatedNutrients(fullDieta);
+		return fullDieta;
 	}
 
 	/**

--- a/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
@@ -113,7 +113,18 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 
 		final List<Dieta> mockDietasDisponibles = new ArrayList<>();
 		mockDietasDisponibles.add(mockDieta);
+		final Dieta dietaAlta = new Dieta();
+		dietaAlta.setId(2L);
+		dietaAlta.setNombre("Dieta 2200 kcal");
+		dietaAlta.setEnergia(2200);
+		mockDietasDisponibles.add(dietaAlta);
+		final Dieta dietaBaja = new Dieta();
+		dietaBaja.setId(3L);
+		dietaBaja.setNombre("Dieta 1500 kcal");
+		dietaBaja.setEnergia(1500);
+		mockDietasDisponibles.add(dietaBaja);
 		variables.put("dietasDisponibles", mockDietasDisponibles);
+		variables.put("requerimientoKcal", 2000.0);
 	}
 
 	private void addMockConsulta(final Map<String, Object> variables, final Paciente paciente) {

--- a/src/main/java/com/nutriconsultas/paciente/calculation/EnergyExpenditureResolver.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/EnergyExpenditureResolver.java
@@ -18,17 +18,24 @@ public final class EnergyExpenditureResolver {
 		// Utility class
 	}
 
-	public record EnergyResult(Double bmr, Double activityFactor, Double getKcal) {
+	public record EnergyResult(Double bmr, Double activityFactor, Double getKcal, Double activityKcal, Double tefKcal,
+			Double totalAdjustedKcal) {
+
+		public EnergyResult(final Double bmr, final Double activityFactor, final Double getKcal) {
+			this(bmr, activityFactor, getKcal, null, null, getKcal);
+		}
+
 	}
 
 	/**
-	 * Computes BMR, activity factor and GET from patient context and inputs.
+	 * Computes BMR, activity factor, GET, TEF and total adjusted energy from patient
+	 * context.
 	 */
 	public static EnergyResult resolve(final Paciente paciente, @Nullable final BmrFormulaType bmrFormulaOverride,
 			@Nullable final PhysicalActivityLevel activityLevel, @Nullable final Double customFactorValue,
 			final Double weight, final Double height) {
 		if (paciente == null || weight == null || height == null || weight <= 0 || height <= 0) {
-			return new EnergyResult(null, null, null);
+			return new EnergyResult(null, null, null, null, null, null);
 		}
 		final Integer age = calculateAge(paciente.getDob());
 		final Boolean isMale = "M".equalsIgnoreCase(paciente.getGender());
@@ -36,14 +43,44 @@ public final class EnergyExpenditureResolver {
 				: PatientEnergyPreferences.resolveBmrFormula(paciente);
 		final Double bmr = TdeeCalculationService.calculateBmr(formula, weight, height, age, isMale);
 		if (bmr == null || activityLevel == null) {
-			return new EnergyResult(bmr, null, null);
+			return new EnergyResult(bmr, null, null, null, null, null);
 		}
 		final ActivityFactorScale scale = PatientEnergyPreferences.resolveScale(paciente);
 		final CustomActivityFactors customFactors = PatientEnergyPreferences.customFactorsFrom(paciente);
 		final Double factor = TdeeCalculationService.resolveActivityFactor(scale, activityLevel, customFactors,
 				customFactorValue);
 		final Double getKcal = TdeeCalculationService.calculateGet(bmr, factor);
-		return new EnergyResult(bmr, factor, getKcal);
+		return applyTef(paciente, bmr, factor, getKcal);
+	}
+
+	/**
+	 * Applies TEF preferences to an existing GET/BMR result.
+	 */
+	public static EnergyResult applyTef(final Paciente paciente, final Double bmr, final Double activityFactor,
+			final Double getKcal) {
+		if (getKcal == null) {
+			return new EnergyResult(bmr, activityFactor, null, null, null, null);
+		}
+		final Double tefKcal = TefCalculationService.calculateTef(PatientEnergyPreferences.resolveTefMethod(paciente),
+				PatientEnergyPreferences.resolveTefBase(paciente), paciente.getTefFixedPercent(),
+				paciente.getTefMacroProteinPercent(), paciente.getTefMacroCarbsPercent(),
+				paciente.getTefMacroFatPercent(), bmr, getKcal);
+		final Double totalAdjustedKcal = TefCalculationService.calculateTotalAdjustedKcal(getKcal, tefKcal);
+		final Double activityKcal = TefCalculationService.calculateActivityKcal(bmr, getKcal);
+		return new EnergyResult(bmr, activityFactor, getKcal, activityKcal, tefKcal, totalAdjustedKcal);
+	}
+
+	/**
+	 * Target daily calories for diet assignment (GET + TEF when available).
+	 */
+	public static Double resolveTargetDailyCalories(final Paciente paciente) {
+		if (paciente == null) {
+			return null;
+		}
+		if (paciente.getTotalAdjustedKcal() != null) {
+			return paciente.getTotalAdjustedKcal();
+		}
+		return paciente.getGetKcal();
 	}
 
 	/**
@@ -59,6 +96,12 @@ public final class EnergyExpenditureResolver {
 		}
 		if (result.getKcal() != null) {
 			paciente.setGetKcal(result.getKcal());
+		}
+		if (result.tefKcal() != null) {
+			paciente.setTefKcal(result.tefKcal());
+		}
+		if (result.totalAdjustedKcal() != null) {
+			paciente.setTotalAdjustedKcal(result.totalAdjustedKcal());
 		}
 		if (activityLevel != null) {
 			paciente.setPhysicalActivityLevel(activityLevel);

--- a/src/main/java/com/nutriconsultas/paciente/calculation/PatientEnergyPreferences.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/PatientEnergyPreferences.java
@@ -34,4 +34,18 @@ public final class PatientEnergyPreferences {
 		return paciente.getPreferredBmrFormula();
 	}
 
+	public static TefMethod resolveTefMethod(final Paciente paciente) {
+		if (paciente == null || paciente.getTefMethod() == null) {
+			return TefMethod.FIXED;
+		}
+		return paciente.getTefMethod();
+	}
+
+	public static TefBase resolveTefBase(final Paciente paciente) {
+		if (paciente == null || paciente.getTefBase() == null) {
+			return TefBase.GET;
+		}
+		return paciente.getTefBase();
+	}
+
 }

--- a/src/main/java/com/nutriconsultas/paciente/calculation/TefBase.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/TefBase.java
@@ -1,0 +1,20 @@
+package com.nutriconsultas.paciente.calculation;
+
+/**
+ * Energy base used when applying a fixed TEF percentage.
+ */
+public enum TefBase {
+
+	GET("GET (TMB × actividad)"), BMR("TMB");
+
+	private final String displayName;
+
+	TefBase(final String displayName) {
+		this.displayName = displayName;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/calculation/TefCalculationService.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/TefCalculationService.java
@@ -74,11 +74,11 @@ public final class TefCalculationService {
 	static Double calculateFixedTef(final TefBase base, final Double fixedPercent, final Double bmr,
 			final Double getKcal) {
 		final TefBase resolvedBase = base != null ? base : TefBase.GET;
-		final double percent = fixedPercent != null && fixedPercent > 0 ? fixedPercent : DEFAULT_FIXED_TEF_PERCENT;
 		final Double tefBase = resolvedBase == TefBase.BMR ? bmr : getKcal;
 		if (tefBase == null || tefBase <= 0) {
 			return null;
 		}
+		final double percent = fixedPercent != null && fixedPercent > 0 ? fixedPercent : DEFAULT_FIXED_TEF_PERCENT;
 		final double tef = tefBase * (percent / 100.0);
 		log.debug("Calculated fixed TEF: {} kcal/day (base={}, percent={}%)", tef, tefBase, percent);
 		return tef;

--- a/src/main/java/com/nutriconsultas/paciente/calculation/TefCalculationService.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/TefCalculationService.java
@@ -1,0 +1,121 @@
+package com.nutriconsultas.paciente.calculation;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * Thermic effect of food (TEF / ETA) calculations.
+ *
+ * <p>
+ * <strong>Fixed method:</strong> TEF = base × (percent / 100), where base is GET or TMB
+ * per {@link TefBase}.
+ *
+ * <p>
+ * <strong>Macronutrient method:</strong> TEF = GET × weighted TEF coefficients (protein
+ * ~25%, carbohydrates ~7.5%, fat ~2% of each macro's caloric contribution).
+ */
+@Service
+@Slf4j
+public final class TefCalculationService {
+
+	/** Default fixed TEF when no percent is configured (10% of base). */
+	public static final double DEFAULT_FIXED_TEF_PERCENT = 10.0;
+
+	private static final double PROTEIN_TEF_COEFFICIENT = 0.25;
+
+	private static final double CARBOHYDRATE_TEF_COEFFICIENT = 0.075;
+
+	private static final double FAT_TEF_COEFFICIENT = 0.02;
+
+	private TefCalculationService() {
+		// Utility class
+	}
+
+	/**
+	 * Calculates TEF in kcal/day from patient preferences and computed GET/BMR.
+	 */
+	public static Double calculateTef(final TefMethod method, final TefBase base, final Double fixedPercent,
+			final Double proteinPercent, final Double carbsPercent, final Double fatPercent, final Double bmr,
+			final Double getKcal) {
+		if (bmr == null && getKcal == null) {
+			return null;
+		}
+		final TefMethod resolvedMethod = method != null ? method : TefMethod.FIXED;
+		if (resolvedMethod == TefMethod.MACRONUTRIENTS) {
+			return calculateMacronutrientTef(getKcal, proteinPercent, carbsPercent, fatPercent);
+		}
+		return calculateFixedTef(base, fixedPercent, bmr, getKcal);
+	}
+
+	/**
+	 * Total daily energy requirement including TEF: GET + TEF.
+	 */
+	public static Double calculateTotalAdjustedKcal(final Double getKcal, final Double tefKcal) {
+		if (getKcal == null) {
+			return null;
+		}
+		if (tefKcal == null) {
+			return getKcal;
+		}
+		return getKcal + tefKcal;
+	}
+
+	/**
+	 * Activity energy beyond basal metabolism (GET − TMB).
+	 */
+	public static Double calculateActivityKcal(final Double bmr, final Double getKcal) {
+		if (bmr == null || getKcal == null) {
+			return null;
+		}
+		return getKcal - bmr;
+	}
+
+	static Double calculateFixedTef(final TefBase base, final Double fixedPercent, final Double bmr,
+			final Double getKcal) {
+		final TefBase resolvedBase = base != null ? base : TefBase.GET;
+		final double percent = fixedPercent != null && fixedPercent > 0 ? fixedPercent : DEFAULT_FIXED_TEF_PERCENT;
+		final Double tefBase = resolvedBase == TefBase.BMR ? bmr : getKcal;
+		if (tefBase == null || tefBase <= 0) {
+			return null;
+		}
+		final double tef = tefBase * (percent / 100.0);
+		log.debug("Calculated fixed TEF: {} kcal/day (base={}, percent={}%)", tef, tefBase, percent);
+		return tef;
+	}
+
+	static Double calculateMacronutrientTef(final Double getKcal, final Double proteinPercent,
+			final Double carbsPercent, final Double fatPercent) {
+		if (getKcal == null || getKcal <= 0) {
+			return null;
+		}
+		final MacroDistribution distribution = resolveMacroDistribution(proteinPercent, carbsPercent, fatPercent);
+		if (distribution == null) {
+			return null;
+		}
+		final double weightedCoefficient = (distribution.protein() / 100.0) * PROTEIN_TEF_COEFFICIENT
+				+ (distribution.carbs() / 100.0) * CARBOHYDRATE_TEF_COEFFICIENT
+				+ (distribution.fat() / 100.0) * FAT_TEF_COEFFICIENT;
+		final double tef = getKcal * weightedCoefficient;
+		log.debug("Calculated macronutrient TEF: {} kcal/day (GET={}, P={}%, C={}%, F={}%)", tef, getKcal,
+				distribution.protein(), distribution.carbs(), distribution.fat());
+		return tef;
+	}
+
+	private static MacroDistribution resolveMacroDistribution(final Double proteinPercent, final Double carbsPercent,
+			final Double fatPercent) {
+		if (proteinPercent != null && carbsPercent != null && fatPercent != null && proteinPercent >= 0
+				&& carbsPercent >= 0 && fatPercent >= 0) {
+			final double sum = proteinPercent + carbsPercent + fatPercent;
+			if (sum > 0) {
+				return new MacroDistribution(proteinPercent, carbsPercent, fatPercent);
+			}
+		}
+		// Balanced default when macros are not configured
+		return new MacroDistribution(30.0, 50.0, 20.0);
+	}
+
+	private record MacroDistribution(double protein, double carbs, double fat) {
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/calculation/TefMethod.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/TefMethod.java
@@ -1,0 +1,20 @@
+package com.nutriconsultas.paciente.calculation;
+
+/**
+ * Method for calculating the thermic effect of food (TEF / ETA).
+ */
+public enum TefMethod {
+
+	FIXED("Porcentaje fijo"), MACRONUTRIENTS("Por macronutrientes");
+
+	private final String displayName;
+
+	TefMethod(final String displayName) {
+		this.displayName = displayName;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecord.java
+++ b/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecord.java
@@ -84,4 +84,10 @@ public class BodyMetricRecord {
 	@Column(precision = 7)
 	private Double getKcal;
 
+	@Column(precision = 7)
+	private Double tefKcal;
+
+	@Column(precision = 7)
+	private Double totalAdjustedKcal;
+
 }

--- a/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordServiceImpl.java
@@ -64,7 +64,8 @@ public class BodyMetricRecordServiceImpl implements BodyMetricRecordService {
 		}
 		upsertRecord(new BodyMetricUpsertData(event.getPaciente(), event.getEventDateTime(),
 				BodyMetricSource.CONSULTATION, event.getId(), event.getPeso(), event.getEstatura(), event.getImc(),
-				event.getNivelPeso(), event.getIndiceGrasaCorporal(), null, event.getBmrUsed(), event.getGetKcal()));
+				event.getNivelPeso(), event.getIndiceGrasaCorporal(), null, event.getBmrUsed(), event.getGetKcal(),
+				event.getTefKcal(), event.getTotalAdjustedKcal()));
 	}
 
 	@Override
@@ -77,7 +78,8 @@ public class BodyMetricRecordServiceImpl implements BodyMetricRecordService {
 		upsertRecord(new BodyMetricUpsertData(measurement.getPaciente(), measurement.getMeasurementDateTime(),
 				BodyMetricSource.ANTHROPOMETRIC, measurement.getId(), measurement.getPeso(), measurement.getEstatura(),
 				measurement.getImc(), measurement.getNivelPeso(), measurement.getIndiceGrasaCorporal(),
-				measurement.getPorcentajeGrasaCorporal(), measurement.getBmrUsed(), measurement.getGetKcal()));
+				measurement.getPorcentajeGrasaCorporal(), measurement.getBmrUsed(), measurement.getGetKcal(),
+				measurement.getTefKcal(), measurement.getTotalAdjustedKcal()));
 	}
 
 	@Override
@@ -88,7 +90,7 @@ public class BodyMetricRecordServiceImpl implements BodyMetricRecordService {
 		}
 		upsertRecord(new BodyMetricUpsertData(exam.getPaciente(), exam.getExamDateTime(),
 				BodyMetricSource.CLINICAL_EXAM, exam.getId(), exam.getPeso(), exam.getEstatura(), exam.getImc(),
-				exam.getNivelPeso(), exam.getIndiceGrasaCorporal(), null, null, null));
+				exam.getNivelPeso(), exam.getIndiceGrasaCorporal(), null, null, null, null, null));
 	}
 
 	@Override
@@ -194,12 +196,14 @@ public class BodyMetricRecordServiceImpl implements BodyMetricRecordService {
 		record.setBodyFatPercentage(data.bodyFatPercentage());
 		record.setBmr(data.bmr());
 		record.setGetKcal(data.getKcal());
+		record.setTefKcal(data.tefKcal());
+		record.setTotalAdjustedKcal(data.totalAdjustedKcal());
 		repository.save(record);
 	}
 
 	private record BodyMetricUpsertData(Paciente paciente, java.util.Date recordedAt, BodyMetricSource source,
 			Long sourceId, Double weight, Double height, Double imc, NivelPeso nivelPeso, Double bodyFatIndex,
-			Double bodyFatPercentage, Double bmr, Double getKcal) {
+			Double bodyFatPercentage, Double bmr, Double getKcal, Double tefKcal, Double totalAdjustedKcal) {
 	}
 
 	private boolean hasBodyMetricData(final Double weight, final Double height, final Double imc,
@@ -230,6 +234,8 @@ public class BodyMetricRecordServiceImpl implements BodyMetricRecordService {
 			paciente.setNivelPeso(record.getNivelPeso());
 			paciente.setBmr(record.getBmr());
 			paciente.setGetKcal(record.getGetKcal());
+			paciente.setTefKcal(record.getTefKcal());
+			paciente.setTotalAdjustedKcal(record.getTotalAdjustedKcal());
 		}
 		else {
 			paciente.setPeso(null);
@@ -238,6 +244,8 @@ public class BodyMetricRecordServiceImpl implements BodyMetricRecordService {
 			paciente.setNivelPeso(null);
 			paciente.setBmr(null);
 			paciente.setGetKcal(null);
+			paciente.setTefKcal(null);
+			paciente.setTotalAdjustedKcal(null);
 		}
 		refreshPatientBmrIfPossible(paciente);
 		pacienteRepository.save(paciente);
@@ -265,6 +273,8 @@ public class BodyMetricRecordServiceImpl implements BodyMetricRecordService {
 				if (result.getKcal() != null) {
 					paciente.setGetKcal(result.getKcal());
 					paciente.setActivityFactor(result.activityFactor());
+					paciente.setTefKcal(result.tefKcal());
+					paciente.setTotalAdjustedKcal(result.totalAdjustedKcal());
 				}
 			}
 		}

--- a/src/main/resources/templates/sbadmin/calendar/listado.html
+++ b/src/main/resources/templates/sbadmin/calendar/listado.html
@@ -668,6 +668,30 @@
           OMS: { SEDENTARY: 1.40, LIGHT: 1.60, MODERATE: 1.80, INTENSE: 2.00, VERY_INTENSE: 2.20 }
         };
 
+        function calculateWizardTef(bmr, getVal) {
+          const method = window.patientTefMethod || 'FIXED';
+          if (!getVal) {
+            return null;
+          }
+          if (method === 'MACRONUTRIENTS') {
+            const protein = window.patientTefMacroProtein != null ? window.patientTefMacroProtein : 30;
+            const carbs = window.patientTefMacroCarbs != null ? window.patientTefMacroCarbs : 50;
+            const fat = window.patientTefMacroFat != null ? window.patientTefMacroFat : 20;
+            const sum = protein + carbs + fat;
+            if (sum <= 0) {
+              return null;
+            }
+            const weighted = (protein / sum) * 0.25 + (carbs / sum) * 0.075 + (fat / sum) * 0.02;
+            return Math.round(getVal * weighted);
+          }
+          const percent = window.patientTefFixedPercent > 0 ? window.patientTefFixedPercent : 10;
+          const base = (window.patientTefBase || 'GET') === 'BMR' ? bmr : getVal;
+          if (!base) {
+            return null;
+          }
+          return Math.round(base * (percent / 100));
+        }
+
         function updateWizardGetPreview() {
           const preview = $('#wizardGetPreview');
           if (!preview.length) return;
@@ -677,6 +701,7 @@
           const scale = window.patientActivityScale || 'HARRIS_BENEDICT';
           if (!peso || !estatura || !level) {
             preview.text('GET estimado: — kcal/día');
+            window.wizardTotalAdjustedKcal = null;
             return;
           }
           let factor = null;
@@ -687,11 +712,31 @@
           }
           if (!factor) {
             preview.text('GET estimado: — kcal/día');
+            window.wizardTotalAdjustedKcal = null;
             return;
           }
           const bmrApprox = 10 * peso + 6.25 * (estatura * 100) - 5 * 30;
           const getVal = Math.round(bmrApprox * factor);
-          preview.text('GET estimado: ' + getVal + ' kcal/día (aprox.; se recalcula al guardar)');
+          const tefVal = calculateWizardTef(bmrApprox, getVal);
+          const totalVal = tefVal != null ? getVal + tefVal : getVal;
+          window.wizardTotalAdjustedKcal = totalVal;
+          let previewText = 'GET estimado: ' + getVal + ' kcal/día';
+          if (tefVal != null) {
+            previewText += ' | TEF: ' + tefVal + ' | Total: ' + totalVal + ' kcal/día';
+          }
+          preview.text(previewText + ' (aprox.; se recalcula al guardar)');
+        }
+
+        function prefillWizardDailyCalories() {
+          const caloriesInput = $('#summaryNotesWizardModal input[name="caloriasDiarias"]');
+          if (!caloriesInput.length || caloriesInput.val()) {
+            return;
+          }
+          if (window.wizardTotalAdjustedKcal) {
+            caloriesInput.val(window.wizardTotalAdjustedKcal);
+          } else if (window.currentEventWizardProps && window.currentEventWizardProps.totalAdjustedKcal) {
+            caloriesInput.val(Math.round(window.currentEventWizardProps.totalAdjustedKcal));
+          }
         }
 
         function showSummaryNotesWizard(eventId) {
@@ -707,12 +752,20 @@
             physicalActivityLevel: props.physicalActivityLevel || null,
             bmrFormula: props.bmrFormula || null,
             activityFactor: props.activityFactor || null,
-            getKcal: props.getKcal || null
+            getKcal: props.getKcal || null,
+            totalAdjustedKcal: props.totalAdjustedKcal || null
           };
           const patientActivityScale = props.patientActivityFactorScale || 'HARRIS_BENEDICT';
           const patientPreferredBmr = props.patientPreferredBmrFormula || 'PROMEDIO';
           window.patientActivityScale = patientActivityScale;
           window.patientPreferredBmr = patientPreferredBmr;
+          window.patientTefMethod = props.patientTefMethod || 'FIXED';
+          window.patientTefBase = props.patientTefBase || 'GET';
+          window.patientTefFixedPercent = props.patientTefFixedPercent != null ? props.patientTefFixedPercent : 10;
+          window.patientTefMacroProtein = props.patientTefMacroProteinPercent != null ? props.patientTefMacroProteinPercent : null;
+          window.patientTefMacroCarbs = props.patientTefMacroCarbsPercent != null ? props.patientTefMacroCarbsPercent : null;
+          window.patientTefMacroFat = props.patientTefMacroFatPercent != null ? props.patientTefMacroFatPercent : null;
+          window.currentEventWizardProps = props;
 
           // Create wizard modal
           let wizardHtml = '<div class="modal fade" id="summaryNotesWizardModal" tabindex="-1" role="dialog">';
@@ -846,7 +899,8 @@
           wizardHtml += '<h6>Plan de Alimentación</h6>';
           wizardHtml += '<div class="form-group">';
           wizardHtml += '<label>Calorías diarias recomendadas:</label>';
-          wizardHtml += '<input type="number" class="form-control" name="caloriasDiarias" placeholder="Ej: 2000">';
+          wizardHtml += '<input type="number" class="form-control" name="caloriasDiarias" id="wizardCaloriasDiarias" placeholder="Ej: 2000">';
+          wizardHtml += '<small class="form-text text-muted">Se sugiere automáticamente el total ajustado (GET + TEF) del paciente.</small>';
           wizardHtml += '</div>';
           wizardHtml += '<div class="form-group">';
           wizardHtml += '<label>Distribución de macronutrientes:</label>';
@@ -1010,6 +1064,10 @@
           $('#wizardSaveBtn').toggle(window.currentWizardStep === window.totalWizardSteps);
         }
         
+        $(document).on('shown.bs.tab', '#wizardTabs a[href="#step3"]', function() {
+          prefillWizardDailyCalories();
+        });
+
         // Handle tab shown event to sync currentWizardStep
         $(document).on('shown.bs.tab', '#wizardTabs a[data-toggle="tab"]', function(e) {
           const target = $(e.target).attr('href');

--- a/src/main/resources/templates/sbadmin/calendar/ver.html
+++ b/src/main/resources/templates/sbadmin/calendar/ver.html
@@ -109,6 +109,12 @@
                         <div class="col-md-3" th:if="${event.getKcal != null}">
                           <p><strong>GET:</strong> <span th:text="${#numbers.formatDecimal(event.getKcal, 1, 0)} + ' kcal/día'">-</span></p>
                         </div>
+                        <div class="col-md-3" th:if="${event.tefKcal != null}">
+                          <p><strong>TEF:</strong> <span th:text="${#numbers.formatDecimal(event.tefKcal, 1, 0)} + ' kcal/día'">-</span></p>
+                        </div>
+                        <div class="col-md-3" th:if="${event.totalAdjustedKcal != null}">
+                          <p><strong>Total ajustado:</strong> <span class="font-weight-bold text-success" th:text="${#numbers.formatDecimal(event.totalAdjustedKcal, 1, 0)} + ' kcal/día'">-</span></p>
+                        </div>
                         <div class="col-md-3" th:if="${event.physicalActivityLevel != null}">
                           <p><strong>Actividad:</strong> <span th:text="${event.physicalActivityLevel.displayName}">-</span></p>
                         </div>
@@ -371,6 +377,30 @@
         OMS: { SEDENTARY: 1.40, LIGHT: 1.60, MODERATE: 1.80, INTENSE: 2.00, VERY_INTENSE: 2.20 }
       };
 
+      function calculateWizardTef(bmr, getVal) {
+        const method = window.patientTefMethod || 'FIXED';
+        if (!getVal) {
+          return null;
+        }
+        if (method === 'MACRONUTRIENTS') {
+          const protein = window.patientTefMacroProtein != null ? window.patientTefMacroProtein : 30;
+          const carbs = window.patientTefMacroCarbs != null ? window.patientTefMacroCarbs : 50;
+          const fat = window.patientTefMacroFat != null ? window.patientTefMacroFat : 20;
+          const sum = protein + carbs + fat;
+          if (sum <= 0) {
+            return null;
+          }
+          const weighted = (protein / sum) * 0.25 + (carbs / sum) * 0.075 + (fat / sum) * 0.02;
+          return Math.round(getVal * weighted);
+        }
+        const percent = window.patientTefFixedPercent > 0 ? window.patientTefFixedPercent : 10;
+        const base = (window.patientTefBase || 'GET') === 'BMR' ? bmr : getVal;
+        if (!base) {
+          return null;
+        }
+        return Math.round(base * (percent / 100));
+      }
+
       function updateWizardGetPreview() {
         const preview = jQuery('#wizardGetPreview');
         if (!preview.length) return;
@@ -380,6 +410,7 @@
         const scale = window.patientActivityScale || 'HARRIS_BENEDICT';
         if (!peso || !estatura || !level) {
           preview.text('GET estimado: — kcal/día');
+          window.wizardTotalAdjustedKcal = null;
           return;
         }
         let factor = null;
@@ -390,13 +421,31 @@
         }
         if (!factor) {
           preview.text('GET estimado: — kcal/día');
+          window.wizardTotalAdjustedKcal = null;
           return;
         }
         const imc = peso / (estatura * estatura);
         const age = /*[[${event.paciente.dob != null ? 30 : 30}]]*/ 30;
         const bmrApprox = 10 * peso + 6.25 * (estatura * 100) - 5 * age;
         const getVal = Math.round(bmrApprox * factor);
-        preview.text('GET estimado: ' + getVal + ' kcal/día (aprox.; se recalcula al guardar)');
+        const tefVal = calculateWizardTef(bmrApprox, getVal);
+        const totalVal = tefVal != null ? getVal + tefVal : getVal;
+        window.wizardTotalAdjustedKcal = totalVal;
+        let previewText = 'GET estimado: ' + getVal + ' kcal/día';
+        if (tefVal != null) {
+          previewText += ' | TEF: ' + tefVal + ' | Total: ' + totalVal + ' kcal/día';
+        }
+        preview.text(previewText + ' (aprox.; se recalcula al guardar)');
+      }
+
+      function prefillWizardDailyCalories() {
+        const caloriesInput = jQuery('#summaryNotesWizardModal input[name="caloriasDiarias"]');
+        if (!caloriesInput.length || caloriesInput.val()) {
+          return;
+        }
+        if (window.wizardTotalAdjustedKcal) {
+          caloriesInput.val(window.wizardTotalAdjustedKcal);
+        }
       }
       
       // Function to show summary notes wizard
@@ -413,12 +462,19 @@
           physicalActivityLevel: /*[[${event.physicalActivityLevel != null ? event.physicalActivityLevel.name() : null}]]*/ null,
           bmrFormula: /*[[${event.bmrFormula != null ? event.bmrFormula.name() : null}]]*/ null,
           activityFactor: /*[[${event.activityFactor}]]*/ null,
-          getKcal: /*[[${event.getKcal}]]*/ null
+          getKcal: /*[[${event.getKcal}]]*/ null,
+          totalAdjustedKcal: /*[[${event.totalAdjustedKcal}]]*/ null
         };
         const patientActivityScale = /*[[${event.paciente.activityFactorScale != null ? event.paciente.activityFactorScale.name() : 'HARRIS_BENEDICT'}]]*/ 'HARRIS_BENEDICT';
         const patientPreferredBmr = /*[[${event.paciente.preferredBmrFormula != null ? event.paciente.preferredBmrFormula.name() : 'PROMEDIO'}]]*/ 'PROMEDIO';
         window.patientActivityScale = patientActivityScale;
         window.patientPreferredBmr = patientPreferredBmr;
+        window.patientTefMethod = /*[[${event.paciente.tefMethod != null ? event.paciente.tefMethod.name() : 'FIXED'}]]*/ 'FIXED';
+        window.patientTefBase = /*[[${event.paciente.tefBase != null ? event.paciente.tefBase.name() : 'GET'}]]*/ 'GET';
+        window.patientTefFixedPercent = /*[[${event.paciente.tefFixedPercent != null ? event.paciente.tefFixedPercent : 10}]]*/ 10;
+        window.patientTefMacroProtein = /*[[${event.paciente.tefMacroProteinPercent}]]*/ null;
+        window.patientTefMacroCarbs = /*[[${event.paciente.tefMacroCarbsPercent}]]*/ null;
+        window.patientTefMacroFat = /*[[${event.paciente.tefMacroFatPercent}]]*/ null;
         
         // Create wizard modal
         let wizardHtml = '<div class="modal fade" id="summaryNotesWizardModal" tabindex="-1" role="dialog">';
@@ -552,7 +608,8 @@
         wizardHtml += '<h6>Plan de Alimentación</h6>';
         wizardHtml += '<div class="form-group">';
         wizardHtml += '<label>Calorías diarias recomendadas:</label>';
-        wizardHtml += '<input type="number" class="form-control" name="caloriasDiarias" placeholder="Ej: 2000">';
+        wizardHtml += '<input type="number" class="form-control" name="caloriasDiarias" id="wizardCaloriasDiarias" placeholder="Ej: 2000">';
+        wizardHtml += '<small class="form-text text-muted">Se sugiere automáticamente el total ajustado (GET + TEF) del paciente.</small>';
         wizardHtml += '</div>';
         wizardHtml += '<div class="form-group">';
         wizardHtml += '<label>Distribución de macronutrientes:</label>';
@@ -681,6 +738,10 @@
         });
         
         // Generate summary when moving to final step
+        jQuery('#summaryNotesWizardModal').on('shown.bs.tab', '#wizardTabs a[href="#step3"]', function() {
+          prefillWizardDailyCalories();
+        });
+
         jQuery('#summaryNotesWizardModal').on('shown.bs.tab', '#wizardTabs a[href="#step5"]', function() {
           generateSummaryNotes();
         });

--- a/src/main/resources/templates/sbadmin/pacientes/asignar-dieta.html
+++ b/src/main/resources/templates/sbadmin/pacientes/asignar-dieta.html
@@ -23,6 +23,58 @@
   <!-- Custom styles for this template-->
   <link th:href="@{/sbadmin/css/sb-admin-2.min.css}" rel="stylesheet">
 
+  <style>
+    .dieta-picker-list {
+      max-height: 360px;
+      overflow-y: auto;
+      border: 1px solid #e3e6f0;
+      border-radius: 0.35rem;
+    }
+
+    .dieta-picker-item {
+      cursor: pointer;
+      border-left: 4px solid transparent;
+      transition: background-color 0.15s ease;
+    }
+
+    .dieta-picker-item:hover {
+      background-color: #f8f9fc;
+    }
+
+    .dieta-picker-item.selected {
+      border-color: #4e73df;
+      background-color: #eaecf4;
+    }
+
+    .dieta-picker-item.dieta-fit-match {
+      border-left-color: #1cc88a;
+    }
+
+    .dieta-picker-item.dieta-fit-under {
+      border-left-color: #f6c23e;
+    }
+
+    .dieta-picker-item.dieta-fit-over {
+      border-left-color: #e74a3b;
+    }
+
+    .dieta-picker-item.hidden-by-search {
+      display: none;
+    }
+
+    .dieta-fit-badge-match {
+      color: #1cc88a;
+    }
+
+    .dieta-fit-badge-under {
+      color: #f6c23e;
+    }
+
+    .dieta-picker-status {
+      font-size: 0.875rem;
+    }
+  </style>
+
 </head>
 
 <body id="page-top">
@@ -43,15 +95,17 @@
           <div class="d-sm-flex align-items-center justify-content-between mb-4">
             <h1 class="h3 mb-0 text-gray-800">Asignar Dieta a Paciente [[(${paciente != null ? paciente.name : ''})]]</h1>
           </div>
-          <div class="alert alert-info" th:if="${paciente.totalAdjustedKcal != null}">
+          <div class="alert alert-info" th:if="${requerimientoKcal != null}">
             <i class="fas fa-info-circle"></i>
-            Requerimiento energético total ajustado del paciente (GET + TEF):
-            <strong th:text="${#numbers.formatDecimal(paciente.totalAdjustedKcal, 1, 0)} + ' kcal/día'">0 kcal/día</strong>
+            Requerimiento energético del paciente
+            <span th:if="${paciente.totalAdjustedKcal != null}">(GET + TEF)</span>
+            <span th:if="${paciente.totalAdjustedKcal == null && paciente.getKcal != null}">(GET)</span>:
+            <strong th:text="${#numbers.formatDecimal(requerimientoKcal, 1, 'COMMA', 0, 'POINT')} + ' kcal/día'">0 kcal/día</strong>
           </div>
-          <div class="alert alert-secondary" th:if="${paciente.totalAdjustedKcal == null && paciente.getKcal != null}">
+          <div class="alert alert-secondary" th:if="${requerimientoKcal == null}">
             <i class="fas fa-info-circle"></i>
-            GET del paciente: <strong th:text="${#numbers.formatDecimal(paciente.getKcal, 1, 0)} + ' kcal/día'">0 kcal/día</strong>
-            (sin TEF configurado).
+            No hay requerimiento calórico registrado para este paciente. Puede asignar una dieta, pero no se marcarán
+            coincidencias calóricas hasta calcular GET/TEF en antropométricos o consulta.
           </div>
 
           <!-- Content Row -->
@@ -62,17 +116,44 @@
                 <div class="col-sm-10 offset-sm-1">
 
                   <div class="info-form p-5">
-                    <form th:action="@{/admin/pacientes/{id}/dietas/asignar(id=${paciente != null ? paciente.id : 0})}" 
+                    <form id="asignarDietaForm"
+                          th:action="@{/admin/pacientes/{id}/dietas/asignar(id=${paciente != null ? paciente.id : 0})}" 
                           th:object="${pacienteDieta}" method="POST">
                       <div class="form-group">
                         <label>Dieta<span style="color:red;">*</span></label>
-                        <select class="form-control" name="dietaId" required>
-                          <option value="">Seleccione una dieta</option>
-                          <option th:each="dieta : ${dietasDisponibles}" 
-                                  th:value="${dieta.id}" 
-                                  th:text="${dieta.nombre}">
-                          </option>
-                        </select>
+                        <input type="hidden" name="dietaId" id="dietaIdInput" value="">
+                        <div id="dietaSelectionError" class="alert alert-danger py-2 d-none" role="alert">
+                          Seleccione una dieta de la lista.
+                        </div>
+                        <div id="dietaSelectedSummary" class="alert alert-primary py-2 d-none mb-2" role="status">
+                          <i class="fas fa-check-circle"></i>
+                          <strong>Seleccionada:</strong> <span id="dietaSelectedLabel">-</span>
+                        </div>
+                        <div class="input-group mb-2">
+                          <div class="input-group-prepend">
+                            <span class="input-group-text"><i class="fas fa-search"></i></span>
+                          </div>
+                          <input type="search" class="form-control" id="dietaSearchInput"
+                                 placeholder="Buscar por nombre o kilocalorías..." autocomplete="off">
+                        </div>
+                        <div class="d-flex flex-wrap small text-muted mb-2" th:if="${requerimientoKcal != null}">
+                          <span class="mr-3"><i class="fas fa-check-circle dieta-fit-badge-match"></i> Adecuada (±5%)</span>
+                          <span class="mr-3"><i class="fas fa-arrow-down dieta-fit-badge-under"></i> Por debajo</span>
+                          <span><i class="fas fa-arrow-up dieta-fit-badge-over"></i> Por encima</span>
+                        </div>
+                        <div id="dietaPickerList" class="list-group dieta-picker-list"></div>
+                        <div id="dietaPickerLoading" class="text-center text-muted py-2 dieta-picker-status d-none">
+                          <i class="fas fa-spinner fa-spin"></i> Cargando dietas...
+                        </div>
+                        <div id="dietaPickerEnd" class="text-center text-muted py-2 dieta-picker-status d-none">
+                          Fin de la lista
+                        </div>
+                        <div id="dietaPickerEmpty" class="alert alert-warning mb-0 d-none">
+                          No hay dietas disponibles. Cree una dieta en el catálogo antes de asignar.
+                        </div>
+                        <div id="dietaSearchNoResults" class="alert alert-secondary mt-2 mb-0 d-none">
+                          No hay dietas que coincidan con la búsqueda.
+                        </div>
                         <span th:if="${#fields.hasErrors('dieta')}" th:errors="*{dieta}"></span>
                       </div>
                       <div class="form-group">
@@ -133,6 +214,253 @@
 
     <!-- Custom scripts for all pages-->
     <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
+
+    <script th:inline="javascript">
+      document.addEventListener('DOMContentLoaded', function() {
+        const requerimientoKcal = /*[[${requerimientoKcal}]]*/ null;
+        const pickerPageSize = 20;
+        const dietaIdInput = document.getElementById('dietaIdInput');
+        const searchInput = document.getElementById('dietaSearchInput');
+        const pickerList = document.getElementById('dietaPickerList');
+        const pickerLoading = document.getElementById('dietaPickerLoading');
+        const pickerEnd = document.getElementById('dietaPickerEnd');
+        const pickerEmpty = document.getElementById('dietaPickerEmpty');
+        const selectedSummary = document.getElementById('dietaSelectedSummary');
+        const selectedLabel = document.getElementById('dietaSelectedLabel');
+        const selectionError = document.getElementById('dietaSelectionError');
+        const noResults = document.getElementById('dietaSearchNoResults');
+        const form = document.getElementById('asignarDietaForm');
+
+        if (!pickerList) {
+          return;
+        }
+
+        let currentPage = 0;
+        let hasNextPage = true;
+        let loading = false;
+        let searchTerm = '';
+        let searchDebounceTimer = null;
+        let selectedDietaId = null;
+
+        function formatKcal(value) {
+          if (value === null || value === undefined || isNaN(value)) {
+            return '-';
+          }
+          return Math.round(value).toLocaleString('es-MX', {
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 0
+          });
+        }
+
+        function classifyCaloricFit(dietKcal) {
+          if (requerimientoKcal == null || dietKcal == null || dietKcal <= 0) {
+            return { fit: 'unknown', label: 'Sin comparación', diff: null };
+          }
+          const tolerance = Math.max(50, requerimientoKcal * 0.05);
+          const diff = dietKcal - requerimientoKcal;
+          if (Math.abs(diff) <= tolerance) {
+            return { fit: 'match', label: 'Adecuada', diff: diff };
+          }
+          if (diff < 0) {
+            return { fit: 'under', label: 'Por debajo (' + formatKcal(Math.abs(diff)) + ' kcal)', diff: diff };
+          }
+          return { fit: 'over', label: 'Por encima (+' + formatKcal(diff) + ' kcal)', diff: diff };
+        }
+
+        function buildPickerItem(dieta) {
+          const item = document.createElement('button');
+          item.type = 'button';
+          item.className = 'list-group-item list-group-item-action dieta-picker-item';
+          item.setAttribute('data-dieta-id', String(dieta.id));
+          item.setAttribute('data-nombre', dieta.nombre || '');
+          item.setAttribute('data-energia', String(dieta.energiaKcal != null ? dieta.energiaKcal : 0));
+
+          const fitInfo = classifyCaloricFit(dieta.energiaKcal);
+          item.classList.add('dieta-fit-' + fitInfo.fit);
+
+          let iconClass = 'fas fa-minus-circle text-muted';
+          let fitLabelClass = 'small dieta-fit-label text-muted mt-1';
+          if (fitInfo.fit === 'match') {
+            iconClass = 'fas fa-check-circle dieta-fit-badge-match';
+            fitLabelClass = 'small dieta-fit-label dieta-fit-badge-match mt-1';
+          } else if (fitInfo.fit === 'under') {
+            iconClass = 'fas fa-arrow-down dieta-fit-badge-under';
+            fitLabelClass = 'small dieta-fit-label dieta-fit-badge-under mt-1';
+          } else if (fitInfo.fit === 'over') {
+            iconClass = 'fas fa-arrow-up dieta-fit-badge-over';
+            fitLabelClass = 'small dieta-fit-label dieta-fit-badge-over mt-1';
+          }
+
+          item.innerHTML =
+            '<div class="d-flex justify-content-between align-items-center">' +
+              '<div>' +
+                '<span class="dieta-fit-icon mr-2"><i class="' + iconClass + '"></i></span>' +
+                '<strong>' + escapeHtml(dieta.nombre || '') + '</strong>' +
+              '</div>' +
+              '<div class="text-right">' +
+                '<span class="badge badge-light dieta-kcal-label">' + formatKcal(dieta.energiaKcal) + ' kcal</span>' +
+                '<div class="' + fitLabelClass + '">' + fitInfo.label + '</div>' +
+              '</div>' +
+            '</div>';
+
+          item.addEventListener('click', function() {
+            selectDieta(item, dieta);
+          });
+
+          if (selectedDietaId != null && String(selectedDietaId) === String(dieta.id)) {
+            item.classList.add('selected');
+          }
+
+          return item;
+        }
+
+        function escapeHtml(value) {
+          return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+        }
+
+        function setLoading(isLoading) {
+          loading = isLoading;
+          if (pickerLoading) {
+            pickerLoading.classList.toggle('d-none', !isLoading);
+          }
+        }
+
+        let totalElements = 0;
+
+        function updateStatus() {
+          if (pickerEmpty) {
+            pickerEmpty.classList.toggle('d-none', totalElements > 0 || loading);
+          }
+          if (noResults) {
+            noResults.classList.toggle('d-none', totalElements > 0 || loading || !searchTerm);
+          }
+          if (pickerEnd) {
+            pickerEnd.classList.toggle('d-none', hasNextPage || totalElements === 0 || loading);
+          }
+        }
+
+        function buildPickerUrl(page) {
+          const params = new URLSearchParams();
+          params.set('page', String(page));
+          params.set('size', String(pickerPageSize));
+          if (searchTerm) {
+            params.set('q', searchTerm);
+          }
+          if (requerimientoKcal != null) {
+            params.set('requerimientoKcal', String(requerimientoKcal));
+          }
+          return '/rest/dietas/picker?' + params.toString();
+        }
+
+        function loadPickerPage(page, append) {
+          if (loading || (!append && page > 0) || (append && !hasNextPage)) {
+            return;
+          }
+          setLoading(true);
+          fetch(buildPickerUrl(page), {
+            headers: { 'Accept': 'application/json' }
+          })
+            .then(function(response) {
+              if (!response.ok) {
+                throw new Error('HTTP ' + response.status);
+              }
+              return response.json();
+            })
+            .then(function(data) {
+              if (!append) {
+                pickerList.innerHTML = '';
+              }
+              const items = data.items || [];
+              items.forEach(function(dieta) {
+                pickerList.appendChild(buildPickerItem(dieta));
+              });
+              currentPage = data.page != null ? data.page : page;
+              hasNextPage = !!data.hasNext;
+              totalElements = data.totalElements != null ? data.totalElements : pickerList.children.length;
+              updateStatus();
+            })
+            .catch(function() {
+              if (!append && pickerList.children.length === 0 && pickerEmpty) {
+                pickerEmpty.classList.remove('d-none');
+                pickerEmpty.textContent = 'No se pudieron cargar las dietas. Intente de nuevo.';
+              }
+            })
+            .finally(function() {
+              setLoading(false);
+              updateStatus();
+            });
+        }
+
+        function resetAndLoad() {
+          currentPage = 0;
+          hasNextPage = true;
+          totalElements = 0;
+          loadPickerPage(0, false);
+        }
+
+        function selectDieta(item, dieta) {
+          pickerList.querySelectorAll('.dieta-picker-item').forEach(function(el) {
+            el.classList.remove('selected');
+          });
+          item.classList.add('selected');
+          selectedDietaId = dieta.id;
+          dietaIdInput.value = String(dieta.id);
+          if (selectionError) {
+            selectionError.classList.add('d-none');
+          }
+          if (selectedSummary && selectedLabel) {
+            const fitInfo = classifyCaloricFit(dieta.energiaKcal);
+            selectedLabel.textContent = (dieta.nombre || '') + ' — ' + formatKcal(dieta.energiaKcal)
+              + ' kcal (' + fitInfo.label + ')';
+            selectedSummary.classList.remove('d-none');
+          }
+        }
+
+        pickerList.addEventListener('scroll', function() {
+          if (loading || !hasNextPage) {
+            return;
+          }
+          const threshold = 40;
+          if (pickerList.scrollTop + pickerList.clientHeight >= pickerList.scrollHeight - threshold) {
+            loadPickerPage(currentPage + 1, true);
+          }
+        });
+
+        if (searchInput) {
+          searchInput.addEventListener('input', function() {
+            const nextTerm = searchInput.value.trim();
+            if (searchDebounceTimer) {
+              clearTimeout(searchDebounceTimer);
+            }
+            searchDebounceTimer = setTimeout(function() {
+              searchTerm = nextTerm;
+              resetAndLoad();
+            }, 300);
+          });
+        }
+
+        if (form) {
+          form.addEventListener('submit', function(e) {
+            if (!dietaIdInput.value) {
+              e.preventDefault();
+              if (selectionError) {
+                selectionError.classList.remove('d-none');
+              }
+              if (searchInput) {
+                searchInput.focus();
+              }
+            }
+          });
+        }
+
+        resetAndLoad();
+      });
+    </script>
 
 </body>
 

--- a/src/main/resources/templates/sbadmin/pacientes/asignar-dieta.html
+++ b/src/main/resources/templates/sbadmin/pacientes/asignar-dieta.html
@@ -43,6 +43,16 @@
           <div class="d-sm-flex align-items-center justify-content-between mb-4">
             <h1 class="h3 mb-0 text-gray-800">Asignar Dieta a Paciente [[(${paciente != null ? paciente.name : ''})]]</h1>
           </div>
+          <div class="alert alert-info" th:if="${paciente.totalAdjustedKcal != null}">
+            <i class="fas fa-info-circle"></i>
+            Requerimiento energético total ajustado del paciente (GET + TEF):
+            <strong th:text="${#numbers.formatDecimal(paciente.totalAdjustedKcal, 1, 0)} + ' kcal/día'">0 kcal/día</strong>
+          </div>
+          <div class="alert alert-secondary" th:if="${paciente.totalAdjustedKcal == null && paciente.getKcal != null}">
+            <i class="fas fa-info-circle"></i>
+            GET del paciente: <strong th:text="${#numbers.formatDecimal(paciente.getKcal, 1, 0)} + ' kcal/día'">0 kcal/día</strong>
+            (sin TEF configurado).
+          </div>
 
           <!-- Content Row -->
           <div class="row">

--- a/src/main/resources/templates/sbadmin/pacientes/calculation-script.html
+++ b/src/main/resources/templates/sbadmin/pacientes/calculation-script.html
@@ -284,12 +284,12 @@
       const tefHidden = document.getElementById('get-tef-hidden');
       const totalHidden = document.getElementById('get-total-hidden');
 
-      if (bmrResult) bmrResult.textContent = formatNumber(bmr);
-      if (activityResult) activityResult.textContent = formatNumber(activityKcal);
+      if (bmrResult) bmrResult.textContent = formatEnergyKcal(bmr);
+      if (activityResult) activityResult.textContent = formatEnergyKcal(activityKcal);
       if (factorResult) factorResult.textContent = factor ? factor.toFixed(3) : '-';
-      if (getResult) getResult.textContent = formatNumber(getValue);
-      if (tefResult) tefResult.textContent = formatNumber(tefValue);
-      if (totalResult) totalResult.textContent = formatNumber(totalValue);
+      if (getResult) getResult.textContent = formatEnergyKcal(getValue);
+      if (tefResult) tefResult.textContent = formatEnergyKcal(tefValue);
+      if (totalResult) totalResult.textContent = formatEnergyKcal(totalValue);
       if (bmrHidden && bmr) bmrHidden.value = bmr.toFixed(2);
       if (getHidden && getValue) getHidden.value = getValue.toFixed(2);
       if (tefHidden && tefValue) tefHidden.value = tefValue.toFixed(2);
@@ -389,6 +389,17 @@
         return '-';
       }
       return value.toFixed(2);
+    }
+
+    // Energy values (kcal) with thousands separator — matches Thymeleaf COMMA grouping
+    function formatEnergyKcal(value) {
+      if (value === null || value === undefined || isNaN(value)) {
+        return '-';
+      }
+      return Math.round(value).toLocaleString('es-MX', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0
+      });
     }
 
     // Calculate Nivel de Peso from BMI

--- a/src/main/resources/templates/sbadmin/pacientes/calculation-script.html
+++ b/src/main/resources/templates/sbadmin/pacientes/calculation-script.html
@@ -13,6 +13,12 @@
       intense: [[${paciente != null && paciente.customFactorIntense != null ? paciente.customFactorIntense : 'null'}]],
       veryIntense: [[${paciente != null && paciente.customFactorVeryIntense != null ? paciente.customFactorVeryIntense : 'null'}]]
     };
+    const patientTefMethod = '[[${paciente != null && paciente.tefMethod != null ? paciente.tefMethod.name() : "FIXED"}]]';
+    const patientTefBase = '[[${paciente != null && paciente.tefBase != null ? paciente.tefBase.name() : "GET"}]]';
+    const patientTefFixedPercent = [[${paciente != null && paciente.tefFixedPercent != null ? paciente.tefFixedPercent : 10.0}]];
+    const patientTefMacroProtein = [[${paciente != null && paciente.tefMacroProteinPercent != null ? paciente.tefMacroProteinPercent : 'null'}]];
+    const patientTefMacroCarbs = [[${paciente != null && paciente.tefMacroCarbsPercent != null ? paciente.tefMacroCarbsPercent : 'null'}]];
+    const patientTefMacroFat = [[${paciente != null && paciente.tefMacroFatPercent != null ? paciente.tefMacroFatPercent : 'null'}]];
     const calculationEnableSync = [[${enableSync}]];
 
     function getCalcSubTabPanes(tabContent) {
@@ -219,6 +225,29 @@
       }
     }
 
+    function calculateTef(bmr, getValue) {
+      if (!getValue) {
+        return null;
+      }
+      if (patientTefMethod === 'MACRONUTRIENTS') {
+        const protein = patientTefMacroProtein != null ? patientTefMacroProtein : 30;
+        const carbs = patientTefMacroCarbs != null ? patientTefMacroCarbs : 50;
+        const fat = patientTefMacroFat != null ? patientTefMacroFat : 20;
+        const sum = protein + carbs + fat;
+        if (sum <= 0) {
+          return null;
+        }
+        const weighted = (protein / sum) * 0.25 + (carbs / sum) * 0.075 + (fat / sum) * 0.02;
+        return getValue * weighted;
+      }
+      const percent = patientTefFixedPercent > 0 ? patientTefFixedPercent : 10;
+      const base = patientTefBase === 'BMR' ? bmr : getValue;
+      if (!base) {
+        return null;
+      }
+      return base * (percent / 100);
+    }
+
     function updateGetCalculations() {
       const formulaEl = document.getElementById('get-bmr-formula');
       const levelEl = document.getElementById('get-activity-level');
@@ -240,18 +269,31 @@
       const bmr = calculateBmrByFormula(formula, weight, height, age, patientIsMale);
       const factor = resolveActivityFactor(patientActivityScale, level, customFactor);
       const getValue = bmr && factor ? bmr * factor : null;
+      const activityKcal = bmr && getValue ? getValue - bmr : null;
+      const tefValue = calculateTef(bmr, getValue);
+      const totalValue = getValue != null ? getValue + (tefValue || 0) : null;
 
       const bmrResult = document.getElementById('get-bmr-used-result');
+      const activityResult = document.getElementById('get-activity-kcal-result');
       const factorResult = document.getElementById('get-factor-result');
       const getResult = document.getElementById('get-result');
+      const tefResult = document.getElementById('get-tef-result');
+      const totalResult = document.getElementById('get-total-result');
       const bmrHidden = document.getElementById('get-bmr-used-hidden');
       const getHidden = document.getElementById('get-kcal-hidden');
+      const tefHidden = document.getElementById('get-tef-hidden');
+      const totalHidden = document.getElementById('get-total-hidden');
 
       if (bmrResult) bmrResult.textContent = formatNumber(bmr);
+      if (activityResult) activityResult.textContent = formatNumber(activityKcal);
       if (factorResult) factorResult.textContent = factor ? factor.toFixed(3) : '-';
       if (getResult) getResult.textContent = formatNumber(getValue);
+      if (tefResult) tefResult.textContent = formatNumber(tefValue);
+      if (totalResult) totalResult.textContent = formatNumber(totalValue);
       if (bmrHidden && bmr) bmrHidden.value = bmr.toFixed(2);
       if (getHidden && getValue) getHidden.value = getValue.toFixed(2);
+      if (tefHidden && tefValue) tefHidden.value = tefValue.toFixed(2);
+      if (totalHidden && totalValue) totalHidden.value = totalValue.toFixed(2);
     }
 
     // Ideal Weight Calculation Functions

--- a/src/main/resources/templates/sbadmin/pacientes/get-calculation-section.html
+++ b/src/main/resources/templates/sbadmin/pacientes/get-calculation-section.html
@@ -15,7 +15,7 @@
               <div class="form-group">
                 <label class="small">Fórmula TMB:</label>
                 <select class="form-control form-control-sm" id="get-bmr-formula" th:field="*{bmrFormula}">
-                  <option value="">Usar preferencia del paciente</option>
+                  <option value="">Usar preferencia guardada</option>
                   <option th:each="formula : ${T(com.nutriconsultas.paciente.calculation.BmrFormulaType).values()}"
                           th:value="${formula.name()}" th:text="${formula.displayName}"></option>
                 </select>

--- a/src/main/resources/templates/sbadmin/pacientes/get-calculation-section.html
+++ b/src/main/resources/templates/sbadmin/pacientes/get-calculation-section.html
@@ -4,7 +4,10 @@
       <div class="card border-left-warning">
         <div class="card-body">
           <p class="text-muted small mb-3">
-            GET = TMB × factor de actividad. Escala del paciente:
+            GET = TMB × factor de actividad. TEF según preferencias del paciente
+            (<span th:text="${paciente.tefMethod != null ? paciente.tefMethod.displayName : 'Porcentaje fijo'}">Porcentaje fijo</span>,
+            base <span th:text="${paciente.tefBase != null ? paciente.tefBase.displayName : 'GET'}">GET</span>).
+            Escala de actividad:
             <strong th:text="${paciente.activityFactorScale != null ? paciente.activityFactorScale.displayName : 'Harris-Benedict'}">Harris-Benedict</strong>
           </p>
           <div class="row">
@@ -39,24 +42,39 @@
             </div>
           </div>
           <div class="row mt-2">
-            <div class="col-md-4">
+            <div class="col-md-3">
               <div class="alert alert-light mb-0 py-2">
                 <strong>TMB:</strong> <span id="get-bmr-used-result" class="text-primary">-</span> <small>kcal/día</small>
               </div>
             </div>
-            <div class="col-md-4">
+            <div class="col-md-3">
               <div class="alert alert-light mb-0 py-2">
-                <strong>Factor:</strong> <span id="get-factor-result" class="text-primary">-</span>
+                <strong>Actividad:</strong> <span id="get-activity-kcal-result" class="text-info">-</span> <small>kcal/día</small>
               </div>
             </div>
-            <div class="col-md-4">
-              <div class="alert alert-warning mb-0 py-2">
+            <div class="col-md-2">
+              <div class="alert alert-light mb-0 py-2">
                 <strong>GET:</strong> <span id="get-result" class="text-dark font-weight-bold">-</span> <small>kcal/día</small>
               </div>
             </div>
+            <div class="col-md-2">
+              <div class="alert alert-light mb-0 py-2">
+                <strong>TEF:</strong> <span id="get-tef-result" class="text-success">-</span> <small>kcal/día</small>
+              </div>
+            </div>
+            <div class="col-md-2">
+              <div class="alert alert-warning mb-0 py-2">
+                <strong>Total:</strong> <span id="get-total-result" class="text-dark font-weight-bold">-</span> <small>kcal/día</small>
+              </div>
+            </div>
           </div>
+          <p class="text-muted small mb-0 mt-2">
+            Total ajustado = TMB + actividad + TEF = GET + TEF
+          </p>
           <input type="hidden" id="get-bmr-used-hidden" th:field="*{bmrUsed}">
           <input type="hidden" id="get-kcal-hidden" th:field="*{getKcal}">
+          <input type="hidden" id="get-tef-hidden" th:field="*{tefKcal}">
+          <input type="hidden" id="get-total-hidden" th:field="*{totalAdjustedKcal}">
         </div>
       </div>
     </div>
@@ -66,7 +84,7 @@
 <div th:fragment="energyPreferencesSection">
   <hr>
   <h5 class="mb-3"><i class="fas fa-sliders-h"></i> Preferencias Energéticas</h5>
-  <p class="text-muted small">Se aplican por paciente al calcular GET en antropométricos y consultas.</p>
+  <p class="text-muted small">Se aplican por paciente al calcular GET y TEF en antropométricos y consultas.</p>
   <div class="form-group">
     <label>Escala de factores de actividad</label>
     <select class="form-control" th:field="*{activityFactorScale}" id="activityFactorScaleSelect">
@@ -106,18 +124,86 @@
       </div>
     </div>
   </div>
+  <hr>
+  <h6 class="mb-3"><i class="fas fa-thermometer-half"></i> Efecto termogénico (TEF / ETA)</h6>
+  <div class="form-group">
+    <label>Método de cálculo TEF</label>
+    <select class="form-control" th:field="*{tefMethod}" id="tefMethodSelect">
+      <option th:each="method : ${T(com.nutriconsultas.paciente.calculation.TefMethod).values()}"
+              th:value="${method.name()}" th:text="${method.displayName}"></option>
+    </select>
+  </div>
+  <div id="tefFixedSection">
+    <div class="row">
+      <div class="col-md-6 form-group">
+        <label>Base del porcentaje fijo</label>
+        <select class="form-control" th:field="*{tefBase}" id="tefBaseSelect">
+          <option th:each="base : ${T(com.nutriconsultas.paciente.calculation.TefBase).values()}"
+                  th:value="${base.name()}" th:text="${base.displayName}"></option>
+        </select>
+      </div>
+      <div class="col-md-6 form-group">
+        <label>Porcentaje TEF fijo (%)</label>
+        <input type="number" step="0.1" min="0" max="30" class="form-control" th:field="*{tefFixedPercent}"
+               placeholder="Ej: 10">
+      </div>
+    </div>
+  </div>
+  <div id="tefMacroSection" style="display:none;">
+    <label>Distribución de macronutrientes para TEF (% del total calórico)</label>
+    <div class="row">
+      <div class="col-md-4 form-group">
+        <label class="small">Proteínas (%)</label>
+        <input type="number" step="0.1" min="0" max="100" class="form-control" th:field="*{tefMacroProteinPercent}"
+               placeholder="Ej: 30">
+      </div>
+      <div class="col-md-4 form-group">
+        <label class="small">Carbohidratos (%)</label>
+        <input type="number" step="0.1" min="0" max="100" class="form-control" th:field="*{tefMacroCarbsPercent}"
+               placeholder="Ej: 50">
+      </div>
+      <div class="col-md-4 form-group">
+        <label class="small">Grasas (%)</label>
+        <input type="number" step="0.1" min="0" max="100" class="form-control" th:field="*{tefMacroFatPercent}"
+               placeholder="Ej: 20">
+      </div>
+    </div>
+    <p class="text-muted small">Coeficientes: proteína ~25%, carbohidratos ~7.5%, grasa ~2% de cada macro.</p>
+  </div>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
       const scaleSelect = document.getElementById('activityFactorScaleSelect');
       const customSection = document.getElementById('customFactorsSection');
+      const tefMethodSelect = document.getElementById('tefMethodSelect');
+      const tefFixedSection = document.getElementById('tefFixedSection');
+      const tefMacroSection = document.getElementById('tefMacroSection');
+
       function toggleCustom() {
         if (scaleSelect && customSection) {
           customSection.style.display = scaleSelect.value === 'CUSTOM' ? '' : 'none';
         }
       }
+
+      function toggleTefSections() {
+        if (!tefMethodSelect) {
+          return;
+        }
+        const isMacro = tefMethodSelect.value === 'MACRONUTRIENTS';
+        if (tefFixedSection) {
+          tefFixedSection.style.display = isMacro ? 'none' : '';
+        }
+        if (tefMacroSection) {
+          tefMacroSection.style.display = isMacro ? '' : 'none';
+        }
+      }
+
       if (scaleSelect) {
         scaleSelect.addEventListener('change', toggleCustom);
         toggleCustom();
+      }
+      if (tefMethodSelect) {
+        tefMethodSelect.addEventListener('change', toggleTefSections);
+        toggleTefSections();
       }
     });
   </script>

--- a/src/main/resources/templates/sbadmin/pacientes/perfil.html
+++ b/src/main/resources/templates/sbadmin/pacientes/perfil.html
@@ -79,6 +79,12 @@
                       </p>
                       <p class="mb-0 text-muted" th:if="${paciente.getKcal == null}">GET: sin dato</p>
                     </li>
+                    <li class="list-group-item d-flex justify-content-between align-items-center p-3" th:if="${paciente.totalAdjustedKcal != null}">
+                      <i class="fas fa-thermometer-half fa-lg" style="color: #28a745;"></i>
+                      <p class="mb-0">
+                        Total (GET+TEF): [[(${#numbers.formatDecimal(paciente.totalAdjustedKcal,1,'COMMA',0,'POINT')})]] kcal/día
+                      </p>
+                    </li>
                     <li class="list-group-item d-flex justify-content-between align-items-center p-3">
                       <i class="fas fa-fire fa-lg" style="color: #ff6b35;"></i>
                       <p class="mb-0" th:if="${paciente.bmr != null}">

--- a/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
+++ b/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
@@ -828,6 +828,12 @@
                               <div class="col-md-3" th:if="${measurement.getKcal != null}">
                                 <p><strong>GET:</strong> <span class="font-weight-bold text-warning" th:text="${#numbers.formatDecimal(measurement.getKcal, 1, 0)} + ' kcal/día'">-</span></p>
                               </div>
+                              <div class="col-md-3" th:if="${measurement.tefKcal != null}">
+                                <p><strong>TEF:</strong> <span th:text="${#numbers.formatDecimal(measurement.tefKcal, 1, 0)} + ' kcal/día'">-</span></p>
+                              </div>
+                              <div class="col-md-3" th:if="${measurement.totalAdjustedKcal != null}">
+                                <p><strong>Total ajustado:</strong> <span class="font-weight-bold text-success" th:text="${#numbers.formatDecimal(measurement.totalAdjustedKcal, 1, 0)} + ' kcal/día'">-</span></p>
+                              </div>
                             </div>
                           </div>
                           <div class="alert alert-secondary mb-0" th:unless="${measurement.getKcal != null || measurement.physicalActivityLevel != null}">

--- a/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
+++ b/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
@@ -823,16 +823,16 @@
                                 <p><strong>Factor:</strong> <span th:text="${#numbers.formatDecimal(measurement.activityFactor, 1, 3)}">-</span></p>
                               </div>
                               <div class="col-md-3" th:if="${measurement.bmrUsed != null}">
-                                <p><strong>TMB:</strong> <span th:text="${#numbers.formatDecimal(measurement.bmrUsed, 1, 0)} + ' kcal/día'">-</span></p>
+                                <p><strong>TMB:</strong> <span th:text="${#numbers.formatDecimal(measurement.bmrUsed, 1, 'COMMA', 0, 'POINT')} + ' kcal/día'">-</span></p>
                               </div>
                               <div class="col-md-3" th:if="${measurement.getKcal != null}">
-                                <p><strong>GET:</strong> <span class="font-weight-bold text-warning" th:text="${#numbers.formatDecimal(measurement.getKcal, 1, 0)} + ' kcal/día'">-</span></p>
+                                <p><strong>GET:</strong> <span class="font-weight-bold text-warning" th:text="${#numbers.formatDecimal(measurement.getKcal, 1, 'COMMA', 0, 'POINT')} + ' kcal/día'">-</span></p>
                               </div>
                               <div class="col-md-3" th:if="${measurement.tefKcal != null}">
-                                <p><strong>TEF:</strong> <span th:text="${#numbers.formatDecimal(measurement.tefKcal, 1, 0)} + ' kcal/día'">-</span></p>
+                                <p><strong>TEF:</strong> <span th:text="${#numbers.formatDecimal(measurement.tefKcal, 1, 'COMMA', 0, 'POINT')} + ' kcal/día'">-</span></p>
                               </div>
                               <div class="col-md-3" th:if="${measurement.totalAdjustedKcal != null}">
-                                <p><strong>Total ajustado:</strong> <span class="font-weight-bold text-success" th:text="${#numbers.formatDecimal(measurement.totalAdjustedKcal, 1, 0)} + ' kcal/día'">-</span></p>
+                                <p><strong>Total ajustado:</strong> <span class="font-weight-bold text-success" th:text="${#numbers.formatDecimal(measurement.totalAdjustedKcal, 1, 'COMMA', 0, 'POINT')} + ' kcal/día'">-</span></p>
                               </div>
                             </div>
                           </div>

--- a/src/test/java/com/nutriconsultas/dieta/DietaNutritionCalculatorTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaNutritionCalculatorTest.java
@@ -1,0 +1,23 @@
+package com.nutriconsultas.dieta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DietaNutritionCalculatorTest {
+
+	@Test
+	void calculateTotalKcalUsesMacroFormula() {
+		final Dieta dieta = new Dieta();
+		final Ingesta ingesta = new Ingesta();
+		final PlatilloIngesta platillo = new PlatilloIngesta();
+		platillo.setProteina(20.0);
+		platillo.setLipidos(10.0);
+		platillo.setHidratosDeCarbono(50.0);
+		ingesta.getPlatillos().add(platillo);
+		dieta.getIngestas().add(ingesta);
+
+		assertThat(DietaNutritionCalculator.calculateTotalKcal(dieta)).isEqualTo(370.0);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/dieta/DietaServiceImplPickerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaServiceImplPickerTest.java
@@ -1,0 +1,60 @@
+package com.nutriconsultas.dieta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+
+@ExtendWith(MockitoExtension.class)
+class DietaServiceImplPickerTest {
+
+	@InjectMocks
+	private DietaServiceImpl dietaService;
+
+	@Mock
+	private DietaRepository dietaRepository;
+
+	@Test
+	void findPickerPageReturnsFirstPageAndHasNext() {
+		final List<Dieta> dietas = new ArrayList<>();
+		IntStream.rangeClosed(1, 25).forEach(i -> {
+			final Dieta dieta = new Dieta();
+			dieta.setId((long) i);
+			dieta.setNombre("Dieta " + i);
+			dietas.add(dieta);
+		});
+		when(dietaRepository.findAll(Sort.by("nombre"))).thenReturn(dietas);
+
+		final DietaPickerPageDto page = dietaService.findPickerPage(null, 0, 20, null);
+
+		assertThat(page.getItems()).hasSize(20);
+		assertThat(page.getTotalElements()).isEqualTo(25);
+		assertThat(page.isHasNext()).isTrue();
+	}
+
+	@Test
+	void findPickerPageFiltersBySearchTerm() {
+		final Dieta match = new Dieta();
+		match.setId(1L);
+		match.setNombre("Dieta 2000 kcal");
+		final Dieta other = new Dieta();
+		other.setId(2L);
+		other.setNombre("Otra dieta");
+		when(dietaRepository.findAll(Sort.by("nombre"))).thenReturn(List.of(match, other));
+
+		final DietaPickerPageDto page = dietaService.findPickerPage("2000", 0, 20, null);
+
+		assertThat(page.getItems()).hasSize(1);
+		assertThat(page.getItems().get(0).getNombre()).isEqualTo("Dieta 2000 kcal");
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/dieta/DietasRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietasRestControllerTest.java
@@ -242,6 +242,23 @@ public class DietasRestControllerTest {
 	}
 
 	@Test
+	public void testGetPickerPageDelegatesToService() {
+		final DietaPickerPageDto expected = new DietaPickerPageDto();
+		expected.setPage(0);
+		expected.setSize(20);
+		expected.setTotalElements(1);
+		expected.setHasNext(false);
+		expected.setItems(List.of(new DietaPickerItemDto(1L, "Dieta", 2000)));
+		when(dietaService.findPickerPage("test", 0, 20, 2000.0)).thenReturn(expected);
+
+		final DietaPickerPageDto result = dietasRestController.getPickerPage("test", 0, 20, 2000.0);
+
+		assertThat(result.getItems()).hasSize(1);
+		assertThat(result.getItems().get(0).getEnergiaKcal()).isEqualTo(2000);
+		verify(dietaService).findPickerPage("test", 0, 20, 2000.0);
+	}
+
+	@Test
 	public void testGetPageArrayEmptyDietShowsEmptyDistribution() {
 		log.info("Starting testGetPageArrayEmptyDietShowsEmptyDistribution");
 

--- a/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
@@ -674,7 +674,6 @@ public class PacienteControllerTest {
 		log.info("starting testAsignarDieta");
 		// Arrange
 		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
-		when(dietaService.getDietas()).thenReturn(new ArrayList<>());
 
 		final Model model = org.mockito.Mockito.mock(Model.class);
 
@@ -684,7 +683,7 @@ public class PacienteControllerTest {
 		// Assert
 		assertThat(result).isEqualTo("sbadmin/pacientes/asignar-dieta");
 		verify(model).addAttribute("paciente", paciente);
-		verify(model).addAttribute("dietasDisponibles", new ArrayList<>());
+		verify(model).addAttribute("requerimientoKcal", null);
 		verify(model).addAttribute(eq("pacienteDieta"), any(PacienteDieta.class));
 		log.info("finished testAsignarDieta");
 	}

--- a/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
@@ -734,7 +734,6 @@ public class PacienteControllerTest {
 
 		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
 		when(dietaRepository.findById(1L)).thenReturn(java.util.Optional.of(dieta));
-		when(dietaService.getDietas()).thenReturn(new ArrayList<>());
 		when(bindingResult.getAllErrors()).thenReturn(new ArrayList<>());
 
 		final Model model = org.mockito.Mockito.mock(Model.class);
@@ -750,7 +749,7 @@ public class PacienteControllerTest {
 		verify(bindingResult).rejectValue(eq("status"), eq("NotNull"), eq("El estado es requerido"));
 		verify(model).addAttribute("activeMenu", "perfil");
 		verify(model).addAttribute("paciente", paciente);
-		verify(model).addAttribute("dietasDisponibles", new ArrayList<>());
+		verify(model).addAttribute("requerimientoKcal", null);
 		verify(pacienteDietaService, org.mockito.Mockito.never()).assignDieta(any(Long.class), any(Long.class),
 				any(PacienteDieta.class), any(String.class));
 		log.info("finished testGuardarAsignacionDietaWithErrors");
@@ -770,7 +769,6 @@ public class PacienteControllerTest {
 
 		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
 		when(dietaRepository.findById(1L)).thenReturn(java.util.Optional.of(dieta));
-		when(dietaService.getDietas()).thenReturn(new ArrayList<>());
 		when(bindingResult.getAllErrors()).thenReturn(new ArrayList<>());
 
 		final Model model = org.mockito.Mockito.mock(Model.class);
@@ -801,7 +799,6 @@ public class PacienteControllerTest {
 
 		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
 		when(dietaRepository.findById(1L)).thenReturn(java.util.Optional.of(dieta));
-		when(dietaService.getDietas()).thenReturn(new ArrayList<>());
 		when(bindingResult.getAllErrors()).thenReturn(new ArrayList<>());
 
 		final Model model = org.mockito.Mockito.mock(Model.class);

--- a/src/test/java/com/nutriconsultas/paciente/calculation/EnergyExpenditureResolverTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/calculation/EnergyExpenditureResolverTest.java
@@ -1,0 +1,67 @@
+package com.nutriconsultas.paciente.calculation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.paciente.Paciente;
+
+class EnergyExpenditureResolverTest {
+
+	private Paciente paciente;
+
+	@BeforeEach
+	void setUp() {
+		paciente = new Paciente();
+		paciente.setDob(new Date(System.currentTimeMillis() - 30L * 365 * 24 * 60 * 60 * 1000));
+		paciente.setGender("M");
+		paciente.setTefMethod(TefMethod.FIXED);
+		paciente.setTefBase(TefBase.GET);
+		paciente.setTefFixedPercent(10.0);
+	}
+
+	@Test
+	void resolveIncludesTefAndTotalAdjusted() {
+		final EnergyExpenditureResolver.EnergyResult result = EnergyExpenditureResolver.resolve(paciente,
+				BmrFormulaType.MIFFLIN_ST_JEOR, PhysicalActivityLevel.MODERATE, null, 70.0, 1.75);
+
+		assertThat(result.bmr()).isNotNull();
+		assertThat(result.getKcal()).isNotNull();
+		assertThat(result.tefKcal()).isNotNull();
+		assertThat(result.totalAdjustedKcal()).isEqualTo(result.getKcal() + result.tefKcal());
+		assertThat(result.activityKcal()).isEqualTo(result.getKcal() - result.bmr());
+	}
+
+	@Test
+	void applyTefUsesMacronutrientPreferences() {
+		paciente.setTefMethod(TefMethod.MACRONUTRIENTS);
+		paciente.setTefMacroProteinPercent(40.0);
+		paciente.setTefMacroCarbsPercent(40.0);
+		paciente.setTefMacroFatPercent(20.0);
+
+		final EnergyExpenditureResolver.EnergyResult result = EnergyExpenditureResolver.applyTef(paciente, 1500.0, 1.55,
+				2325.0);
+
+		assertThat(result.tefKcal()).isNotNull();
+		assertThat(result.totalAdjustedKcal()).isGreaterThan(result.getKcal());
+	}
+
+	@Test
+	void resolveTargetDailyCaloriesPrefersTotalAdjusted() {
+		paciente.setGetKcal(2000.0);
+		paciente.setTotalAdjustedKcal(2200.0);
+
+		assertThat(EnergyExpenditureResolver.resolveTargetDailyCalories(paciente)).isEqualTo(2200.0);
+	}
+
+	@Test
+	void resolveTargetDailyCaloriesFallsBackToGet() {
+		paciente.setGetKcal(2000.0);
+
+		assertThat(EnergyExpenditureResolver.resolveTargetDailyCalories(paciente)).isEqualTo(2000.0);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/calculation/TefCalculationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/calculation/TefCalculationServiceTest.java
@@ -1,0 +1,52 @@
+package com.nutriconsultas.paciente.calculation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TefCalculationServiceTest {
+
+	@Test
+	void calculateFixedTefOnGetDefaultPercent() {
+		final Double tef = TefCalculationService.calculateTef(TefMethod.FIXED, TefBase.GET, null, null, null, null,
+				1500.0, 2000.0);
+		assertThat(tef).isEqualTo(200.0);
+	}
+
+	@Test
+	void calculateFixedTefOnBmr() {
+		final Double tef = TefCalculationService.calculateTef(TefMethod.FIXED, TefBase.BMR, 10.0, null, null, null,
+				1500.0, 2000.0);
+		assertThat(tef).isEqualTo(150.0);
+	}
+
+	@Test
+	void calculateMacronutrientTefUsesConfiguredDistribution() {
+		final Double tef = TefCalculationService.calculateTef(TefMethod.MACRONUTRIENTS, TefBase.GET, null, 30.0, 50.0,
+				20.0, 1500.0, 2000.0);
+		assertThat(tef).isEqualTo(2000.0 * (0.30 * 0.25 + 0.50 * 0.075 + 0.20 * 0.02));
+	}
+
+	@Test
+	void calculateMacronutrientTefUsesBalancedDefaultWhenMacrosMissing() {
+		final Double tef = TefCalculationService.calculateTef(TefMethod.MACRONUTRIENTS, TefBase.GET, null, null, null,
+				null, 1500.0, 2000.0);
+		assertThat(tef).isEqualTo(2000.0 * (0.30 * 0.25 + 0.50 * 0.075 + 0.20 * 0.02));
+	}
+
+	@Test
+	void calculateTotalAdjustedKcalAddsTefToGet() {
+		assertThat(TefCalculationService.calculateTotalAdjustedKcal(2000.0, 200.0)).isEqualTo(2200.0);
+	}
+
+	@Test
+	void calculateTotalAdjustedKcalWithoutTefReturnsGet() {
+		assertThat(TefCalculationService.calculateTotalAdjustedKcal(2000.0, null)).isEqualTo(2000.0);
+	}
+
+	@Test
+	void calculateActivityKcal() {
+		assertThat(TefCalculationService.calculateActivityKcal(1500.0, 2325.0)).isEqualTo(825.0);
+	}
+
+}


### PR DESCRIPTION
## Summary

- Adds thermic effect of food (TEF/ETA) to the energy expenditure pipeline on top of GET/TDEE (#121): fixed percent (on GET or TMB) or macronutrient-weighted calculation per patient preferences.
- Persists `tefKcal` and `totalAdjustedKcal` (GET + TEF) on patient snapshots, anthropometric measurements, consultations, and body metric history; UI shows TMB + activity + GET + TEF = total in Cálculos and consultation wizard.
- Pre-fills recommended daily calories in the consultation wizard (step 3) and surfaces total adjusted kcal when assigning diets.

Resolves decisions from issue comments: nutritionist chooses fixed vs macro method, GET vs TMB base for fixed TEF, and TEF flows into automatic calorie suggestion for diet planning.

Follow-up: [#156](https://github.com/diego-torres/nutriconsultas/issues/156) Phase B should fold new TEF preference fields into `PacienteEnergyPreferences` embeddable (temporary `@SuppressWarnings("PMD.TooManyFields")` on `Paciente` until then).

Closes #122

## Test plan

### Automated

- [x] `mvn test` — `TefCalculationServiceTest`, `EnergyExpenditureResolverTest`, `CalendarEventRestControllerTest`, `AnthropometricMeasurementServiceTest`
- [x] `./lint.sh` / `mvn pmd:check` clean

### Manual QA (local: http://localhost:3000)

**Prerequisites:** Auth0 login, one patient with sex/edad/peso/estatura, server + Postgres running (`./dev-start.sh`).

| # | Scenario | Route | Verify |
|---|----------|-------|--------|
| 1 | TEF fijo 10% sobre GET | `/admin/pacientes/{id}/afiliacion` | Guardar preferencias; método *Porcentaje fijo*, base *GET*, 10% |
| 2 | Desglose en antropométricos | `/admin/pacientes/{id}/antropometricos` → pestaña **Cálculos** | TMB, Actividad, GET, TEF, Total; guardar y revisar en ver-antropométrico |
| 3 | TEF fijo sobre TMB | Afiliación | Base *TMB*; TEF ≠ 10% del GET si TMB < GET |
| 4 | TEF por macronutrientes | Afiliación | Método *Por macronutrientes*, P/C/G (ej. 30/50/20); preview coherente |
| 5 | Wizard consulta | `/admin/calendario` → evento → notas/resumen | Paso 2: preview GET \| TEF \| Total; paso 3: `caloriasDiarias` prellenado |
| 6 | Perfil + asignar dieta | `/admin/pacientes/{id}` y `.../dietas/asignar` | Total (GET+TEF) visible |

### Manual QA evidence (screenshots)

Drag images into this section (or paste from clipboard); replace each `PLACEHOLDER` line.

<!-- screenshot-1 -->
**1. Afiliación — Preferencias TEF (fijo 10% sobre GET)**  
_Pending screenshot_

![screenshot-1-afiliacion-tef-fixed-get](PLACEHOLDER)

<!-- screenshot-2 -->
**2. Antropométricos — pestaña Cálculos (desglose TMB + actividad + GET + TEF + total)**  
_Pending screenshot_

![screenshot-2-antropometricos-calculos](PLACEHOLDER)

<!-- screenshot-3 -->
**3. Ver antropométrico — valores persistidos (TEF y total ajustado)**  
_Pending screenshot_

![screenshot-3-ver-antropometrico-tef](PLACEHOLDER)

<!-- screenshot-4 -->
**4. Afiliación — TEF por macronutrientes (o fijo sobre TMB)**  
_Pending screenshot_

![screenshot-4-afiliacion-tef-alternate-method](PLACEHOLDER)

<!-- screenshot-5 -->
**5. Calendario — wizard paso 2 (preview GET \| TEF \| Total)**  
_Pending screenshot_

![screenshot-5-calendar-wizard-step2](PLACEHOLDER)

<!-- screenshot-6 -->
**6. Calendario — wizard paso 3 (calorías diarias prellenadas con total ajustado)**  
_Pending screenshot_

![screenshot-6-calendar-wizard-step3-prefill](PLACEHOLDER)

<!-- screenshot-7 -->
**7. Perfil del paciente — Total (GET+TEF)**  
_Pending screenshot_

![screenshot-7-perfil-total-adjusted](PLACEHOLDER)

<!-- screenshot-8 -->
**8. Asignar dieta — banner requerimiento energético (GET + TEF)**  
_Pending screenshot_

![screenshot-8-asignar-dieta-total](PLACEHOLDER)