### PR TITLE
Antropométricos: consolidar composición corporal (#124)

### DIFF
--- a/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/BodyCompositionService.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/BodyCompositionService.java
@@ -1,0 +1,153 @@
+package com.nutriconsultas.clinical.exam.anthropometric;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.springframework.stereotype.Service;
+
+import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
+import com.nutriconsultas.paciente.BodyFatCalculatorService;
+import com.nutriconsultas.paciente.Paciente;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Consolidates body composition fields on anthropometric measurements.
+ *
+ * <p>
+ * Precedence: manual {@code porcentajeGrasaCorporal} / {@code indiceGrasaCorporal},
+ * bioimpedance {@code bodyFatPercentage}, Jackson-Pollock skinfolds, Deurenberg estimate.
+ */
+@Service
+@Slf4j
+public class BodyCompositionService {
+
+	private final BodyFatCalculatorService bodyFatCalculatorService;
+
+	public BodyCompositionService(final BodyFatCalculatorService bodyFatCalculatorService) {
+		this.bodyFatCalculatorService = bodyFatCalculatorService;
+	}
+
+	public void applyToMeasurement(final AnthropometricMeasurement measurement, final Paciente paciente,
+			final Double imc) {
+		ensureBodyComposition(measurement);
+
+		if (measurement.getPorcentajeGrasaCorporal() != null) {
+			syncFatFields(measurement, measurement.getPorcentajeGrasaCorporal());
+			applyMusclePercentageIfAbsent(measurement, measurement.getPorcentajeGrasaCorporal());
+			return;
+		}
+
+		if (measurement.getIndiceGrasaCorporal() != null) {
+			syncFatFields(measurement, measurement.getIndiceGrasaCorporal());
+			applyMusclePercentageIfAbsent(measurement, measurement.getIndiceGrasaCorporal());
+			return;
+		}
+
+		final Double calculatedFat = resolveCalculatedFatPercentage(measurement, paciente, imc);
+		if (calculatedFat != null) {
+			syncFatFields(measurement, calculatedFat);
+			applyMusclePercentageIfAbsent(measurement, calculatedFat);
+		}
+	}
+
+	private Double resolveCalculatedFatPercentage(final AnthropometricMeasurement measurement, final Paciente paciente,
+			final Double imc) {
+		final Double bioimpedanceFat = resolveBioimpedanceFatPercentage(measurement);
+		if (bioimpedanceFat != null) {
+			log.debug("Using bioimpedance body fat percentage for measurement");
+			return bioimpedanceFat;
+		}
+
+		final Double skinfoldFat = calculateSkinfoldFatPercentage(measurement, paciente);
+		if (skinfoldFat != null) {
+			log.debug("Using Jackson-Pollock skinfold body fat percentage for measurement");
+			return skinfoldFat;
+		}
+
+		final Double deurenbergFat = calculateDeurenbergFatPercentage(imc, paciente);
+		if (deurenbergFat != null) {
+			log.debug("Using Deurenberg body fat percentage for measurement");
+			return deurenbergFat;
+		}
+
+		return null;
+	}
+
+	private Double resolveBioimpedanceFatPercentage(final AnthropometricMeasurement measurement) {
+		if (measurement.getBioimpedance() == null) {
+			return null;
+		}
+		return measurement.getBioimpedance().getBodyFatPercentage();
+	}
+
+	private Double calculateSkinfoldFatPercentage(final AnthropometricMeasurement measurement,
+			final Paciente paciente) {
+		if (measurement.getSkinfolds() == null || paciente.getGender() == null) {
+			return null;
+		}
+		final Skinfolds skinfolds = measurement.getSkinfolds();
+		final Double chest = skinfolds.getPectoralSkinfold();
+		final Double abdominal = skinfolds.getAbdominalSkinfold();
+		final Double thigh = skinfolds.getFrontalThighSkinfold();
+		final Integer age = calculateAge(paciente.getDob());
+		if (chest == null || abdominal == null || thigh == null || age == null) {
+			return null;
+		}
+		return bodyFatCalculatorService.calculateBodyFatFromSkinfolds(chest, abdominal, thigh, age,
+				paciente.getGender());
+	}
+
+	private Double calculateDeurenbergFatPercentage(final Double imc, final Paciente paciente) {
+		if (imc == null || paciente.getDob() == null || paciente.getGender() == null) {
+			return null;
+		}
+		final Integer age = calculateAge(paciente.getDob());
+		if (age == null) {
+			return null;
+		}
+		return bodyFatCalculatorService.calculateBodyFatPercentage(imc, age, paciente.getGender());
+	}
+
+	private void syncFatFields(final AnthropometricMeasurement measurement, final Double fatPercentage) {
+		measurement.setPorcentajeGrasaCorporal(fatPercentage);
+		measurement.setIndiceGrasaCorporal(fatPercentage);
+	}
+
+	private void applyMusclePercentageIfAbsent(final AnthropometricMeasurement measurement,
+			final Double fatPercentage) {
+		if (measurement.getPorcentajeMasaMuscular() != null || fatPercentage == null) {
+			return;
+		}
+		final double muscleMassPercentage = 100.0 - fatPercentage;
+		final double clamped = Math.max(20.0, Math.min(80.0, muscleMassPercentage));
+		measurement.setPorcentajeMasaMuscular(clamped);
+	}
+
+	private void ensureBodyComposition(final AnthropometricMeasurement measurement) {
+		if (measurement.getBodyComposition() == null) {
+			measurement.setBodyComposition(new BodyComposition());
+		}
+	}
+
+	private Integer calculateAge(final Date dob) {
+		if (dob == null) {
+			return null;
+		}
+		final LocalDate birthDate;
+		if (dob instanceof java.sql.Date sqlDate) {
+			birthDate = sqlDate.toLocalDate();
+		}
+		else {
+			birthDate = dob.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+		}
+		final LocalDate currentDate = LocalDate.now();
+		if (birthDate.isAfter(currentDate)) {
+			return null;
+		}
+		return Period.between(birthDate, currentDate).getYears();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -69,6 +69,9 @@ public class PacienteController extends AbstractAuthorizedController {
 	private BodyFatCalculatorService bodyFatCalculatorService;
 
 	@Autowired
+	private com.nutriconsultas.clinical.exam.anthropometric.BodyCompositionService bodyCompositionService;
+
+	@Autowired
 	private PacienteDietaService pacienteDietaService;
 
 	@Autowired
@@ -194,9 +197,12 @@ public class PacienteController extends AbstractAuthorizedController {
 			model.addAttribute("ultimaEstatura", latest.getHeight());
 			model.addAttribute("ultimoImc", latest.getImc());
 			model.addAttribute("ultimoNivelPeso", latest.getNivelPeso());
-			model.addAttribute("ultimoIndiceGrasaCorporal",
-					latest.getBodyFatIndex() != null ? latest.getBodyFatIndex() : latest.getBodyFatPercentage());
+			final Double ultimoPorcentajeGrasa = latest.getBodyFatPercentage() != null ? latest.getBodyFatPercentage()
+					: latest.getBodyFatIndex();
+			model.addAttribute("ultimoPorcentajeGrasaCorporal", ultimoPorcentajeGrasa);
+			model.addAttribute("ultimoIndiceGrasaCorporal", ultimoPorcentajeGrasa);
 		});
+		addLatestMuscleMassToModel(id, model);
 		// Calculate age and check if patient is under 18 for growth table display
 		final Integer age = calculateAge(paciente.getDob());
 		final boolean isUnder18 = age != null && age < 18;
@@ -357,8 +363,7 @@ public class PacienteController extends AbstractAuthorizedController {
 		model.addAttribute("paciente", paciente);
 		model.addAttribute("isEligibleForPregnancy", isEligibleForPregnancy(paciente));
 		model.addAttribute("suggestedStressTypes",
-				com.nutriconsultas.paciente.calculation.PhysiologicalStressCatalog
-					.suggestFromPathologies(paciente));
+				com.nutriconsultas.paciente.calculation.PhysiologicalStressCatalog.suggestFromPathologies(paciente));
 		return "sbadmin/pacientes/desarrollo";
 	}
 
@@ -462,7 +467,8 @@ public class PacienteController extends AbstractAuthorizedController {
 			}
 		}
 		model.addAttribute("dietasActivas", dietasActivas);
-		// obtener todas las dietas disponibles para asignar (legacy attribute for dietas template)
+		// obtener todas las dietas disponibles para asignar (legacy attribute for dietas
+		// template)
 		model.addAttribute("dietasDisponibles", getDietasDisponiblesWithCalculatedNutrients());
 		return "sbadmin/pacientes/dietas";
 	}
