### PR TITLE
Gasto energético: componente por estrés fisiológico (#123)

### DIFF
--- a/src/main/java/com/nutriconsultas/calendar/CalendarEvent.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarEvent.java
@@ -26,6 +26,9 @@ import com.nutriconsultas.paciente.NivelPeso;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.calculation.BmrFormulaType;
 import com.nutriconsultas.paciente.calculation.PhysicalActivityLevel;
+import com.nutriconsultas.paciente.calculation.PhysiologicalStressType;
+import com.nutriconsultas.paciente.calculation.StressFormulaTable;
+import com.nutriconsultas.paciente.calculation.StressIncrementMode;
 
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -122,5 +125,39 @@ public class CalendarEvent {
 
 	@Column(precision = 7)
 	private Double totalAdjustedKcal;
+
+	@Column(precision = 7)
+	private Double stressKcal;
+
+	@Column(precision = 7)
+	private Double finalTotalKcal;
+
+	private Boolean physiologicalStressActive = false;
+
+	@Enumerated(EnumType.STRING)
+	@Column(length = 40)
+	private PhysiologicalStressType physiologicalStressType;
+
+	@Enumerated(EnumType.STRING)
+	@Column(length = 30)
+	private StressFormulaTable stressFormulaTable;
+
+	@Enumerated(EnumType.STRING)
+	@Column(length = 30)
+	private StressIncrementMode stressIncrementMode;
+
+	@Column(precision = 5)
+	private Double stressFactorValue;
+
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	@Temporal(TemporalType.DATE)
+	private Date stressValidFrom;
+
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	@Temporal(TemporalType.DATE)
+	private Date stressValidUntil;
+
+	@Column(precision = 4)
+	private Double stressFeverTemperature;
 
 }

--- a/src/main/java/com/nutriconsultas/calendar/CalendarEventRestController.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarEventRestController.java
@@ -44,6 +44,9 @@ import com.nutriconsultas.paciente.calculation.BmrFormulaType;
 import com.nutriconsultas.paciente.calculation.EnergyExpenditureResolver;
 import com.nutriconsultas.paciente.calculation.PatientEnergyPreferences;
 import com.nutriconsultas.paciente.calculation.PhysicalActivityLevel;
+import com.nutriconsultas.paciente.calculation.PhysiologicalStressType;
+import com.nutriconsultas.paciente.calculation.StressFormulaTable;
+import com.nutriconsultas.paciente.calculation.StressIncrementMode;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -206,6 +209,14 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 		putIfPresent(extendedProps, "getKcal", event.getGetKcal());
 		putIfPresent(extendedProps, "tefKcal", event.getTefKcal());
 		putIfPresent(extendedProps, "totalAdjustedKcal", event.getTotalAdjustedKcal());
+		putIfPresent(extendedProps, "stressKcal", event.getStressKcal());
+		putIfPresent(extendedProps, "finalTotalKcal", event.getFinalTotalKcal());
+		putIfPresent(extendedProps, "physiologicalStressActive", event.getPhysiologicalStressActive());
+		putEnumNameIfPresent(extendedProps, "physiologicalStressType", event.getPhysiologicalStressType());
+		putEnumNameIfPresent(extendedProps, "stressFormulaTable", event.getStressFormulaTable());
+		putEnumNameIfPresent(extendedProps, "stressIncrementMode", event.getStressIncrementMode());
+		putIfPresent(extendedProps, "stressFactorValue", event.getStressFactorValue());
+		putIfPresent(extendedProps, "stressFeverTemperature", event.getStressFeverTemperature());
 		return extendedProps;
 	}
 
@@ -679,31 +690,57 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 		if (event.getGetKcal() != null) {
 			final EnergyExpenditureResolver.EnergyResult tefResult = EnergyExpenditureResolver.applyTef(paciente,
 					event.getBmrUsed(), event.getActivityFactor(), event.getGetKcal());
-			event.setTefKcal(tefResult.tefKcal());
-			event.setTotalAdjustedKcal(tefResult.totalAdjustedKcal());
-			EnergyExpenditureResolver.applyToPatient(paciente, tefResult, event.getPhysicalActivityLevel());
+			final EnergyExpenditureResolver.EnergyResult withStress = EnergyExpenditureResolver.applyStress(paciente,
+					tefResult, event, null, event.getTemperatura());
+			event.setTefKcal(withStress.tefKcal());
+			event.setTotalAdjustedKcal(withStress.totalAdjustedKcal());
+			event.setStressKcal(withStress.stressKcal());
+			event.setFinalTotalKcal(withStress.finalTotalKcal());
+			EnergyExpenditureResolver.applyToPatient(paciente, withStress, event.getPhysicalActivityLevel());
+			syncPatientStressFromEvent(paciente, event);
 			changed = true;
 		}
 		else if (event.getPeso() != null && event.getEstatura() != null) {
 			final BmrFormulaType formula = event.getBmrFormula() != null ? event.getBmrFormula()
 					: PatientEnergyPreferences.resolveBmrFormula(paciente);
+			final Double customFactor = event.getPhysicalActivityLevel() == PhysicalActivityLevel.CUSTOM
+					? event.getActivityFactor() : null;
 			final EnergyExpenditureResolver.EnergyResult result = EnergyExpenditureResolver.resolve(paciente, formula,
-					event.getPhysicalActivityLevel(), event.getActivityFactor(), event.getPeso(), event.getEstatura());
+					event.getPhysicalActivityLevel(), customFactor, event.getPeso(), event.getEstatura(), event, null,
+					event.getTemperatura());
 			if (result.bmr() != null) {
 				event.setBmrUsed(result.bmr());
 				event.setActivityFactor(result.activityFactor());
 				event.setGetKcal(result.getKcal());
 				event.setTefKcal(result.tefKcal());
 				event.setTotalAdjustedKcal(result.totalAdjustedKcal());
+				event.setStressKcal(result.stressKcal());
+				event.setFinalTotalKcal(result.finalTotalKcal());
 				EnergyExpenditureResolver.applyToPatient(paciente, result, event.getPhysicalActivityLevel());
+				syncPatientStressFromEvent(paciente, event);
 				changed = true;
 			}
 		}
 		if (changed) {
 			pacienteRepository.save(paciente);
-			log.debug("Updated patient {} snapshot: imc={}, bmr={}, get={}, total={}", paciente.getId(),
-					paciente.getImc(), paciente.getBmr(), paciente.getGetKcal(), paciente.getTotalAdjustedKcal());
+			log.debug("Updated patient {} snapshot: imc={}, bmr={}, get={}, total={}, final={}", paciente.getId(),
+					paciente.getImc(), paciente.getBmr(), paciente.getGetKcal(), paciente.getTotalAdjustedKcal(),
+					paciente.getFinalTotalKcal());
 		}
+	}
+
+	private void syncPatientStressFromEvent(final Paciente paciente, final CalendarEvent event) {
+		if (paciente == null || event == null || !Boolean.TRUE.equals(event.getPhysiologicalStressActive())) {
+			return;
+		}
+		paciente.setPhysiologicalStressActive(event.getPhysiologicalStressActive());
+		paciente.setPhysiologicalStressType(event.getPhysiologicalStressType());
+		paciente.setStressFormulaTable(event.getStressFormulaTable());
+		paciente.setStressIncrementMode(event.getStressIncrementMode());
+		paciente.setStressFactorValue(event.getStressFactorValue());
+		paciente.setStressValidFrom(event.getStressValidFrom());
+		paciente.setStressValidUntil(event.getStressValidUntil());
+		paciente.setStressFeverTemperature(event.getStressFeverTemperature());
 	}
 
 	private void applyEnergyFields(final CalendarEvent event, final Map<String, Object> eventData) {
@@ -719,6 +756,7 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 			event.setPhysicalActivityLevel(PhysicalActivityLevel.CUSTOM);
 			event.setActivityFactor(customFactor);
 		}
+		applyStressFields(event, eventData);
 		final Paciente paciente = event.getPaciente();
 		if (paciente == null || event.getPeso() == null || event.getEstatura() == null
 				|| event.getPhysicalActivityLevel() == null) {
@@ -729,13 +767,44 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 		final Double customFactor = event.getPhysicalActivityLevel() == PhysicalActivityLevel.CUSTOM
 				? event.getActivityFactor() : null;
 		final EnergyExpenditureResolver.EnergyResult result = EnergyExpenditureResolver.resolve(paciente, formula,
-				event.getPhysicalActivityLevel(), customFactor, event.getPeso(), event.getEstatura());
+				event.getPhysicalActivityLevel(), customFactor, event.getPeso(), event.getEstatura(), event, null,
+				event.getTemperatura());
 		event.setBmrFormula(formula);
 		event.setBmrUsed(result.bmr());
 		event.setActivityFactor(result.activityFactor());
 		event.setGetKcal(result.getKcal());
 		event.setTefKcal(result.tefKcal());
 		event.setTotalAdjustedKcal(result.totalAdjustedKcal());
+		event.setStressKcal(result.stressKcal());
+		event.setFinalTotalKcal(result.finalTotalKcal());
+	}
+
+	private void applyStressFields(final CalendarEvent event, final Map<String, Object> eventData) {
+		if (eventData.get("physiologicalStressActive") != null) {
+			event.setPhysiologicalStressActive(Boolean.parseBoolean(eventData.get("physiologicalStressActive").toString()));
+		}
+		if (eventData.get("physiologicalStressType") != null) {
+			event.setPhysiologicalStressType(
+					PhysiologicalStressType.valueOf(eventData.get("physiologicalStressType").toString()));
+		}
+		if (eventData.get("stressFormulaTable") != null) {
+			event.setStressFormulaTable(StressFormulaTable.valueOf(eventData.get("stressFormulaTable").toString()));
+		}
+		if (eventData.get("stressIncrementMode") != null) {
+			event.setStressIncrementMode(StressIncrementMode.valueOf(eventData.get("stressIncrementMode").toString()));
+		}
+		if (eventData.get("stressFactorValue") != null) {
+			event.setStressFactorValue(Double.parseDouble(eventData.get("stressFactorValue").toString()));
+		}
+		if (eventData.get("stressFeverTemperature") != null) {
+			event.setStressFeverTemperature(Double.parseDouble(eventData.get("stressFeverTemperature").toString()));
+		}
+		if (eventData.get("stressValidFrom") != null && !eventData.get("stressValidFrom").toString().isBlank()) {
+			event.setStressValidFrom(java.sql.Date.valueOf(eventData.get("stressValidFrom").toString()));
+		}
+		if (eventData.get("stressValidUntil") != null && !eventData.get("stressValidUntil").toString().isBlank()) {
+			event.setStressValidUntil(java.sql.Date.valueOf(eventData.get("stressValidUntil").toString()));
+		}
 	}
 
 	/**

--- a/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurement.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurement.java
@@ -31,6 +31,9 @@ import com.nutriconsultas.paciente.NivelPeso;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.calculation.BmrFormulaType;
 import com.nutriconsultas.paciente.calculation.PhysicalActivityLevel;
+import com.nutriconsultas.paciente.calculation.PhysiologicalStressType;
+import com.nutriconsultas.paciente.calculation.StressFormulaTable;
+import com.nutriconsultas.paciente.calculation.StressIncrementMode;
 
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -111,6 +114,40 @@ public class AnthropometricMeasurement {
 
 	@Column(precision = 7)
 	private Double totalAdjustedKcal;
+
+	@Column(precision = 7)
+	private Double stressKcal;
+
+	@Column(precision = 7)
+	private Double finalTotalKcal;
+
+	private Boolean physiologicalStressActive = false;
+
+	@Enumerated(EnumType.STRING)
+	@Column(length = 40)
+	private PhysiologicalStressType physiologicalStressType;
+
+	@Enumerated(EnumType.STRING)
+	@Column(length = 30)
+	private StressFormulaTable stressFormulaTable;
+
+	@Enumerated(EnumType.STRING)
+	@Column(length = 30)
+	private StressIncrementMode stressIncrementMode;
+
+	@Column(precision = 5)
+	private Double stressFactorValue;
+
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	@Temporal(TemporalType.DATE)
+	private Date stressValidFrom;
+
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	@Temporal(TemporalType.DATE)
+	private Date stressValidUntil;
+
+	@Column(precision = 4)
+	private Double stressFeverTemperature;
 
 	// Convenience methods for backward compatibility
 	public Double getPeso() {

--- a/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurementServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurementServiceImpl.java
@@ -72,13 +72,15 @@ public class AnthropometricMeasurementServiceImpl implements AnthropometricMeasu
 				? measurement.getActivityFactor() : null;
 		final EnergyExpenditureResolver.EnergyResult result = EnergyExpenditureResolver.resolve(
 				measurement.getPaciente(), formula, measurement.getPhysicalActivityLevel(), customFactor, weight,
-				height);
+				height, null, measurement, null);
 		measurement.setBmrFormula(formula);
 		measurement.setBmrUsed(result.bmr());
 		measurement.setActivityFactor(result.activityFactor());
 		measurement.setGetKcal(result.getKcal());
 		measurement.setTefKcal(result.tefKcal());
 		measurement.setTotalAdjustedKcal(result.totalAdjustedKcal());
+		measurement.setStressKcal(result.stressKcal());
+		measurement.setFinalTotalKcal(result.finalTotalKcal());
 	}
 
 	private void syncPatientEnergySnapshot(final AnthropometricMeasurement measurement) {
@@ -88,7 +90,8 @@ public class AnthropometricMeasurementServiceImpl implements AnthropometricMeasu
 		final Paciente paciente = measurement.getPaciente();
 		EnergyExpenditureResolver.applyToPatient(paciente,
 				new EnergyExpenditureResolver.EnergyResult(measurement.getBmrUsed(), measurement.getActivityFactor(),
-						measurement.getGetKcal(), null, measurement.getTefKcal(), measurement.getTotalAdjustedKcal()),
+						measurement.getGetKcal(), null, measurement.getTefKcal(), measurement.getTotalAdjustedKcal(),
+						measurement.getStressKcal(), measurement.getFinalTotalKcal()),
 				measurement.getPhysicalActivityLevel());
 		pacienteRepository.save(paciente);
 	}

--- a/src/main/java/com/nutriconsultas/paciente/Paciente.java
+++ b/src/main/java/com/nutriconsultas/paciente/Paciente.java
@@ -21,6 +21,9 @@ import org.springframework.format.annotation.DateTimeFormat.ISO;
 import com.nutriconsultas.paciente.calculation.ActivityFactorScale;
 import com.nutriconsultas.paciente.calculation.BmrFormulaType;
 import com.nutriconsultas.paciente.calculation.PhysicalActivityLevel;
+import com.nutriconsultas.paciente.calculation.PhysiologicalStressType;
+import com.nutriconsultas.paciente.calculation.StressFormulaTable;
+import com.nutriconsultas.paciente.calculation.StressIncrementMode;
 import com.nutriconsultas.paciente.calculation.TefBase;
 import com.nutriconsultas.paciente.calculation.TefCalculationService;
 import com.nutriconsultas.paciente.calculation.TefMethod;
@@ -112,6 +115,46 @@ public class Paciente {
 	 */
 	@Column(precision = 7)
 	private Double totalAdjustedKcal;
