### PR TITLE
Fix Auth0 email linkage when AUTH0_MGMT_DOMAIN is empty

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -256,7 +256,7 @@ resource "aws_instance" "app" {
         platform_admin_emails_b64 = base64encode(join(",", var.platform_admin_emails))
         auth0_mgmt_client_id_b64     = base64encode(var.auth0_mgmt_client_id)
         auth0_mgmt_client_secret_b64 = base64encode(var.auth0_mgmt_client_secret)
-        auth0_mgmt_domain_b64        = base64encode(var.auth0_mgmt_domain)
+        auth0_mgmt_domain_b64        = base64encode(var.auth0_mgmt_domain != "" ? var.auth0_mgmt_domain : var.auth_issuer)
         nginx_config = templatefile("${path.module}/templates/nutriconsultas-nginx.conf.tpl", {
           nginx_server_names = local.app_nginx_server_names
         })

--- a/src/main/java/com/nutriconsultas/auth0/Auth0UserLookupImpl.java
+++ b/src/main/java/com/nutriconsultas/auth0/Auth0UserLookupImpl.java
@@ -38,11 +38,12 @@ public class Auth0UserLookupImpl implements Auth0UserLookup {
 	public Auth0UserLookupImpl(final RestClient.Builder restClientBuilder,
 			@Value("${app.auth0.management.client-id}") final String clientId,
 			@Value("${app.auth0.management.client-secret}") final String clientSecret,
-			@Value("${app.auth0.management.domain}") final String domain) {
+			@Value("${app.auth0.management.domain}") final String domain,
+			@Value("${AUTH_ISSUER:}") final String authIssuer) {
 		this.restClient = restClientBuilder.build();
 		this.clientId = clientId;
 		this.clientSecret = clientSecret;
-		this.domain = normalizeDomain(domain);
+		this.domain = normalizeDomain(StringUtils.hasText(domain) ? domain : authIssuer);
 	}
 
 	@Override


### PR DESCRIPTION
## Summary
- Fall back to `AUTH_ISSUER` in `Auth0UserLookupImpl` when `AUTH0_MGMT_DOMAIN` is set but blank (Spring does not apply property defaults for empty env vars).
- Default `auth0_mgmt_domain` to `auth_issuer` in Terraform app user_data so new EC2 hosts get a valid Management API domain.

Fixes production symptom on minutriporcion.com where Afiliación showed *"Vinculación por correo no disponible"* despite `AUTH0_MGMT_CLIENT_ID` being configured.

## Test plan
- [x] Pre-commit checkstyle passed locally
- [ ] CI lint + tests green
- [ ] After merge/deploy, Afiliación shows email linkage button when M2M credentials are present


Made with [Cursor](https://cursor.com)