### PR TITLE
feat(mobile-api): OpenAPI spec for /rest/mobile/patient/** (#112)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -10,7 +10,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) | Canonical cross-repo contract — §F8 schema/enum map, per-issue corrected scope |
 | [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) | Endpoint request/response specs (#91–#99) with field mappings |
 
-**Current next issue:** [#112 — OpenAPI spec for `/rest/mobile/patient/**`](https://github.com/diego-torres/nutriconsultas/issues/112) — **in-progress** on `mobile-api/112-openapi` (P1 cross-cutting).
+**Current next issue:** [#112 — OpenAPI spec for `/rest/mobile/patient/**`](https://github.com/diego-torres/nutriconsultas/issues/112) — **in-progress** ([PR #164](https://github.com/diego-torres/nutriconsultas/pull/164)).
 
 ---
 
@@ -323,8 +323,8 @@ gh pr create ...
 | Field | Value |
 |-------|-------|
 | **Next issue** | [#112 — OpenAPI spec for `/rest/mobile/patient/**`](https://github.com/diego-torres/nutriconsultas/issues/112) |
-| **Status** | **in-progress** (`mobile-api/112-openapi`) |
-| **Suggested branch** | `mobile-api/112-openapi` |
+| **Status** | **in-progress** — [PR #164](https://github.com/diego-torres/nutriconsultas/pull/164) |
+| **Branch** | `mobile-api/112-openapi` |
 | **Phase** | Cross-cutting (P1) |
 | **Depends on** | #110, endpoints (#91–#99) |
 | **Blocks** | — |

--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -6,11 +6,11 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 | File | Purpose |
 |------|---------|
-| [`ISSUE.md`](ISSUE.md) | All `[Mobile API]` issues (#91–#99, #107–#116), integration prerequisites (#156, #46), URLs, states, dependencies, and data-contract sources |
+| [`ISSUE.md`](ISSUE.md) | All `[Mobile API]` issues (#91–#99, #107–#116, #132–#141), integration prerequisites (#156, #46), URLs, states, dependencies, and data-contract sources |
 | [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) | Canonical cross-repo contract — §F8 schema/enum map, per-issue corrected scope |
 | [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) | Endpoint request/response specs (#91–#99) with field mappings |
 
-**Current next issue:** [#112 — OpenAPI spec for `/rest/mobile/patient/**`](https://github.com/diego-torres/nutriconsultas/issues/112) — **NEXT** (P1 cross-cutting). All endpoints #91–#99 **done** (PR #153 closes #99).
+**Current next issue:** [#112 — OpenAPI spec for `/rest/mobile/patient/**`](https://github.com/diego-torres/nutriconsultas/issues/112) — **in-progress** on `mobile-api/112-openapi` (P1 cross-cutting).
 
 ---
 
@@ -303,11 +303,11 @@ Precise list of what changed. For each technical term, add a one-line plain-Engl
 ```bash
 # Start of session
 git fetch origin && git checkout main && git pull origin main
-gh issue view 110
+gh issue view 112
 cat ISSUE.md
 
 # During work
-git checkout -b mobile-api/110-dto-envelope
+git checkout -b mobile-api/112-openapi
 ./lint.sh && bash scripts/audit-logging.sh && mvn -B verify
 ./dev-start.sh   # run locally when touching security config or startup
 
@@ -323,6 +323,7 @@ gh pr create ...
 | Field | Value |
 |-------|-------|
 | **Next issue** | [#112 — OpenAPI spec for `/rest/mobile/patient/**`](https://github.com/diego-torres/nutriconsultas/issues/112) |
+| **Status** | **in-progress** (`mobile-api/112-openapi`) |
 | **Suggested branch** | `mobile-api/112-openapi` |
 | **Phase** | Cross-cutting (P1) |
 | **Depends on** | #110, endpoints (#91–#99) |
@@ -337,16 +338,18 @@ gh pr create ...
 | Phase 0 foundation | ~~#107~~ ✓, ~~#109~~ ✓, ~~#110~~ ✓ | **Done** |
 | Auth linkage (tenant) | #108 (tenant config; prod audience deployed #118) | Before full Auth0 tenant hardening |
 | Endpoints | ~~#91–#99~~ ✓ | **Done** (PR #153) |
-| Cross-cutting | ~~#111~~ ✓, **#112** (OpenAPI), #115 (PHI audit) | **#112 is NEXT** |
+| Cross-cutting | ~~#111~~ ✓, **#112** (OpenAPI, in progress), #115 (PHI audit) | **#112 in progress** |
 | Hardening / additive | ~~#113~~ ✓, #116 (senderDisplayName), #114 (nutritionist reply) | With/after owning feature |
-| Schema / Liquibase | **#156** (`Paciente` refactor) → **#46** (Liquibase baseline) → #132 (onboarding) | **#156 before any Liquibase cut** |
+| Schema / Liquibase | **#156** (`Paciente` refactor) → **#46** (Liquibase baseline) → **#132–#141** (invitation onboarding) | **#156 before any Liquibase cut**; invitation epic not active sprint |
 
-### Status snapshot (2026-06-14)
+### Status snapshot (2026-06-15)
 
 **Patient mobile API on `main`:** JWT resource server (#107), DTO envelope (#110), patient linkage (#109), visits (#91/#92), diet plans (#93–#95), messages list/send (#96/#97 with HTTP 201 + rate limit), progress snapshot (#98) + measurements time series (#99, PR #153), localized API errors (#111), Resilience4j write throttling (#113). Dashboard IMC gauge (#106) done for web tablero.
 
-**Next:** #112 OpenAPI spec for `/rest/mobile/patient/**`, then #115 (PHI audit), additive #116 / web #114.
+**Next:** #112 OpenAPI spec (in progress), then #115 (PHI audit), additive #116 / web #114.
 
-**Schema gate (parallel track):** [#156](https://github.com/diego-torres/nutriconsultas/issues/156) `Paciente` decomposition blocks [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46); coordinate [#132](https://github.com/diego-torres/nutriconsultas/issues/132) onboarding columns after #156 Phase B.
+**GitHub drift (close when convenient):** #97 and #111 are **done on `main`** but still **open on GitHub** (implemented in PRs #147, #151).
+
+**Schema gate (parallel track):** [#156](https://github.com/diego-torres/nutriconsultas/issues/156) `Paciente` decomposition blocks [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46); then [#132–#141](https://github.com/diego-torres/nutriconsultas/issues/132) invitation onboarding (see [`ISSUE.md`](ISSUE.md) Phase 2).
 
 See [`ISSUE.md`](ISSUE.md) Data contracts and [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) §F8 for per-endpoint field requirements.

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-15 — #112 OpenAPI spec **in progress** on branch `mobile-api/112-openapi`.
+**Last updated:** 2026-06-15 — #112 OpenAPI **in progress** → [PR #164](https://github.com/diego-torres/nutriconsultas/pull/164).
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -76,7 +76,7 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 |---|-------|-----|-------|-----------|-------|
 | 111 | Accept-Language filter + MessageSource i18n for REST errors | https://github.com/diego-torres/nutriconsultas/issues/111 | **done** | 110 | Merged PR #151: `LocaleContextFilter`, `MobileApiErrorResponses`, `MobileApiExceptionHandler` (403/404/400/429). GitHub issue still open — close when convenient. |
 | 115 | PHI log redaction audit for all mobile controllers | https://github.com/diego-torres/nutriconsultas/issues/115 | open | 110 | Audit every `/rest/mobile/**` controller against `util/LogRedaction`; CI gate `scripts/audit-logging.sh`. No names/emails/DOB at INFO. |
-| 112 | OpenAPI spec for `/rest/mobile/patient/**` | https://github.com/diego-torres/nutriconsultas/issues/112 | **in-progress** | 110, endpoints | springdoc + `docs/api/openapi-mobile.yaml`; branch `mobile-api/112-openapi`. |
+| 112 | OpenAPI spec for `/rest/mobile/patient/**` | https://github.com/diego-torres/nutriconsultas/issues/112 | **in-progress** | 110, endpoints | [PR #164](https://github.com/diego-torres/nutriconsultas/pull/164): springdoc + `docs/api/openapi-mobile.yaml`. |
 
 ---
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,9 +6,11 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-14 — **#99 done** (PR #153). All endpoints #91–#99 **done** on `main`. **NEXT:** [#112](https://github.com/diego-torres/nutriconsultas/issues/112) OpenAPI spec.
+**Last updated:** 2026-06-15 — #112 OpenAPI spec **in progress** on branch `mobile-api/112-openapi`.
 
-> **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
+> **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
+
+> **GitHub sync note (2026-06-15):** **#97** and **#111** are **done on `main`** (PRs #147, #151) but remain **open on GitHub** — close them when convenient so remote matches this registry. **#113** is closed on GitHub and **done** here.
 
 ---
 
@@ -72,9 +74,9 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| 111 | Accept-Language filter + MessageSource i18n for REST errors | https://github.com/diego-torres/nutriconsultas/issues/111 | **done** | 110 | Merged PR #151: `LocaleContextFilter`, `MobileApiErrorResponses`, `MobileApiExceptionHandler` (403/404/400/429), localized `PatientLinkageFilter` |
+| 111 | Accept-Language filter + MessageSource i18n for REST errors | https://github.com/diego-torres/nutriconsultas/issues/111 | **done** | 110 | Merged PR #151: `LocaleContextFilter`, `MobileApiErrorResponses`, `MobileApiExceptionHandler` (403/404/400/429). GitHub issue still open — close when convenient. |
 | 115 | PHI log redaction audit for all mobile controllers | https://github.com/diego-torres/nutriconsultas/issues/115 | open | 110 | Audit every `/rest/mobile/**` controller against `util/LogRedaction`; CI gate `scripts/audit-logging.sh`. No names/emails/DOB at INFO. |
-| 112 | OpenAPI spec for `/rest/mobile/patient/**` | https://github.com/diego-torres/nutriconsultas/issues/112 | **NEXT** | 110, endpoints | springdoc spec; mobile reads it as the integration contract. All #91–#99 endpoints landed — document full surface. |
+| 112 | OpenAPI spec for `/rest/mobile/patient/**` | https://github.com/diego-torres/nutriconsultas/issues/112 | **in-progress** | 110, endpoints | springdoc + `docs/api/openapi-mobile.yaml`; branch `mobile-api/112-openapi`. |
 
 ---
 
@@ -95,12 +97,12 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 | **94** | `GET /rest/mobile/patient/diet-plans/{assignmentId}` — structured meal JSON | https://github.com/diego-torres/nutriconsultas/issues/94 | **done** | 93 | Merged PR #143: `DietPlanDetailDto` + ingesta/platillo/alimento tree; `findByIdAndPacienteId` IDOR guard → 404. |
 | **95** | `GET /rest/mobile/patient/diet-plans/{assignmentId}/pdf` — printable PDF | https://github.com/diego-torres/nutriconsultas/issues/95 | **done** | 94 | Merged PR #144: `DietaPdfService.generatePdfForAssignment`, `Content-Disposition`, ownership → 404. |
 
-### Messages — **greenfield** (no entity exists)
+### Messages — `PatientMessage`
 
 | # | Endpoint | URL | State | Backend source |
 |---|----------|-----|-------|----------------|
 | 96 | `GET /rest/mobile/patient/messages` — list thread | https://github.com/diego-torres/nutriconsultas/issues/96 | **done** | Merged PR #146: cursor pagination; contact form → `ContactInquiry`; admin inbox |
-| 97 | `POST /rest/mobile/patient/messages` — send to nutritionist | https://github.com/diego-torres/nutriconsultas/issues/97 | **done** | Merged PR #147 (`senderRole=PATIENT`, validation); PR #151 adds HTTP 201 + #113 rate limit |
+| 97 | `POST /rest/mobile/patient/messages` — send to nutritionist | https://github.com/diego-torres/nutriconsultas/issues/97 | **done** | Merged PR #147 (`senderRole=PATIENT`, validation); PR #151 adds HTTP 201 + #113 rate limit. GitHub issue still open — close when convenient. |
 
 ### Progress — `AnthropometricMeasurement` / `Paciente`
 
@@ -130,7 +132,27 @@ Schema-affecting work must respect mobile DTO contracts (§F8). These issues are
 |---|-------|-----|-------|-----------|--------|-------|
 | **156** | `[Integration]` Paciente domain refactor — incremental decomposition | https://github.com/diego-torres/nutriconsultas/issues/156 | open | [#121](https://github.com/diego-torres/nutriconsultas/issues/121) GET/TDEE | [#46](https://github.com/diego-torres/nutriconsultas/issues/46) Liquibase, [#132](https://github.com/diego-torres/nutriconsultas/issues/132) timing | Phases A–B (projections + `@Embeddable`, no mobile JSON changes); Phase C optional satellite tables. `#98`/`#99` DTO keys stable; `patientAuthSub` immovable. |
 | 46 | Implement Liquibase for database change management | https://github.com/diego-torres/nutriconsultas/issues/46 | open | **156** (Phases A–B min.) | — | First Liquibase baseline must capture post-#156 `Paciente` schema. Until then: `ddl-auto=update` + manual SQL if Phase C. |
-| 132 | Invitation & patient onboarding data model | https://github.com/diego-torres/nutriconsultas/issues/132 | open | #107 | — | Coordinate with #156 — add `Paciente.status` / `Invitation` **after** embeddable decomposition, not onto the monolith mid-refactor. |
+| 132 | Invitation & patient onboarding data model | https://github.com/diego-torres/nutriconsultas/issues/132 | open | #107, **156** (Phase B) | — | `Paciente.status` enum + `Invitation` entity; Liquibase via #46 after #156. |
+
+---
+
+## Phase 2 — Invitation onboarding (P1 · gated by #156 → #46 → #132)
+
+Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Not active sprint** — start after #156 Phase B and Liquibase baseline (#46). Issues decomposed from `invitation-system-research.md`.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| 133 | Invitation token generation & hashing service | https://github.com/diego-torres/nutriconsultas/issues/133 | open | 132 | CSPRNG token; store hash only; constant-time verify; optional signed JWS for Auth0 Action |
+| 134 | `POST /rest/mobile/invitations` — nutritionist creates patient + invitation | https://github.com/diego-torres/nutriconsultas/issues/134 | open | 132, 133 | Nutritionist JWT (not patient); creates `Paciente` + `Invitation` |
+| 135 | `GET /rest/mobile/invitations/{token}/preview` — public rate-limited preview | https://github.com/diego-torres/nutriconsultas/issues/135 | open | 133 | Public; enumeration protection (#141) |
+| 136 | `POST /rest/mobile/invitations/{token}/redeem` — bind Auth0 sub → patient | https://github.com/diego-torres/nutriconsultas/issues/136 | open | 132, 133, 107 | **Authoritative** redeem gate; patient JWT required |
+| 137 | CurrentPatient resolver + onboarding data gate (403 onboarding required) | https://github.com/diego-torres/nutriconsultas/issues/137 | open | 132, 107 | Centralizes `sub → Paciente`; 403 until onboarded |
+| 138 | `PATCH` & `GET /rest/mobile/patient/me` — onboarding profile + status→ACTIVE | https://github.com/diego-torres/nutriconsultas/issues/138 | open | 132, 137 | Patient completes profile; transitions to `ACTIVE` |
+| 139 | `POST /rest/mobile/invitations/{id}/revoke` — nutritionist invalidates invite | https://github.com/diego-torres/nutriconsultas/issues/139 | open | 132, 134 | Nutritionist JWT |
+| 140 | Auth0 Post-Login Action gate — first-login invitation validation | https://github.com/diego-torres/nutriconsultas/issues/140 | open | 133, 136 | **Post-Login** (not Pre-User-Registration — social logins skip PUR); docs + Action script |
+| 141 | Invitation security hardening — rate limits, enumeration protection, no-token logging | https://github.com/diego-torres/nutriconsultas/issues/141 | open | 133, 135, 136 | Relates #115; never log raw tokens |
+
+**Suggested build order (after #132):** #133 → #134/#135 → #136 → #137 → #138 → #139/#140 → #141.
 
 ---
 
@@ -148,6 +170,7 @@ Each mobile feature consumes these backend endpoints. Two-way linking with the m
 | 116 | `senderDisplayName` (optional) | mobile #19 | Read-only (additive) |
 | 114 | nutritionist reply | — (web only; feeds #96) | — |
 | 156 | `Paciente` internal refactor (pre-Liquibase) | — (backend only) | — | No mobile JSON change; `#98`/`#99` regression required per PR |
+| 132–141 | Invitation onboarding | mobile (future) | Auth + profile | Replaces #109 manual linkage for new patients; gated by #156 |
 
 **Common contract for every #91–#99** (ALIGNMENT-SPEC §"CORRECTED SCOPE"):
 - Auth: OAuth2 Resource Server JWT, separate `@Order(1)` `SecurityFilterChain`, stateless.
@@ -156,7 +179,7 @@ Each mobile feature consumes these backend endpoints. Two-way linking with the m
 - i18n: `Accept-Language` (es-MX default) error bodies (#111).
 - PHI-safe logging (`LogRedaction`, #115); no names/emails/DOB at INFO.
 
-**E2E HTTP codes (2026-06-14):**
+**E2E HTTP codes (2026-06-15):**
 - **401** — missing/invalid JWT or wrong `aud` (check mobile `AUTH0_AUDIENCE` = `https://api.nutriconsultas.minutriporcion.com`).
 - **403** — JWT valid, no `Paciente.patientAuthSub` match (#109 linkage required). Localized `ApiResponse` with `error.patient.not.linked` (#111).
 - **404** — linkage OK but resource not found (localized `error.resource.not.found`).

--- a/docs/api/openapi-mobile.yaml
+++ b/docs/api/openapi-mobile.yaml
@@ -1,0 +1,872 @@
+openapi: 3.1.0
+info:
+  title: Minutriporcion Patient Mobile API
+  description: Patient-facing JSON API under /rest/mobile/patient/**. Requires Auth0
+    Bearer JWT (resource server).
+  contact:
+    name: Minutriporcion
+    url: https://minutriporcion.com
+  version: "1.0"
+servers:
+- url: http://localhost
+  description: Generated server url
+security:
+- bearer-jwt: []
+tags:
+- name: Mobile
+  description: Patient mobile API
+paths:
+  /rest/mobile/patient/messages:
+    get:
+      tags:
+      - Mobile
+      summary: List messages
+      description: Returns cursor-paged messages for the authenticated patient.
+      operationId: listMessages
+      parameters:
+      - name: cursor
+        in: query
+        description: Opaque cursor from a previous page
+        required: false
+        schema:
+          type: string
+      - name: size
+        in: query
+        description: Page size
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        "200":
+          description: Cursor-paged message summaries
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseCursorPagedResponsePatientMessageSummaryDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseCursorPagedResponsePatientMessageSummaryDto"
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseCursorPagedResponsePatientMessageSummaryDto"
+    post:
+      tags:
+      - Mobile
+      summary: Send message
+      description: Creates a patient-to-nutritionist message.
+      operationId: sendMessage
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SendPatientMessageRequest"
+        required: true
+      responses:
+        "201":
+          description: Created message summary
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientMessageSummaryDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientMessageSummaryDto"
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientMessageSummaryDto"
+        "400":
+          description: Validation failed
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientMessageSummaryDto"
+        "429":
+          description: "Rate limit exceeded (Retry-After: 60)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientMessageSummaryDto"
+  /rest/mobile/patient/visits:
+    get:
+      tags:
+      - Mobile
+      summary: List patient visits
+      description: Returns a paged list of visit summaries for the authenticated patient.
+      operationId: listVisits
+      parameters:
+      - name: page
+        in: query
+        description: Zero-based page index
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      - name: size
+        in: query
+        description: Page size
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      - name: status
+        in: query
+        description: Filter by visit status
+        required: false
+        schema:
+          type: string
+          enum:
+          - SCHEDULED
+          - COMPLETED
+          - CANCELLED
+      - name: from
+        in: query
+        description: Inclusive start instant (ISO-8601)
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: to
+        in: query
+        description: Inclusive end instant (ISO-8601)
+        required: false
+        schema:
+          type: string
+          format: date-time
+      responses:
+        "200":
+          description: Paged visit summaries
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePagedResponseVisitSummaryDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePagedResponseVisitSummaryDto"
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePagedResponseVisitSummaryDto"
+  /rest/mobile/patient/visits/{visitId}:
+    get:
+      tags:
+      - Mobile
+      summary: Get visit detail
+      description: Returns a single visit owned by the authenticated patient.
+      operationId: getVisitDetail
+      parameters:
+      - name: visitId
+        in: path
+        description: Visit identifier
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: Visit detail
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseVisitDetailDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseVisitDetailDto"
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseVisitDetailDto"
+        "404":
+          description: Resource not found or not owned by patient
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseVisitDetailDto"
+  /rest/mobile/patient/progress:
+    get:
+      tags:
+      - Mobile
+      summary: Get progress snapshot
+      description: Returns latest BMI/BMR and related progress snapshot for the patient.
+      operationId: getProgress
+      responses:
+        "200":
+          description: Progress snapshot
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientProgressSnapshotDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientProgressSnapshotDto"
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientProgressSnapshotDto"
+  /rest/mobile/patient/progress/measurements:
+    get:
+      tags:
+      - Mobile
+      summary: List progress measurements
+      description: Returns anthropometric measurement time series for the patient.
+      operationId: listMeasurements
+      parameters:
+      - name: from
+        in: query
+        description: Inclusive start instant (ISO-8601)
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: to
+        in: query
+        description: Inclusive end instant (ISO-8601)
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: maxRows
+        in: query
+        description: Maximum rows (capped at 365)
+        required: false
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: "Measurement time series (ASC, max 365 rows)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseProgressMeasurementsDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseProgressMeasurementsDto"
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseProgressMeasurementsDto"
+  /rest/mobile/patient/diet-plans:
+    get:
+      tags:
+      - Mobile
+      summary: List diet plans
+      description: Returns assigned diet plans for the authenticated patient.
+      operationId: listDietPlans
+      parameters:
+      - name: page
+        in: query
+        description: Zero-based page index
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      - name: size
+        in: query
+        description: Page size
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      - name: activeOnly
+        in: query
+        description: "When true, return only active assignments"
+        required: false
+        schema:
+          type: boolean
+          default: false
+      responses:
+        "200":
+          description: Paged diet plan summaries
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePagedResponseDietPlanSummaryDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePagedResponseDietPlanSummaryDto"
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePagedResponseDietPlanSummaryDto"
+  /rest/mobile/patient/diet-plans/{assignmentId}:
+    get:
+      tags:
+      - Mobile
+      summary: Get diet plan detail
+      description: Returns structured meal JSON for an assignment owned by the patient.
+      operationId: getDietPlanDetail
+      parameters:
+      - name: assignmentId
+        in: path
+        description: PacienteDieta assignment identifier
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: Diet plan detail with ingestas and platillos
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseDietPlanDetailDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseDietPlanDetailDto"
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseDietPlanDetailDto"
+        "404":
+          description: Resource not found or not owned by patient
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseDietPlanDetailDto"
+  /rest/mobile/patient/diet-plans/{assignmentId}/pdf:
+    get:
+      tags:
+      - Mobile
+      summary: Download diet plan PDF
+      description: Returns a printable PDF for an assignment owned by the patient.
+      operationId: getDietPlanPdf
+      parameters:
+      - name: assignmentId
+        in: path
+        description: PacienteDieta assignment identifier
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: PDF bytes
+          content:
+            application/pdf: {}
+        "401":
+          description: Missing or invalid JWT
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: byte
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: byte
+        "404":
+          description: Resource not found or not owned by patient
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: byte
+components:
+  schemas:
+    SendPatientMessageRequest:
+      type: object
+      properties:
+        body:
+          type: string
+          maxLength: 2000
+          minLength: 0
+      required:
+      - body
+    ApiResponsePatientMessageSummaryDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/PatientMessageSummaryDto"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    PatientMessageSummaryDto:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        sentAt:
+          type: string
+          format: date-time
+        senderRole:
+          type: string
+          enum:
+          - PATIENT
+          - NUTRITIONIST
+        body:
+          type: string
+        read:
+          type: boolean
+    ApiResponsePagedResponseVisitSummaryDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/PagedResponseVisitSummaryDto"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    PagedResponseVisitSummaryDto:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/VisitSummaryDto"
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+        last:
+          type: boolean
+    VisitSummaryDto:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        eventDateTime:
+          type: string
+          format: date-time
+        title:
+          type: string
+        status:
+          type: string
+          enum:
+          - SCHEDULED
+          - COMPLETED
+          - CANCELLED
+        durationMinutes:
+          type: integer
+          format: int32
+        summaryNotes:
+          type: string
+    ApiResponseVisitDetailDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/VisitDetailDto"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    VisitDetailDto:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        eventDateTime:
+          type: string
+          format: date-time
+        title:
+          type: string
+        status:
+          type: string
+          enum:
+          - SCHEDULED
+          - COMPLETED
+          - CANCELLED
+        durationMinutes:
+          type: integer
+          format: int32
+        summaryNotes:
+          type: string
+        description:
+          type: string
+        peso:
+          type: number
+          format: double
+        estatura:
+          type: number
+          format: double
+        imc:
+          type: number
+          format: double
+        indiceGrasaCorporal:
+          type: number
+          format: double
+        nivelPeso:
+          type: string
+          enum:
+          - BAJO
+          - NORMAL
+          - ALTO
+          - SOBREPESO
+        sistolica:
+          type: integer
+          format: int32
+        diastolica:
+          type: integer
+          format: int32
+        pulso:
+          type: integer
+          format: int32
+        indiceGlucemico:
+          type: integer
+          format: int32
+        spo2:
+          type: number
+          format: double
+        temperatura:
+          type: number
+          format: double
+    ApiResponsePatientProgressSnapshotDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/PatientProgressSnapshotDto"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    PatientProgressSnapshotDto:
+      type: object
+      properties:
+        latestMeasurementAt:
+          type: string
+          format: date-time
+        previousMeasurementAt:
+          type: string
+          format: date-time
+        weightKg:
+          type: number
+          format: double
+        heightM:
+          type: number
+          format: double
+        bmi:
+          type: number
+          format: double
+        nivelPeso:
+          type: string
+          enum:
+          - BAJO
+          - NORMAL
+          - ALTO
+          - SOBREPESO
+        imcLabel:
+          type: string
+        bmr:
+          type: number
+          format: double
+        bodyFatPercentage:
+          type: number
+          format: double
+        deltaPeso:
+          type: number
+          format: double
+        deltaImc:
+          type: number
+          format: double
+        circumferences:
+          $ref: "#/components/schemas/ProgressCircumferenceDto"
+    ProgressCircumferenceDto:
+      type: object
+      properties:
+        waistCm:
+          type: number
+          format: double
+        hipCm:
+          type: number
+          format: double
+    ApiResponseProgressMeasurementsDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/ProgressMeasurementsDto"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    ProgressMeasurementPointDto:
+      type: object
+      properties:
+        recordedAt:
+          type: string
+          format: date-time
+        weightKg:
+          type: number
+          format: double
+        heightM:
+          type: number
+          format: double
+        bmi:
+          type: number
+          format: double
+        bodyFatPercentage:
+          type: number
+          format: double
+        circumferences:
+          $ref: "#/components/schemas/ProgressCircumferenceDto"
+    ProgressMeasurementsDto:
+      type: object
+      properties:
+        measurements:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProgressMeasurementPointDto"
+        count:
+          type: integer
+          format: int32
+        truncated:
+          type: boolean
+    ApiResponseCursorPagedResponsePatientMessageSummaryDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/CursorPagedResponsePatientMessageSummaryDto"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    CursorPagedResponsePatientMessageSummaryDto:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/PatientMessageSummaryDto"
+        nextCursor:
+          type: string
+        hasMore:
+          type: boolean
+    ApiResponsePagedResponseDietPlanSummaryDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/PagedResponseDietPlanSummaryDto"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    DietPlanSummaryDto:
+      type: object
+      properties:
+        assignmentId:
+          type: integer
+          format: int64
+        status:
+          type: string
+          enum:
+          - ACTIVE
+          - COMPLETED
+          - CANCELLED
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        notes:
+          type: string
+        dietaName:
+          type: string
+        totalKcal:
+          type: integer
+          format: int32
+        totalProteina:
+          type: number
+          format: double
+        totalGrasas:
+          type: number
+          format: double
+        totalCarbohidratos:
+          type: number
+          format: double
+    PagedResponseDietPlanSummaryDto:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/DietPlanSummaryDto"
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+        last:
+          type: boolean
+    ApiResponseDietPlanDetailDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/DietPlanDetailDto"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    DietAlimentoDto:
+      type: object
+      properties:
+        nombre:
+          type: string
+        porciones:
+          type: integer
+          format: int32
+        kcal:
+          type: integer
+          format: int32
+        unidad:
+          type: string
+    DietIngestaDto:
+      type: object
+      properties:
+        tipo:
+          type: string
+        totalKcal:
+          type: integer
+          format: int32
+        totalProteina:
+          type: number
+          format: double
+        totalGrasas:
+          type: number
+          format: double
+        totalCarbohidratos:
+          type: number
+          format: double
+        platillos:
+          type: array
+          items:
+            $ref: "#/components/schemas/DietPlatilloDto"
+        alimentos:
+          type: array
+          items:
+            $ref: "#/components/schemas/DietAlimentoDto"
+    DietPlanDetailDto:
+      type: object
+      properties:
+        assignmentId:
+          type: integer
+          format: int64
+        status:
+          type: string
+          enum:
+          - ACTIVE
+          - COMPLETED
+          - CANCELLED
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        notes:
+          type: string
+        dietaName:
+          type: string
+        totalKcal:
+          type: integer
+          format: int32
+        totalProteina:
+          type: number
+          format: double
+        totalGrasas:
+          type: number
+          format: double
+        totalCarbohidratos:
+          type: number
+          format: double
+        ingestas:
+          type: array
+          items:
+            $ref: "#/components/schemas/DietIngestaDto"
+    DietPlatilloDto:
+      type: object
+      properties:
+        nombre:
+          type: string
+        porciones:
+          type: integer
+          format: int32
+        kcal:
+          type: integer
+          format: int32
+        recommendations:
+          type: string
+        imageUrl:
+          type: string
+  securitySchemes:
+    bearer-jwt:
+      type: http
+      description: Auth0 access token with audience https://api.nutriconsultas.test/mobile
+      scheme: bearer
+      bearerFormat: JWT

--- a/docs/api/openapi-mobile.yaml
+++ b/docs/api/openapi-mobile.yaml
@@ -269,6 +269,12 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/ApiResponseProgressMeasurementsDto"
+        "400":
+          description: Invalid date range (from after to)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseProgressMeasurementsDto"
         "401":
           description: Missing or invalid JWT
           content:
@@ -419,6 +425,7 @@ components:
       properties:
         body:
           type: string
+          description: Message body
           maxLength: 2000
           minLength: 0
       required:

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -4,7 +4,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track, vendored into this 
 
 | File | What it is |
 |------|-----------|
-| `ALIGNMENT-SPEC.md` | Source-of-truth contract for all agents. §F8 = backend↔mobile field/enum map. Phase 0 + endpoints **#91–#99 done** on `main`. **#112 OpenAPI** in progress → `docs/api/openapi-mobile.yaml`. Invitation **#132–#141** deferred (see §F8.6). |
+| `ALIGNMENT-SPEC.md` | Source-of-truth contract for all agents. §F8 = backend↔mobile field/enum map. Phase 0 + endpoints **#91–#99 done** on `main`. **#112 OpenAPI** → [PR #164](https://github.com/diego-torres/nutriconsultas/pull/164) + `docs/api/openapi-mobile.yaml`. Invitation **#132–#141** deferred (see §F8.6). |
 | `mobile-api-roadmap-v2.md` | Per-endpoint (#91–#99) request/response JSON and field mappings. All endpoints **done**; cross-cutting #112 is next. |
 
 **Last synced:** 2026-06-15 (registry triage with GitHub).

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -4,8 +4,10 @@ Canonical cross-repo contracts for the `[Mobile API]` track, vendored into this 
 
 | File | What it is |
 |------|-----------|
-| `ALIGNMENT-SPEC.md` | Source-of-truth contract for all agents. §F8 = backend↔mobile field/enum map. Phase 0 + endpoints **#91–#99 done** on `main` (PR #153). **NEXT:** #112 OpenAPI. |
+| `ALIGNMENT-SPEC.md` | Source-of-truth contract for all agents. §F8 = backend↔mobile field/enum map. Phase 0 + endpoints **#91–#99 done** on `main`. **#112 OpenAPI** in progress → `docs/api/openapi-mobile.yaml`. Invitation **#132–#141** deferred (see §F8.6). |
 | `mobile-api-roadmap-v2.md` | Per-endpoint (#91–#99) request/response JSON and field mappings. All endpoints **done**; cross-cutting #112 is next. |
+
+**Last synced:** 2026-06-15 (registry triage with GitHub).
 
 **Provenance / drift:** these are synced copies of the workspace-root originals
 (`/Users/joelmartinez/Documents/Work/ALIGNMENT-SPEC.md` and `mobile-api-roadmap-v2.md`),

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>2.8.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.session</groupId>
       <artifactId>spring-session-core</artifactId>
       <scope>runtime</scope>

--- a/scripts/export-openapi-mobile.sh
+++ b/scripts/export-openapi-mobile.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Export OpenAPI 3 YAML for /rest/mobile/patient/** (#112).
+# Writes docs/api/openapi-mobile.yaml using the test profile (no running server required).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+mvn -B -Dtest=MobileOpenApiIntegrationTest#mobileOpenApiYamlIsAvailableForExport -Dopenapi.export=true test
+
+echo "Wrote docs/api/openapi-mobile.yaml"

--- a/src/main/java/com/nutriconsultas/SecurityConfig.java
+++ b/src/main/java/com/nutriconsultas/SecurityConfig.java
@@ -40,6 +40,8 @@ public class SecurityConfig {
 				.authenticated()
 				.requestMatchers("/admin/**")
 				.authenticated()
+				.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
+				.authenticated()
 				.anyRequest()
 				.permitAll())
 			.oauth2Login(withDefaults())

--- a/src/main/java/com/nutriconsultas/dieta/DietaServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaServiceImpl.java
@@ -104,27 +104,21 @@ public class DietaServiceImpl implements DietaService {
 		if (term.isEmpty()) {
 			return true;
 		}
-		if (dieta.getNombre() != null && dieta.getNombre().toLowerCase().contains(term)) {
-			return true;
-		}
 		final int kcal = DietaNutritionCalculator.calculateTotalKcal(dieta).intValue();
-		if (String.valueOf(kcal).contains(term)) {
-			return true;
-		}
-		if (dieta.getIngestas() != null) {
-			return dieta.getIngestas()
-				.stream()
-				.anyMatch(ingesta -> ingesta.getNombre() != null
-						&& ingesta.getNombre().toLowerCase().contains(term));
-		}
-		return false;
+		return (dieta.getNombre() != null && dieta.getNombre().toLowerCase().contains(term))
+				|| String.valueOf(kcal).contains(term)
+				|| (dieta.getIngestas() != null && dieta.getIngestas()
+					.stream()
+					.anyMatch(ingesta -> ingesta.getNombre() != null
+							&& ingesta.getNombre().toLowerCase().contains(term)));
 	}
 
 	private Comparator<DietaPickerItemDto> pickerComparator(final Double requerimientoKcal) {
 		if (requerimientoKcal == null) {
 			return Comparator.comparing(DietaPickerItemDto::getNombre, String.CASE_INSENSITIVE_ORDER);
 		}
-		return Comparator.comparingInt((DietaPickerItemDto item) -> caloricFitRank(item.getEnergiaKcal(), requerimientoKcal))
+		return Comparator
+			.comparingInt((DietaPickerItemDto item) -> caloricFitRank(item.getEnergiaKcal(), requerimientoKcal))
 			.thenComparingInt(item -> Math.abs(item.getEnergiaKcal() - requerimientoKcal.intValue()))
 			.thenComparing(DietaPickerItemDto::getNombre, String.CASE_INSENSITIVE_ORDER);
 	}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nutriconsultas.mobile.config.MobileOpenApiResponses;
 import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
 import com.nutriconsultas.mobile.dto.DietPlanPdfResult;
@@ -19,10 +20,15 @@ import com.nutriconsultas.mobile.dto.PagedResponse;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.util.LogRedaction;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/rest/mobile/patient/diet-plans")
+@Tag(name = "Mobile", description = "Patient mobile API")
 @Slf4j
 public class MobilePatientDietPlanController extends AbstractMobilePatientController {
 
@@ -35,9 +41,15 @@ public class MobilePatientDietPlanController extends AbstractMobilePatientContro
 	}
 
 	@GetMapping
+	@Operation(summary = "List diet plans", description = "Returns assigned diet plans for the authenticated patient.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+			description = "Paged diet plan summaries")
 	public ApiResponse<PagedResponse<DietPlanSummaryDto>> listDietPlans(@AuthenticationPrincipal final Jwt jwt,
-			@RequestParam(defaultValue = "0") final int page, @RequestParam(defaultValue = "20") final int size,
-			@RequestParam(defaultValue = "false") final boolean activeOnly) {
+			@Parameter(description = "Zero-based page index") @RequestParam(defaultValue = "0") final int page,
+			@Parameter(description = "Page size") @RequestParam(defaultValue = "20") final int size,
+			@Parameter(description = "When true, return only active assignments") @RequestParam(
+					defaultValue = "false") final boolean activeOnly) {
 		final Paciente paciente = getAuthenticatedPaciente(jwt);
 		if (log.isDebugEnabled()) {
 			log.debug("Mobile list diet plans for patient {} activeOnly={}",
@@ -49,8 +61,14 @@ public class MobilePatientDietPlanController extends AbstractMobilePatientContro
 	}
 
 	@GetMapping("/{assignmentId}")
+	@Operation(summary = "Get diet plan detail",
+			description = "Returns structured meal JSON for an assignment owned by the patient.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	@MobileOpenApiResponses.NotFoundWhenMissing
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+			description = "Diet plan detail with ingestas and platillos")
 	public ApiResponse<DietPlanDetailDto> getDietPlanDetail(@AuthenticationPrincipal final Jwt jwt,
-			@PathVariable final Long assignmentId) {
+			@Parameter(description = "PacienteDieta assignment identifier") @PathVariable final Long assignmentId) {
 		final Paciente paciente = getAuthenticatedPaciente(jwt);
 		if (log.isDebugEnabled()) {
 			log.debug("Mobile get diet plan {} for patient {}", assignmentId,
@@ -61,8 +79,14 @@ public class MobilePatientDietPlanController extends AbstractMobilePatientContro
 	}
 
 	@GetMapping(value = "/{assignmentId}/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+	@Operation(summary = "Download diet plan PDF",
+			description = "Returns a printable PDF for an assignment owned by the patient.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	@MobileOpenApiResponses.NotFoundWhenMissing
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "PDF bytes",
+			content = @Content(mediaType = MediaType.APPLICATION_PDF_VALUE))
 	public ResponseEntity<byte[]> getDietPlanPdf(@AuthenticationPrincipal final Jwt jwt,
-			@PathVariable final Long assignmentId) {
+			@Parameter(description = "PacienteDieta assignment identifier") @PathVariable final Long assignmentId) {
 		final Paciente paciente = getAuthenticatedPaciente(jwt);
 		if (log.isDebugEnabled()) {
 			log.debug("Mobile get diet plan PDF {} for patient {}", assignmentId,

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nutriconsultas.mobile.config.MobileOpenApiResponses;
 import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.CursorPagedResponse;
 import com.nutriconsultas.mobile.dto.PatientMessageSummaryDto;
@@ -18,11 +19,15 @@ import com.nutriconsultas.mobile.dto.SendPatientMessageRequest;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.util.LogRedaction;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/rest/mobile/patient/messages")
+@Tag(name = "Mobile", description = "Patient mobile API")
 @Slf4j
 public class MobilePatientMessageController extends AbstractMobilePatientController {
 
@@ -35,9 +40,15 @@ public class MobilePatientMessageController extends AbstractMobilePatientControl
 	}
 
 	@GetMapping
+	@Operation(summary = "List messages", description = "Returns cursor-paged messages for the authenticated patient.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+			description = "Cursor-paged message summaries")
 	public ApiResponse<CursorPagedResponse<PatientMessageSummaryDto>> listMessages(
-			@AuthenticationPrincipal final Jwt jwt, @RequestParam(required = false) final String cursor,
-			@RequestParam(defaultValue = "20") final int size) {
+			@AuthenticationPrincipal final Jwt jwt,
+			@Parameter(description = "Opaque cursor from a previous page") @RequestParam(
+					required = false) final String cursor,
+			@Parameter(description = "Page size") @RequestParam(defaultValue = "20") final int size) {
 		final Paciente paciente = getAuthenticatedPaciente(jwt);
 		if (log.isDebugEnabled()) {
 			log.debug("Mobile list messages request for patient {}", LogRedaction.redactPaciente(paciente.getId()));
@@ -49,6 +60,10 @@ public class MobilePatientMessageController extends AbstractMobilePatientControl
 
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
+	@Operation(summary = "Send message", description = "Creates a patient-to-nutritionist message.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	@MobileOpenApiResponses.WriteEndpoint
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Created message summary")
 	public ApiResponse<PatientMessageSummaryDto> sendMessage(@AuthenticationPrincipal final Jwt jwt,
 			@Valid @RequestBody final SendPatientMessageRequest request) {
 		final Paciente paciente = getAuthenticatedPaciente(jwt);

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressController.java
@@ -55,6 +55,8 @@ public class MobilePatientProgressController extends AbstractMobilePatientContro
 	@MobileOpenApiResponses.AuthenticatedPatient
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
 			description = "Measurement time series (ASC, max 365 rows)")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400",
+			description = "Invalid date range (from after to)")
 	public ApiResponse<ProgressMeasurementsDto> listMeasurements(@AuthenticationPrincipal final Jwt jwt,
 			@Parameter(description = "Inclusive start instant (ISO-8601)") @RequestParam(
 					required = false) final Instant from,

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressController.java
@@ -9,16 +9,21 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nutriconsultas.mobile.config.MobileOpenApiResponses;
 import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.PatientProgressSnapshotDto;
 import com.nutriconsultas.mobile.dto.ProgressMeasurementsDto;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.util.LogRedaction;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/rest/mobile/patient/progress")
+@Tag(name = "Mobile", description = "Patient mobile API")
 @Slf4j
 public class MobilePatientProgressController extends AbstractMobilePatientController {
 
@@ -31,6 +36,10 @@ public class MobilePatientProgressController extends AbstractMobilePatientContro
 	}
 
 	@GetMapping
+	@Operation(summary = "Get progress snapshot",
+			description = "Returns latest BMI/BMR and related progress snapshot for the patient.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Progress snapshot")
 	public ApiResponse<PatientProgressSnapshotDto> getProgress(@AuthenticationPrincipal final Jwt jwt) {
 		final Paciente paciente = getAuthenticatedPaciente(jwt);
 		if (log.isDebugEnabled()) {
@@ -41,9 +50,18 @@ public class MobilePatientProgressController extends AbstractMobilePatientContro
 	}
 
 	@GetMapping("/measurements")
+	@Operation(summary = "List progress measurements",
+			description = "Returns anthropometric measurement time series for the patient.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+			description = "Measurement time series (ASC, max 365 rows)")
 	public ApiResponse<ProgressMeasurementsDto> listMeasurements(@AuthenticationPrincipal final Jwt jwt,
-			@RequestParam(required = false) final Instant from, @RequestParam(required = false) final Instant to,
-			@RequestParam(required = false) final Integer maxRows) {
+			@Parameter(description = "Inclusive start instant (ISO-8601)") @RequestParam(
+					required = false) final Instant from,
+			@Parameter(description = "Inclusive end instant (ISO-8601)") @RequestParam(
+					required = false) final Instant to,
+			@Parameter(description = "Maximum rows (capped at 365)") @RequestParam(
+					required = false) final Integer maxRows) {
 		final Paciente paciente = getAuthenticatedPaciente(jwt);
 		if (log.isDebugEnabled()) {
 			log.debug("Mobile progress measurements request for patient {}",

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nutriconsultas.calendar.EventStatus;
+import com.nutriconsultas.mobile.config.MobileOpenApiResponses;
 import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.PagedResponse;
 import com.nutriconsultas.mobile.dto.VisitDetailDto;
@@ -18,10 +19,14 @@ import com.nutriconsultas.mobile.dto.VisitSummaryDto;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.util.LogRedaction;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/rest/mobile/patient/visits")
+@Tag(name = "Mobile", description = "Patient mobile API")
 @Slf4j
 public class MobilePatientVisitController extends AbstractMobilePatientController {
 
@@ -34,10 +39,18 @@ public class MobilePatientVisitController extends AbstractMobilePatientControlle
 	}
 
 	@GetMapping
+	@Operation(summary = "List patient visits",
+			description = "Returns a paged list of visit summaries for the authenticated patient.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Paged visit summaries")
 	public ApiResponse<PagedResponse<VisitSummaryDto>> listVisits(@AuthenticationPrincipal final Jwt jwt,
-			@RequestParam(defaultValue = "0") final int page, @RequestParam(defaultValue = "20") final int size,
-			@RequestParam(required = false) final EventStatus status,
-			@RequestParam(required = false) final Instant from, @RequestParam(required = false) final Instant to) {
+			@Parameter(description = "Zero-based page index") @RequestParam(defaultValue = "0") final int page,
+			@Parameter(description = "Page size") @RequestParam(defaultValue = "20") final int size,
+			@Parameter(description = "Filter by visit status") @RequestParam(required = false) final EventStatus status,
+			@Parameter(description = "Inclusive start instant (ISO-8601)") @RequestParam(
+					required = false) final Instant from,
+			@Parameter(description = "Inclusive end instant (ISO-8601)") @RequestParam(
+					required = false) final Instant to) {
 		final Paciente paciente = getAuthenticatedPaciente(jwt);
 		if (log.isDebugEnabled()) {
 			log.debug("Mobile list visits request for patient {}", LogRedaction.redactPaciente(paciente.getId()));
@@ -48,8 +61,12 @@ public class MobilePatientVisitController extends AbstractMobilePatientControlle
 	}
 
 	@GetMapping("/{visitId}")
+	@Operation(summary = "Get visit detail", description = "Returns a single visit owned by the authenticated patient.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	@MobileOpenApiResponses.NotFoundWhenMissing
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Visit detail")
 	public ApiResponse<VisitDetailDto> getVisitDetail(@AuthenticationPrincipal final Jwt jwt,
-			@PathVariable final Long visitId) {
+			@Parameter(description = "Visit identifier") @PathVariable final Long visitId) {
 		final Paciente paciente = getAuthenticatedPaciente(jwt);
 		if (log.isDebugEnabled()) {
 			log.debug("Mobile get visit {} for patient {}", visitId, LogRedaction.redactPaciente(paciente.getId()));

--- a/src/main/java/com/nutriconsultas/mobile/config/MobileOpenApiConfig.java
+++ b/src/main/java/com/nutriconsultas/mobile/config/MobileOpenApiConfig.java
@@ -1,0 +1,43 @@
+package com.nutriconsultas.mobile.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import org.springdoc.core.models.GroupedOpenApi;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class MobileOpenApiConfig {
+
+	private static final String BEARER_JWT_SCHEME = "bearer-jwt";
+
+	@Bean
+	public GroupedOpenApi mobileApi() {
+		return GroupedOpenApi.builder().group("mobile").pathsToMatch("/rest/mobile/**").build();
+	}
+
+	@Bean
+	public OpenAPI mobileOpenApi(@Value("${app.security.jwt.audience:}") final String audience) {
+		final String audienceNote = audience.isBlank() ? "configured AUTH_AUDIENCE" : audience;
+		return new OpenAPI()
+			.info(new Info().title("Minutriporcion Patient Mobile API")
+				.version("1.0")
+				.description("Patient-facing JSON API under /rest/mobile/patient/**. "
+						+ "Requires Auth0 Bearer JWT (resource server).")
+				.contact(new Contact().name("Minutriporcion").url("https://minutriporcion.com")))
+			.components(new Components().addSecuritySchemes(BEARER_JWT_SCHEME,
+					new SecurityScheme().type(SecurityScheme.Type.HTTP)
+						.scheme("bearer")
+						.bearerFormat("JWT")
+						.description("Auth0 access token with audience " + audienceNote)))
+			.addSecurityItem(new SecurityRequirement().addList(BEARER_JWT_SCHEME));
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/config/MobileOpenApiResponses.java
+++ b/src/main/java/com/nutriconsultas/mobile/config/MobileOpenApiResponses.java
@@ -1,0 +1,39 @@
+package com.nutriconsultas.mobile.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+/**
+ * Shared OpenAPI response declarations for {@code /rest/mobile/patient/**} (#112).
+ */
+public interface MobileOpenApiResponses {
+
+	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Retention(RetentionPolicy.RUNTIME)
+	@ApiResponses({ @ApiResponse(responseCode = "401", description = "Missing or invalid JWT"),
+			@ApiResponse(responseCode = "403", description = "Patient account not linked to Auth0 sub") })
+	@interface AuthenticatedPatient {
+
+	}
+
+	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Retention(RetentionPolicy.RUNTIME)
+	@ApiResponses({ @ApiResponse(responseCode = "404", description = "Resource not found or not owned by patient") })
+	@interface NotFoundWhenMissing {
+
+	}
+
+	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Retention(RetentionPolicy.RUNTIME)
+	@ApiResponses({ @ApiResponse(responseCode = "400", description = "Validation failed"),
+			@ApiResponse(responseCode = "429", description = "Rate limit exceeded (Retry-After: 60)") })
+	@interface WriteEndpoint {
+
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/SendPatientMessageRequest.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/SendPatientMessageRequest.java
@@ -1,7 +1,9 @@
 package com.nutriconsultas.mobile.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-public record SendPatientMessageRequest(@NotBlank @Size(max = 2000) String body) {
+public record SendPatientMessageRequest(@NotBlank @Size(max = 2000) @Schema(minLength = 1, maxLength = 2000,
+		description = "Message body") String body) {
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,6 +39,8 @@ app.security.jwt.audience=${AUTH_AUDIENCE}
 springdoc.api-docs.enabled=${SPRINGDOC_API_DOCS_ENABLED:false}
 springdoc.swagger-ui.enabled=${SPRINGDOC_SWAGGER_UI_ENABLED:false}
 springdoc.swagger-ui.urls-primary-name=mobile
+springdoc.packages-to-scan=com.nutriconsultas.mobile
+springdoc.paths-to-match=/rest/mobile/**
 # Patient write rate limits (#113)
 resilience4j.ratelimiter.instances.patientMessages.limit-for-period=10
 resilience4j.ratelimiter.instances.patientMessages.limit-refresh-period=1m

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,6 +35,10 @@ spring.security.oauth2.client.provider.auth0.issuer-uri=${AUTH_ISSUER}
 # Patient mobile API — JWT resource server (separate from nutritionist oauth2Login session)
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${AUTH_ISSUER}
 app.security.jwt.audience=${AUTH_AUDIENCE}
+# OpenAPI / Swagger UI — disabled in production; enable locally via SPRINGDOC_* env vars (#112)
+springdoc.api-docs.enabled=${SPRINGDOC_API_DOCS_ENABLED:false}
+springdoc.swagger-ui.enabled=${SPRINGDOC_SWAGGER_UI_ENABLED:false}
+springdoc.swagger-ui.urls-primary-name=mobile
 # Patient write rate limits (#113)
 resilience4j.ratelimiter.instances.patientMessages.limit-for-period=10
 resilience4j.ratelimiter.instances.patientMessages.limit-refresh-period=1m

--- a/src/test/java/com/nutriconsultas/mobile/MobileOpenApiIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileOpenApiIntegrationTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -24,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@WithMockUser
 class MobileOpenApiIntegrationTest {
 
 	private static final List<String> REQUIRED_PATHS = List.of("/rest/mobile/patient/visits",

--- a/src/test/java/com/nutriconsultas/mobile/MobileOpenApiIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileOpenApiIntegrationTest.java
@@ -1,0 +1,77 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MobileOpenApiIntegrationTest {
+
+	private static final List<String> REQUIRED_PATHS = List.of("/rest/mobile/patient/visits",
+			"/rest/mobile/patient/visits/{visitId}", "/rest/mobile/patient/diet-plans",
+			"/rest/mobile/patient/diet-plans/{assignmentId}", "/rest/mobile/patient/diet-plans/{assignmentId}/pdf",
+			"/rest/mobile/patient/messages", "/rest/mobile/patient/progress",
+			"/rest/mobile/patient/progress/measurements");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	void mobileOpenApiGroupDocumentsPatientEndpoints() throws Exception {
+		final MvcResult result = mockMvc.perform(get("/v3/api-docs/mobile"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.openapi").value("3.1.0"))
+			.andExpect(jsonPath("$.info.title").value("Minutriporcion Patient Mobile API"))
+			.andExpect(jsonPath("$.components.securitySchemes['bearer-jwt']").exists())
+			.andReturn();
+
+		final JsonNode paths = objectMapper.readTree(result.getResponse().getContentAsString()).path("paths");
+		for (final String path : REQUIRED_PATHS) {
+			assertThat(paths.has(path)).as("OpenAPI path %s", path).isTrue();
+		}
+		assertThat(paths.path("/rest/mobile/patient/messages").has("get")).isTrue();
+		assertThat(paths.path("/rest/mobile/patient/messages").has("post")).isTrue();
+	}
+
+	@Test
+	void mobileOpenApiYamlIsAvailableForExport() throws Exception {
+		mockMvc.perform(get("/v3/api-docs.yaml/mobile"))
+			.andExpect(status().isOk())
+			.andExpect(result -> assertThat(result.getResponse().getContentType()).contains("openapi"));
+
+		if (Boolean.getBoolean("openapi.export")) {
+			exportYamlSpec();
+		}
+	}
+
+	private void exportYamlSpec() throws Exception {
+		final MvcResult yamlResult = mockMvc.perform(get("/v3/api-docs.yaml/mobile")).andReturn();
+		final Path output = Path.of("docs", "api", "openapi-mobile.yaml");
+		Files.createDirectories(output.getParent());
+		Files.writeString(output, yamlResult.getResponse().getContentAsString(StandardCharsets.UTF_8),
+				StandardCharsets.UTF_8);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/security/WebSecurityConfigRegressionTest.java
+++ b/src/test/java/com/nutriconsultas/security/WebSecurityConfigRegressionTest.java
@@ -30,4 +30,9 @@ class WebSecurityConfigRegressionTest {
 		mockMvc.perform(get("/admin/pacientes")).andExpect(status().is3xxRedirection());
 	}
 
+	@Test
+	void openApiDocs_withoutSession_requiresNutritionistLogin() throws Exception {
+		mockMvc.perform(get("/v3/api-docs/mobile")).andExpect(status().is3xxRedirection());
+	}
+
 }

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -27,3 +27,6 @@ nutriconsultas.platform.admin-user-ids=auth0|platform-admin-test
 resilience4j.ratelimiter.instances.patientMessages.limit-for-period=2
 resilience4j.ratelimiter.instances.patientMessages.limit-refresh-period=1m
 resilience4j.ratelimiter.instances.patientMessages.timeout-duration=0s
+# OpenAPI spec generation in tests (#112)
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true


### PR DESCRIPTION
## Summary
- Implements #112 — springdoc OpenAPI 3.1 for all `/rest/mobile/patient/**` endpoints (9 operations across visits, diet plans, messages, progress)
- Adds `MobileOpenApiConfig` with Bearer JWT security scheme, `@Operation`/`@Tag` annotations on mobile controllers, and committed export `docs/api/openapi-mobile.yaml`
- Swagger UI / api-docs disabled in production by default (`SPRINGDOC_*` env vars); `scripts/export-openapi-mobile.sh` refreshes the YAML from tests

## Test plan
- [x] `./lint.sh && bash scripts/audit-logging.sh` green
- [x] `mvn -B checkstyle:check pmd:check -Pci spotbugs:check verify jacoco:check -Pci` green (Java 21)
- [x] `MobileOpenApiIntegrationTest` documents all patient paths at `/v3/api-docs/mobile`
- [x] Local Swagger UI: `SPRINGDOC_API_DOCS_ENABLED=true SPRINGDOC_SWAGGER_UI_ENABLED=true` → `/swagger-ui/index.html?urls.primaryName=mobile`

Closes #112

Made with [Cursor](https://cursor.com)