+
+	/**
+	 * Additional energy from physiological stress in kcal/day.
+	 */
+	@Column(precision = 7)
+	private Double stressKcal;
+
+	/**
+	 * Final daily energy requirement (GET + TEF + stress) in kcal/day.
+	 */
+	@Column(precision = 7)
+	private Double finalTotalKcal;
+
+	private Boolean physiologicalStressActive = false;
+
+	@Enumerated(EnumType.STRING)
+	@Column(length = 40)
+	private PhysiologicalStressType physiologicalStressType;
+
+	@Enumerated(EnumType.STRING)
+	@Column(length = 30)
+	private StressFormulaTable stressFormulaTable = StressFormulaTable.LONG;
+
+	@Enumerated(EnumType.STRING)
+	@Column(length = 30)
+	private StressIncrementMode stressIncrementMode = StressIncrementMode.MULTIPLIER_BMR;
+
+	@Column(precision = 5)
+	private Double stressFactorValue;
+
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	@Temporal(TemporalType.DATE)
+	private Date stressValidFrom;
+
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	@Temporal(TemporalType.DATE)
+	private Date stressValidUntil;
+
+	@Column(precision = 4)
+	private Double stressFeverTemperature;
 
 	@Enumerated(EnumType.STRING)
 	@Column(length = 30)

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -356,6 +356,9 @@ public class PacienteController extends AbstractAuthorizedController {
 		model.addAttribute("activeMenu", "desarrollo");
 		model.addAttribute("paciente", paciente);
 		model.addAttribute("isEligibleForPregnancy", isEligibleForPregnancy(paciente));
+		model.addAttribute("suggestedStressTypes",
+				com.nutriconsultas.paciente.calculation.PhysiologicalStressCatalog
+					.suggestFromPathologies(paciente));
 		return "sbadmin/pacientes/desarrollo";
 	}
 
@@ -394,6 +397,20 @@ public class PacienteController extends AbstractAuthorizedController {
 			}
 		}
 		pacienteEntity.setPregnancy(paciente.getPregnancy() != null ? paciente.getPregnancy() : false);
+
+		pacienteEntity.setPhysiologicalStressActive(
+				paciente.getPhysiologicalStressActive() != null ? paciente.getPhysiologicalStressActive() : false);
+		pacienteEntity.setPhysiologicalStressType(paciente.getPhysiologicalStressType());
+		if (paciente.getStressFormulaTable() != null) {
+			pacienteEntity.setStressFormulaTable(paciente.getStressFormulaTable());
+		}
+		if (paciente.getStressIncrementMode() != null) {
+			pacienteEntity.setStressIncrementMode(paciente.getStressIncrementMode());
+		}
+		pacienteEntity.setStressFactorValue(paciente.getStressFactorValue());
+		pacienteEntity.setStressValidFrom(paciente.getStressValidFrom());
+		pacienteEntity.setStressValidUntil(paciente.getStressValidUntil());
+		pacienteEntity.setStressFeverTemperature(paciente.getStressFeverTemperature());
 
 		pacienteRepository.save(pacienteEntity);
 		return String.format("redirect:/admin/pacientes/%d", id);
@@ -487,7 +504,20 @@ public class PacienteController extends AbstractAuthorizedController {
 		evento.setTitle("Consulta");
 		evento.setDurationMinutes(60);
 		evento.setStatus(EventStatus.SCHEDULED);
+		if (Boolean.TRUE.equals(paciente.getPhysiologicalStressActive())) {
+			evento.setPhysiologicalStressActive(true);
+			evento.setPhysiologicalStressType(paciente.getPhysiologicalStressType());
+			evento.setStressFormulaTable(paciente.getStressFormulaTable());
+			evento.setStressIncrementMode(paciente.getStressIncrementMode());
+			evento.setStressFactorValue(paciente.getStressFactorValue());
+			evento.setStressValidFrom(paciente.getStressValidFrom());
+			evento.setStressValidUntil(paciente.getStressValidUntil());
+			evento.setStressFeverTemperature(paciente.getStressFeverTemperature());
+		}
 		model.addAttribute("consulta", evento);
+		model.addAttribute("suggestedStressTypes",
+				com.nutriconsultas.paciente.calculation.PhysiologicalStressCatalog
+					.suggestFromPathologies(paciente));
 		return "sbadmin/pacientes/consulta";
 	}
 
@@ -513,7 +543,18 @@ public class PacienteController extends AbstractAuthorizedController {
 		setEventDefaultValues(evento);
 
 		log.debug("Evento lista para grabar {}", LogRedaction.redactCalendarEvent(evento));
-		calendarEventService.save(evento);
+		final CalendarEvent savedEvent = calendarEventService.save(evento);
+		if (Boolean.TRUE.equals(savedEvent.getPhysiologicalStressActive())) {
+			paciente.setPhysiologicalStressActive(savedEvent.getPhysiologicalStressActive());
+			paciente.setPhysiologicalStressType(savedEvent.getPhysiologicalStressType());
+			paciente.setStressFormulaTable(savedEvent.getStressFormulaTable());
+			paciente.setStressIncrementMode(savedEvent.getStressIncrementMode());
+			paciente.setStressFactorValue(savedEvent.getStressFactorValue());
+			paciente.setStressValidFrom(savedEvent.getStressValidFrom());
+			paciente.setStressValidUntil(savedEvent.getStressValidUntil());
+			paciente.setStressFeverTemperature(savedEvent.getStressFeverTemperature());
+			pacienteRepository.save(paciente);
+		}
 		return String.format("redirect:/admin/pacientes/%d/historial", pacienteId);
 	}
 

--- a/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
@@ -40,6 +40,7 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 		variables.put("ultimoNivelPeso", null);
 		variables.put("isEligibleForPregnancy", false);
 		variables.put("isUnder18", false);
+		variables.put("suggestedStressTypes", List.of());
 		variables.put("growthMeasurements", new ArrayList<AnthropometricMeasurement>());
 		// Calculation tab variables
 		variables.put("patientAge", 30);

--- a/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
@@ -7,6 +7,9 @@ import java.util.Map;
 
 import com.nutriconsultas.calendar.CalendarEvent;
 import com.nutriconsultas.calendar.EventStatus;
+import com.nutriconsultas.paciente.calculation.PhysiologicalStressType;
+import com.nutriconsultas.paciente.calculation.StressFormulaTable;
+import com.nutriconsultas.paciente.calculation.StressIncrementMode;
 import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
 import com.nutriconsultas.clinical.exam.ClinicalExam;
 import com.nutriconsultas.dieta.Dieta;
@@ -238,6 +241,20 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 		measurement.setMuslo(null);
 		measurement.setPorcentajeGrasaCorporal(null);
 		measurement.setPorcentajeMasaMuscular(null);
+		measurement.setBmrUsed(1500.0);
+		measurement.setGetKcal(2100.0);
+		measurement.setTefKcal(210.0);
+		measurement.setTotalAdjustedKcal(2310.0);
+		measurement.setPhysiologicalStressActive(true);
+		measurement.setPhysiologicalStressType(PhysiologicalStressType.FEVER);
+		measurement.setStressFormulaTable(StressFormulaTable.LONG);
+		measurement.setStressIncrementMode(StressIncrementMode.MULTIPLIER_BMR);
+		measurement.setStressFactorValue(1.2);
+		measurement.setStressFeverTemperature(38.5);
+		measurement.setStressValidFrom(new Date());
+		measurement.setStressValidUntil(new Date());
+		measurement.setStressKcal(462.0);
+		measurement.setFinalTotalKcal(2772.0);
 		return measurement;
 	}
 

--- a/src/main/java/com/nutriconsultas/paciente/calculation/EnergyExpenditureResolver.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/EnergyExpenditureResolver.java
@@ -7,6 +7,8 @@ import java.util.Date;
 
 import org.springframework.lang.Nullable;
 
