### PR TITLE
Antropométricos: calcular somatotipo Heath-Carter (#125)

### DIFF
--- a/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurement.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurement.java
@@ -282,4 +282,59 @@ public class AnthropometricMeasurement {
 		bodyComposition.setPorcentajeMasaMuscular(porcentajeMasaMuscular);
 	}
 
+	public Double getEndomorphy() {
+		return bodyComposition != null ? bodyComposition.getEndomorphy() : null;
+	}
+
+	public void setEndomorphy(final Double endomorphy) {
+		if (bodyComposition == null) {
+			bodyComposition = new BodyComposition();
+		}
+		bodyComposition.setEndomorphy(endomorphy);
+	}
+
+	public Double getMesomorphy() {
+		return bodyComposition != null ? bodyComposition.getMesomorphy() : null;
+	}
+
+	public void setMesomorphy(final Double mesomorphy) {
+		if (bodyComposition == null) {
+			bodyComposition = new BodyComposition();
+		}
+		bodyComposition.setMesomorphy(mesomorphy);
+	}
+
+	public Double getEctomorphy() {
+		return bodyComposition != null ? bodyComposition.getEctomorphy() : null;
+	}
+
+	public void setEctomorphy(final Double ectomorphy) {
+		if (bodyComposition == null) {
+			bodyComposition = new BodyComposition();
+		}
+		bodyComposition.setEctomorphy(ectomorphy);
+	}
+
+	public Double getSomatocartaX() {
+		return bodyComposition != null ? bodyComposition.getSomatocartaX() : null;
+	}
+
+	public void setSomatocartaX(final Double somatocartaX) {
+		if (bodyComposition == null) {
+			bodyComposition = new BodyComposition();
+		}
+		bodyComposition.setSomatocartaX(somatocartaX);
+	}
+
+	public Double getSomatocartaY() {
+		return bodyComposition != null ? bodyComposition.getSomatocartaY() : null;
+	}
+
+	public void setSomatocartaY(final Double somatocartaY) {
+		if (bodyComposition == null) {
+			bodyComposition = new BodyComposition();
+		}
+		bodyComposition.setSomatocartaY(somatocartaY);
+	}
+
 }

--- a/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/BodyComposition.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/BodyComposition.java
@@ -29,4 +29,24 @@ public class BodyComposition {
 	@Column(precision = 3)
 	private Double porcentajeMasaMuscular;
 
+	/** Heath-Carter endomorphy rating (adults). */
+	@Column(precision = 4)
+	private Double endomorphy;
+
+	/** Heath-Carter mesomorphy rating (adults). */
+	@Column(precision = 4)
+	private Double mesomorphy;
+
+	/** Heath-Carter ectomorphy rating (adults). */
+	@Column(precision = 4)
+	private Double ectomorphy;
+
+	/** Somatocarta X: ectomorphy - endomorphy. */
+	@Column(precision = 4)
+	private Double somatocartaX;
+
+	/** Somatocarta Y: 2×mesomorphy - (ectomorphy + endomorphy). */
+	@Column(precision = 4)
+	private Double somatocartaY;
+
 }