@@ -516,8 +522,7 @@ public class PacienteController extends AbstractAuthorizedController {
 		}
 		model.addAttribute("consulta", evento);
 		model.addAttribute("suggestedStressTypes",
-				com.nutriconsultas.paciente.calculation.PhysiologicalStressCatalog
-					.suggestFromPathologies(paciente));
+				com.nutriconsultas.paciente.calculation.PhysiologicalStressCatalog.suggestFromPathologies(paciente));
 		return "sbadmin/pacientes/consulta";
 	}
 
@@ -1324,18 +1329,26 @@ public class PacienteController extends AbstractAuthorizedController {
 			final com.nutriconsultas.clinical.exam.AnthropometricMeasurement measurement, final Paciente paciente) {
 		Double imc = null;
 		NivelPeso np = null;
-		Double bodyFatPercentage = null;
 
 		if (measurement.getPeso() != null && measurement.getEstatura() != null) {
 			imc = measurement.getPeso() / Math.pow(measurement.getEstatura(), 2);
 			np = calculateNivelPeso(imc);
-			bodyFatPercentage = calculateBodyFatPercentage(imc, paciente);
-			if (bodyFatPercentage != null) {
-				measurement.setIndiceGrasaCorporal(bodyFatPercentage);
-			}
 		}
 
+		bodyCompositionService.applyToMeasurement(measurement, paciente, imc);
+		final Double bodyFatPercentage = measurement.getPorcentajeGrasaCorporal();
+
 		return new BmiCalculationResult(imc, np, bodyFatPercentage);
+	}
+
+	private void addLatestMuscleMassToModel(final Long pacienteId, final Model model) {
+		anthropometricMeasurementService.findByPacienteId(pacienteId)
+			.stream()
+			.filter(measurement -> measurement.getPorcentajeMasaMuscular() != null)
+			.max(Comparator.comparing(AnthropometricMeasurement::getMeasurementDateTime)
+				.thenComparing(AnthropometricMeasurement::getId, Comparator.nullsLast(Comparator.naturalOrder())))
+			.ifPresent(
+					latest -> model.addAttribute("ultimoPorcentajeMasaMuscular", latest.getPorcentajeMasaMuscular()));
 	}
 
 	/**

--- a/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
@@ -92,6 +92,7 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 		paciente.setBulimia(false);
 		paciente.setAnorexia(false);
 		paciente.setPregnancy(false);
+		paciente.setPhysiologicalStressActive(null);
 		return paciente;
 	}
 

--- a/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
@@ -41,6 +41,9 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 		variables.put("ultimaEstatura", null);
 		variables.put("ultimoImc", null);
 		variables.put("ultimoNivelPeso", null);
+		variables.put("ultimoPorcentajeGrasaCorporal", null);
+		variables.put("ultimoIndiceGrasaCorporal", null);
+		variables.put("ultimoPorcentajeMasaMuscular", null);
 		variables.put("isEligibleForPregnancy", false);
 		variables.put("isUnder18", false);
 		variables.put("suggestedStressTypes", List.of());

--- a/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordServiceImpl.java
@@ -213,10 +213,10 @@ public class BodyMetricRecordServiceImpl implements BodyMetricRecordService {
 	}
 
 	private Double resolveBodyFatValue(final BodyMetricRecord record) {
-		if (record.getBodyFatIndex() != null) {
-			return record.getBodyFatIndex();
+		if (record.getBodyFatPercentage() != null) {
+			return record.getBodyFatPercentage();
 		}
-		return record.getBodyFatPercentage();
+		return record.getBodyFatIndex();
 	}
 
 	private void refreshPatientSnapshot(@NonNull final Long pacienteId) {

--- a/src/main/resources/templates/sbadmin/pacientes/antropometricos.html
+++ b/src/main/resources/templates/sbadmin/pacientes/antropometricos.html
@@ -125,6 +125,7 @@
                             </div>
                           </div>
                           <div th:insert="~{sbadmin/pacientes/body-mass-imc-live :: bodyMassImcDisplay}"></div>
+                          <div th:insert="~{sbadmin/pacientes/body-composition-fields :: bodyCompositionFields}"></div>
                           <div class="row">
                             <div class="col-md-12">
                               <div class="form-group">
@@ -138,7 +139,6 @@
                           <input type="hidden" th:field="*{bodyMass.bodyMassValue}">
                           <input type="hidden" th:field="*{bodyMass.imc}">
                           <input type="hidden" th:field="*{bodyMass.nivelPeso}">
-                          <input type="hidden" th:field="*{bodyComposition.indiceGrasaCorporal}">
                         </div>
 
                         <!-- Bioimpedance Tab -->

--- a/src/main/resources/templates/sbadmin/pacientes/body-composition-fields.html
+++ b/src/main/resources/templates/sbadmin/pacientes/body-composition-fields.html
@@ -1,0 +1,64 @@
+<!--
+  Body composition inputs for anthropometric body-mass tab.
+  Fragments: bodyCompositionFields (form), bodyCompositionDisplay (read-only view)
+-->
+<div th:fragment="bodyCompositionFields">
+  <hr class="my-3">
+  <h5 class="mb-3">Composición Corporal</h5>
+  <p class="text-muted small mb-3">
+    Opcional. Al guardar se calcula automáticamente si hay peso/estatura, pliegues completos o % grasa de bioimpedancia.
+  </p>
+  <div class="row">
+    <div class="col-md-4">
+      <div class="form-group">
+        <label>% Grasa Corporal</label>
+        <input type="number" step="0.1" th:field="*{bodyComposition.porcentajeGrasaCorporal}" class="form-control"
+               min="0" max="100" placeholder="Ej: 22.5">
+        <span th:if="${#fields.hasErrors('bodyComposition.porcentajeGrasaCorporal')}"
+              th:errors="*{bodyComposition.porcentajeGrasaCorporal}"></span>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="form-group">
+        <label>Índice de Grasa Corporal (%)</label>
+        <input type="number" step="0.01" th:field="*{bodyComposition.indiceGrasaCorporal}" class="form-control"
+               min="0" max="100" placeholder="Ej: 22.50">
+        <span th:if="${#fields.hasErrors('bodyComposition.indiceGrasaCorporal')}"
+              th:errors="*{bodyComposition.indiceGrasaCorporal}"></span>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="form-group">
+        <label>% Masa Muscular</label>
+        <input type="number" step="0.1" th:field="*{bodyComposition.porcentajeMasaMuscular}" class="form-control"
+               min="0" max="100" placeholder="Ej: 45.0">
+        <span th:if="${#fields.hasErrors('bodyComposition.porcentajeMasaMuscular')}"
+              th:errors="*{bodyComposition.porcentajeMasaMuscular}"></span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div th:fragment="bodyCompositionDisplay(measurement)">
+  <div th:with="fatPct=${measurement.porcentajeGrasaCorporal != null ? measurement.porcentajeGrasaCorporal : (measurement.bioimpedance != null ? measurement.bioimpedance.bodyFatPercentage : null)},
+                fatIdx=${measurement.indiceGrasaCorporal},
+                musclePct=${measurement.porcentajeMasaMuscular != null ? measurement.porcentajeMasaMuscular : null}"
+       th:if="${fatPct != null || fatIdx != null || musclePct != null}">
+    <hr class="my-3">
+    <h5 class="mb-3">Composición Corporal</h5>
+    <div class="row">
+      <div class="col-md-4" th:if="${fatPct != null}">
+        <p><strong>% Grasa Corporal:</strong>
+          <span th:text="${#numbers.formatDecimal(fatPct, 1, 1)} + '%'">-</span></p>
+      </div>
+      <div class="col-md-4" th:if="${fatIdx != null}">
+        <p><strong>Índice de Grasa Corporal:</strong>
+          <span th:text="${#numbers.formatDecimal(fatIdx, 1, 2)} + '%'">-</span></p>
+      </div>
+      <div class="col-md-4" th:if="${musclePct != null}">
+        <p><strong>% Masa Muscular:</strong>
+          <span th:text="${#numbers.formatDecimal(musclePct, 1, 1)} + '%'">-</span></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/main/resources/templates/sbadmin/pacientes/perfil.html
+++ b/src/main/resources/templates/sbadmin/pacientes/perfil.html
@@ -73,6 +73,20 @@
                       </div>
                     </li>
                     <li class="list-group-item d-flex justify-content-between align-items-center p-3">
+                      <i class="fas fa-percentage fa-lg" style="color: #e67e22;"></i>
+                      <p class="mb-0" th:if="${ultimoPorcentajeGrasaCorporal != null}">
+                        % Grasa: [[(${#numbers.formatDecimal(ultimoPorcentajeGrasaCorporal,1,'COMMA',1,'POINT')})]]%
+                      </p>
+                      <p class="mb-0 text-muted" th:if="${ultimoPorcentajeGrasaCorporal == null}">% Grasa: sin dato</p>
+                    </li>
+                    <li class="list-group-item d-flex justify-content-between align-items-center p-3">
+                      <i class="fas fa-dumbbell fa-lg" style="color: #6f42c1;"></i>
+                      <p class="mb-0" th:if="${ultimoPorcentajeMasaMuscular != null}">
+                        % Masa muscular: [[(${#numbers.formatDecimal(ultimoPorcentajeMasaMuscular,1,'COMMA',1,'POINT')})]]%
+                      </p>
+                      <p class="mb-0 text-muted" th:if="${ultimoPorcentajeMasaMuscular == null}">% Masa muscular: sin dato</p>
+                    </li>
+                    <li class="list-group-item d-flex justify-content-between align-items-center p-3">
                       <i class="fas fa-bolt fa-lg" style="color: #ff6b35;"></i>
                       <p class="mb-0" th:if="${paciente.getKcal != null}">
                         GET: [[(${#numbers.formatDecimal(paciente.getKcal,1,'COMMA',0,'POINT')})]] kcal/día
@@ -179,7 +193,7 @@
                             <i class="fas fa-weight"></i> IMC
                           </a>
                           <a class="dropdown-item" href="#" data-chart-type="grasa-corporal">
-                            <i class="fas fa-percentage"></i> Índice de Grasa Corporal
+                            <i class="fas fa-percentage"></i> % Grasa Corporal
                           </a>
                           <a class="dropdown-item" href="#" data-chart-type="get">
                             <i class="fas fa-bolt"></i> GET (kcal/día)
@@ -394,13 +408,13 @@
         ? '<i class="fas fa-weight"></i> IMC'
         : chartType === 'get'
           ? '<i class="fas fa-bolt"></i> GET'
-          : '<i class="fas fa-percentage"></i> Índice de Grasa Corporal';
+          : '<i class="fas fa-percentage"></i> % Grasa Corporal';
       $('#chartTypeDropdown').html(buttonText + ' <i class="fas fa-caret-down"></i>');
       var chartTitle = chartType === 'imc'
         ? 'Indice de Masa Corporal Historico'
         : chartType === 'get'
           ? 'Gasto Energetico Total Historico'
-          : 'Indice de Grasa Corporal Historico';
+          : 'Porcentaje de Grasa Corporal Historico';
       $('#chartTitle').text(chartTitle);
     });
 
@@ -411,7 +425,7 @@
 
       var label = chartType === 'imc' ? 'IMC'
         : chartType === 'get' ? 'GET (kcal/día)'
-        : 'Índice de Grasa Corporal (%)';
+        : '% Grasa Corporal';
       myLineChart.data.datasets[0].label = label;
       myLineChart.update();
     }

--- a/src/main/resources/templates/sbadmin/pacientes/stress-section.html
+++ b/src/main/resources/templates/sbadmin/pacientes/stress-section.html
@@ -106,11 +106,11 @@
   <h6 class="mb-2"><i class="fas fa-heartbeat text-danger"></i> Estrés fisiológico</h6>
   <p class="text-muted small mb-2">
     Valores base del paciente:
-    <span th:if="${paciente != null && paciente.physiologicalStressActive}">
+    <span th:if="${paciente != null and paciente.physiologicalStressActive == true}">
       <strong th:text="${paciente.physiologicalStressType != null ? paciente.physiologicalStressType.displayName : 'Activo'}">Activo</strong>
       (<span th:text="${paciente.stressFormulaTable != null ? paciente.stressFormulaTable.displayName : 'Long'}">Long</span>)
     </span>
-    <span th:unless="${paciente != null && paciente.physiologicalStressActive}">sin estrés registrado</span>.
+    <span th:unless="${paciente != null and paciente.physiologicalStressActive == true}">sin estrés registrado</span>.
     Puede ajustar valores solo para este cálculo.
   </p>
   <div class="alert alert-warning py-2 small">

--- a/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
+++ b/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
@@ -125,6 +125,7 @@
                           <div th:replace="~{sbadmin/pacientes/imc-gauge :: imcGauge(${measurement.imc}, ${measurement.nivelPeso})}"></div>
                         </div>
                       </div>
+                      <div th:replace="~{sbadmin/pacientes/body-composition-fields :: bodyCompositionDisplay(${measurement})}"></div>
                       <div class="row" th:if="${measurement.notes != null && !measurement.notes.isEmpty()}">
                         <div class="col-md-12">
                           <p><strong>Notas:</strong></p>

--- a/src/main/resources/templates/sbadmin/reports/patient-progress.html
+++ b/src/main/resources/templates/sbadmin/reports/patient-progress.html
@@ -356,6 +356,8 @@
 					<th>Peso (kg)</th>
 					<th>Estatura (m)</th>
 					<th>IMC</th>
+					<th>% Grasa</th>
+					<th>% Masa muscular</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -365,6 +367,8 @@
 					<td th:text="${measurement.peso != null ? (#numbers.formatDecimal(measurement.peso, 1, 2) + ' kg') : 'N/A'}"></td>
 					<td th:text="${measurement.estatura != null ? (#numbers.formatDecimal(measurement.estatura, 2, 2) + ' m') : 'N/A'}"></td>
 					<td th:text="${measurement.bodyMass != null && measurement.bodyMass.imc != null ? #numbers.formatDecimal(measurement.bodyMass.imc, 1, 2) : 'N/A'}"></td>
+					<td th:text="${measurement.porcentajeGrasaCorporal != null ? (#numbers.formatDecimal(measurement.porcentajeGrasaCorporal, 1, 1) + '%') : 'N/A'}"></td>
+					<td th:text="${measurement.porcentajeMasaMuscular != null ? (#numbers.formatDecimal(measurement.porcentajeMasaMuscular, 1, 1) + '%') : 'N/A'}"></td>
 				</tr>
 			</tbody>
 		</table>

--- a/src/test/java/com/nutriconsultas/clinical/exam/anthropometric/BodyCompositionServiceTest.java
+++ b/src/test/java/com/nutriconsultas/clinical/exam/anthropometric/BodyCompositionServiceTest.java
@@ -1,0 +1,138 @@
+package com.nutriconsultas.clinical.exam.anthropometric;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
+import com.nutriconsultas.paciente.BodyFatCalculatorService;
+import com.nutriconsultas.paciente.Paciente;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class BodyCompositionServiceTest {
+
+	@InjectMocks
+	private BodyCompositionService service;
+
+	@Mock
+	private BodyFatCalculatorService bodyFatCalculatorService;
+
+	private Paciente paciente;
+
+	@BeforeEach
+	void setUp() {
+		paciente = new Paciente();
+		paciente.setId(1L);
+		paciente.setGender("M");
+		final LocalDate dob = LocalDate.now().minusYears(30);
+		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+	}
+
+	@Test
+	void applyToMeasurementUsesManualPorcentajeGrasaCorporal() {
+		final AnthropometricMeasurement measurement = createMeasurementWithWeight(70.0, 1.75);
+		measurement.setPorcentajeGrasaCorporal(18.5);
+
+		service.applyToMeasurement(measurement, paciente, 22.86);
+
+		assertThat(measurement.getPorcentajeGrasaCorporal()).isEqualTo(18.5);
+		assertThat(measurement.getIndiceGrasaCorporal()).isEqualTo(18.5);
+		assertThat(measurement.getPorcentajeMasaMuscular()).isEqualTo(80.0);
+		verify(bodyFatCalculatorService, never()).calculateBodyFatPercentage(any(), any(), any());
+	}
+
+	@Test
+	void applyToMeasurementUsesBioimpedanceBeforeDeurenberg() {
+		final AnthropometricMeasurement measurement = createMeasurementWithWeight(70.0, 1.75);
+		final Bioimpedance bioimpedance = new Bioimpedance();
+		bioimpedance.setBodyFatPercentage(24.0);
+		measurement.setBioimpedance(bioimpedance);
+
+		service.applyToMeasurement(measurement, paciente, 22.86);
+
+		assertThat(measurement.getPorcentajeGrasaCorporal()).isEqualTo(24.0);
+		assertThat(measurement.getIndiceGrasaCorporal()).isEqualTo(24.0);
+		assertThat(measurement.getPorcentajeMasaMuscular()).isEqualTo(76.0);
+		verify(bodyFatCalculatorService, never()).calculateBodyFatPercentage(any(), any(), any());
+	}
+
+	@Test
+	void applyToMeasurementUsesSkinfoldsBeforeDeurenberg() {
+		final AnthropometricMeasurement measurement = createMeasurementWithWeight(70.0, 1.75);
+		final Skinfolds skinfolds = new Skinfolds();
+		skinfolds.setPectoralSkinfold(10.0);
+		skinfolds.setAbdominalSkinfold(15.0);
+		skinfolds.setFrontalThighSkinfold(12.0);
+		measurement.setSkinfolds(skinfolds);
+		when(bodyFatCalculatorService.calculateBodyFatFromSkinfolds(10.0, 15.0, 12.0, 30, "M")).thenReturn(19.0);
+
+		service.applyToMeasurement(measurement, paciente, 22.86);
+
+		assertThat(measurement.getPorcentajeGrasaCorporal()).isEqualTo(19.0);
+		assertThat(measurement.getPorcentajeMasaMuscular()).isEqualTo(80.0);
+		verify(bodyFatCalculatorService).calculateBodyFatFromSkinfolds(10.0, 15.0, 12.0, 30, "M");
+		verify(bodyFatCalculatorService, never()).calculateBodyFatPercentage(any(), any(), any());
+	}
+
+	@Test
+	void applyToMeasurementUsesDeurenbergWhenNoOtherSourceAvailable() {
+		final AnthropometricMeasurement measurement = createMeasurementWithWeight(70.0, 1.75);
+		when(bodyFatCalculatorService.calculateBodyFatPercentage(eq(22.86), eq(30), eq("M"))).thenReturn(16.5);
+
+		service.applyToMeasurement(measurement, paciente, 22.86);
+
+		assertThat(measurement.getPorcentajeGrasaCorporal()).isEqualTo(16.5);
+		assertThat(measurement.getIndiceGrasaCorporal()).isEqualTo(16.5);
+		assertThat(measurement.getPorcentajeMasaMuscular()).isEqualTo(80.0);
+		verify(bodyFatCalculatorService).calculateBodyFatPercentage(22.86, 30, "M");
+	}
+
+	@Test
+	void applyToMeasurementKeepsManualMusclePercentage() {
+		final AnthropometricMeasurement measurement = createMeasurementWithWeight(70.0, 1.75);
+		measurement.setPorcentajeGrasaCorporal(20.0);
+		measurement.setPorcentajeMasaMuscular(42.0);
+
+		service.applyToMeasurement(measurement, paciente, 22.86);
+
+		assertThat(measurement.getPorcentajeMasaMuscular()).isEqualTo(42.0);
+	}
+
+	@Test
+	void applyToMeasurementDoesNothingWhenNoInputsAvailable() {
+		final AnthropometricMeasurement measurement = new AnthropometricMeasurement();
+
+		service.applyToMeasurement(measurement, paciente, null);
+
+		assertThat(measurement.getBodyComposition()).isNotNull();
+		assertThat(measurement.getPorcentajeGrasaCorporal()).isNull();
+		assertThat(measurement.getIndiceGrasaCorporal()).isNull();
+		assertThat(measurement.getPorcentajeMasaMuscular()).isNull();
+	}
+
+	private AnthropometricMeasurement createMeasurementWithWeight(final Double weight, final Double height) {
+		final AnthropometricMeasurement measurement = new AnthropometricMeasurement();
+		final BodyMass bodyMass = new BodyMass();
+		bodyMass.setWeight(weight);
+		bodyMass.setHeight(height);
+		measurement.setBodyMass(bodyMass);
+		return measurement;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 
@@ -121,6 +122,9 @@ public class PacienteControllerTest {
 		principal = org.mockito.Mockito.mock(OidcUser.class);
 		lenient().when(principal.getSubject()).thenReturn(TEST_USER_ID);
 		lenient().when(bodyMetricRecordService.findLatestByPacienteId(any())).thenReturn(java.util.Optional.empty());
+		final com.nutriconsultas.clinical.exam.anthropometric.BodyCompositionService realBodyCompositionService = new com.nutriconsultas.clinical.exam.anthropometric.BodyCompositionService(
+				new BodyFatCalculatorService());
+		ReflectionTestUtils.setField(controller, "bodyCompositionService", realBodyCompositionService);
 
 		log.info("finished setting up PacienteController test");
 	}
@@ -1511,9 +1515,6 @@ public class PacienteControllerTest {
 		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
 		when(anthropometricMeasurementService.save(any(AnthropometricMeasurement.class))).thenReturn(measurement);
 		when(pacienteRepository.save(any(Paciente.class))).thenReturn(paciente);
-		when(bodyFatCalculatorService.calculateBodyFatPercentage(any(Double.class), any(Integer.class),
-				any(String.class)))
-			.thenReturn(15.5);
 
 		final Model model = org.mockito.Mockito.mock(Model.class);
 
@@ -1529,6 +1530,9 @@ public class PacienteControllerTest {
 		verify(pacienteRepository).save(any(Paciente.class));
 		assertThat(measurement.getImc()).isNotNull();
 		assertThat(measurement.getNivelPeso()).isNotNull();
+		assertThat(measurement.getPorcentajeGrasaCorporal()).isNotNull();
+		assertThat(measurement.getIndiceGrasaCorporal()).isEqualTo(measurement.getPorcentajeGrasaCorporal());
+		assertThat(measurement.getPorcentajeMasaMuscular()).isNotNull();
 		assertPacienteBmrMatchesPromedio(70.0, 1.75);
 		log.info("finished testAgregarAntropometricosPaciente");
 	}
@@ -1555,9 +1559,6 @@ public class PacienteControllerTest {
 		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
 		when(anthropometricMeasurementService.save(any(AnthropometricMeasurement.class))).thenReturn(measurement);
 		when(pacienteRepository.save(any(Paciente.class))).thenReturn(paciente);
-		when(bodyFatCalculatorService.calculateBodyFatPercentage(any(Double.class), any(Integer.class),
-				any(String.class)))
-			.thenReturn(15.5);
 
 		final Model model = org.mockito.Mockito.mock(Model.class);
 
@@ -1573,6 +1574,7 @@ public class PacienteControllerTest {
 		assertThat(measurement.getBodyMass().getWeight()).isEqualTo(70.0);
 		assertThat(measurement.getCircumferences()).isNotNull();
 		assertThat(measurement.getCircumferences().getWaistCircumference()).isEqualTo(80.0);
+		assertThat(measurement.getPorcentajeGrasaCorporal()).isNotNull();
 		verify(pacienteRepository).findByIdAndUserId(1L, TEST_USER_ID);
 		verify(anthropometricMeasurementService).save(any(AnthropometricMeasurement.class));
 		verify(pacienteRepository).save(any(Paciente.class));

--- a/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
@@ -629,6 +629,7 @@ public class PacienteControllerTest {
 		// Arrange - Use existing paciente (30 years old)
 		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
 		when(calendarEventService.findByPacienteId(1L)).thenReturn(new ArrayList<>());
+		when(anthropometricMeasurementService.findByPacienteId(1L)).thenReturn(new ArrayList<>());
 
 		final Model model = org.mockito.Mockito.mock(Model.class);
 
@@ -638,8 +639,8 @@ public class PacienteControllerTest {
 		// Assert
 		assertThat(result).isEqualTo("sbadmin/pacientes/perfil");
 		verify(model).addAttribute("isUnder18", false);
-		// Should not fetch measurements for patients 18 or older
-		verify(anthropometricMeasurementService, org.mockito.Mockito.never()).findByPacienteId(any());
+		verify(anthropometricMeasurementService).findByPacienteId(1L);
+		verify(model, org.mockito.Mockito.never()).addAttribute(eq("growthMeasurements"), any(List.class));
 		log.info("finished testPerfilPaciente18OrOlder");
 	}
 
@@ -658,6 +659,7 @@ public class PacienteControllerTest {
 		when(pacienteRepository.findByIdAndUserId(4L, TEST_USER_ID))
 			.thenReturn(java.util.Optional.of(exactly18Paciente));
 		when(calendarEventService.findByPacienteId(4L)).thenReturn(new ArrayList<>());
+		when(anthropometricMeasurementService.findByPacienteId(4L)).thenReturn(new ArrayList<>());
 
 		final Model model = org.mockito.Mockito.mock(Model.class);
 
@@ -668,8 +670,8 @@ public class PacienteControllerTest {
 		assertThat(result).isEqualTo("sbadmin/pacientes/perfil");
 		// Patient exactly 18 should not show growth table (age < 18, not <= 18)
 		verify(model).addAttribute("isUnder18", false);
-		// Should not fetch measurements for patients 18 or older
-		verify(anthropometricMeasurementService, org.mockito.Mockito.never()).findByPacienteId(any());
+		verify(anthropometricMeasurementService).findByPacienteId(4L);
+		verify(model, org.mockito.Mockito.never()).addAttribute(eq("growthMeasurements"), any(List.class));
 		log.info("finished testPerfilPacienteBoundaryCaseExactly18");
 	}
 

--- a/src/test/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordServiceTest.java
@@ -61,6 +61,47 @@ class BodyMetricRecordServiceTest {
 	}
 
 	@Test
+	void buildChartResponsePrefersBodyFatPercentageOverIndex() {
+		final BodyMetricRecord record = new BodyMetricRecord();
+		record.setRecordedAt(new Date());
+		record.setBodyFatPercentage(21.0);
+		record.setBodyFatIndex(25.0);
+
+		when(repository.existsByPacienteId(1L)).thenReturn(true);
+		when(repository.findByPacienteIdOrderByRecordedAtAsc(1L)).thenReturn(List.of(record));
+
+		final ChartResponse response = service.buildChartResponse(1L);
+
+		@SuppressWarnings("unchecked")
+		final List<Double> fatData = (List<Double>) response.getData().get("grasaCorporal");
+		assertThat(fatData).containsExactly(21.0);
+	}
+
+	@Test
+	void syncFromAnthropometricPersistsBodyFatPercentage() {
+		final AnthropometricMeasurement measurement = new AnthropometricMeasurement();
+		measurement.setId(10L);
+		measurement.setPaciente(paciente);
+		measurement.setMeasurementDateTime(new Date());
+		measurement.setPorcentajeGrasaCorporal(20.5);
+		measurement.setIndiceGrasaCorporal(20.5);
+
+		when(repository.findBySourceAndSourceId(BodyMetricSource.ANTHROPOMETRIC, 10L)).thenReturn(Optional.empty());
+		when(repository.save(any(BodyMetricRecord.class))).thenAnswer(invocation -> {
+			final BodyMetricRecord saved = invocation.getArgument(0);
+			saved.setId(99L);
+			return saved;
+		});
+
+		service.syncFromAnthropometric(measurement);
+
+		final ArgumentCaptor<BodyMetricRecord> captor = ArgumentCaptor.forClass(BodyMetricRecord.class);
+		verify(repository).save(captor.capture());
+		assertThat(captor.getValue().getBodyFatPercentage()).isEqualTo(20.5);
+		assertThat(captor.getValue().getBodyFatIndex()).isEqualTo(20.5);
+	}
+
+	@Test
 	void syncFromAnthropometricPersistsImcAndNivelPeso() {
 		final AnthropometricMeasurement measurement = new AnthropometricMeasurement();
 		measurement.setId(10L);


### PR DESCRIPTION
## Summary
- Add `BodyCompositionService` to consolidate `% grasa`, índice and `% masa muscular` on anthropometric save with precedence: manual → bioimpedancia → Jackson-Pollock (pliegues) → Deurenberg.
- Show body composition fields directly on the **Masa corporal** tab (form + read view) without navigating to Bioimpedancia or copying from Cálculos.
- Surface latest `% grasa` / `% masa muscular` in patient profile sidebar; align chart timeline to prefer `porcentajeGrasaCorporal`.
- Extend patient progress PDF anthropometrics table with composition columns.

Closes #124 (partial — method-of-acquisition enum, bone mass, and somatocarta remain follow-ups per open questions).

## Test plan
- [ ] Create anthropometric with only peso/estatura → verify auto-filled `% grasa` and `% masa muscular` on body-mass tab after save.
- [ ] Enter bioimpedance `% grasa` → verify it overrides Deurenberg estimate on save.
- [ ] Complete Jackson-Pollock pliegues (pecho, abdominal, muslo) without bioimpedance → verify skinfold-based `% grasa`.
- [ ] Patient profile sidebar shows latest `% grasa` and `% masa muscular`.
- [ ] Profile chart “% Grasa Corporal” renders historical series.
- [ ] Patient PDF report includes composition columns in anthropometrics section.
- [x] `mvn test -Dtest=BodyCompositionServiceTest,BodyMetricRecordServiceTest,PacienteControllerTest#testAgregarAntropometricosPaciente`
- [x] Thymeleaf template validation passes


Made with [Cursor](https://cursor.com)