+import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
 import com.nutriconsultas.paciente.Paciente;
 
 /**
@@ -19,10 +21,15 @@ public final class EnergyExpenditureResolver {
 	}
 
 	public record EnergyResult(Double bmr, Double activityFactor, Double getKcal, Double activityKcal, Double tefKcal,
-			Double totalAdjustedKcal) {
+			Double totalAdjustedKcal, Double stressKcal, Double finalTotalKcal) {
 
 		public EnergyResult(final Double bmr, final Double activityFactor, final Double getKcal) {
-			this(bmr, activityFactor, getKcal, null, null, getKcal);
+			this(bmr, activityFactor, getKcal, null, null, getKcal, null, getKcal);
+		}
+
+		public EnergyResult(final Double bmr, final Double activityFactor, final Double getKcal,
+				final Double activityKcal, final Double tefKcal, final Double totalAdjustedKcal) {
+			this(bmr, activityFactor, getKcal, activityKcal, tefKcal, totalAdjustedKcal, null, totalAdjustedKcal);
 		}
 
 	}
@@ -34,8 +41,19 @@ public final class EnergyExpenditureResolver {
 	public static EnergyResult resolve(final Paciente paciente, @Nullable final BmrFormulaType bmrFormulaOverride,
 			@Nullable final PhysicalActivityLevel activityLevel, @Nullable final Double customFactorValue,
 			final Double weight, final Double height) {
+		return resolve(paciente, bmrFormulaOverride, activityLevel, customFactorValue, weight, height, null, null,
+				null);
+	}
+
+	/**
+	 * Computes full energy breakdown including optional physiological stress.
+	 */
+	public static EnergyResult resolve(final Paciente paciente, @Nullable final BmrFormulaType bmrFormulaOverride,
+			@Nullable final PhysicalActivityLevel activityLevel, @Nullable final Double customFactorValue,
+			final Double weight, final Double height, @Nullable final CalendarEvent event,
+			@Nullable final AnthropometricMeasurement measurement, @Nullable final Double bodyTemperature) {
 		if (paciente == null || weight == null || height == null || weight <= 0 || height <= 0) {
-			return new EnergyResult(null, null, null, null, null, null);
+			return new EnergyResult(null, null, null, null, null, null, null, null);
 		}
 		final Integer age = calculateAge(paciente.getDob());
 		final Boolean isMale = "M".equalsIgnoreCase(paciente.getGender());
@@ -43,14 +61,15 @@ public final class EnergyExpenditureResolver {
 				: PatientEnergyPreferences.resolveBmrFormula(paciente);
 		final Double bmr = TdeeCalculationService.calculateBmr(formula, weight, height, age, isMale);
 		if (bmr == null || activityLevel == null) {
-			return new EnergyResult(bmr, null, null, null, null, null);
+			return new EnergyResult(bmr, null, null, null, null, null, null, null);
 		}
 		final ActivityFactorScale scale = PatientEnergyPreferences.resolveScale(paciente);
 		final CustomActivityFactors customFactors = PatientEnergyPreferences.customFactorsFrom(paciente);
 		final Double factor = TdeeCalculationService.resolveActivityFactor(scale, activityLevel, customFactors,
 				customFactorValue);
 		final Double getKcal = TdeeCalculationService.calculateGet(bmr, factor);
-		return applyTef(paciente, bmr, factor, getKcal);
+		final EnergyResult withTef = applyTef(paciente, bmr, factor, getKcal);
+		return applyStress(paciente, withTef, event, measurement, bodyTemperature);
 	}
 
 	/**
@@ -59,7 +78,7 @@ public final class EnergyExpenditureResolver {
 	public static EnergyResult applyTef(final Paciente paciente, final Double bmr, final Double activityFactor,
 			final Double getKcal) {
 		if (getKcal == null) {
-			return new EnergyResult(bmr, activityFactor, null, null, null, null);
+			return new EnergyResult(bmr, activityFactor, null, null, null, null, null, null);
 		}
 		final Double tefKcal = TefCalculationService.calculateTef(PatientEnergyPreferences.resolveTefMethod(paciente),
 				PatientEnergyPreferences.resolveTefBase(paciente), paciente.getTefFixedPercent(),
@@ -67,15 +86,39 @@ public final class EnergyExpenditureResolver {
 				paciente.getTefMacroFatPercent(), bmr, getKcal);
 		final Double totalAdjustedKcal = TefCalculationService.calculateTotalAdjustedKcal(getKcal, tefKcal);
 		final Double activityKcal = TefCalculationService.calculateActivityKcal(bmr, getKcal);
-		return new EnergyResult(bmr, activityFactor, getKcal, activityKcal, tefKcal, totalAdjustedKcal);
+		return new EnergyResult(bmr, activityFactor, getKcal, activityKcal, tefKcal, totalAdjustedKcal, null,
+				totalAdjustedKcal);
 	}
 
 	/**
-	 * Target daily calories for diet assignment (GET + TEF when available).
+	 * Applies physiological stress to an energy result that already includes TEF.
+	 */
+	public static EnergyResult applyStress(final Paciente paciente, final EnergyResult result,
+			@Nullable final CalendarEvent event, @Nullable final AnthropometricMeasurement measurement,
+			@Nullable final Double bodyTemperature) {
+		if (result == null || result.getKcal() == null) {
+			return result;
+		}
+		final LocalDate referenceDate = resolveReferenceDate(event, measurement);
+		final StressContext stressContext = PhysiologicalStressPreferences.resolveEffective(paciente, event, measurement,
+				referenceDate);
+		final Double stressKcal = PhysiologicalStressCalculationService.calculateStressKcal(stressContext, result.bmr(),
+				result.getKcal(), bodyTemperature);
+		final Double finalTotalKcal = PhysiologicalStressCalculationService
+			.calculateFinalTotalKcal(result.totalAdjustedKcal(), stressKcal);
+		return new EnergyResult(result.bmr(), result.activityFactor(), result.getKcal(), result.activityKcal(),
+				result.tefKcal(), result.totalAdjustedKcal(), stressKcal, finalTotalKcal);
+	}
+
+	/**
+	 * Target daily calories for diet assignment (GET + TEF + stress when available).
 	 */
 	public static Double resolveTargetDailyCalories(final Paciente paciente) {
 		if (paciente == null) {
 			return null;
+		}
+		if (paciente.getFinalTotalKcal() != null) {
+			return paciente.getFinalTotalKcal();
 		}
 		if (paciente.getTotalAdjustedKcal() != null) {
 			return paciente.getTotalAdjustedKcal();
@@ -103,12 +146,29 @@ public final class EnergyExpenditureResolver {
 		if (result.totalAdjustedKcal() != null) {
 			paciente.setTotalAdjustedKcal(result.totalAdjustedKcal());
 		}
+		if (result.stressKcal() != null) {
+			paciente.setStressKcal(result.stressKcal());
+		}
+		if (result.finalTotalKcal() != null) {
+			paciente.setFinalTotalKcal(result.finalTotalKcal());
+		}
 		if (activityLevel != null) {
 			paciente.setPhysicalActivityLevel(activityLevel);
 		}
 		if (result.activityFactor() != null) {
 			paciente.setActivityFactor(result.activityFactor());
 		}
+	}
+
+	private static LocalDate resolveReferenceDate(@Nullable final CalendarEvent event,
+			@Nullable final AnthropometricMeasurement measurement) {
+		if (measurement != null && measurement.getMeasurementDateTime() != null) {
+			return measurement.getMeasurementDateTime().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+		}
+		if (event != null && event.getEventDateTime() != null) {
+			return event.getEventDateTime().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+		}
+		return LocalDate.now();
 	}
 
 	private static Integer calculateAge(final Date dob) {

--- a/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCalculationService.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCalculationService.java
@@ -1,0 +1,102 @@
+package com.nutriconsultas.paciente.calculation;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Calculates additional energy expenditure from physiological stress.
+ */
+public final class PhysiologicalStressCalculationService {
+
+	private static final double NORMAL_BODY_TEMPERATURE_CELSIUS = 37.0;
+
+	private PhysiologicalStressCalculationService() {
+		// Utility class
+	}
+
+	/**
+	 * Calculates stress kcal/day from resolved context and energy components.
+	 *
+	 * @param context resolved stress configuration
+	 * @param bmr basal metabolic rate (kcal/day)
+	 * @param getKcal total daily energy expenditure before TEF (kcal/day)
+	 * @param bodyTemperature optional body temperature in °C (for fever formulas)
+	 * @return additional kcal/day from stress, or {@code null} when inactive
+	 */
+	public static Double calculateStressKcal(final StressContext context, @Nullable final Double bmr,
+			@Nullable final Double getKcal, @Nullable final Double bodyTemperature) {
+		if (context == null || !Boolean.TRUE.equals(context.active()) || context.stressType() == null
+				|| context.stressType() == PhysiologicalStressType.NONE) {
+			return null;
+		}
+		final StressFormulaTable formulaTable = context.formulaTable() != null ? context.formulaTable()
+				: StressFormulaTable.LONG;
+		if (formulaTable == StressFormulaTable.FEVER_PER_DEGREE
+				&& context.stressType() == PhysiologicalStressType.FEVER) {
+			return calculateFeverStressKcal(bmr, resolveFeverTemperature(context, bodyTemperature));
+		}
+		final StressIncrementMode mode = context.incrementMode() != null ? context.incrementMode()
+				: StressIncrementMode.MULTIPLIER_BMR;
+		if (mode == StressIncrementMode.FIXED_KCAL) {
+			return resolveFixedKcal(context);
+		}
+		final Double multiplier = resolveMultiplier(context, formulaTable);
+		if (multiplier == null || multiplier <= 1.0) {
+			return null;
+		}
+		return calculateMultiplierStressKcal(mode, multiplier, bmr, getKcal);
+	}
+
+	public static Double calculateFinalTotalKcal(final Double totalAdjustedKcal, final Double stressKcal) {
+		if (totalAdjustedKcal == null) {
+			return null;
+		}
+		if (stressKcal == null || stressKcal <= 0) {
+			return totalAdjustedKcal;
+		}
+		return totalAdjustedKcal + stressKcal;
+	}
+
+	private static Double calculateFeverStressKcal(final Double bmr, @Nullable final Double temperature) {
+		if (bmr == null || bmr <= 0 || temperature == null || temperature <= NORMAL_BODY_TEMPERATURE_CELSIUS) {
+			return null;
+		}
+		final double degreesAboveNormal = temperature - NORMAL_BODY_TEMPERATURE_CELSIUS;
+		return bmr * PhysiologicalStressCatalog.FEVER_INCREMENT_PER_DEGREE * degreesAboveNormal;
+	}
+
+	private static Double resolveFeverTemperature(final StressContext context, @Nullable final Double bodyTemperature) {
+		if (bodyTemperature != null) {
+			return bodyTemperature;
+		}
+		return context.feverTemperature();
+	}
+
+	private static Double resolveFixedKcal(final StressContext context) {
+		if (context.factorValue() == null || context.factorValue() <= 0) {
+			return null;
+		}
+		return context.factorValue();
+	}
+
+	private static Double resolveMultiplier(final StressContext context, final StressFormulaTable formulaTable) {
+		if (context.factorValue() != null && context.factorValue() > 0) {
+			return context.factorValue();
+		}
+		return PhysiologicalStressCatalog.defaultMultiplier(context.stressType(), formulaTable);
+	}
+
+	private static Double calculateMultiplierStressKcal(final StressIncrementMode mode, final Double multiplier,
+			@Nullable final Double bmr, @Nullable final Double getKcal) {
+		if (mode == StressIncrementMode.MULTIPLIER_GET) {
+			if (getKcal == null || getKcal <= 0) {
+				return null;
+			}
+			return getKcal * (multiplier - 1.0);
+		}
+		if (bmr == null || bmr <= 0) {
+			return null;
+		}
+		return bmr * (multiplier - 1.0);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCatalog.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCatalog.java
@@ -1,0 +1,143 @@
+package com.nutriconsultas.paciente.calculation;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.nutriconsultas.paciente.Paciente;
+
+/**
+ * Catalog of default stress multipliers by clinical reference table and stress type.
+ *
+ * <p>
+ * Values are documented clinical approximations (Long, ASPEN) for nutrition planning.
+ */
+public final class PhysiologicalStressCatalog {
+
+	/** Increment per °C above 37 °C applied to BMR (fever formula). */
+	public static final double FEVER_INCREMENT_PER_DEGREE = 0.13;
+
+	private PhysiologicalStressCatalog() {
+		// Utility class
+	}
+
+	/**
+	 * Returns the default multiplier for a stress type and reference table, or {@code null}
+	 * when the nutritionist must supply a custom value.
+	 */
+	public static Double defaultMultiplier(final PhysiologicalStressType stressType,
+			final StressFormulaTable formulaTable) {
+		if (stressType == null || stressType == PhysiologicalStressType.NONE
+				|| stressType == PhysiologicalStressType.OTHER) {
+			return null;
+		}
+		if (formulaTable == StressFormulaTable.FEVER_PER_DEGREE && stressType == PhysiologicalStressType.FEVER) {
+			return null;
+		}
+		if (formulaTable == StressFormulaTable.CUSTOM) {
+			return null;
+		}
+		final StressFormulaTable table = formulaTable != null ? formulaTable : StressFormulaTable.LONG;
+		return switch (table) {
+			case LONG -> longMultiplier(stressType);
+			case ASPEN -> aspenMultiplier(stressType);
+			case FEVER_PER_DEGREE, CUSTOM -> null;
+		};
+	}
+
+	/**
+	 * Suggests stress types based on pathology flags already captured on the patient record.
+	 */
+	public static List<PhysiologicalStressType> suggestFromPathologies(final Paciente paciente) {
+		if (paciente == null) {
+			return List.of();
+		}
+		final Set<PhysiologicalStressType> suggestions = new LinkedHashSet<>();
+		if (Boolean.TRUE.equals(paciente.getDiabetes())) {
+			suggestions.add(PhysiologicalStressType.MODERATE_INFECTION);
+		}
+		if (Boolean.TRUE.equals(paciente.getEnfermedadesHepaticas())) {
+			suggestions.add(PhysiologicalStressType.ORGAN_FAILURE);
+		}
+		if (Boolean.TRUE.equals(paciente.getHipertension())) {
+			suggestions.add(PhysiologicalStressType.ORGAN_FAILURE);
+		}
+		if (Boolean.TRUE.equals(paciente.getAnemia())) {
+			suggestions.add(PhysiologicalStressType.MODERATE_INFECTION);
+		}
+		if (Boolean.TRUE.equals(paciente.getObesidad())) {
+			suggestions.add(PhysiologicalStressType.POST_OPERATIVE);
+		}
+		if (Boolean.TRUE.equals(paciente.getPregnancy())) {
+			suggestions.add(PhysiologicalStressType.PREGNANCY_COMPLICATION);
+		}
+		if (Boolean.TRUE.equals(paciente.getBulimia()) || Boolean.TRUE.equals(paciente.getAnorexia())) {
+			suggestions.add(PhysiologicalStressType.OTHER);
+		}
+		suggestions.remove(PhysiologicalStressType.NONE);
+		return new ArrayList<>(suggestions);
+	}
+
+	public static List<PhysiologicalStressType> commonTypes() {
+		return EnumSet.allOf(PhysiologicalStressType.class)
+			.stream()
+			.filter(PhysiologicalStressType::isCommon)
+			.filter(type -> type != PhysiologicalStressType.NONE)
+			.toList();
+	}
+
+	public static List<PhysiologicalStressType> uncommonTypes() {
+		return EnumSet.allOf(PhysiologicalStressType.class)
+			.stream()
+			.filter(type -> !type.isCommon())
+			.filter(type -> type != PhysiologicalStressType.NONE)
+			.toList();
+	}
+
+	private static Double longMultiplier(final PhysiologicalStressType stressType) {
+		return switch (stressType) {
+			case FEVER -> null;
+			case MINOR_SURGERY -> 1.10;
+			case MAJOR_SURGERY -> 1.20;
+			case MODERATE_INFECTION -> 1.20;
+			case SEVERE_INFECTION -> 1.40;
+			case SEPSIS -> 1.50;
+			case TRAUMA -> 1.35;
+			case BURNS -> 1.50;
+			case CANCER -> 1.25;
+			case FRACTURE -> 1.20;
+			case POST_OPERATIVE -> 1.15;
+			case MULTIPLE_TRAUMA -> 1.50;
+			case HEAD_INJURY -> 1.40;
+			case ORGAN_FAILURE -> 1.50;
+			case PREGNANCY_COMPLICATION -> 1.20;
+			case COPD_EXACERBATION -> 1.20;
+			default -> null;
+		};
+	}
+
+	private static Double aspenMultiplier(final PhysiologicalStressType stressType) {
+		return switch (stressType) {
+			case FEVER -> null;
+			case MINOR_SURGERY -> 1.10;
+			case MAJOR_SURGERY -> 1.25;
+			case MODERATE_INFECTION -> 1.30;
+			case SEVERE_INFECTION -> 1.55;
+			case SEPSIS -> 1.60;
+			case TRAUMA -> 1.40;
+			case BURNS -> 1.80;
+			case CANCER -> 1.30;
+			case FRACTURE -> 1.20;
+			case POST_OPERATIVE -> 1.15;
+			case MULTIPLE_TRAUMA -> 1.60;
+			case HEAD_INJURY -> 1.45;
+			case ORGAN_FAILURE -> 1.55;
+			case PREGNANCY_COMPLICATION -> 1.25;
+			case COPD_EXACERBATION -> 1.25;
+			default -> null;
+		};
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressPreferences.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressPreferences.java
@@ -1,0 +1,102 @@
+package com.nutriconsultas.paciente.calculation;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.springframework.lang.Nullable;
+
+import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
+import com.nutriconsultas.paciente.Paciente;
+
+/**
+ * Resolves physiological stress preferences from patient records and clinical event overrides.
+ */
+public final class PhysiologicalStressPreferences {
+
+	private PhysiologicalStressPreferences() {
+		// Utility class
+	}
+
+	public static StressContext fromPatient(final Paciente paciente) {
+		if (paciente == null) {
+			return StressContext.inactive();
+		}
+		return StressContext.of(paciente.getPhysiologicalStressActive(), paciente.getPhysiologicalStressType(),
+				paciente.getStressFormulaTable(), paciente.getStressIncrementMode(), paciente.getStressFactorValue(),
+				paciente.getStressValidFrom(), paciente.getStressValidUntil(), paciente.getStressFeverTemperature());
+	}
+
+	public static StressContext fromCalendarEvent(final CalendarEvent event) {
+		if (event == null) {
+			return StressContext.inactive();
+		}
+		return StressContext.of(event.getPhysiologicalStressActive(), event.getPhysiologicalStressType(),
+				event.getStressFormulaTable(), event.getStressIncrementMode(), event.getStressFactorValue(),
+				event.getStressValidFrom(), event.getStressValidUntil(), event.getStressFeverTemperature());
+	}
+
+	public static StressContext fromMeasurement(final AnthropometricMeasurement measurement) {
+		if (measurement == null) {
+			return StressContext.inactive();
+		}
+		return StressContext.of(measurement.getPhysiologicalStressActive(), measurement.getPhysiologicalStressType(),
+				measurement.getStressFormulaTable(), measurement.getStressIncrementMode(),
+				measurement.getStressFactorValue(), measurement.getStressValidFrom(),
+				measurement.getStressValidUntil(), measurement.getStressFeverTemperature());
+	}
+
+	/**
+	 * Resolves effective stress context: event/measurement override when explicitly active,
+	 * otherwise patient baseline when valid on the reference date.
+	 */
+	public static StressContext resolveEffective(final Paciente paciente, @Nullable final CalendarEvent event,
+			@Nullable final AnthropometricMeasurement measurement, @Nullable final LocalDate referenceDate) {
+		final LocalDate effectiveDate = referenceDate != null ? referenceDate : LocalDate.now();
+		if (measurement != null && Boolean.TRUE.equals(measurement.getPhysiologicalStressActive())) {
+			final StressContext context = fromMeasurement(measurement);
+			if (isActive(context, effectiveDate)) {
+				return context;
+			}
+		}
+		if (event != null && Boolean.TRUE.equals(event.getPhysiologicalStressActive())) {
+			final StressContext context = fromCalendarEvent(event);
+			if (isActive(context, effectiveDate)) {
+				return context;
+			}
+		}
+		final StressContext patientContext = fromPatient(paciente);
+		if (isActive(patientContext, effectiveDate)) {
+			return patientContext;
+		}
+		return StressContext.inactive();
+	}
+
+	public static boolean isActive(final StressContext context, final LocalDate referenceDate) {
+		if (context == null || !Boolean.TRUE.equals(context.active())) {
+			return false;
+		}
+		if (context.stressType() == null || context.stressType() == PhysiologicalStressType.NONE) {
+			return false;
+		}
+		final LocalDate validFrom = toLocalDate(context.validFrom());
+		final LocalDate validUntil = toLocalDate(context.validUntil());
+		if (validFrom != null && referenceDate.isBefore(validFrom)) {
+			return false;
+		}
+		if (validUntil != null && referenceDate.isAfter(validUntil)) {
+			return false;
+		}
+		return true;
+	}
+
+	private static LocalDate toLocalDate(final Date date) {
+		if (date == null) {
+			return null;
+		}
+		final Date utilDate = date instanceof java.sql.Date ? new Date(date.getTime()) : date;
+		return utilDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressPreferences.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressPreferences.java
@@ -23,7 +23,7 @@ public final class PhysiologicalStressPreferences {
 		if (paciente == null) {
 			return StressContext.inactive();
 		}
-		return StressContext.of(paciente.getPhysiologicalStressActive(), paciente.getPhysiologicalStressType(),
+		return StressContext.fromValues(paciente.getPhysiologicalStressActive(), paciente.getPhysiologicalStressType(),
 				paciente.getStressFormulaTable(), paciente.getStressIncrementMode(), paciente.getStressFactorValue(),
 				paciente.getStressValidFrom(), paciente.getStressValidUntil(), paciente.getStressFeverTemperature());
 	}
@@ -32,7 +32,7 @@ public final class PhysiologicalStressPreferences {
 		if (event == null) {
 			return StressContext.inactive();
 		}
-		return StressContext.of(event.getPhysiologicalStressActive(), event.getPhysiologicalStressType(),
+		return StressContext.fromValues(event.getPhysiologicalStressActive(), event.getPhysiologicalStressType(),
 				event.getStressFormulaTable(), event.getStressIncrementMode(), event.getStressFactorValue(),
 				event.getStressValidFrom(), event.getStressValidUntil(), event.getStressFeverTemperature());
 	}
@@ -41,7 +41,8 @@ public final class PhysiologicalStressPreferences {
 		if (measurement == null) {
 			return StressContext.inactive();
 		}
-		return StressContext.of(measurement.getPhysiologicalStressActive(), measurement.getPhysiologicalStressType(),
+		return StressContext.fromValues(measurement.getPhysiologicalStressActive(),
+				measurement.getPhysiologicalStressType(),
 				measurement.getStressFormulaTable(), measurement.getStressIncrementMode(),
 				measurement.getStressFactorValue(), measurement.getStressValidFrom(),
 				measurement.getStressValidUntil(), measurement.getStressFeverTemperature());
@@ -85,10 +86,7 @@ public final class PhysiologicalStressPreferences {
 		if (validFrom != null && referenceDate.isBefore(validFrom)) {
 			return false;
 		}
-		if (validUntil != null && referenceDate.isAfter(validUntil)) {
-			return false;
-		}
-		return true;
+		return validUntil == null || !referenceDate.isAfter(validUntil);
 	}
 
 	private static LocalDate toLocalDate(final Date date) {

--- a/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressType.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressType.java
@@ -1,0 +1,34 @@
+package com.nutriconsultas.paciente.calculation;
+
+/**
+ * Catalog of physiological stress conditions affecting energy expenditure.
+ */
+public enum PhysiologicalStressType {
+
+	NONE("Sin estrés", true), FEVER("Fiebre", true), MINOR_SURGERY("Cirugía menor", true),
+	MAJOR_SURGERY("Cirugía mayor", true), MODERATE_INFECTION("Infección moderada", true),
+	SEVERE_INFECTION("Infección severa", true), SEPSIS("Sepsis", true), TRAUMA("Trauma", true),
+	BURNS("Quemaduras", true), CANCER("Cáncer", true), FRACTURE("Fractura", true),
+	POST_OPERATIVE("Post-operatorio", true), MULTIPLE_TRAUMA("Politraumatismo", false),
+	HEAD_INJURY("Traumatismo craneoencefálico", false), ORGAN_FAILURE("Fallo orgánico", false),
+	PREGNANCY_COMPLICATION("Complicación obstétrica", false), COPD_EXACERBATION("Exacerbación EPOC", false),
+	OTHER("Otro (factor personalizado)", false);
+
+	private final String displayName;
+
+	private final boolean common;
+
+	PhysiologicalStressType(final String displayName, final boolean common) {
+		this.displayName = displayName;
+		this.common = common;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
+	public boolean isCommon() {
+		return common;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/calculation/StressContext.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/StressContext.java
@@ -15,7 +15,7 @@ public record StressContext(Boolean active, PhysiologicalStressType stressType, 
 		return new StressContext(false, null, null, null, null, null, null, null);
 	}
 
-	public static StressContext of(final Boolean active, @Nullable final PhysiologicalStressType stressType,
+	public static StressContext fromValues(final Boolean active, @Nullable final PhysiologicalStressType stressType,
 			@Nullable final StressFormulaTable formulaTable, @Nullable final StressIncrementMode incrementMode,
 			@Nullable final Double factorValue, @Nullable final Date validFrom, @Nullable final Date validUntil,
 			@Nullable final Double feverTemperature) {

--- a/src/main/java/com/nutriconsultas/paciente/calculation/StressContext.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/StressContext.java
@@ -1,0 +1,26 @@
+package com.nutriconsultas.paciente.calculation;
+
+import java.util.Date;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Resolved physiological stress configuration for energy calculations.
+ */
+public record StressContext(Boolean active, PhysiologicalStressType stressType, StressFormulaTable formulaTable,
+		StressIncrementMode incrementMode, Double factorValue, Date validFrom, Date validUntil,
+		Double feverTemperature) {
+
+	public static StressContext inactive() {
+		return new StressContext(false, null, null, null, null, null, null, null);
+	}
+
+	public static StressContext of(final Boolean active, @Nullable final PhysiologicalStressType stressType,
+			@Nullable final StressFormulaTable formulaTable, @Nullable final StressIncrementMode incrementMode,
+			@Nullable final Double factorValue, @Nullable final Date validFrom, @Nullable final Date validUntil,
+			@Nullable final Double feverTemperature) {
+		return new StressContext(active, stressType, formulaTable, incrementMode, factorValue, validFrom, validUntil,
+				feverTemperature);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/calculation/StressFormulaTable.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/StressFormulaTable.java
@@ -1,0 +1,21 @@
+package com.nutriconsultas.paciente.calculation;
+
+/**
+ * Clinical reference table used to derive physiological stress factors.
+ */
+public enum StressFormulaTable {
+
+	LONG("Factores de Long"), FEVER_PER_DEGREE("Incremento por °C de fiebre (13% TMB/°C)"), ASPEN("Factores ASPEN"),
+	CUSTOM("Personalizado");
+
+	private final String displayName;
+
+	StressFormulaTable(final String displayName) {
+		this.displayName = displayName;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/calculation/StressIncrementMode.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/StressIncrementMode.java
@@ -1,0 +1,21 @@
+package com.nutriconsultas.paciente.calculation;
+
+/**
+ * How physiological stress adjusts daily energy requirements.
+ */
+public enum StressIncrementMode {
+
+	MULTIPLIER_BMR("Multiplicador sobre TMB"), MULTIPLIER_GET("Multiplicador sobre GET"),
+	FIXED_KCAL("Suma fija de kcal/día");
+
+	private final String displayName;
+
+	StressIncrementMode(final String displayName) {
+		this.displayName = displayName;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordServiceImpl.java
@@ -275,6 +275,8 @@ public class BodyMetricRecordServiceImpl implements BodyMetricRecordService {
 					paciente.setActivityFactor(result.activityFactor());
 					paciente.setTefKcal(result.tefKcal());
 					paciente.setTotalAdjustedKcal(result.totalAdjustedKcal());
+					paciente.setStressKcal(result.stressKcal());
+					paciente.setFinalTotalKcal(result.finalTotalKcal());
 				}
 			}
 		}

--- a/src/main/resources/templates/sbadmin/calendar/ver.html
+++ b/src/main/resources/templates/sbadmin/calendar/ver.html
@@ -113,7 +113,13 @@
                           <p><strong>TEF:</strong> <span th:text="${#numbers.formatDecimal(event.tefKcal, 1, 0)} + ' kcal/día'">-</span></p>
                         </div>
                         <div class="col-md-3" th:if="${event.totalAdjustedKcal != null}">
-                          <p><strong>Total ajustado:</strong> <span class="font-weight-bold text-success" th:text="${#numbers.formatDecimal(event.totalAdjustedKcal, 1, 0)} + ' kcal/día'">-</span></p>
+                          <p><strong>Total (GET+TEF):</strong> <span th:text="${#numbers.formatDecimal(event.totalAdjustedKcal, 1, 0)} + ' kcal/día'">-</span></p>
+                        </div>
+                        <div class="col-md-3" th:if="${event.stressKcal != null}">
+                          <p><strong>Estrés:</strong> <span class="text-danger" th:text="${#numbers.formatDecimal(event.stressKcal, 1, 0)} + ' kcal/día'">-</span></p>
+                        </div>
+                        <div class="col-md-3" th:if="${event.finalTotalKcal != null}">
+                          <p><strong>Total final:</strong> <span class="font-weight-bold text-success" th:text="${#numbers.formatDecimal(event.finalTotalKcal, 1, 0)} + ' kcal/día'">-</span></p>
                         </div>
                         <div class="col-md-3" th:if="${event.physicalActivityLevel != null}">
                           <p><strong>Actividad:</strong> <span th:text="${event.physicalActivityLevel.displayName}">-</span></p>
@@ -555,6 +561,44 @@
         wizardHtml += '</div>';
         wizardHtml += '</div>';
         wizardHtml += '</div>';
+        wizardHtml += '<hr>';
+        wizardHtml += '<h6 class="text-danger">Estrés fisiológico</h6>';
+        wizardHtml += '<div class="alert alert-warning py-2 small">Requiere validación clínica profesional.</div>';
+        wizardHtml += '<div class="form-check mb-2">';
+        wizardHtml += '<input class="form-check-input" type="checkbox" name="physiologicalStressActive" id="wizardStressActive">';
+        wizardHtml += '<label class="form-check-label" for="wizardStressActive">Aplicar estrés fisiológico (sobrescribe paciente)</label>';
+        wizardHtml += '</div>';
+        wizardHtml += '<div class="row" id="wizardStressFields">';
+        wizardHtml += '<div class="col-md-4 form-group"><label class="small">Tipo</label>';
+        wizardHtml += '<select class="form-control form-control-sm" name="physiologicalStressType" id="wizardStressType">';
+        wizardHtml += '<option value="">Seleccione...</option>';
+        wizardHtml += '<option value="FEVER">Fiebre</option><option value="MINOR_SURGERY">Cirugía menor</option>';
+        wizardHtml += '<option value="MAJOR_SURGERY">Cirugía mayor</option><option value="MODERATE_INFECTION">Infección moderada</option>';
+        wizardHtml += '<option value="SEVERE_INFECTION">Infección severa</option><option value="SEPSIS">Sepsis</option>';
+        wizardHtml += '<option value="TRAUMA">Trauma</option><option value="BURNS">Quemaduras</option>';
+        wizardHtml += '<option value="CANCER">Cáncer</option><option value="OTHER">Otro</option>';
+        wizardHtml += '</select></div>';
+        wizardHtml += '<div class="col-md-4 form-group"><label class="small">Tabla / fórmula</label>';
+        wizardHtml += '<select class="form-control form-control-sm" name="stressFormulaTable" id="wizardStressFormula">';
+        wizardHtml += '<option value="LONG">Factores de Long</option>';
+        wizardHtml += '<option value="FEVER_PER_DEGREE">Incremento por °C de fiebre</option>';
+        wizardHtml += '<option value="ASPEN">Factores ASPEN</option><option value="CUSTOM">Personalizado</option>';
+        wizardHtml += '</select></div>';
+        wizardHtml += '<div class="col-md-4 form-group"><label class="small">Modo</label>';
+        wizardHtml += '<select class="form-control form-control-sm" name="stressIncrementMode" id="wizardStressIncrementMode">';
+        wizardHtml += '<option value="MULTIPLIER_BMR">Multiplicador sobre TMB</option>';
+        wizardHtml += '<option value="MULTIPLIER_GET">Multiplicador sobre GET</option>';
+        wizardHtml += '<option value="FIXED_KCAL">Suma fija kcal/día</option>';
+        wizardHtml += '</select></div>';
+        wizardHtml += '<div class="col-md-3 form-group"><label class="small">Factor / kcal</label>';
+        wizardHtml += '<input type="number" step="0.01" min="0" class="form-control form-control-sm" name="stressFactorValue" id="wizardStressFactor"></div>';
+        wizardHtml += '<div class="col-md-3 form-group"><label class="small">Temp. fiebre (°C)</label>';
+        wizardHtml += '<input type="number" step="0.1" min="35" max="43" class="form-control form-control-sm" name="stressFeverTemperature" id="wizardStressFeverTemp"></div>';
+        wizardHtml += '<div class="col-md-3 form-group"><label class="small">Vigencia desde</label>';
+        wizardHtml += '<input type="date" class="form-control form-control-sm" name="stressValidFrom" id="wizardStressValidFrom"></div>';
+        wizardHtml += '<div class="col-md-3 form-group"><label class="small">Vigencia hasta</label>';
+        wizardHtml += '<input type="date" class="form-control form-control-sm" name="stressValidUntil" id="wizardStressValidUntil"></div>';
+        wizardHtml += '</div>';
         wizardHtml += '</div>';
         
         // Step 2: Nutritional Assessment
@@ -930,6 +974,25 @@
         if (bmrFormula) formData.bmrFormula = bmrFormula;
         if (activityLevel === 'CUSTOM' && customFactor) {
           formData.customActivityFactor = parseFloat(customFactor);
+        }
+
+        const stressActive = jQuery('#wizardStressActive').is(':checked');
+        formData.physiologicalStressActive = stressActive;
+        if (stressActive) {
+          const stressType = jQuery('#wizardStressType').val();
+          const stressFormula = jQuery('#wizardStressFormula').val();
+          const stressMode = jQuery('#wizardStressIncrementMode').val();
+          const stressFactor = jQuery('#wizardStressFactor').val();
+          const stressFeverTemp = jQuery('#wizardStressFeverTemp').val();
+          const stressValidFrom = jQuery('#wizardStressValidFrom').val();
+          const stressValidUntil = jQuery('#wizardStressValidUntil').val();
+          if (stressType) formData.physiologicalStressType = stressType;
+          if (stressFormula) formData.stressFormulaTable = stressFormula;
+          if (stressMode) formData.stressIncrementMode = stressMode;
+          if (stressFactor) formData.stressFactorValue = parseFloat(stressFactor);
+          if (stressFeverTemp) formData.stressFeverTemperature = parseFloat(stressFeverTemp);
+          if (stressValidFrom) formData.stressValidFrom = stressValidFrom;
+          if (stressValidUntil) formData.stressValidUntil = stressValidUntil;
         }
         
         jQuery.ajax({

--- a/src/main/resources/templates/sbadmin/pacientes/calculation-script.html
+++ b/src/main/resources/templates/sbadmin/pacientes/calculation-script.html
@@ -19,6 +19,12 @@
     const patientTefMacroProtein = [[${paciente != null && paciente.tefMacroProteinPercent != null ? paciente.tefMacroProteinPercent : 'null'}]];
     const patientTefMacroCarbs = [[${paciente != null && paciente.tefMacroCarbsPercent != null ? paciente.tefMacroCarbsPercent : 'null'}]];
     const patientTefMacroFat = [[${paciente != null && paciente.tefMacroFatPercent != null ? paciente.tefMacroFatPercent : 'null'}]];
+    const patientStressActive = [[${paciente != null && paciente.physiologicalStressActive != null ? paciente.physiologicalStressActive : false}]];
+    const patientStressType = '[[${paciente != null && paciente.physiologicalStressType != null ? paciente.physiologicalStressType.name() : ""}]]';
+    const patientStressFormula = '[[${paciente != null && paciente.stressFormulaTable != null ? paciente.stressFormulaTable.name() : "LONG"}]]';
+    const patientStressIncrementMode = '[[${paciente != null && paciente.stressIncrementMode != null ? paciente.stressIncrementMode.name() : "MULTIPLIER_BMR"}]]';
+    const patientStressFactorValue = [[${paciente != null && paciente.stressFactorValue != null ? paciente.stressFactorValue : 'null'}]];
+    const patientStressFeverTemperature = [[${paciente != null && paciente.stressFeverTemperature != null ? paciente.stressFeverTemperature : 'null'}]];
     const calculationEnableSync = [[${enableSync}]];
 
     function getCalcSubTabPanes(tabContent) {
@@ -194,6 +200,68 @@
       OMS: { SEDENTARY: 1.40, LIGHT: 1.60, MODERATE: 1.80, INTENSE: 2.00, VERY_INTENSE: 2.20 }
     };
 
+    const STRESS_LONG_FACTORS = {
+      MINOR_SURGERY: 1.10, MAJOR_SURGERY: 1.20, MODERATE_INFECTION: 1.20, SEVERE_INFECTION: 1.40,
+      SEPSIS: 1.50, TRAUMA: 1.35, BURNS: 1.50, CANCER: 1.25, FRACTURE: 1.20, POST_OPERATIVE: 1.15,
+      MULTIPLE_TRAUMA: 1.50, HEAD_INJURY: 1.40, ORGAN_FAILURE: 1.50, PREGNANCY_COMPLICATION: 1.20,
+      COPD_EXACERBATION: 1.20
+    };
+
+    const STRESS_ASPEN_FACTORS = {
+      MINOR_SURGERY: 1.10, MAJOR_SURGERY: 1.25, MODERATE_INFECTION: 1.30, SEVERE_INFECTION: 1.55,
+      SEPSIS: 1.60, TRAUMA: 1.40, BURNS: 1.80, CANCER: 1.30, FRACTURE: 1.20, POST_OPERATIVE: 1.15,
+      MULTIPLE_TRAUMA: 1.60, HEAD_INJURY: 1.45, ORGAN_FAILURE: 1.55, PREGNANCY_COMPLICATION: 1.25,
+      COPD_EXACERBATION: 1.25
+    };
+
+    function resolveStressCatalogFactor(formula, stressType) {
+      if (!stressType) return null;
+      if (formula === 'ASPEN') return STRESS_ASPEN_FACTORS[stressType] || null;
+      return STRESS_LONG_FACTORS[stressType] || null;
+    }
+
+    function readStressCalculationInputs() {
+      const activeEl = document.getElementById('calcPhysiologicalStressActive');
+      const active = activeEl ? activeEl.checked : patientStressActive;
+      const typeEl = document.getElementById('calcStressType');
+      const formulaEl = document.getElementById('calcStressFormula');
+      const modeEl = document.getElementById('calcStressIncrementMode');
+      const factorEl = document.getElementById('calcStressFactorValue');
+      const feverEl = document.getElementById('calcStressFeverTemperature');
+      return {
+        active: active,
+        stressType: (typeEl && typeEl.value) ? typeEl.value : patientStressType,
+        formula: (formulaEl && formulaEl.value) ? formulaEl.value : patientStressFormula,
+        incrementMode: (modeEl && modeEl.value) ? modeEl.value : patientStressIncrementMode,
+        factorValue: factorEl && factorEl.value ? parseFloat(factorEl.value) : patientStressFactorValue,
+        feverTemperature: feverEl && feverEl.value ? parseFloat(feverEl.value) : patientStressFeverTemperature
+      };
+    }
+
+    function calculateStressKcal(bmr, getValue, stressConfig) {
+      if (!stressConfig.active || !stressConfig.stressType || stressConfig.stressType === 'NONE') {
+        return null;
+      }
+      const formula = stressConfig.formula || 'LONG';
+      const mode = stressConfig.incrementMode || 'MULTIPLIER_BMR';
+      if (formula === 'FEVER_PER_DEGREE' && stressConfig.stressType === 'FEVER') {
+        const temp = stressConfig.feverTemperature;
+        if (!bmr || !temp || temp <= 37) return null;
+        return bmr * 0.13 * (temp - 37);
+      }
+      if (mode === 'FIXED_KCAL') {
+        return stressConfig.factorValue > 0 ? stressConfig.factorValue : null;
+      }
+      const multiplier = stressConfig.factorValue > 0
+        ? stressConfig.factorValue
+        : resolveStressCatalogFactor(formula, stressConfig.stressType);
+      if (!multiplier || multiplier <= 1) return null;
+      if (mode === 'MULTIPLIER_GET') {
+        return getValue ? getValue * (multiplier - 1) : null;
+      }
+      return bmr ? bmr * (multiplier - 1) : null;
+    }
+
     function resolveActivityFactor(scale, level, customFactorValue) {
       if (!level) return null;
       if (level === 'CUSTOM') {
@@ -272,6 +340,8 @@
       const activityKcal = bmr && getValue ? getValue - bmr : null;
       const tefValue = calculateTef(bmr, getValue);
       const totalValue = getValue != null ? getValue + (tefValue || 0) : null;
+      const stressValue = calculateStressKcal(bmr, getValue, readStressCalculationInputs());
+      const finalValue = totalValue != null ? totalValue + (stressValue || 0) : null;
 
       const bmrResult = document.getElementById('get-bmr-used-result');
       const activityResult = document.getElementById('get-activity-kcal-result');
@@ -279,10 +349,14 @@
       const getResult = document.getElementById('get-result');
       const tefResult = document.getElementById('get-tef-result');
       const totalResult = document.getElementById('get-total-result');
+      const stressResult = document.getElementById('get-stress-result');
+      const finalResult = document.getElementById('get-final-result');
       const bmrHidden = document.getElementById('get-bmr-used-hidden');
       const getHidden = document.getElementById('get-kcal-hidden');
       const tefHidden = document.getElementById('get-tef-hidden');
       const totalHidden = document.getElementById('get-total-hidden');
+      const stressHidden = document.getElementById('get-stress-hidden');
+      const finalHidden = document.getElementById('get-final-hidden');
 
       if (bmrResult) bmrResult.textContent = formatEnergyKcal(bmr);
       if (activityResult) activityResult.textContent = formatEnergyKcal(activityKcal);
@@ -290,10 +364,22 @@
       if (getResult) getResult.textContent = formatEnergyKcal(getValue);
       if (tefResult) tefResult.textContent = formatEnergyKcal(tefValue);
       if (totalResult) totalResult.textContent = formatEnergyKcal(totalValue);
+      if (stressResult) stressResult.textContent = formatEnergyKcal(stressValue);
+      if (finalResult) finalResult.textContent = formatEnergyKcal(finalValue);
       if (bmrHidden && bmr) bmrHidden.value = bmr.toFixed(2);
       if (getHidden && getValue) getHidden.value = getValue.toFixed(2);
       if (tefHidden && tefValue) tefHidden.value = tefValue.toFixed(2);
       if (totalHidden && totalValue) totalHidden.value = totalValue.toFixed(2);
+      if (stressHidden && stressValue) stressHidden.value = stressValue.toFixed(2);
+      if (finalHidden && finalValue) finalHidden.value = finalValue.toFixed(2);
+    }
+
+    function toggleStressCalculationFields() {
+      const activeEl = document.getElementById('calcPhysiologicalStressActive');
+      const fields = document.getElementById('stressCalculationFields');
+      if (activeEl && fields) {
+        fields.style.display = activeEl.checked ? '' : 'none';
+      }
     }
 
     // Ideal Weight Calculation Functions
@@ -789,6 +875,15 @@
       safeAddEventListener('get-bmr-formula', 'change', updateGetCalculations);
       safeAddEventListener('get-activity-level', 'change', updateGetCalculations);
       safeAddEventListener('get-custom-factor', 'input', updateGetCalculations);
+      safeAddEventListener('calcPhysiologicalStressActive', 'change', function() {
+        toggleStressCalculationFields();
+        updateGetCalculations();
+      });
+      safeAddEventListener('calcStressType', 'change', updateGetCalculations);
+      safeAddEventListener('calcStressFormula', 'change', updateGetCalculations);
+      safeAddEventListener('calcStressIncrementMode', 'change', updateGetCalculations);
+      safeAddEventListener('calcStressFactorValue', 'input', updateGetCalculations);
+      safeAddEventListener('calcStressFeverTemperature', 'input', updateGetCalculations);
 
       // Ideal Weight inputs
       safeAddEventListener('ideal-weight-height-rob', 'input', updateIdealWeightCalculations);
@@ -848,6 +943,7 @@
       updateIdealWeightCalculations();
       updateTotalBodyWaterCalculations();
       updateBodyCompositionCalculations();
+      toggleStressCalculationFields();
       updateGetCalculations();
     });
 

--- a/src/main/resources/templates/sbadmin/pacientes/consulta.html
+++ b/src/main/resources/templates/sbadmin/pacientes/consulta.html
@@ -108,6 +108,7 @@
                         <input type="number" step="0.1" th:field="*{temperatura}" class="form-control">
                         <span th:if="${#fields.hasErrors('temperatura')}" th:errors="*{temperatura}"></span>
                       </div>
+                      <div th:insert="~{sbadmin/pacientes/stress-section :: stressPatientSection}"></div>
                       <div class="form-group">
                         <label>Notas</label>
                         <textarea class="form-control" rows="3" th:field="*{summaryNotes}"></textarea>

--- a/src/main/resources/templates/sbadmin/pacientes/desarrollo.html
+++ b/src/main/resources/templates/sbadmin/pacientes/desarrollo.html
@@ -116,6 +116,7 @@
                         <input class="form-check-input" type="checkbox" th:field="*{pregnancy}">
                         <label class="form-check-label" for="pregnancy">Embarazada</label>
                       </div>
+                      <div th:insert="~{sbadmin/pacientes/stress-section :: stressPatientSection}"></div>
                       <div style="height: 30px;"></div>
                       <button type="submit" class="btn btn-success ">Listo!</button>
                     </form>

--- a/src/main/resources/templates/sbadmin/pacientes/get-calculation-section.html
+++ b/src/main/resources/templates/sbadmin/pacientes/get-calculation-section.html
@@ -67,9 +67,20 @@
                 <strong>Total:</strong> <span id="get-total-result" class="text-dark font-weight-bold">-</span> <small>kcal/día</small>
               </div>
             </div>
+            <div class="col-md-2">
+              <div class="alert alert-danger mb-0 py-2">
+                <strong>Estrés:</strong> <span id="get-stress-result" class="text-danger">-</span> <small>kcal/día</small>
+              </div>
+            </div>
+            <div class="col-md-2">
+              <div class="alert alert-success mb-0 py-2">
+                <strong>Final:</strong> <span id="get-final-result" class="text-dark font-weight-bold">-</span> <small>kcal/día</small>
+              </div>
+            </div>
           </div>
+          <div th:insert="~{sbadmin/pacientes/stress-section :: stressCalculationSection}"></div>
           <p class="text-muted small mb-0 mt-2">
-            Total ajustado = TMB + actividad + TEF = GET + TEF
+            Total final = TMB + actividad + TEF + estrés = GET + TEF + estrés
           </p>
           <input type="hidden" id="get-bmr-used-hidden" th:field="*{bmrUsed}">
           <input type="hidden" id="get-kcal-hidden" th:field="*{getKcal}">

--- a/src/main/resources/templates/sbadmin/pacientes/stress-section.html
+++ b/src/main/resources/templates/sbadmin/pacientes/stress-section.html
@@ -164,3 +164,113 @@
   <input type="hidden" id="get-stress-hidden" th:field="*{stressKcal}">
   <input type="hidden" id="get-final-hidden" th:field="*{finalTotalKcal}">
 </div>
+
+<!-- Read-only: energy breakdown + stress config (ver antropométrico, consulta, etc.) -->
+<div th:fragment="stressViewSection(record)" class="mt-3">
+  <h6 class="text-muted mb-2">Gasto energético y estrés fisiológico</h6>
+  <div class="row mb-2">
+    <div class="col-6 col-md-4 col-lg-2 mb-2">
+      <div class="alert alert-secondary mb-0 py-2 text-center h-100">
+        <small class="d-block text-muted">TMB</small>
+        <strong th:text="${record.bmrUsed != null ? #numbers.formatDecimal(record.bmrUsed, 1, 0) + ' kcal' : '—'}">—</strong>
+      </div>
+    </div>
+    <div class="col-6 col-md-4 col-lg-2 mb-2">
+      <div class="alert alert-secondary mb-0 py-2 text-center h-100">
+        <small class="d-block text-muted">Actividad</small>
+        <strong th:text="${record.getKcal != null and record.bmrUsed != null ? #numbers.formatDecimal(record.getKcal - record.bmrUsed, 1, 0) + ' kcal' : '—'}">—</strong>
+      </div>
+    </div>
+    <div class="col-6 col-md-4 col-lg-2 mb-2">
+      <div class="alert alert-info mb-0 py-2 text-center h-100">
+        <small class="d-block text-muted">GET</small>
+        <strong th:text="${record.getKcal != null ? #numbers.formatDecimal(record.getKcal, 1, 0) + ' kcal' : '—'}">—</strong>
+      </div>
+    </div>
+    <div class="col-6 col-md-4 col-lg-2 mb-2">
+      <div class="alert alert-warning mb-0 py-2 text-center h-100">
+        <small class="d-block text-muted">TEF</small>
+        <strong th:text="${record.tefKcal != null ? #numbers.formatDecimal(record.tefKcal, 1, 0) + ' kcal' : '—'}">—</strong>
+      </div>
+    </div>
+    <div class="col-6 col-md-4 col-lg-2 mb-2">
+      <div class="alert alert-primary mb-0 py-2 text-center h-100">
+        <small class="d-block text-muted">Total (GET+TEF)</small>
+        <strong th:text="${record.totalAdjustedKcal != null ? #numbers.formatDecimal(record.totalAdjustedKcal, 1, 0) + ' kcal' : '—'}">—</strong>
+      </div>
+    </div>
+    <div class="col-6 col-md-4 col-lg-2 mb-2" th:if="${record.stressKcal != null}">
+      <div class="alert alert-danger mb-0 py-2 text-center h-100">
+        <small class="d-block text-muted">Estrés</small>
+        <strong th:text="${#numbers.formatDecimal(record.stressKcal, 1, 0) + ' kcal'}">—</strong>
+      </div>
+    </div>
+    <div class="col-6 col-md-4 col-lg-2 mb-2" th:if="${record.finalTotalKcal != null}">
+      <div class="alert alert-success mb-0 py-2 text-center h-100">
+        <small class="d-block text-muted">Final</small>
+        <strong th:text="${#numbers.formatDecimal(record.finalTotalKcal, 1, 0) + ' kcal'}">—</strong>
+      </div>
+    </div>
+  </div>
+
+  <div class="card border-warning mb-3"
+       th:if="${record.physiologicalStressActive == true or record.stressKcal != null}">
+    <div class="card-header bg-warning text-dark py-2">
+      <strong><i class="fas fa-heartbeat mr-1"></i> Factor de estrés fisiológico</strong>
+    </div>
+    <div class="card-body py-2">
+      <div class="row">
+        <div class="col-md-3">
+          <small class="text-muted d-block">Estado</small>
+          <span th:if="${record.physiologicalStressActive == true}" class="badge badge-warning">Activo</span>
+          <span th:unless="${record.physiologicalStressActive == true}" class="badge badge-secondary">Inactivo</span>
+        </div>
+        <div class="col-md-3" th:if="${record.physiologicalStressType != null}">
+          <small class="text-muted d-block">Tipo</small>
+          <span th:text="${record.physiologicalStressType.displayName}">—</span>
+        </div>
+        <div class="col-md-3" th:if="${record.stressFormulaTable != null}">
+          <small class="text-muted d-block">Tabla</small>
+          <span th:text="${record.stressFormulaTable.displayName}">—</span>
+        </div>
+        <div class="col-md-3" th:if="${record.stressIncrementMode != null}">
+          <small class="text-muted d-block">Modo</small>
+          <span th:text="${record.stressIncrementMode.displayName}">—</span>
+        </div>
+      </div>
+      <div class="row mt-2">
+        <div class="col-md-3" th:if="${record.stressFactorValue != null}">
+          <small class="text-muted d-block">Factor aplicado</small>
+          <strong th:text="${#numbers.formatDecimal(record.stressFactorValue, 1, 2)}">—</strong>
+        </div>
+        <div class="col-md-3" th:if="${record.stressFeverTemperature != null}">
+          <small class="text-muted d-block">Temperatura (°C)</small>
+          <span th:text="${#numbers.formatDecimal(record.stressFeverTemperature, 1, 1) + ' °C'}">—</span>
+        </div>
+        <div class="col-md-3" th:if="${record.stressValidFrom != null}">
+          <small class="text-muted d-block">Vigencia desde</small>
+          <span th:text="${#dates.format(record.stressValidFrom, 'dd/MM/yyyy')}">—</span>
+        </div>
+        <div class="col-md-3" th:if="${record.stressValidUntil != null}">
+          <small class="text-muted d-block">Vigencia hasta</small>
+          <span th:text="${#dates.format(record.stressValidUntil, 'dd/MM/yyyy')}">—</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="alert alert-warning mb-0"
+       th:if="${record.stressKcal != null or record.physiologicalStressActive == true}">
+    <i class="fas fa-exclamation-triangle mr-1"></i>
+    <strong>Requiere validación clínica profesional.</strong>
+    Los valores de estrés fisiológico son orientativos y deben ser confirmados por el nutricionista
+    o el equipo clínico antes de usarse en la prescripción dietética.
+  </div>
+  <div class="alert alert-light border mb-0"
+       th:if="${record.stressKcal == null and record.physiologicalStressActive != true}">
+    <small class="text-muted">
+      <i class="fas fa-info-circle mr-1"></i>
+      No se aplicó factor de estrés fisiológico en este registro.
+    </small>
+  </div>
+</div>

--- a/src/main/resources/templates/sbadmin/pacientes/stress-section.html
+++ b/src/main/resources/templates/sbadmin/pacientes/stress-section.html
@@ -1,0 +1,166 @@
+<div th:fragment="stressPatientSection">
+  <hr>
+  <div class="form-group">
+    <label><i class="fas fa-heartbeat text-danger"></i> Estrés fisiológico</label>
+    <p class="text-muted small mb-2">
+      Registre una condición de estrés con vigencia. Los valores se usan como base en consultas y cálculos energéticos.
+    </p>
+    <div th:if="${suggestedStressTypes != null && !suggestedStressTypes.isEmpty()}" class="alert alert-info py-2">
+      <strong>Sugerencias según patologías:</strong>
+      <span th:each="type, iter : ${suggestedStressTypes}">
+        <span th:text="${type.displayName}">Tipo</span><span th:if="${!iter.last}">, </span>
+      </span>
+    </div>
+    <div class="form-check mb-2">
+      <input class="form-check-input" type="checkbox" th:field="*{physiologicalStressActive}" id="physiologicalStressActive">
+      <label class="form-check-label" for="physiologicalStressActive">Paciente con estrés fisiológico activo</label>
+    </div>
+    <div class="alert alert-warning py-2 small mb-3">
+      El incremento por estrés requiere validación clínica profesional antes de aplicarlo al plan nutricional.
+    </div>
+  </div>
+  <div id="stressPatientFields">
+    <div class="row">
+      <div class="col-md-6 form-group">
+        <label class="small">Tipo de estrés</label>
+        <select class="form-control" th:field="*{physiologicalStressType}" id="physiologicalStressType">
+          <option value="">Seleccione...</option>
+          <optgroup label="Comunes">
+            <option th:each="type : ${T(com.nutriconsultas.paciente.calculation.PhysiologicalStressCatalog).commonTypes()}"
+                    th:value="${type.name()}" th:text="${type.displayName}"></option>
+          </optgroup>
+          <optgroup label="Poco frecuentes">
+            <option th:each="type : ${T(com.nutriconsultas.paciente.calculation.PhysiologicalStressCatalog).uncommonTypes()}"
+                    th:value="${type.name()}" th:text="${type.displayName}"></option>
+          </optgroup>
+        </select>
+      </div>
+      <div class="col-md-6 form-group">
+        <label class="small">Tabla / fórmula</label>
+        <select class="form-control" th:field="*{stressFormulaTable}" id="stressFormulaTable">
+          <option th:each="table : ${T(com.nutriconsultas.paciente.calculation.StressFormulaTable).values()}"
+                  th:value="${table.name()}" th:text="${table.displayName}"></option>
+        </select>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-4 form-group">
+        <label class="small">Modo de incremento</label>
+        <select class="form-control" th:field="*{stressIncrementMode}" id="stressIncrementMode">
+          <option th:each="mode : ${T(com.nutriconsultas.paciente.calculation.StressIncrementMode).values()}"
+                  th:value="${mode.name()}" th:text="${mode.displayName}"></option>
+        </select>
+      </div>
+      <div class="col-md-4 form-group">
+        <label class="small">Factor / kcal personalizado</label>
+        <input type="number" step="0.01" min="0" class="form-control" th:field="*{stressFactorValue}"
+               placeholder="Ej: 1.3 o 400">
+      </div>
+      <div class="col-md-4 form-group" id="stressFeverTempGroup">
+        <label class="small">Temperatura (°C) para fiebre</label>
+        <input type="number" step="0.1" min="35" max="43" class="form-control" th:field="*{stressFeverTemperature}"
+               placeholder="Ej: 38.5">
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-6 form-group">
+        <label class="small">Vigencia desde</label>
+        <input type="date" class="form-control" th:field="*{stressValidFrom}">
+      </div>
+      <div class="col-md-6 form-group">
+        <label class="small">Vigencia hasta</label>
+        <input type="date" class="form-control" th:field="*{stressValidUntil}">
+      </div>
+    </div>
+  </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      const activeCheckbox = document.getElementById('physiologicalStressActive');
+      const fields = document.getElementById('stressPatientFields');
+      const formulaSelect = document.getElementById('stressFormulaTable');
+      const feverGroup = document.getElementById('stressFeverTempGroup');
+      function toggleStressFields() {
+        if (fields && activeCheckbox) {
+          fields.style.display = activeCheckbox.checked ? '' : 'none';
+        }
+      }
+      function toggleFeverField() {
+        if (feverGroup && formulaSelect) {
+          feverGroup.style.display = formulaSelect.value === 'FEVER_PER_DEGREE' ? '' : 'none';
+        }
+      }
+      if (activeCheckbox) {
+        activeCheckbox.addEventListener('change', toggleStressFields);
+        toggleStressFields();
+      }
+      if (formulaSelect) {
+        formulaSelect.addEventListener('change', toggleFeverField);
+        toggleFeverField();
+      }
+    });
+  </script>
+</div>
+
+<div th:fragment="stressCalculationSection">
+  <hr class="mt-3">
+  <h6 class="mb-2"><i class="fas fa-heartbeat text-danger"></i> Estrés fisiológico</h6>
+  <p class="text-muted small mb-2">
+    Valores base del paciente:
+    <span th:if="${paciente != null && paciente.physiologicalStressActive}">
+      <strong th:text="${paciente.physiologicalStressType != null ? paciente.physiologicalStressType.displayName : 'Activo'}">Activo</strong>
+      (<span th:text="${paciente.stressFormulaTable != null ? paciente.stressFormulaTable.displayName : 'Long'}">Long</span>)
+    </span>
+    <span th:unless="${paciente != null && paciente.physiologicalStressActive}">sin estrés registrado</span>.
+    Puede ajustar valores solo para este cálculo.
+  </p>
+  <div class="alert alert-warning py-2 small">
+    Requiere validación clínica profesional cuando se active estrés fisiológico.
+  </div>
+  <div class="form-check mb-2">
+    <input class="form-check-input" type="checkbox" th:field="*{physiologicalStressActive}" id="calcPhysiologicalStressActive">
+    <label class="form-check-label" for="calcPhysiologicalStressActive">Aplicar estrés fisiológico en este cálculo</label>
+  </div>
+  <div id="stressCalculationFields">
+    <div class="row">
+      <div class="col-md-4 form-group">
+        <label class="small">Tipo</label>
+        <select class="form-control form-control-sm" th:field="*{physiologicalStressType}" id="calcStressType">
+          <option value="">Usar preferencia del paciente</option>
+          <option th:each="type : ${T(com.nutriconsultas.paciente.calculation.PhysiologicalStressType).values()}"
+                  th:if="${type.name() != 'NONE'}"
+                  th:value="${type.name()}" th:text="${type.displayName}"></option>
+        </select>
+      </div>
+      <div class="col-md-4 form-group">
+        <label class="small">Tabla / fórmula</label>
+        <select class="form-control form-control-sm" th:field="*{stressFormulaTable}" id="calcStressFormula">
+          <option value="">Usar preferencia del paciente</option>
+          <option th:each="table : ${T(com.nutriconsultas.paciente.calculation.StressFormulaTable).values()}"
+                  th:value="${table.name()}" th:text="${table.displayName}"></option>
+        </select>
+      </div>
+      <div class="col-md-4 form-group">
+        <label class="small">Modo</label>
+        <select class="form-control form-control-sm" th:field="*{stressIncrementMode}" id="calcStressIncrementMode">
+          <option value="">Usar preferencia del paciente</option>
+          <option th:each="mode : ${T(com.nutriconsultas.paciente.calculation.StressIncrementMode).values()}"
+                  th:value="${mode.name()}" th:text="${mode.displayName}"></option>
+        </select>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-4 form-group">
+        <label class="small">Factor / kcal (override)</label>
+        <input type="number" step="0.01" min="0" class="form-control form-control-sm" th:field="*{stressFactorValue}"
+               id="calcStressFactorValue" placeholder="Opcional">
+      </div>
+      <div class="col-md-4 form-group">
+        <label class="small">Temperatura (°C)</label>
+        <input type="number" step="0.1" min="35" max="43" class="form-control form-control-sm"
+               th:field="*{stressFeverTemperature}" id="calcStressFeverTemperature">
+      </div>
+    </div>
+  </div>
+  <input type="hidden" id="get-stress-hidden" th:field="*{stressKcal}">
+  <input type="hidden" id="get-final-hidden" th:field="*{finalTotalKcal}">
+</div>

--- a/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
+++ b/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
@@ -812,29 +812,18 @@
                           <!-- GET -->
                           <div class="tab-pane fade" id="calc-get" role="tabpanel" aria-labelledby="calc-get-subtab">
                           <div class="mb-4" th:if="${measurement.getKcal != null || measurement.physicalActivityLevel != null}">
-                            <div class="row">
+                            <div class="row mb-3">
                               <div class="col-md-3" th:if="${measurement.bmrFormula != null}">
                                 <p><strong>Fórmula TMB:</strong> <span th:text="${measurement.bmrFormula.displayName}">-</span></p>
                               </div>
                               <div class="col-md-3" th:if="${measurement.physicalActivityLevel != null}">
-                                <p><strong>Actividad:</strong> <span th:text="${measurement.physicalActivityLevel.displayName}">-</span></p>
+                                <p><strong>Nivel de actividad:</strong> <span th:text="${measurement.physicalActivityLevel.displayName}">-</span></p>
                               </div>
                               <div class="col-md-3" th:if="${measurement.activityFactor != null}">
-                                <p><strong>Factor:</strong> <span th:text="${#numbers.formatDecimal(measurement.activityFactor, 1, 3)}">-</span></p>
-                              </div>
-                              <div class="col-md-3" th:if="${measurement.bmrUsed != null}">
-                                <p><strong>TMB:</strong> <span th:text="${#numbers.formatDecimal(measurement.bmrUsed, 1, 'COMMA', 0, 'POINT')} + ' kcal/día'">-</span></p>
-                              </div>
-                              <div class="col-md-3" th:if="${measurement.getKcal != null}">
-                                <p><strong>GET:</strong> <span class="font-weight-bold text-warning" th:text="${#numbers.formatDecimal(measurement.getKcal, 1, 'COMMA', 0, 'POINT')} + ' kcal/día'">-</span></p>
-                              </div>
-                              <div class="col-md-3" th:if="${measurement.tefKcal != null}">
-                                <p><strong>TEF:</strong> <span th:text="${#numbers.formatDecimal(measurement.tefKcal, 1, 'COMMA', 0, 'POINT')} + ' kcal/día'">-</span></p>
-                              </div>
-                              <div class="col-md-3" th:if="${measurement.totalAdjustedKcal != null}">
-                                <p><strong>Total ajustado:</strong> <span class="font-weight-bold text-success" th:text="${#numbers.formatDecimal(measurement.totalAdjustedKcal, 1, 'COMMA', 0, 'POINT')} + ' kcal/día'">-</span></p>
+                                <p><strong>Factor de actividad:</strong> <span th:text="${#numbers.formatDecimal(measurement.activityFactor, 1, 3)}">-</span></p>
                               </div>
                             </div>
+                            <div th:replace="~{sbadmin/pacientes/stress-section :: stressViewSection(${measurement})}"></div>
                           </div>
                           <div class="alert alert-secondary mb-0" th:unless="${measurement.getKcal != null || measurement.physicalActivityLevel != null}">
                             <i class="fas fa-info-circle"></i> Esta medición no tiene GET registrado.

--- a/src/test/java/com/nutriconsultas/paciente/calculation/EnergyExpenditureResolverTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/calculation/EnergyExpenditureResolverTest.java
@@ -32,7 +32,22 @@ class EnergyExpenditureResolverTest {
 		assertThat(result.getKcal()).isNotNull();
 		assertThat(result.tefKcal()).isNotNull();
 		assertThat(result.totalAdjustedKcal()).isEqualTo(result.getKcal() + result.tefKcal());
+		assertThat(result.finalTotalKcal()).isEqualTo(result.totalAdjustedKcal());
 		assertThat(result.activityKcal()).isEqualTo(result.getKcal() - result.bmr());
+	}
+
+	@Test
+	void resolveIncludesStressWhenPatientStressActive() {
+		paciente.setPhysiologicalStressActive(true);
+		paciente.setPhysiologicalStressType(PhysiologicalStressType.MINOR_SURGERY);
+		paciente.setStressFormulaTable(StressFormulaTable.LONG);
+		paciente.setStressIncrementMode(StressIncrementMode.MULTIPLIER_BMR);
+
+		final EnergyExpenditureResolver.EnergyResult result = EnergyExpenditureResolver.resolve(paciente,
+				BmrFormulaType.MIFFLIN_ST_JEOR, PhysicalActivityLevel.MODERATE, null, 70.0, 1.75);
+
+		assertThat(result.stressKcal()).isNotNull().isPositive();
+		assertThat(result.finalTotalKcal()).isEqualTo(result.totalAdjustedKcal() + result.stressKcal());
 	}
 
 	@Test
@@ -47,6 +62,15 @@ class EnergyExpenditureResolverTest {
 
 		assertThat(result.tefKcal()).isNotNull();
 		assertThat(result.totalAdjustedKcal()).isGreaterThan(result.getKcal());
+	}
+
+	@Test
+	void resolveTargetDailyCaloriesPrefersFinalTotal() {
+		paciente.setGetKcal(2000.0);
+		paciente.setTotalAdjustedKcal(2200.0);
+		paciente.setFinalTotalKcal(2500.0);
+
+		assertThat(EnergyExpenditureResolver.resolveTargetDailyCalories(paciente)).isEqualTo(2500.0);
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCalculationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCalculationServiceTest.java
@@ -8,7 +8,7 @@ class PhysiologicalStressCalculationServiceTest {
 
 	@Test
 	void calculateLongMultiplierStressOnBmr() {
-		final StressContext context = StressContext.of(true, PhysiologicalStressType.MAJOR_SURGERY,
+		final StressContext context = StressContext.fromValues(true, PhysiologicalStressType.MAJOR_SURGERY,
 				StressFormulaTable.LONG, StressIncrementMode.MULTIPLIER_BMR, null, null, null, null);
 		final Double stressKcal = PhysiologicalStressCalculationService.calculateStressKcal(context, 1500.0, 2000.0,
 				null);
@@ -17,7 +17,7 @@ class PhysiologicalStressCalculationServiceTest {
 
 	@Test
 	void calculateAspenMultiplierStressOnGet() {
-		final StressContext context = StressContext.of(true, PhysiologicalStressType.TRAUMA, StressFormulaTable.ASPEN,
+		final StressContext context = StressContext.fromValues(true, PhysiologicalStressType.TRAUMA, StressFormulaTable.ASPEN,
 				StressIncrementMode.MULTIPLIER_GET, null, null, null, null);
 		final Double stressKcal = PhysiologicalStressCalculationService.calculateStressKcal(context, 1500.0, 2000.0,
 				null);
@@ -26,7 +26,7 @@ class PhysiologicalStressCalculationServiceTest {
 
 	@Test
 	void calculateFixedKcalStress() {
-		final StressContext context = StressContext.of(true, PhysiologicalStressType.OTHER, StressFormulaTable.CUSTOM,
+		final StressContext context = StressContext.fromValues(true, PhysiologicalStressType.OTHER, StressFormulaTable.CUSTOM,
 				StressIncrementMode.FIXED_KCAL, 450.0, null, null, null);
 		assertThat(PhysiologicalStressCalculationService.calculateStressKcal(context, 1500.0, 2000.0, null))
 			.isEqualTo(450.0);
@@ -34,7 +34,7 @@ class PhysiologicalStressCalculationServiceTest {
 
 	@Test
 	void calculateFeverPerDegreeStress() {
-		final StressContext context = StressContext.of(true, PhysiologicalStressType.FEVER,
+		final StressContext context = StressContext.fromValues(true, PhysiologicalStressType.FEVER,
 				StressFormulaTable.FEVER_PER_DEGREE, StressIncrementMode.MULTIPLIER_BMR, null, null, null, 39.0);
 		final Double stressKcal = PhysiologicalStressCalculationService.calculateStressKcal(context, 1500.0, 2000.0,
 				null);
@@ -43,7 +43,7 @@ class PhysiologicalStressCalculationServiceTest {
 
 	@Test
 	void calculateStressUsesCustomFactorOverride() {
-		final StressContext context = StressContext.of(true, PhysiologicalStressType.OTHER, StressFormulaTable.LONG,
+		final StressContext context = StressContext.fromValues(true, PhysiologicalStressType.OTHER, StressFormulaTable.LONG,
 				StressIncrementMode.MULTIPLIER_BMR, 1.50, null, null, null);
 		assertThat(PhysiologicalStressCalculationService.calculateStressKcal(context, 1000.0, 1500.0, null))
 			.isEqualTo(500.0);
@@ -56,7 +56,7 @@ class PhysiologicalStressCalculationServiceTest {
 
 	@Test
 	void inactiveStressReturnsNull() {
-		final StressContext context = StressContext.of(false, PhysiologicalStressType.FEVER, StressFormulaTable.LONG,
+		final StressContext context = StressContext.fromValues(false, PhysiologicalStressType.FEVER, StressFormulaTable.LONG,
 				StressIncrementMode.MULTIPLIER_BMR, null, null, null, null);
 		assertThat(PhysiologicalStressCalculationService.calculateStressKcal(context, 1500.0, 2000.0, null)).isNull();
 	}

--- a/src/test/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCalculationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCalculationServiceTest.java
@@ -1,0 +1,64 @@
+package com.nutriconsultas.paciente.calculation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PhysiologicalStressCalculationServiceTest {
+
+	@Test
+	void calculateLongMultiplierStressOnBmr() {
+		final StressContext context = StressContext.of(true, PhysiologicalStressType.MAJOR_SURGERY,
+				StressFormulaTable.LONG, StressIncrementMode.MULTIPLIER_BMR, null, null, null, null);
+		final Double stressKcal = PhysiologicalStressCalculationService.calculateStressKcal(context, 1500.0, 2000.0,
+				null);
+		assertThat(stressKcal).isCloseTo(300.0, org.assertj.core.data.Offset.offset(0.01));
+	}
+
+	@Test
+	void calculateAspenMultiplierStressOnGet() {
+		final StressContext context = StressContext.of(true, PhysiologicalStressType.TRAUMA, StressFormulaTable.ASPEN,
+				StressIncrementMode.MULTIPLIER_GET, null, null, null, null);
+		final Double stressKcal = PhysiologicalStressCalculationService.calculateStressKcal(context, 1500.0, 2000.0,
+				null);
+		assertThat(stressKcal).isCloseTo(800.0, org.assertj.core.data.Offset.offset(0.01));
+	}
+
+	@Test
+	void calculateFixedKcalStress() {
+		final StressContext context = StressContext.of(true, PhysiologicalStressType.OTHER, StressFormulaTable.CUSTOM,
+				StressIncrementMode.FIXED_KCAL, 450.0, null, null, null);
+		assertThat(PhysiologicalStressCalculationService.calculateStressKcal(context, 1500.0, 2000.0, null))
+			.isEqualTo(450.0);
+	}
+
+	@Test
+	void calculateFeverPerDegreeStress() {
+		final StressContext context = StressContext.of(true, PhysiologicalStressType.FEVER,
+				StressFormulaTable.FEVER_PER_DEGREE, StressIncrementMode.MULTIPLIER_BMR, null, null, null, 39.0);
+		final Double stressKcal = PhysiologicalStressCalculationService.calculateStressKcal(context, 1500.0, 2000.0,
+				null);
+		assertThat(stressKcal).isEqualTo(390.0);
+	}
+
+	@Test
+	void calculateStressUsesCustomFactorOverride() {
+		final StressContext context = StressContext.of(true, PhysiologicalStressType.OTHER, StressFormulaTable.LONG,
+				StressIncrementMode.MULTIPLIER_BMR, 1.50, null, null, null);
+		assertThat(PhysiologicalStressCalculationService.calculateStressKcal(context, 1000.0, 1500.0, null))
+			.isEqualTo(500.0);
+	}
+
+	@Test
+	void calculateFinalTotalAddsStressToAdjustedTotal() {
+		assertThat(PhysiologicalStressCalculationService.calculateFinalTotalKcal(2200.0, 300.0)).isEqualTo(2500.0);
+	}
+
+	@Test
+	void inactiveStressReturnsNull() {
+		final StressContext context = StressContext.of(false, PhysiologicalStressType.FEVER, StressFormulaTable.LONG,
+				StressIncrementMode.MULTIPLIER_BMR, null, null, null, null);
+		assertThat(PhysiologicalStressCalculationService.calculateStressKcal(context, 1500.0, 2000.0, null)).isNull();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCatalogTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCatalogTest.java
@@ -1,0 +1,47 @@
+package com.nutriconsultas.paciente.calculation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.paciente.Paciente;
+
+class PhysiologicalStressCatalogTest {
+
+	@Test
+	void defaultLongMultiplierForMajorSurgery() {
+		assertThat(PhysiologicalStressCatalog.defaultMultiplier(PhysiologicalStressType.MAJOR_SURGERY,
+				StressFormulaTable.LONG)).isEqualTo(1.20);
+	}
+
+	@Test
+	void defaultAspenMultiplierForBurns() {
+		assertThat(PhysiologicalStressCatalog.defaultMultiplier(PhysiologicalStressType.BURNS, StressFormulaTable.ASPEN))
+			.isEqualTo(1.80);
+	}
+
+	@Test
+	void suggestFromPathologiesUsesPatientFlags() {
+		final Paciente paciente = new Paciente();
+		paciente.setDiabetes(true);
+		paciente.setEnfermedadesHepaticas(true);
+		paciente.setPregnancy(true);
+
+		final List<PhysiologicalStressType> suggestions = PhysiologicalStressCatalog.suggestFromPathologies(paciente);
+
+		assertThat(suggestions).contains(PhysiologicalStressType.MODERATE_INFECTION,
+				PhysiologicalStressType.ORGAN_FAILURE, PhysiologicalStressType.PREGNANCY_COMPLICATION);
+	}
+
+	@Test
+	void commonAndUncommonTypeListsExcludeNone() {
+		assertThat(PhysiologicalStressCatalog.commonTypes()).contains(PhysiologicalStressType.FEVER)
+			.doesNotContain(PhysiologicalStressType.NONE);
+		assertThat(PhysiologicalStressCatalog.uncommonTypes()).contains(PhysiologicalStressType.HEAD_INJURY)
+			.doesNotContain(PhysiologicalStressType.NONE);
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds a physiological stress catalog (Long, ASPEN, fever per °C, custom) with common and uncommon stress types, multiplier or fixed-kcal modes, and validity dates on the patient record.
- Integrates stress into the energy breakdown (TMB + activity + TEF + stress = final total) in anthropometric calculations, consultations, and the calendar wizard, with per-event overrides that sync back to the patient.
- Suggests stress types from existing pathology flags (diabetes, hepatic disease, pregnancy, etc.) and includes unit tests for catalog and calculation services.

Closes #123

## Test plan
- [x] Register stress on **Desarrollo → Patologías** with validity dates and confirm values persist on reload
- [x] Create a consultation with stress override and verify patient stress is updated
- [x] Open anthropometric **Cálculos → GET** tab, enable stress override, and confirm breakdown shows TMB, activity, TEF, stress, and final total
- [x] Save a calendar consultation via the summary wizard (step 1) with stress active and verify displayed kcal include stress component
- [x] Run `mvn test -Dtest=PhysiologicalStressCalculationServiceTest,PhysiologicalStressCatalogTest,EnergyExpenditureResolverTest`


Made with [Cursor](https://cursor.com)