--- a/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeCalculationService.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeCalculationService.java
@@ -1,0 +1,132 @@
+package com.nutriconsultas.clinical.exam.anthropometric;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Heath-Carter anthropometric somatotype (classic method, Carter &amp; Heath 1990).
+ *
+ * <p>
+ * Formulas (metric units):
+ * <ul>
+ * <li><b>Endomorphy:</b> {@code -0.7182 + 0.1451X - 0.00068X² + 0.0000014X³} where
+ * {@code X = (triceps + subscapular + supraspinal) × (170.18 / heightCm)}</li>
+ * <li><b>Mesomorphy:</b>
+ * {@code 0.858×humerus + 0.601×femur + 0.188×correctedArm + 0.161×correctedCalf - 0.131×heightCm + 4.5}
+ * with corrected girths = girth - skinfold/10</li>
+ * <li><b>Ectomorphy:</b> from HWR = heightCm / ∛weightKg; piecewise linear (see
+ * {@link #calculateEctomorphy(double)})</li>
+ * </ul>
+ * Ratings ≤ 0 are assigned 0.1 per Heath-Carter convention. Same formulas apply to both
+ * sexes; reference norms differ by sex but calculation does not.
+ */
+public final class SomatotypeCalculationService {
+
+	public static final int MIN_ADULT_AGE_YEARS = 18;
+
+	private static final double HEIGHT_CORRECTION = 170.18;
+
+	private SomatotypeCalculationService() {
+	}
+
+	public static SomatotypeResult calculate(final Double weightKg, final Double heightMeters,
+			final Double tricepsSkinfoldMm, final Double subscapularSkinfoldMm, final Double supraspinalSkinfoldMm,
+			final Double flexedArmGirthCm, final Double calfGirthCm, final Double medialCalfSkinfoldMm,
+			final Double humerusBreadthCm, final Double femurBreadthCm, final Integer patientAgeYears) {
+		if (patientAgeYears != null && patientAgeYears < MIN_ADULT_AGE_YEARS) {
+			return SomatotypeResult.builder()
+				.missingMeasurements(List.of("Paciente menor de 18 años (somatotipo solo para adultos)"))
+				.build();
+		}
+
+		final List<String> missing = collectMissingMeasurements(weightKg, heightMeters, tricepsSkinfoldMm,
+				subscapularSkinfoldMm, supraspinalSkinfoldMm, flexedArmGirthCm, calfGirthCm, medialCalfSkinfoldMm,
+				humerusBreadthCm, femurBreadthCm);
+		if (!missing.isEmpty()) {
+			return SomatotypeResult.builder().missingMeasurements(missing).build();
+		}
+
+		final double heightCm = heightMeters * 100.0;
+		final double endomorphy = SomatotypeResult.clampRating(
+				calculateEndomorphy(tricepsSkinfoldMm, subscapularSkinfoldMm, supraspinalSkinfoldMm, heightCm));
+		final double correctedArm = flexedArmGirthCm - tricepsSkinfoldMm / 10.0;
+		final double correctedCalf = calfGirthCm - medialCalfSkinfoldMm / 10.0;
+		final double mesomorphy = SomatotypeResult
+			.clampRating(calculateMesomorphy(correctedArm, correctedCalf, humerusBreadthCm, femurBreadthCm, heightCm));
+		final double ectomorphy = SomatotypeResult.clampRating(calculateEctomorphy(heightCm, weightKg));
+		final double chartX = ectomorphy - endomorphy;
+		final double chartY = 2.0 * mesomorphy - (ectomorphy + endomorphy);
+
+		return SomatotypeResult.builder()
+			.endomorphy(endomorphy)
+			.mesomorphy(mesomorphy)
+			.ectomorphy(ectomorphy)
+			.somatocartaX(chartX)
+			.somatocartaY(chartY)
+			.missingMeasurements(List.of())
+			.build();
+	}
+
+	static double calculateEndomorphy(final double tricepsMm, final double subscapularMm, final double supraspinalMm,
+			final double heightCm) {
+		final double sumSkinfolds = tricepsMm + subscapularMm + supraspinalMm;
+		final double x = sumSkinfolds * (HEIGHT_CORRECTION / heightCm);
+		return -0.7182 + 0.1451 * x - 0.00068 * x * x + 0.0000014 * x * x * x;
+	}
+
+	static double calculateMesomorphy(final double correctedArmGirthCm, final double correctedCalfGirthCm,
+			final double humerusBreadthCm, final double femurBreadthCm, final double heightCm) {
+		return 0.858 * humerusBreadthCm + 0.601 * femurBreadthCm + 0.188 * correctedArmGirthCm
+				+ 0.161 * correctedCalfGirthCm - 0.131 * heightCm + 4.5;
+	}
+
+	static double calculateEctomorphy(final double heightCm, final double weightKg) {
+		final double hwr = heightCm / Math.cbrt(weightKg);
+		if (hwr >= 40.75) {
+			return 0.732 * hwr - 28.58;
+		}
+		if (hwr > 38.25) {
+			return 0.463 * hwr - 17.63;
+		}
+		return 0.1;
+	}
+
+	private static List<String> collectMissingMeasurements(final Double weightKg, final Double heightMeters,
+			final Double tricepsSkinfoldMm, final Double subscapularSkinfoldMm, final Double supraspinalSkinfoldMm,
+			final Double flexedArmGirthCm, final Double calfGirthCm, final Double medialCalfSkinfoldMm,
+			final Double humerusBreadthCm, final Double femurBreadthCm) {
+		final List<String> missing = new ArrayList<>();
+		if (weightKg == null || weightKg <= 0) {
+			missing.add("Peso");
+		}
+		if (heightMeters == null || heightMeters <= 0) {
+			missing.add("Estatura");
+		}
+		if (tricepsSkinfoldMm == null) {
+			missing.add("Pliegue tríceps");
+		}
+		if (subscapularSkinfoldMm == null) {
+			missing.add("Pliegue subescapular");
+		}
+		if (supraspinalSkinfoldMm == null) {
+			missing.add("Pliegue supraespinal");
+		}
+		if (flexedArmGirthCm == null) {
+			missing.add("Perímetro brazo contraído");
+		}
+		if (calfGirthCm == null) {
+			missing.add("Perímetro pantorrilla");
+		}
+		if (medialCalfSkinfoldMm == null) {
+			missing.add("Pliegue pantorrilla medial");
+		}
+		if (humerusBreadthCm == null) {
+			missing.add("Diámetro húmero");
+		}
+		if (femurBreadthCm == null) {
+			missing.add("Diámetro fémur");
+		}
+		return missing;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeCalculationService.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeCalculationService.java
@@ -15,7 +15,7 @@ import java.util.List;
  * {@code 0.858×humerus + 0.601×femur + 0.188×correctedArm + 0.161×correctedCalf - 0.131×heightCm + 4.5}
  * with corrected girths = girth - skinfold/10</li>
  * <li><b>Ectomorphy:</b> from HWR = heightCm / ∛weightKg; piecewise linear (see
- * {@link #calculateEctomorphy(double)})</li>
+ * {@link #calculateEctomorphy(double, double)})</li>
  * </ul>
  * Ratings ≤ 0 are assigned 0.1 per Heath-Carter convention. Same formulas apply to both
  * sexes; reference norms differ by sex but calculation does not.
@@ -26,34 +26,34 @@ public final class SomatotypeCalculationService {
 
 	private static final double HEIGHT_CORRECTION = 170.18;
 
+	private static final double ENDO_CUBIC_COEFFICIENT = 0.000_001_4;
+
+	private static final double ENDO_QUADRATIC_COEFFICIENT = 0.000_68;
+
 	private SomatotypeCalculationService() {
 	}
 
-	public static SomatotypeResult calculate(final Double weightKg, final Double heightMeters,
-			final Double tricepsSkinfoldMm, final Double subscapularSkinfoldMm, final Double supraspinalSkinfoldMm,
-			final Double flexedArmGirthCm, final Double calfGirthCm, final Double medialCalfSkinfoldMm,
-			final Double humerusBreadthCm, final Double femurBreadthCm, final Integer patientAgeYears) {
+	public static SomatotypeResult calculate(final SomatotypeMeasurements measurements, final Integer patientAgeYears) {
 		if (patientAgeYears != null && patientAgeYears < MIN_ADULT_AGE_YEARS) {
 			return SomatotypeResult.builder()
 				.missingMeasurements(List.of("Paciente menor de 18 años (somatotipo solo para adultos)"))
 				.build();
 		}
 
-		final List<String> missing = collectMissingMeasurements(weightKg, heightMeters, tricepsSkinfoldMm,
-				subscapularSkinfoldMm, supraspinalSkinfoldMm, flexedArmGirthCm, calfGirthCm, medialCalfSkinfoldMm,
-				humerusBreadthCm, femurBreadthCm);
+		final List<String> missing = collectMissingMeasurements(measurements);
 		if (!missing.isEmpty()) {
 			return SomatotypeResult.builder().missingMeasurements(missing).build();
 		}
 
-		final double heightCm = heightMeters * 100.0;
-		final double endomorphy = SomatotypeResult.clampRating(
-				calculateEndomorphy(tricepsSkinfoldMm, subscapularSkinfoldMm, supraspinalSkinfoldMm, heightCm));
-		final double correctedArm = flexedArmGirthCm - tricepsSkinfoldMm / 10.0;
-		final double correctedCalf = calfGirthCm - medialCalfSkinfoldMm / 10.0;
-		final double mesomorphy = SomatotypeResult
-			.clampRating(calculateMesomorphy(correctedArm, correctedCalf, humerusBreadthCm, femurBreadthCm, heightCm));
-		final double ectomorphy = SomatotypeResult.clampRating(calculateEctomorphy(heightCm, weightKg));
+		final double heightCm = measurements.getHeightMeters() * 100.0;
+		final double endomorphy = SomatotypeResult.clampRating(calculateEndomorphy(measurements.getTricepsSkinfoldMm(),
+				measurements.getSubscapularSkinfoldMm(), measurements.getSupraspinalSkinfoldMm(), heightCm));
+		final double correctedArm = measurements.getFlexedArmGirthCm() - measurements.getTricepsSkinfoldMm() / 10.0;
+		final double correctedCalf = measurements.getCalfGirthCm() - measurements.getMedialCalfSkinfoldMm() / 10.0;
+		final double mesomorphy = SomatotypeResult.clampRating(calculateMesomorphy(correctedArm, correctedCalf,
+				measurements.getHumerusBreadthCm(), measurements.getFemurBreadthCm(), heightCm));
+		final double ectomorphy = SomatotypeResult
+			.clampRating(calculateEctomorphy(heightCm, measurements.getWeightKg()));
 		final double chartX = ectomorphy - endomorphy;
 		final double chartY = 2.0 * mesomorphy - (ectomorphy + endomorphy);
 
@@ -71,7 +71,7 @@ public final class SomatotypeCalculationService {
 			final double heightCm) {
 		final double sumSkinfolds = tricepsMm + subscapularMm + supraspinalMm;
 		final double x = sumSkinfolds * (HEIGHT_CORRECTION / heightCm);
-		return -0.7182 + 0.1451 * x - 0.00068 * x * x + 0.0000014 * x * x * x;
+		return -0.7182 + 0.1451 * x - ENDO_QUADRATIC_COEFFICIENT * x * x + ENDO_CUBIC_COEFFICIENT * x * x * x;
 	}
 
 	static double calculateMesomorphy(final double correctedArmGirthCm, final double correctedCalfGirthCm,
@@ -91,39 +91,36 @@ public final class SomatotypeCalculationService {
 		return 0.1;
 	}
 
-	private static List<String> collectMissingMeasurements(final Double weightKg, final Double heightMeters,
-			final Double tricepsSkinfoldMm, final Double subscapularSkinfoldMm, final Double supraspinalSkinfoldMm,
-			final Double flexedArmGirthCm, final Double calfGirthCm, final Double medialCalfSkinfoldMm,
-			final Double humerusBreadthCm, final Double femurBreadthCm) {
+	private static List<String> collectMissingMeasurements(final SomatotypeMeasurements measurements) {
 		final List<String> missing = new ArrayList<>();
-		if (weightKg == null || weightKg <= 0) {
+		if (measurements.getWeightKg() == null || measurements.getWeightKg() <= 0) {
 			missing.add("Peso");
 		}
-		if (heightMeters == null || heightMeters <= 0) {
+		if (measurements.getHeightMeters() == null || measurements.getHeightMeters() <= 0) {
 			missing.add("Estatura");
 		}
-		if (tricepsSkinfoldMm == null) {
+		if (measurements.getTricepsSkinfoldMm() == null) {
 			missing.add("Pliegue tríceps");
 		}
-		if (subscapularSkinfoldMm == null) {
+		if (measurements.getSubscapularSkinfoldMm() == null) {
 			missing.add("Pliegue subescapular");
 		}
-		if (supraspinalSkinfoldMm == null) {
+		if (measurements.getSupraspinalSkinfoldMm() == null) {
 			missing.add("Pliegue supraespinal");
 		}
-		if (flexedArmGirthCm == null) {
+		if (measurements.getFlexedArmGirthCm() == null) {
 			missing.add("Perímetro brazo contraído");
 		}
-		if (calfGirthCm == null) {
+		if (measurements.getCalfGirthCm() == null) {
 			missing.add("Perímetro pantorrilla");
 		}
-		if (medialCalfSkinfoldMm == null) {
+		if (measurements.getMedialCalfSkinfoldMm() == null) {
 			missing.add("Pliegue pantorrilla medial");
 		}
-		if (humerusBreadthCm == null) {
+		if (measurements.getHumerusBreadthCm() == null) {
 			missing.add("Diámetro húmero");
 		}
-		if (femurBreadthCm == null) {
+		if (measurements.getFemurBreadthCm() == null) {
 			missing.add("Diámetro fémur");
 		}
 		return missing;

--- a/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeMeasurements.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeMeasurements.java
@@ -1,0 +1,31 @@
+package com.nutriconsultas.clinical.exam.anthropometric;
+
+import lombok.Builder;
+import lombok.Value;
+
+/** Raw anthropometric inputs for Heath-Carter somatotype calculation. */
+@Value
+@Builder(toBuilder = true)
+public class SomatotypeMeasurements {
+
+	Double weightKg;
+
+	Double heightMeters;
+
+	Double tricepsSkinfoldMm;
+
+	Double subscapularSkinfoldMm;
+
+	Double supraspinalSkinfoldMm;
+
+	Double flexedArmGirthCm;
+
+	Double calfGirthCm;
+
+	Double medialCalfSkinfoldMm;
+
+	Double humerusBreadthCm;
+
+	Double femurBreadthCm;
+
+}

--- a/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeResult.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeResult.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.clinical.exam.anthropometric;
+
+import java.util.Collections;
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Result of a Heath-Carter somatotype calculation.
+ *
+ * <p>
+ * Chart coordinates follow Carter &amp; Heath (1990):
+ * {@code x = ectomorphy - endomorphy},
+ * {@code y = 2 × mesomorphy - (ectomorphy + endomorphy)}.
+ */
+@Value
+@Builder
+public class SomatotypeResult {
+
+	private static final double MIN_RATING = 0.1;
+
+	Double endomorphy;
+
+	Double mesomorphy;
+
+	Double ectomorphy;
+
+	Double somatocartaX;
+
+	Double somatocartaY;
+
+	@Builder.Default
+	List<String> missingMeasurements = Collections.emptyList();
+
+	public boolean isCalculable() {
+		return endomorphy != null && mesomorphy != null && ectomorphy != null;
+	}
+
+	public static double clampRating(final double value) {
+		return value <= 0 ? MIN_RATING : value;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeService.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeService.java
@@ -1,0 +1,122 @@
+package com.nutriconsultas.clinical.exam.anthropometric;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.springframework.stereotype.Service;
+
+import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
+import com.nutriconsultas.paciente.Paciente;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Applies Heath-Carter somatotype calculation to anthropometric measurements (adults
+ * only).
+ */
+@Service
+@Slf4j
+public class SomatotypeService {
+
+	public SomatotypeResult applyToMeasurement(final AnthropometricMeasurement measurement, final Paciente paciente) {
+		ensureBodyComposition(measurement);
+		final Integer age = calculateAge(paciente != null ? paciente.getDob() : null);
+		final SomatotypeResult result = SomatotypeCalculationService.calculate(measurement.getPeso(),
+				measurement.getEstatura(), getTricepsSkinfold(measurement), getSubscapularSkinfold(measurement),
+				getSupraspinalSkinfold(measurement), getFlexedArmGirth(measurement), getCalfGirth(measurement),
+				getMedialCalfSkinfold(measurement), getHumerusBreadth(measurement), getFemurBreadth(measurement), age);
+
+		if (result.isCalculable()) {
+			persistResult(measurement, result);
+			if (log.isDebugEnabled()) {
+				log.debug("Somatotype calculated for measurement: endo={}, meso={}, ecto={}", result.getEndomorphy(),
+						result.getMesomorphy(), result.getEctomorphy());
+			}
+		}
+		else {
+			clearSomatotype(measurement);
+		}
+		return result;
+	}
+
+	private void persistResult(final AnthropometricMeasurement measurement, final SomatotypeResult result) {
+		final BodyComposition composition = measurement.getBodyComposition();
+		composition.setEndomorphy(result.getEndomorphy());
+		composition.setMesomorphy(result.getMesomorphy());
+		composition.setEctomorphy(result.getEctomorphy());
+		composition.setSomatocartaX(result.getSomatocartaX());
+		composition.setSomatocartaY(result.getSomatocartaY());
+	}
+
+	private void clearSomatotype(final AnthropometricMeasurement measurement) {
+		final BodyComposition composition = measurement.getBodyComposition();
+		if (composition == null) {
+			return;
+		}
+		composition.setEndomorphy(null);
+		composition.setMesomorphy(null);
+		composition.setEctomorphy(null);
+		composition.setSomatocartaX(null);
+		composition.setSomatocartaY(null);
+	}
+
+	private void ensureBodyComposition(final AnthropometricMeasurement measurement) {
+		if (measurement.getBodyComposition() == null) {
+			measurement.setBodyComposition(new BodyComposition());
+		}
+	}
+
+	private Double getTricepsSkinfold(final AnthropometricMeasurement measurement) {
+		return measurement.getSkinfolds() != null ? measurement.getSkinfolds().getTricepsSkinfold() : null;
+	}
+
+	private Double getSubscapularSkinfold(final AnthropometricMeasurement measurement) {
+		return measurement.getSkinfolds() != null ? measurement.getSkinfolds().getSubscapularSkinfold() : null;
+	}
+
+	private Double getSupraspinalSkinfold(final AnthropometricMeasurement measurement) {
+		return measurement.getSkinfolds() != null ? measurement.getSkinfolds().getSupraespinalSkinfold() : null;
+	}
+
+	private Double getMedialCalfSkinfold(final AnthropometricMeasurement measurement) {
+		return measurement.getSkinfolds() != null ? measurement.getSkinfolds().getMedialCalfSkinfold() : null;
+	}
+
+	private Double getFlexedArmGirth(final AnthropometricMeasurement measurement) {
+		return measurement.getCircumferences() != null
+				? measurement.getCircumferences().getMidUpperArmCircumferenceContracted() : null;
+	}
+
+	private Double getCalfGirth(final AnthropometricMeasurement measurement) {
+		return measurement.getCircumferences() != null ? measurement.getCircumferences().getCalfCircumference() : null;
+	}
+
+	private Double getHumerusBreadth(final AnthropometricMeasurement measurement) {
+		return measurement.getDiameters() != null ? measurement.getDiameters().getHumerusDiameter() : null;
+	}
+
+	private Double getFemurBreadth(final AnthropometricMeasurement measurement) {
+		return measurement.getDiameters() != null ? measurement.getDiameters().getFemurDiameter() : null;
+	}
+
+	private Integer calculateAge(final Date dob) {
+		if (dob == null) {
+			return null;
+		}
+		final LocalDate birthDate;
+		if (dob instanceof java.sql.Date sqlDate) {
+			birthDate = sqlDate.toLocalDate();
+		}
+		else {
+			birthDate = dob.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+		}
+		final LocalDate currentDate = LocalDate.now();
+		if (birthDate.isAfter(currentDate)) {
+			return null;
+		}
+		return Period.between(birthDate, currentDate).getYears();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeService.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeService.java
@@ -23,10 +23,19 @@ public class SomatotypeService {
 	public SomatotypeResult applyToMeasurement(final AnthropometricMeasurement measurement, final Paciente paciente) {
 		ensureBodyComposition(measurement);
 		final Integer age = calculateAge(paciente != null ? paciente.getDob() : null);
-		final SomatotypeResult result = SomatotypeCalculationService.calculate(measurement.getPeso(),
-				measurement.getEstatura(), getTricepsSkinfold(measurement), getSubscapularSkinfold(measurement),
-				getSupraspinalSkinfold(measurement), getFlexedArmGirth(measurement), getCalfGirth(measurement),
-				getMedialCalfSkinfold(measurement), getHumerusBreadth(measurement), getFemurBreadth(measurement), age);
+		final SomatotypeMeasurements inputs = SomatotypeMeasurements.builder()
+			.weightKg(measurement.getPeso())
+			.heightMeters(measurement.getEstatura())
+			.tricepsSkinfoldMm(getTricepsSkinfold(measurement))
+			.subscapularSkinfoldMm(getSubscapularSkinfold(measurement))
+			.supraspinalSkinfoldMm(getSupraspinalSkinfold(measurement))
+			.flexedArmGirthCm(getFlexedArmGirth(measurement))
+			.calfGirthCm(getCalfGirth(measurement))
+			.medialCalfSkinfoldMm(getMedialCalfSkinfold(measurement))
+			.humerusBreadthCm(getHumerusBreadth(measurement))
+			.femurBreadthCm(getFemurBreadth(measurement))
+			.build();
+		final SomatotypeResult result = SomatotypeCalculationService.calculate(inputs, age);
 
 		if (result.isCalculable()) {
 			persistResult(measurement, result);

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -72,6 +72,9 @@ public class PacienteController extends AbstractAuthorizedController {
 	private com.nutriconsultas.clinical.exam.anthropometric.BodyCompositionService bodyCompositionService;
 
 	@Autowired
+	private com.nutriconsultas.clinical.exam.anthropometric.SomatotypeService somatotypeService;
+
+	@Autowired
 	private PacienteDietaService pacienteDietaService;
 
 	@Autowired
@@ -691,6 +694,7 @@ public class PacienteController extends AbstractAuthorizedController {
 		updatePatientWeightIfNeededForMeasurement(paciente, measurement, bmiResult.getImc(), bmiResult.getNivelPeso(),
 				pacienteId, measurement.getMeasurementDateTime());
 		setMeasurementCalculatedValues(measurement, bmiResult);
+		somatotypeService.applyToMeasurement(measurement, paciente);
 		setMeasurementDefaultValues(measurement);
 
 		log.debug("Medición antropométrica lista para grabar {}",

--- a/src/main/java/com/nutriconsultas/reports/PatientReportService.java
+++ b/src/main/java/com/nutriconsultas/reports/PatientReportService.java
@@ -129,6 +129,7 @@ public class PatientReportService {
 		final List<ClinicalExam> exams = getExams(pacienteId, startDate, endDate);
 		final List<PacienteDieta> dietaryPlans = getDietaryPlans(pacienteId);
 		final List<WeightBmiDataPoint> weightBmiTrend = buildWeightBmiTrend(consultations, measurements, exams);
+		final AnthropometricMeasurement latestSomatotypeMeasurement = findLatestSomatotypeMeasurement(measurements);
 
 		// Prepare context for Thymeleaf template
 		final Context context = new Context();
@@ -138,6 +139,7 @@ public class PatientReportService {
 		context.setVariable("exams", exams);
 		context.setVariable("dietaryPlans", dietaryPlans);
 		context.setVariable("weightBmiTrend", weightBmiTrend);
+		context.setVariable("latestSomatotypeMeasurement", latestSomatotypeMeasurement);
 		context.setVariable("startDate", startDate);
 		context.setVariable("endDate", endDate);
 		context.setVariable("reportDate", new Date());
@@ -238,6 +240,15 @@ public class PatientReportService {
 		trend.sort(Comparator.comparing(WeightBmiDataPoint::getDate));
 
 		return trend;
+	}
+
+	private AnthropometricMeasurement findLatestSomatotypeMeasurement(
+			final List<AnthropometricMeasurement> measurements) {
+		return measurements.stream()
+			.filter(measurement -> measurement.getEndomorphy() != null)
+			.max(Comparator.comparing(AnthropometricMeasurement::getMeasurementDateTime,
+					Comparator.nullsLast(Comparator.naturalOrder())))
+			.orElse(null);
 	}
 
 	/**

--- a/src/main/java/com/nutriconsultas/reports/ReportTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/reports/ReportTemplateValidator.java
@@ -9,6 +9,7 @@ import com.nutriconsultas.calendar.CalendarEvent;
 import com.nutriconsultas.calendar.EventStatus;
 import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
 import com.nutriconsultas.clinical.exam.ClinicalExam;
+import com.nutriconsultas.clinical.exam.anthropometric.BodyComposition;
 import com.nutriconsultas.clinical.exam.anthropometric.BodyMass;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteDieta;
@@ -55,6 +56,7 @@ public class ReportTemplateValidator extends BaseTemplateValidator {
 		// Create mock weight/BMI trend
 		final List<PatientReportService.WeightBmiDataPoint> mockWeightBmiTrend = createMockWeightBmiTrend();
 		variables.put("weightBmiTrend", mockWeightBmiTrend);
+		variables.put("latestSomatotypeMeasurement", mockMeasurements.isEmpty() ? null : mockMeasurements.get(0));
 
 		// Create date variables
 		final Date now = new Date();
@@ -141,6 +143,13 @@ public class ReportTemplateValidator extends BaseTemplateValidator {
 		bodyMass.setHeight(1.75);
 		bodyMass.setImc(22.86);
 		measurement.setBodyMass(bodyMass);
+		final BodyComposition bodyComposition = new BodyComposition();
+		bodyComposition.setEndomorphy(3.2);
+		bodyComposition.setMesomorphy(4.5);
+		bodyComposition.setEctomorphy(2.8);
+		bodyComposition.setSomatocartaX(-0.4);
+		bodyComposition.setSomatocartaY(3.0);
+		measurement.setBodyComposition(bodyComposition);
 		measurements.add(measurement);
 		return measurements;
 	}

--- a/src/main/resources/templates/sbadmin/pacientes/antropometricos.html
+++ b/src/main/resources/templates/sbadmin/pacientes/antropometricos.html
@@ -568,6 +568,7 @@
                           </div>
 
                           <div th:insert="~{sbadmin/pacientes/calculation-subtabs :: calculationSubTabsStyle}"></div>
+                          <div th:insert="~{sbadmin/pacientes/somatocarta :: somatocartaStyle}"></div>
                           <div th:insert="~{sbadmin/pacientes/calculation-subtabs :: calculationSubTabsNav}"></div>
                           <div class="tab-content border rounded p-3 bg-white" id="calculationSubTabsContent">
 
@@ -1124,6 +1125,63 @@
                                       <i class="fas fa-copy"></i> Copiar a Formulario
                                     </button>
                                   </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          </div>
+
+                          <!-- Somatotipo Heath-Carter -->
+                          <div class="tab-pane fade" id="calc-somatotype" role="tabpanel" aria-labelledby="calc-somatotype-subtab">
+                          <div class="row">
+                            <div class="col-lg-5">
+                              <div class="card mb-3">
+                                <div class="card-body">
+                                  <h6 class="card-title">Somatotipo Heath-Carter</h6>
+                                  <p class="text-muted small mb-2">
+                                    Método clásico (adultos ≥18 años). Se calcula al guardar con pliegues tríceps,
+                                    subescapular y supraespinal; perímetros brazo contraído y pantorrilla; diámetros
+                                    húmero y fémur; peso y estatura.
+                                  </p>
+                                  <div class="row text-center mb-3">
+                                    <div class="col-4">
+                                      <div class="small text-muted">Endomorfia</div>
+                                      <div class="h5 mb-0 text-primary" id="somatotype-endo-result">-</div>
+                                    </div>
+                                    <div class="col-4">
+                                      <div class="small text-muted">Mesomorfia</div>
+                                      <div class="h5 mb-0 text-primary" id="somatotype-meso-result">-</div>
+                                    </div>
+                                    <div class="col-4">
+                                      <div class="small text-muted">Ectomorfia</div>
+                                      <div class="h5 mb-0 text-primary" id="somatotype-ecto-result">-</div>
+                                    </div>
+                                  </div>
+                                  <div class="alert alert-warning small mb-0 d-none" id="somatotype-missing-alert">
+                                    <strong>Mediciones faltantes:</strong>
+                                    <span id="somatotype-missing-list"></span>
+                                  </div>
+                                  <div class="alert alert-info small mb-0 d-none" id="somatotype-pediatric-alert">
+                                    El somatotipo Heath-Carter solo se calcula en pacientes adultos (≥18 años).
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div class="col-lg-7">
+                              <div class="card mb-3">
+                                <div class="card-body text-center">
+                                  <h6 class="card-title">Somatocarta</h6>
+                                  <svg id="somatotype-chart-live" class="somatocarta-svg" viewBox="0 0 220 200"
+                                       xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Somatocarta">
+                                    <polygon points="20,185 200,185 110,15" fill="#f8f9fc" stroke="#858796" stroke-width="1.5"/>
+                                    <text x="8" y="195" font-size="9" fill="#5a5c69">Endo</text>
+                                    <text x="188" y="195" font-size="9" fill="#5a5c69">Meso</text>
+                                    <text x="98" y="12" font-size="9" fill="#5a5c69">Ecto</text>
+                                    <g id="somatotype-chart-point" style="display:none">
+                                      <circle id="somatotype-chart-circle" r="6" fill="#4e73df" stroke="#2e59d9" stroke-width="1.5"/>
+                                      <text id="somatotype-chart-label" font-size="8" fill="#3a3b45"></text>
+                                    </g>
+                                  </svg>
                                 </div>
                               </div>
                             </div>

--- a/src/main/resources/templates/sbadmin/pacientes/calculation-script.html
+++ b/src/main/resources/templates/sbadmin/pacientes/calculation-script.html
@@ -43,6 +43,7 @@
         updateIdealWeightCalculations();
         updateTotalBodyWaterCalculations();
         updateBodyCompositionCalculations();
+        updateSomatotypeCalculations();
       }
     }
 
@@ -527,6 +528,7 @@
         bodyCompBmiField.value = classicBmi.toFixed(2);
         updateBodyCompositionCalculations();
       }
+      updateSomatotypeCalculations();
 
       // Update Masa Corporal (same as weight)
       const bodyMassValueElement = document.getElementById('body-mass-value-result');
@@ -835,6 +837,168 @@
       updateIdealWeightCalculations();
       updateTotalBodyWaterCalculations();
       updateBodyCompositionCalculations();
+      updateSomatotypeCalculations();
+    }
+
+    const SOMATOTYPE_MIN_ADULT_AGE = 18;
+
+    function parseMeasurementInput(selector) {
+      const field = document.querySelector(selector);
+      if (!field || field.value === '' || field.value == null) {
+        return null;
+      }
+      const value = parseFloat(field.value);
+      return Number.isFinite(value) ? value : null;
+    }
+
+    function clampSomatotypeRating(value) {
+      return value <= 0 ? 0.1 : value;
+    }
+
+    function calculateHeathCarterEndomorphy(triceps, subscapular, supraspinal, heightCm) {
+      const sum = triceps + subscapular + supraspinal;
+      const x = sum * (170.18 / heightCm);
+      return -0.7182 + 0.1451 * x - 0.00068 * x * x + 0.0000014 * x * x * x;
+    }
+
+    function calculateHeathCarterMesomorphy(correctedArm, correctedCalf, humerus, femur, heightCm) {
+      return 0.858 * humerus + 0.601 * femur + 0.188 * correctedArm
+        + 0.161 * correctedCalf - 0.131 * heightCm + 4.5;
+    }
+
+    function calculateHeathCarterEctomorphy(heightCm, weightKg) {
+      const hwr = heightCm / Math.cbrt(weightKg);
+      if (hwr >= 40.75) {
+        return 0.732 * hwr - 28.58;
+      }
+      if (hwr > 38.25) {
+        return 0.463 * hwr - 17.63;
+      }
+      return 0.1;
+    }
+
+    function collectSomatotypeMissingMeasurements(weight, height, triceps, subscapular, supraspinal,
+        flexedArm, calf, medialCalf, humerus, femur) {
+      const missing = [];
+      if (!weight || weight <= 0) { missing.push('Peso'); }
+      if (!height || height <= 0) { missing.push('Estatura'); }
+      if (triceps == null) { missing.push('Pliegue tríceps'); }
+      if (subscapular == null) { missing.push('Pliegue subescapular'); }
+      if (supraspinal == null) { missing.push('Pliegue supraespinal'); }
+      if (flexedArm == null) { missing.push('Perímetro brazo contraído'); }
+      if (calf == null) { missing.push('Perímetro pantorrilla'); }
+      if (medialCalf == null) { missing.push('Pliegue pantorrilla medial'); }
+      if (humerus == null) { missing.push('Diámetro húmero'); }
+      if (femur == null) { missing.push('Diámetro fémur'); }
+      return missing;
+    }
+
+    function updateSomatotypeChart(endomorphy, mesomorphy, ectomorphy) {
+      const pointGroup = document.getElementById('somatotype-chart-point');
+      const circle = document.getElementById('somatotype-chart-circle');
+      const label = document.getElementById('somatotype-chart-label');
+      if (!pointGroup || !circle || !label) {
+        return;
+      }
+      if (endomorphy == null || mesomorphy == null || ectomorphy == null) {
+        pointGroup.style.display = 'none';
+        return;
+      }
+      const chartX = ectomorphy - endomorphy;
+      const chartY = 2 * mesomorphy - (ectomorphy + endomorphy);
+      const plotX = 110 + chartX * 7;
+      const plotY = 185 - chartY * 7;
+      circle.setAttribute('cx', plotX);
+      circle.setAttribute('cy', plotY);
+      label.setAttribute('x', plotX + 8);
+      label.setAttribute('y', plotY + 4);
+      label.textContent = endomorphy.toFixed(1) + '-' + mesomorphy.toFixed(1) + '-' + ectomorphy.toFixed(1);
+      pointGroup.style.display = '';
+    }
+
+    function updateSomatotypeCalculations() {
+      const endoEl = document.getElementById('somatotype-endo-result');
+      if (!endoEl) {
+        return;
+      }
+
+      const pediatricAlert = document.getElementById('somatotype-pediatric-alert');
+      const missingAlert = document.getElementById('somatotype-missing-alert');
+      const missingList = document.getElementById('somatotype-missing-list');
+
+      if (patientAge != null && patientAge < SOMATOTYPE_MIN_ADULT_AGE) {
+        endoEl.textContent = '-';
+        document.getElementById('somatotype-meso-result').textContent = '-';
+        document.getElementById('somatotype-ecto-result').textContent = '-';
+        if (pediatricAlert) { pediatricAlert.classList.remove('d-none'); }
+        if (missingAlert) { missingAlert.classList.add('d-none'); }
+        updateSomatotypeChart(null, null, null);
+        return;
+      }
+      if (pediatricAlert) { pediatricAlert.classList.add('d-none'); }
+
+      const weight = parseMeasurementInput('input[name*="bodyMass.weight"]');
+      const height = parseMeasurementInput('input[name*="bodyMass.height"]');
+      const triceps = parseMeasurementInput('input[name*="skinfolds.tricepsSkinfold"]');
+      const subscapular = parseMeasurementInput('input[name*="skinfolds.subscapularSkinfold"]');
+      const supraspinal = parseMeasurementInput('input[name*="skinfolds.supraespinalSkinfold"]');
+      const flexedArm = parseMeasurementInput('input[name*="circumferences.midUpperArmCircumferenceContracted"]');
+      const calf = parseMeasurementInput('input[name*="circumferences.calfCircumference"]');
+      const medialCalf = parseMeasurementInput('input[name*="skinfolds.medialCalfSkinfold"]');
+      const humerus = parseMeasurementInput('input[name*="diameters.humerusDiameter"]');
+      const femur = parseMeasurementInput('input[name*="diameters.femurDiameter"]');
+
+      const missing = collectSomatotypeMissingMeasurements(weight, height, triceps, subscapular, supraspinal,
+        flexedArm, calf, medialCalf, humerus, femur);
+
+      if (missing.length > 0) {
+        endoEl.textContent = '-';
+        document.getElementById('somatotype-meso-result').textContent = '-';
+        document.getElementById('somatotype-ecto-result').textContent = '-';
+        if (missingAlert && missingList) {
+          missingList.textContent = missing.join(', ');
+          missingAlert.classList.remove('d-none');
+        }
+        updateSomatotypeChart(null, null, null);
+        return;
+      }
+
+      if (missingAlert) { missingAlert.classList.add('d-none'); }
+
+      const heightCm = height * 100;
+      const endomorphy = clampSomatotypeRating(
+        calculateHeathCarterEndomorphy(triceps, subscapular, supraspinal, heightCm));
+      const correctedArm = flexedArm - triceps / 10;
+      const correctedCalf = calf - medialCalf / 10;
+      const mesomorphy = clampSomatotypeRating(
+        calculateHeathCarterMesomorphy(correctedArm, correctedCalf, humerus, femur, heightCm));
+      const ectomorphy = clampSomatotypeRating(calculateHeathCarterEctomorphy(heightCm, weight));
+
+      endoEl.textContent = endomorphy.toFixed(1);
+      document.getElementById('somatotype-meso-result').textContent = mesomorphy.toFixed(1);
+      document.getElementById('somatotype-ecto-result').textContent = ectomorphy.toFixed(1);
+      updateSomatotypeChart(endomorphy, mesomorphy, ectomorphy);
+    }
+
+    function attachSomatotypeInputListeners() {
+      const selectors = [
+        'input[name*="bodyMass.weight"]',
+        'input[name*="bodyMass.height"]',
+        'input[name*="skinfolds.tricepsSkinfold"]',
+        'input[name*="skinfolds.subscapularSkinfold"]',
+        'input[name*="skinfolds.supraespinalSkinfold"]',
+        'input[name*="skinfolds.medialCalfSkinfold"]',
+        'input[name*="circumferences.midUpperArmCircumferenceContracted"]',
+        'input[name*="circumferences.calfCircumference"]',
+        'input[name*="diameters.humerusDiameter"]',
+        'input[name*="diameters.femurDiameter"]'
+      ];
+      selectors.forEach(function(selector) {
+        const field = document.querySelector(selector);
+        if (field) {
+          field.addEventListener('input', updateSomatotypeCalculations);
+        }
+      });
     }
 
     // Event listeners for BMI inputs
@@ -943,6 +1107,8 @@
       updateIdealWeightCalculations();
       updateTotalBodyWaterCalculations();
       updateBodyCompositionCalculations();
+      updateSomatotypeCalculations();
+      attachSomatotypeInputListeners();
       toggleStressCalculationFields();
       updateGetCalculations();
     });

--- a/src/main/resources/templates/sbadmin/pacientes/calculation-subtabs.html
+++ b/src/main/resources/templates/sbadmin/pacientes/calculation-subtabs.html
@@ -121,6 +121,13 @@
           <i class="fas fa-percentage"></i> Composición
         </button>
       </li>
+      <li class="nav-item">
+        <button type="button" class="nav-link calc-subtab-link" id="calc-somatotype-subtab"
+                data-calc-target="calc-somatotype" role="tab"
+                aria-controls="calc-somatotype" aria-selected="false">
+          <i class="fas fa-draw-polygon"></i> Somatotipo
+        </button>
+      </li>
     </ul>
   </div>
 </body>

--- a/src/main/resources/templates/sbadmin/pacientes/somatocarta.html
+++ b/src/main/resources/templates/sbadmin/pacientes/somatocarta.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+  <!--
+    Heath-Carter somatocarta (triangular chart).
+    Parameters: endomorphy, mesomorphy, ectomorphy (required for plot point).
+    Optional: chartId suffix for unique SVG ids in pages with multiple charts.
+  -->
+  <div th:fragment="somatocarta(endomorphy, mesomorphy, ectomorphy, chartId)">
+    <svg th:id="${'somatocarta-' + chartId}" class="somatocarta-svg" viewBox="0 0 220 200"
+         xmlns="http://www.w3.org/2000/svg" role="img"
+         th:attr="aria-label=${endomorphy != null ? 'Somatocarta ' + #numbers.formatDecimal(endomorphy,1,1) + '-' + #numbers.formatDecimal(mesomorphy,1,1) + '-' + #numbers.formatDecimal(ectomorphy,1,1) : 'Somatocarta sin datos'}">
+      <polygon points="20,185 200,185 110,15" fill="#f8f9fc" stroke="#858796" stroke-width="1.5"/>
+      <text x="8" y="195" font-size="9" fill="#5a5c69">Endo</text>
+      <text x="188" y="195" font-size="9" fill="#5a5c69">Meso</text>
+      <text x="98" y="12" font-size="9" fill="#5a5c69">Ecto</text>
+      <line x1="20" y1="185" x2="200" y2="185" stroke="#d1d3e2" stroke-width="0.5"/>
+      <line x1="20" y1="185" x2="110" y2="15" stroke="#d1d3e2" stroke-width="0.5"/>
+      <line x1="200" y1="185" x2="110" y2="15" stroke="#d1d3e2" stroke-width="0.5"/>
+      <th:block th:if="${endomorphy != null and mesomorphy != null and ectomorphy != null}">
+        <th:block th:with="chartX=${ectomorphy - endomorphy}, chartY=${2 * mesomorphy - (ectomorphy + endomorphy)}, plotX=${110 + (ectomorphy - endomorphy) * 7}, plotY=${185 - (2 * mesomorphy - (ectomorphy + endomorphy)) * 7}">
+          <circle th:attr="cx=${plotX}, cy=${plotY}" r="6" fill="#4e73df" stroke="#2e59d9" stroke-width="1.5"/>
+          <text th:attr="x=${plotX + 8}, y=${plotY + 4}" font-size="8" fill="#3a3b45"
+                th:text="${#numbers.formatDecimal(endomorphy,1,1) + '-' + #numbers.formatDecimal(mesomorphy,1,1) + '-' + #numbers.formatDecimal(ectomorphy,1,1)}"></text>
+        </th:block>
+      </th:block>
+    </svg>
+  </div>
+
+  <style th:fragment="somatocartaStyle">
+    .somatocarta-svg {
+      max-width: 280px;
+      width: 100%;
+      height: auto;
+      display: block;
+      margin: 0 auto;
+    }
+  </style>
+</body>
+</html>

--- a/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
+++ b/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
@@ -331,6 +331,7 @@
                       </div>
 
                       <div th:insert="~{sbadmin/pacientes/calculation-subtabs :: calculationSubTabsStyle}"></div>
+                      <div th:insert="~{sbadmin/pacientes/somatocarta :: somatocartaStyle}"></div>
                       <div th:insert="~{sbadmin/pacientes/calculation-subtabs :: calculationSubTabsNav}"></div>
                       <div class="tab-content border rounded p-3 bg-white" id="calculationSubTabsContent">
 
@@ -953,6 +954,75 @@
                               <div class="alert alert-light mb-0">
                                 <strong>Resultado:</strong> <span id="muscle-mass-percentage-result" class="text-primary">-</span> <small>%</small>
                               </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      </div>
+
+                      <!-- Somatotipo Heath-Carter -->
+                      <div class="tab-pane fade" id="calc-somatotype" role="tabpanel" aria-labelledby="calc-somatotype-subtab">
+                      <div class="row" th:if="${measurement.bodyComposition != null and measurement.bodyComposition.endomorphy != null}">
+                        <div class="col-12 mb-2">
+                          <div class="alert alert-success small mb-0">
+                            <strong>Valores guardados:</strong>
+                            <span th:text="${#numbers.formatDecimal(measurement.bodyComposition.endomorphy,1,1) + '-' + #numbers.formatDecimal(measurement.bodyComposition.mesomorphy,1,1) + '-' + #numbers.formatDecimal(measurement.bodyComposition.ectomorphy,1,1)}"></span>
+                            <span th:if="${measurement.bodyComposition.somatocartaX != null}"
+                                  th:text="' (carta: X=' + #numbers.formatDecimal(measurement.bodyComposition.somatocartaX,1,2) + ', Y=' + #numbers.formatDecimal(measurement.bodyComposition.somatocartaY,1,2) + ')'"></span>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="row">
+                        <div class="col-lg-5">
+                          <div class="card mb-3">
+                            <div class="card-body">
+                              <h6 class="card-title">Somatotipo Heath-Carter</h6>
+                              <p class="text-muted small mb-2">Método clásico (adultos ≥18 años).</p>
+                              <div class="row text-center mb-3">
+                                <div class="col-4">
+                                  <div class="small text-muted">Endomorfia</div>
+                                  <div class="h5 mb-0 text-primary" id="somatotype-endo-result"
+                                       th:text="${measurement.bodyComposition != null and measurement.bodyComposition.endomorphy != null ? #numbers.formatDecimal(measurement.bodyComposition.endomorphy,1,1) : '-'}">-</div>
+                                </div>
+                                <div class="col-4">
+                                  <div class="small text-muted">Mesomorfia</div>
+                                  <div class="h5 mb-0 text-primary" id="somatotype-meso-result"
+                                       th:text="${measurement.bodyComposition != null and measurement.bodyComposition.mesomorphy != null ? #numbers.formatDecimal(measurement.bodyComposition.mesomorphy,1,1) : '-'}">-</div>
+                                </div>
+                                <div class="col-4">
+                                  <div class="small text-muted">Ectomorfia</div>
+                                  <div class="h5 mb-0 text-primary" id="somatotype-ecto-result"
+                                       th:text="${measurement.bodyComposition != null and measurement.bodyComposition.ectomorphy != null ? #numbers.formatDecimal(measurement.bodyComposition.ectomorphy,1,1) : '-'}">-</div>
+                                </div>
+                              </div>
+                              <div class="alert alert-warning small mb-0 d-none" id="somatotype-missing-alert">
+                                <strong>Mediciones faltantes:</strong>
+                                <span id="somatotype-missing-list"></span>
+                              </div>
+                              <div class="alert alert-info small mb-0 d-none" id="somatotype-pediatric-alert">
+                                El somatotipo Heath-Carter solo se calcula en pacientes adultos (≥18 años).
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col-lg-7">
+                          <div class="card mb-3">
+                            <div class="card-body text-center">
+                              <h6 class="card-title">Somatocarta</h6>
+                              <div th:if="${measurement.bodyComposition != null and measurement.bodyComposition.endomorphy != null}"
+                                   th:insert="~{sbadmin/pacientes/somatocarta :: somatocarta(${measurement.bodyComposition.endomorphy}, ${measurement.bodyComposition.mesomorphy}, ${measurement.bodyComposition.ectomorphy}, 'saved')}"></div>
+                              <svg th:unless="${measurement.bodyComposition != null and measurement.bodyComposition.endomorphy != null}"
+                                   id="somatotype-chart-live" class="somatocarta-svg" viewBox="0 0 220 200"
+                                   xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Somatocarta">
+                                <polygon points="20,185 200,185 110,15" fill="#f8f9fc" stroke="#858796" stroke-width="1.5"/>
+                                <text x="8" y="195" font-size="9" fill="#5a5c69">Endo</text>
+                                <text x="188" y="195" font-size="9" fill="#5a5c69">Meso</text>
+                                <text x="98" y="12" font-size="9" fill="#5a5c69">Ecto</text>
+                                <g id="somatotype-chart-point" style="display:none">
+                                  <circle id="somatotype-chart-circle" r="6" fill="#4e73df" stroke="#2e59d9" stroke-width="1.5"/>
+                                  <text id="somatotype-chart-label" font-size="8" fill="#3a3b45"></text>
+                                </g>
+                              </svg>
                             </div>
                           </div>
                         </div>

--- a/src/main/resources/templates/sbadmin/reports/patient-progress.html
+++ b/src/main/resources/templates/sbadmin/reports/patient-progress.html
@@ -358,6 +358,7 @@
 					<th>IMC</th>
 					<th>% Grasa</th>
 					<th>% Masa muscular</th>
+					<th>Somatotipo</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -369,9 +370,34 @@
 					<td th:text="${measurement.bodyMass != null && measurement.bodyMass.imc != null ? #numbers.formatDecimal(measurement.bodyMass.imc, 1, 2) : 'N/A'}"></td>
 					<td th:text="${measurement.porcentajeGrasaCorporal != null ? (#numbers.formatDecimal(measurement.porcentajeGrasaCorporal, 1, 1) + '%') : 'N/A'}"></td>
 					<td th:text="${measurement.porcentajeMasaMuscular != null ? (#numbers.formatDecimal(measurement.porcentajeMasaMuscular, 1, 1) + '%') : 'N/A'}"></td>
+					<td th:text="${measurement.endomorphy != null ? (#numbers.formatDecimal(measurement.endomorphy,1,1) + '-' + #numbers.formatDecimal(measurement.mesomorphy,1,1) + '-' + #numbers.formatDecimal(measurement.ectomorphy,1,1)) : 'N/A'}"></td>
 				</tr>
 			</tbody>
 		</table>
+	</div>
+
+	<!-- Somatocarta (última medición con somatotipo) -->
+	<div class="section" th:if="${latestSomatotypeMeasurement != null}">
+		<h2>Somatocarta Heath-Carter</h2>
+		<p>
+			<strong>Medición:</strong>
+			<span th:text="${latestSomatotypeMeasurement.title}"></span>
+			(<span th:text="${latestSomatotypeMeasurement.measurementDateTime != null ? #dates.format(latestSomatotypeMeasurement.measurementDateTime, 'dd/MM/yyyy') : 'N/A'}"></span>)
+			—
+			<strong>Somatotipo:</strong>
+			<span th:text="${#numbers.formatDecimal(latestSomatotypeMeasurement.endomorphy,1,1) + '-' + #numbers.formatDecimal(latestSomatotypeMeasurement.mesomorphy,1,1) + '-' + #numbers.formatDecimal(latestSomatotypeMeasurement.ectomorphy,1,1)}"></span>
+		</p>
+		<div style="text-align: center;">
+			<svg viewBox="0 0 220 200" width="220" height="200" xmlns="http://www.w3.org/2000/svg">
+				<polygon points="20,185 200,185 110,15" fill="#f8f9fc" stroke="#858796" stroke-width="1.5"/>
+				<text x="8" y="195" font-size="9" fill="#5a5c69">Endo</text>
+				<text x="188" y="195" font-size="9" fill="#5a5c69">Meso</text>
+				<text x="98" y="12" font-size="9" fill="#5a5c69">Ecto</text>
+				<th:block th:with="endo=${latestSomatotypeMeasurement.endomorphy}, meso=${latestSomatotypeMeasurement.mesomorphy}, ecto=${latestSomatotypeMeasurement.ectomorphy}, plotX=${110 + (latestSomatotypeMeasurement.ectomorphy - latestSomatotypeMeasurement.endomorphy) * 7}, plotY=${185 - (2 * latestSomatotypeMeasurement.mesomorphy - (latestSomatotypeMeasurement.ectomorphy + latestSomatotypeMeasurement.endomorphy)) * 7}">
+					<circle th:attr="cx=${plotX}, cy=${plotY}" r="6" fill="#4e73df" stroke="#2e59d9" stroke-width="1.5"/>
+				</th:block>
+			</svg>
+		</div>
 	</div>
 
 	<!-- Clinical Exams -->

--- a/src/test/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeCalculationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeCalculationServiceTest.java
@@ -1,0 +1,85 @@
+package com.nutriconsultas.clinical.exam.anthropometric;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+class SomatotypeCalculationServiceTest {
+
+	@Test
+	void calculateReturnsFullSomatotypeWithReferenceInputs() {
+		final SomatotypeResult result = SomatotypeCalculationService.calculate(70.0, 1.75, 10.0, 12.0, 8.0, 30.0, 36.0,
+				8.0, 6.5, 9.5, 30);
+
+		assertThat(result.isCalculable()).isTrue();
+		assertThat(result.getMissingMeasurements()).isEmpty();
+		assertThat(result.getEndomorphy()).isCloseTo(2.97, within(0.05));
+		assertThat(result.getMesomorphy()).isCloseTo(3.98, within(0.05));
+		assertThat(result.getEctomorphy()).isCloseTo(2.49, within(0.05));
+		assertThat(result.getSomatocartaX()).isCloseTo(result.getEctomorphy() - result.getEndomorphy(), within(0.001));
+		assertThat(result.getSomatocartaY())
+			.isCloseTo(2.0 * result.getMesomorphy() - (result.getEctomorphy() + result.getEndomorphy()), within(0.001));
+	}
+
+	@Test
+	void calculateEndomorphyMatchesPolynomialFormula() {
+		final double endo = SomatotypeCalculationService.calculateEndomorphy(10.0, 12.0, 8.0, 175.0);
+		final double sum = 30.0 * (170.18 / 175.0);
+		final double expected = -0.7182 + 0.1451 * sum - 0.00068 * sum * sum + 0.0000014 * sum * sum * sum;
+		assertThat(endo).isCloseTo(expected, within(0.0001));
+	}
+
+	@Test
+	void calculateEctomorphyUsesHighLinearityBranch() {
+		final double ecto = SomatotypeCalculationService.calculateEctomorphy(175.0, 70.0);
+		final double hwr = 175.0 / Math.cbrt(70.0);
+		assertThat(hwr).isGreaterThanOrEqualTo(40.75);
+		assertThat(ecto).isCloseTo(0.732 * hwr - 28.58, within(0.0001));
+	}
+
+	@Test
+	void calculateEctomorphyUsesMidLinearityBranch() {
+		final double ecto = SomatotypeCalculationService.calculateEctomorphy(170.0, 80.0);
+		final double hwr = 170.0 / Math.cbrt(80.0);
+		assertThat(hwr).isBetween(38.25, 40.75);
+		assertThat(ecto).isCloseTo(0.463 * hwr - 17.63, within(0.0001));
+	}
+
+	@Test
+	void calculateEctomorphyUsesLowLinearityFloor() {
+		final double ecto = SomatotypeCalculationService.calculateEctomorphy(165.0, 90.0);
+		final double hwr = 165.0 / Math.cbrt(90.0);
+		assertThat(hwr).isLessThanOrEqualTo(38.25);
+		assertThat(ecto).isEqualTo(0.1);
+	}
+
+	@Test
+	void clampRatingAssignsMinimumWhenNegative() {
+		assertThat(SomatotypeResult.clampRating(-1.5)).isEqualTo(0.1);
+		assertThat(SomatotypeResult.clampRating(0.0)).isEqualTo(0.1);
+		assertThat(SomatotypeResult.clampRating(4.5)).isEqualTo(4.5);
+	}
+
+	@Test
+	void calculateListsMissingMeasurements() {
+		final SomatotypeResult result = SomatotypeCalculationService.calculate(70.0, 1.75, null, 12.0, 8.0, 30.0, 36.0,
+				8.0, 6.5, 9.5, 30);
+
+		assertThat(result.isCalculable()).isFalse();
+		assertThat(result.getMissingMeasurements()).contains("Pliegue tríceps");
+	}
+
+	@Test
+	void calculateRejectsPediatricPatients() {
+		final SomatotypeResult result = SomatotypeCalculationService.calculate(50.0, 1.50, 8.0, 7.0, 6.0, 22.0, 28.0,
+				6.0, 5.0, 7.5, 12);
+
+		assertThat(result.isCalculable()).isFalse();
+		assertThat(result.getMissingMeasurements())
+			.contains("Paciente menor de 18 años (somatotipo solo para adultos)");
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeCalculationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeCalculationServiceTest.java
@@ -9,10 +9,24 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class SomatotypeCalculationServiceTest {
 
+	private static SomatotypeMeasurements referenceMeasurements() {
+		return SomatotypeMeasurements.builder()
+			.weightKg(70.0)
+			.heightMeters(1.75)
+			.tricepsSkinfoldMm(10.0)
+			.subscapularSkinfoldMm(12.0)
+			.supraspinalSkinfoldMm(8.0)
+			.flexedArmGirthCm(30.0)
+			.calfGirthCm(36.0)
+			.medialCalfSkinfoldMm(8.0)
+			.humerusBreadthCm(6.5)
+			.femurBreadthCm(9.5)
+			.build();
+	}
+
 	@Test
 	void calculateReturnsFullSomatotypeWithReferenceInputs() {
-		final SomatotypeResult result = SomatotypeCalculationService.calculate(70.0, 1.75, 10.0, 12.0, 8.0, 30.0, 36.0,
-				8.0, 6.5, 9.5, 30);
+		final SomatotypeResult result = SomatotypeCalculationService.calculate(referenceMeasurements(), 30);
 
 		assertThat(result.isCalculable()).isTrue();
 		assertThat(result.getMissingMeasurements()).isEmpty();
@@ -65,8 +79,8 @@ class SomatotypeCalculationServiceTest {
 
 	@Test
 	void calculateListsMissingMeasurements() {
-		final SomatotypeResult result = SomatotypeCalculationService.calculate(70.0, 1.75, null, 12.0, 8.0, 30.0, 36.0,
-				8.0, 6.5, 9.5, 30);
+		final SomatotypeMeasurements measurements = referenceMeasurements().toBuilder().tricepsSkinfoldMm(null).build();
+		final SomatotypeResult result = SomatotypeCalculationService.calculate(measurements, 30);
 
 		assertThat(result.isCalculable()).isFalse();
 		assertThat(result.getMissingMeasurements()).contains("Pliegue tríceps");
@@ -74,8 +88,19 @@ class SomatotypeCalculationServiceTest {
 
 	@Test
 	void calculateRejectsPediatricPatients() {
-		final SomatotypeResult result = SomatotypeCalculationService.calculate(50.0, 1.50, 8.0, 7.0, 6.0, 22.0, 28.0,
-				6.0, 5.0, 7.5, 12);
+		final SomatotypeMeasurements measurements = SomatotypeMeasurements.builder()
+			.weightKg(50.0)
+			.heightMeters(1.50)
+			.tricepsSkinfoldMm(8.0)
+			.subscapularSkinfoldMm(7.0)
+			.supraspinalSkinfoldMm(6.0)
+			.flexedArmGirthCm(22.0)
+			.calfGirthCm(28.0)
+			.medialCalfSkinfoldMm(6.0)
+			.humerusBreadthCm(5.0)
+			.femurBreadthCm(7.5)
+			.build();
+		final SomatotypeResult result = SomatotypeCalculationService.calculate(measurements, 12);
 
 		assertThat(result.isCalculable()).isFalse();
 		assertThat(result.getMissingMeasurements())

--- a/src/test/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeServiceTest.java
+++ b/src/test/java/com/nutriconsultas/clinical/exam/anthropometric/SomatotypeServiceTest.java
@@ -1,0 +1,91 @@
+package com.nutriconsultas.clinical.exam.anthropometric;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
+import com.nutriconsultas.paciente.Paciente;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class SomatotypeServiceTest {
+
+	@InjectMocks
+	private SomatotypeService service;
+
+	private Paciente paciente;
+
+	@BeforeEach
+	void setUp() {
+		paciente = new Paciente();
+		paciente.setId(1L);
+		final LocalDate dob = LocalDate.now().minusYears(30);
+		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+	}
+
+	@Test
+	void applyToMeasurementPersistsSomatotypeWhenInputsComplete() {
+		final AnthropometricMeasurement measurement = createCompleteMeasurement();
+
+		final SomatotypeResult result = service.applyToMeasurement(measurement, paciente);
+
+		assertThat(result.isCalculable()).isTrue();
+		assertThat(measurement.getEndomorphy()).isEqualTo(result.getEndomorphy());
+		assertThat(measurement.getMesomorphy()).isEqualTo(result.getMesomorphy());
+		assertThat(measurement.getEctomorphy()).isEqualTo(result.getEctomorphy());
+		assertThat(measurement.getSomatocartaX()).isEqualTo(result.getSomatocartaX());
+		assertThat(measurement.getSomatocartaY()).isEqualTo(result.getSomatocartaY());
+	}
+
+	@Test
+	void applyToMeasurementClearsSomatotypeWhenInputsIncomplete() {
+		final AnthropometricMeasurement measurement = createCompleteMeasurement();
+		service.applyToMeasurement(measurement, paciente);
+		measurement.getSkinfolds().setTricepsSkinfold(null);
+
+		final SomatotypeResult result = service.applyToMeasurement(measurement, paciente);
+
+		assertThat(result.isCalculable()).isFalse();
+		assertThat(measurement.getEndomorphy()).isNull();
+		assertThat(measurement.getMesomorphy()).isNull();
+		assertThat(measurement.getEctomorphy()).isNull();
+	}
+
+	private AnthropometricMeasurement createCompleteMeasurement() {
+		final AnthropometricMeasurement measurement = new AnthropometricMeasurement();
+		final BodyMass bodyMass = new BodyMass();
+		bodyMass.setWeight(70.0);
+		bodyMass.setHeight(1.75);
+		measurement.setBodyMass(bodyMass);
+
+		final Skinfolds skinfolds = new Skinfolds();
+		skinfolds.setTricepsSkinfold(10.0);
+		skinfolds.setSubscapularSkinfold(12.0);
+		skinfolds.setSupraespinalSkinfold(8.0);
+		skinfolds.setMedialCalfSkinfold(8.0);
+		measurement.setSkinfolds(skinfolds);
+
+		final Circumferences circumferences = new Circumferences();
+		circumferences.setMidUpperArmCircumferenceContracted(30.0);
+		circumferences.setCalfCircumference(36.0);
+		measurement.setCircumferences(circumferences);
+
+		final Diameters diameters = new Diameters();
+		diameters.setHumerusDiameter(6.5);
+		diameters.setFemurDiameter(9.5);
+		measurement.setDiameters(diameters);
+
+		return measurement;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
@@ -125,6 +125,8 @@ public class PacienteControllerTest {
 		final com.nutriconsultas.clinical.exam.anthropometric.BodyCompositionService realBodyCompositionService = new com.nutriconsultas.clinical.exam.anthropometric.BodyCompositionService(
 				new BodyFatCalculatorService());
 		ReflectionTestUtils.setField(controller, "bodyCompositionService", realBodyCompositionService);
+		ReflectionTestUtils.setField(controller, "somatotypeService",
+				new com.nutriconsultas.clinical.exam.anthropometric.SomatotypeService());
 
 		log.info("finished setting up PacienteController test");
 	}
@@ -1537,6 +1539,49 @@ public class PacienteControllerTest {
 		assertThat(measurement.getPorcentajeMasaMuscular()).isNotNull();
 		assertPacienteBmrMatchesPromedio(70.0, 1.75);
 		log.info("finished testAgregarAntropometricosPaciente");
+	}
+
+	@Test
+	public void testAgregarAntropometricosPacienteCalculatesSomatotypeWhenComplete() {
+		log.info("starting testAgregarAntropometricosPacienteCalculatesSomatotypeWhenComplete");
+		final AnthropometricMeasurement measurement = new AnthropometricMeasurement();
+		measurement.setMeasurementDateTime(new Date());
+		measurement.setTitle("Medición Antropométrica");
+		measurement.setPeso(70.0);
+		measurement.setEstatura(1.75);
+
+		final com.nutriconsultas.clinical.exam.anthropometric.Skinfolds skinfolds = new com.nutriconsultas.clinical.exam.anthropometric.Skinfolds();
+		skinfolds.setTricepsSkinfold(10.0);
+		skinfolds.setSubscapularSkinfold(12.0);
+		skinfolds.setSupraespinalSkinfold(8.0);
+		skinfolds.setMedialCalfSkinfold(8.0);
+		measurement.setSkinfolds(skinfolds);
+
+		final Circumferences circumferences = new Circumferences();
+		circumferences.setMidUpperArmCircumferenceContracted(30.0);
+		circumferences.setCalfCircumference(36.0);
+		measurement.setCircumferences(circumferences);
+
+		final com.nutriconsultas.clinical.exam.anthropometric.Diameters diameters = new com.nutriconsultas.clinical.exam.anthropometric.Diameters();
+		diameters.setHumerusDiameter(6.5);
+		diameters.setFemurDiameter(9.5);
+		measurement.setDiameters(diameters);
+
+		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
+		when(anthropometricMeasurementService.save(any(AnthropometricMeasurement.class))).thenReturn(measurement);
+		when(pacienteRepository.save(any(Paciente.class))).thenReturn(paciente);
+
+		final Model model = org.mockito.Mockito.mock(Model.class);
+		final String result = controller.agregarAntropometricosPaciente(1L, measurement, bindingResult, model,
+				principal);
+
+		assertThat(result).contains("redirect:/admin/pacientes/1/historial");
+		assertThat(measurement.getEndomorphy()).isNotNull();
+		assertThat(measurement.getMesomorphy()).isNotNull();
+		assertThat(measurement.getEctomorphy()).isNotNull();
+		assertThat(measurement.getSomatocartaX()).isNotNull();
+		assertThat(measurement.getSomatocartaY()).isNotNull();
+		log.info("finished testAgregarAntropometricosPacienteCalculatesSomatotypeWhenComplete");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Implementa cálculo Heath-Carter clásico (endo/meso/ecto) a partir de pliegues, perímetros, diámetros, peso y estatura en adultos (≥18 años).
- Persiste ratings y coordenadas de somatocarta (`somatocartaX`/`somatocartaY`) al guardar antropométrico.
- Añade sub-pestaña Somatotipo con cálculo en vivo y somatocarta SVG; muestra valores en vista de lectura y en el PDF de progreso del paciente.

## Test plan
- [x] `SomatotypeCalculationServiceTest` — fórmulas con valores de referencia
- [x] `SomatotypeServiceTest` — persistencia y limpieza cuando faltan datos
- [x] `PacienteControllerTest#testAgregarAntropometricosPacienteCalculatesSomatotypeWhenComplete`
- [x] Validación de plantillas Thymeleaf (65/65)
- [ ] Guardar antropométrico con mediciones completas y verificar somatotipo en vista de lectura
- [ ] Exportar PDF de progreso y confirmar somatocarta

Closes #125


Made with [Cursor](https://cursor.com)