### PR TITLE
Show nutritionist name and cédula in clinical PDF headers (#127)

### DIFF
--- a/src/main/java/com/nutriconsultas/calendar/CalendarEventRestController.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarEventRestController.java
@@ -781,7 +781,8 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 
 	private void applyStressFields(final CalendarEvent event, final Map<String, Object> eventData) {
 		if (eventData.get("physiologicalStressActive") != null) {
-			event.setPhysiologicalStressActive(Boolean.parseBoolean(eventData.get("physiologicalStressActive").toString()));
+			event.setPhysiologicalStressActive(
+					Boolean.parseBoolean(eventData.get("physiologicalStressActive").toString()));
 		}
 		if (eventData.get("physiologicalStressType") != null) {
 			event.setPhysiologicalStressType(

--- a/src/main/java/com/nutriconsultas/dieta/DietaNutritionCalculator.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaNutritionCalculator.java
@@ -14,18 +14,14 @@ public final class DietaNutritionCalculator {
 			return 0.0;
 		}
 		return dieta.getIngestas().stream().mapToDouble(ingesta -> {
-			final double platillos = ingesta.getPlatillos() != null
-					? ingesta.getPlatillos()
-						.stream()
-						.mapToDouble(p -> p.getProteina() != null ? p.getProteina() : 0.0)
-						.sum()
-					: 0.0;
-			final double alimentos = ingesta.getAlimentos() != null
-					? ingesta.getAlimentos()
-						.stream()
-						.mapToDouble(a -> a.getProteina() != null ? a.getProteina() : 0.0)
-						.sum()
-					: 0.0;
+			final double platillos = ingesta.getPlatillos() != null ? ingesta.getPlatillos()
+				.stream()
+				.mapToDouble(p -> p.getProteina() != null ? p.getProteina() : 0.0)
+				.sum() : 0.0;
+			final double alimentos = ingesta.getAlimentos() != null ? ingesta.getAlimentos()
+				.stream()
+				.mapToDouble(a -> a.getProteina() != null ? a.getProteina() : 0.0)
+				.sum() : 0.0;
 			return platillos + alimentos;
 		}).sum();
 	}
@@ -35,18 +31,14 @@ public final class DietaNutritionCalculator {
 			return 0.0;
 		}
 		return dieta.getIngestas().stream().mapToDouble(ingesta -> {
-			final double platillos = ingesta.getPlatillos() != null
-					? ingesta.getPlatillos()
-						.stream()
-						.mapToDouble(p -> p.getLipidos() != null ? p.getLipidos() : 0.0)
-						.sum()
-					: 0.0;
-			final double alimentos = ingesta.getAlimentos() != null
-					? ingesta.getAlimentos()
-						.stream()
-						.mapToDouble(a -> a.getLipidos() != null ? a.getLipidos() : 0.0)
-						.sum()
-					: 0.0;
+			final double platillos = ingesta.getPlatillos() != null ? ingesta.getPlatillos()
+				.stream()
+				.mapToDouble(p -> p.getLipidos() != null ? p.getLipidos() : 0.0)
+				.sum() : 0.0;
+			final double alimentos = ingesta.getAlimentos() != null ? ingesta.getAlimentos()
+				.stream()
+				.mapToDouble(a -> a.getLipidos() != null ? a.getLipidos() : 0.0)
+				.sum() : 0.0;
 			return platillos + alimentos;
 		}).sum();
 	}
@@ -56,18 +48,14 @@ public final class DietaNutritionCalculator {
 			return 0.0;
 		}
 		return dieta.getIngestas().stream().mapToDouble(ingesta -> {
-			final double platillos = ingesta.getPlatillos() != null
-					? ingesta.getPlatillos()
-						.stream()
-						.mapToDouble(p -> p.getHidratosDeCarbono() != null ? p.getHidratosDeCarbono() : 0.0)
-						.sum()
-					: 0.0;
-			final double alimentos = ingesta.getAlimentos() != null
-					? ingesta.getAlimentos()
-						.stream()
-						.mapToDouble(a -> a.getHidratosDeCarbono() != null ? a.getHidratosDeCarbono() : 0.0)
-						.sum()
-					: 0.0;
+			final double platillos = ingesta.getPlatillos() != null ? ingesta.getPlatillos()
+				.stream()
+				.mapToDouble(p -> p.getHidratosDeCarbono() != null ? p.getHidratosDeCarbono() : 0.0)
+				.sum() : 0.0;
+			final double alimentos = ingesta.getAlimentos() != null ? ingesta.getAlimentos()
+				.stream()
+				.mapToDouble(a -> a.getHidratosDeCarbono() != null ? a.getHidratosDeCarbono() : 0.0)
+				.sum() : 0.0;
 			return platillos + alimentos;
 		}).sum();
 	}

--- a/src/main/java/com/nutriconsultas/dieta/DietaPdfService.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaPdfService.java
@@ -14,6 +14,7 @@ import org.xhtmlrenderer.pdf.ITextRenderer;
 
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
+import com.nutriconsultas.profile.NutritionistBrandingHelper;
 import com.nutriconsultas.profile.NutritionistProfile;
 import com.nutriconsultas.profile.NutritionistProfileService;
 
@@ -219,13 +220,11 @@ public class DietaPdfService {
 		// Dieta.userId identifies the owning nutritionist tenant
 		if (dieta.getUserId() != null) {
 			final NutritionistProfile profile = nutritionistProfileService.getOrCreateProfile(dieta.getUserId());
-			context.setVariable("nutritionistProfile", profile);
 			final String logoBase64 = nutritionistProfileService.getLogoAsBase64DataUri(dieta.getUserId());
-			context.setVariable("logoBase64", logoBase64);
+			NutritionistBrandingHelper.addBrandingVariables(context, profile, logoBase64);
 		}
 		else {
-			context.setVariable("nutritionistProfile", null);
-			context.setVariable("logoBase64", null);
+			NutritionistBrandingHelper.addBrandingVariables(context, null, null);
 		}
 
 		// Render Thymeleaf template to HTML

--- a/src/main/java/com/nutriconsultas/dieta/DietaTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaTemplateValidator.java
@@ -261,8 +261,10 @@ public class DietaTemplateValidator extends BaseTemplateValidator {
 		// Add nutritionist branding mock variables for printable template header
 		final NutritionistProfile mockProfile = new NutritionistProfile();
 		mockProfile.setId(1L);
+		mockProfile.setDisplayName("Lic. María García López");
 		mockProfile.setCedulaProfesional("12345678");
 		variables.put("nutritionistProfile", mockProfile);
+		variables.put("nutritionistDisplayName", "Lic. María García López");
 		variables.put("logoBase64", null);
 	}
 

--- a/src/main/java/com/nutriconsultas/paciente/calculation/EnergyExpenditureResolver.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/EnergyExpenditureResolver.java
@@ -100,8 +100,8 @@ public final class EnergyExpenditureResolver {
 			return result;
 		}
 		final LocalDate referenceDate = resolveReferenceDate(event, measurement);
-		final StressContext stressContext = PhysiologicalStressPreferences.resolveEffective(paciente, event, measurement,
-				referenceDate);
+		final StressContext stressContext = PhysiologicalStressPreferences.resolveEffective(paciente, event,
+				measurement, referenceDate);
 		final Double stressKcal = PhysiologicalStressCalculationService.calculateStressKcal(stressContext, result.bmr(),
 				result.getKcal(), bodyTemperature);
 		final Double finalTotalKcal = PhysiologicalStressCalculationService

--- a/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCalculationService.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCalculationService.java
@@ -15,7 +15,6 @@ public final class PhysiologicalStressCalculationService {
 
 	/**
 	 * Calculates stress kcal/day from resolved context and energy components.
-	 *
 	 * @param context resolved stress configuration
 	 * @param bmr basal metabolic rate (kcal/day)
 	 * @param getKcal total daily energy expenditure before TEF (kcal/day)

--- a/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCatalog.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCatalog.java
@@ -24,8 +24,8 @@ public final class PhysiologicalStressCatalog {
 	}
 
 	/**
-	 * Returns the default multiplier for a stress type and reference table, or {@code null}
-	 * when the nutritionist must supply a custom value.
+	 * Returns the default multiplier for a stress type and reference table, or
+	 * {@code null} when the nutritionist must supply a custom value.
 	 */
 	public static Double defaultMultiplier(final PhysiologicalStressType stressType,
 			final StressFormulaTable formulaTable) {
@@ -48,7 +48,8 @@ public final class PhysiologicalStressCatalog {
 	}
 
 	/**
-	 * Suggests stress types based on pathology flags already captured on the patient record.
+	 * Suggests stress types based on pathology flags already captured on the patient
+	 * record.
 	 */
 	public static List<PhysiologicalStressType> suggestFromPathologies(final Paciente paciente) {
 		if (paciente == null) {

--- a/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressPreferences.java
+++ b/src/main/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressPreferences.java
@@ -11,7 +11,8 @@ import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
 import com.nutriconsultas.paciente.Paciente;
 
 /**
- * Resolves physiological stress preferences from patient records and clinical event overrides.
+ * Resolves physiological stress preferences from patient records and clinical event
+ * overrides.
  */
 public final class PhysiologicalStressPreferences {
 
@@ -42,15 +43,15 @@ public final class PhysiologicalStressPreferences {
 			return StressContext.inactive();
 		}
 		return StressContext.fromValues(measurement.getPhysiologicalStressActive(),
-				measurement.getPhysiologicalStressType(),
-				measurement.getStressFormulaTable(), measurement.getStressIncrementMode(),
-				measurement.getStressFactorValue(), measurement.getStressValidFrom(),
-				measurement.getStressValidUntil(), measurement.getStressFeverTemperature());
+				measurement.getPhysiologicalStressType(), measurement.getStressFormulaTable(),
+				measurement.getStressIncrementMode(), measurement.getStressFactorValue(),
+				measurement.getStressValidFrom(), measurement.getStressValidUntil(),
+				measurement.getStressFeverTemperature());
 	}
 
 	/**
-	 * Resolves effective stress context: event/measurement override when explicitly active,
-	 * otherwise patient baseline when valid on the reference date.
+	 * Resolves effective stress context: event/measurement override when explicitly
+	 * active, otherwise patient baseline when valid on the reference date.
 	 */
 	public static StressContext resolveEffective(final Paciente paciente, @Nullable final CalendarEvent event,
 			@Nullable final AnthropometricMeasurement measurement, @Nullable final LocalDate referenceDate) {

--- a/src/main/java/com/nutriconsultas/profile/NutritionistBrandingHelper.java
+++ b/src/main/java/com/nutriconsultas/profile/NutritionistBrandingHelper.java
@@ -1,0 +1,92 @@
+package com.nutriconsultas.profile;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.thymeleaf.context.Context;
+
+/**
+ * Resolves nutritionist branding fields for PDF report templates.
+ *
+ * <p>
+ * Display name priority: profile {@code displayName} → OIDC {@code name} claim → omit.
+ */
+public final class NutritionistBrandingHelper {
+
+	private NutritionistBrandingHelper() {
+	}
+
+	/**
+	 * Adds nutritionist profile, logo, and resolved display name to a Thymeleaf context.
+	 * @param context the Thymeleaf context
+	 * @param profile the nutritionist profile (may be null)
+	 * @param logoBase64 the logo as a Base64 data URI (may be null)
+	 * @param oauthDisplayName fallback display name from OAuth (may be null)
+	 */
+	public static void addBrandingVariables(final Context context, final NutritionistProfile profile,
+			final String logoBase64, final String oauthDisplayName) {
+		context.setVariable("nutritionistProfile", profile);
+		context.setVariable("logoBase64", logoBase64);
+		context.setVariable("nutritionistDisplayName", resolveDisplayName(profile, oauthDisplayName));
+	}
+
+	/**
+	 * Adds branding variables using the current security context for OAuth name fallback.
+	 * @param context the Thymeleaf context
+	 * @param profile the nutritionist profile (may be null)
+	 * @param logoBase64 the logo as a Base64 data URI (may be null)
+	 */
+	public static void addBrandingVariables(final Context context, final NutritionistProfile profile,
+			final String logoBase64) {
+		addBrandingVariables(context, profile, logoBase64, resolveOAuthDisplayNameFromSecurityContext());
+	}
+
+	/**
+	 * Resolves the nutritionist display name for PDF headers.
+	 * @param profile the nutritionist profile (may be null)
+	 * @param oauthDisplayName fallback from OIDC {@code name} claim (may be null)
+	 * @return resolved name, or {@code null} when no source is available
+	 */
+	public static String resolveDisplayName(final NutritionistProfile profile, final String oauthDisplayName) {
+		if (profile != null && profile.getDisplayName() != null && !profile.getDisplayName().isBlank()) {
+			return profile.getDisplayName().trim();
+		}
+		if (oauthDisplayName != null && !oauthDisplayName.isBlank()) {
+			return oauthDisplayName.trim();
+		}
+		return null;
+	}
+
+	/**
+	 * Extracts a display name from an OIDC user ({@code name} claim, then full name).
+	 * @param principal the authenticated OIDC user (may be null)
+	 * @return display name, or {@code null} when unavailable
+	 */
+	public static String resolveOAuthDisplayName(final OidcUser principal) {
+		if (principal == null) {
+			return null;
+		}
+		final Object nameClaim = principal.getClaims().get("name");
+		if (nameClaim instanceof String name && !name.isBlank()) {
+			return name.trim();
+		}
+		final String fullName = principal.getFullName();
+		if (fullName != null && !fullName.isBlank()) {
+			return fullName.trim();
+		}
+		return null;
+	}
+
+	/**
+	 * Reads the OIDC display name from the current Spring Security context.
+	 * @return display name, or {@code null} when not authenticated as OIDC user
+	 */
+	public static String resolveOAuthDisplayNameFromSecurityContext() {
+		final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication != null && authentication.getPrincipal() instanceof OidcUser oidcUser) {
+			return resolveOAuthDisplayName(oidcUser);
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/reports/PatientReportService.java
+++ b/src/main/java/com/nutriconsultas/reports/PatientReportService.java
@@ -27,6 +27,7 @@ import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
 import com.nutriconsultas.paciente.PacienteService;
+import com.nutriconsultas.profile.NutritionistBrandingHelper;
 import com.nutriconsultas.profile.NutritionistProfile;
 import com.nutriconsultas.profile.NutritionistProfileService;
 
@@ -146,8 +147,8 @@ public class PatientReportService {
 
 		// Inject nutritionist profile branding
 		final NutritionistProfile profile = nutritionistProfileService.getOrCreateProfile(userId);
-		context.setVariable("nutritionistProfile", profile);
-		context.setVariable("logoBase64", nutritionistProfileService.getLogoAsBase64DataUri(userId));
+		final String logoBase64 = nutritionistProfileService.getLogoAsBase64DataUri(userId);
+		NutritionistBrandingHelper.addBrandingVariables(context, profile, logoBase64);
 
 		// Render Thymeleaf template to HTML
 		final String html = templateEngine.process("sbadmin/reports/patient-progress", context);
@@ -273,8 +274,8 @@ public class PatientReportService {
 
 		// Inject nutritionist profile branding
 		final NutritionistProfile nutritionAnalysisProfile = nutritionistProfileService.getOrCreateProfile(userId);
-		context.setVariable("nutritionistProfile", nutritionAnalysisProfile);
-		context.setVariable("logoBase64", nutritionistProfileService.getLogoAsBase64DataUri(userId));
+		final String nutritionLogoBase64 = nutritionistProfileService.getLogoAsBase64DataUri(userId);
+		NutritionistBrandingHelper.addBrandingVariables(context, nutritionAnalysisProfile, nutritionLogoBase64);
 
 		// Render Thymeleaf template to HTML
 		final String html = templateEngine.process("sbadmin/reports/nutrition-analysis", context);
@@ -307,8 +308,8 @@ public class PatientReportService {
 
 		// Inject nutritionist profile branding
 		final NutritionistProfile clinicProfile = nutritionistProfileService.getOrCreateProfile(userId);
-		context.setVariable("nutritionistProfile", clinicProfile);
-		context.setVariable("logoBase64", nutritionistProfileService.getLogoAsBase64DataUri(userId));
+		final String clinicLogoBase64 = nutritionistProfileService.getLogoAsBase64DataUri(userId);
+		NutritionistBrandingHelper.addBrandingVariables(context, clinicProfile, clinicLogoBase64);
 
 		// Render Thymeleaf template to HTML
 		final String html = templateEngine.process("sbadmin/reports/clinic-statistics-pdf", context);

--- a/src/main/java/com/nutriconsultas/reports/ReportTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/reports/ReportTemplateValidator.java
@@ -83,8 +83,10 @@ public class ReportTemplateValidator extends BaseTemplateValidator {
 		// Add nutritionist branding mock variables for all PDF report templates
 		final NutritionistProfile mockProfile = new NutritionistProfile();
 		mockProfile.setId(1L);
+		mockProfile.setDisplayName("Lic. María García López");
 		mockProfile.setCedulaProfesional("12345678");
 		variables.put("nutritionistProfile", mockProfile);
+		variables.put("nutritionistDisplayName", "Lic. María García López");
 		variables.put("logoBase64", null);
 
 		return variables;

--- a/src/main/resources/templates/sbadmin/dietas/printable.html
+++ b/src/main/resources/templates/sbadmin/dietas/printable.html
@@ -193,6 +193,7 @@
 	<!--
 		OPTIONAL MODEL VARIABLES (added by DietaPdfService):
 		- nutritionistProfile: NutritionistProfile entity (may be null)
+		- nutritionistDisplayName: resolved nutritionist name (may be null)
 		- logoBase64: Base64 Data URI string for the clinic logo (may be null)
 	-->
 	<div class="header">
@@ -201,10 +202,7 @@
 				<td style="vertical-align: bottom;">
 					<h1>Plan de Alimentación</h1>
 					<p>Minutriporcion - Consulta Nutricional</p>
-					<p th:if="${nutritionistProfile != null and nutritionistProfile.cedulaProfesional != null
-					        and !#strings.isEmpty(nutritionistProfile.cedulaProfesional)}">
-						Ced. Prof. <span th:text="${nutritionistProfile.cedulaProfesional}">0000000</span>
-					</p>
+					<div th:replace="~{sbadmin/fragments/pdf-nutritionist-credentials :: credentials}"></div>
 				</td>
 				<td th:if="${logoBase64 != null}" style="text-align: right; vertical-align: bottom; width: 160px;">
 					<img th:src="${logoBase64}" alt="Logo" style="max-height: 70px; max-width: 150px;" />

--- a/src/main/resources/templates/sbadmin/fragments/pdf-nutritionist-credentials.html
+++ b/src/main/resources/templates/sbadmin/fragments/pdf-nutritionist-credentials.html
@@ -1,0 +1,23 @@
+<!--
+  PDF header line: nutritionist name and/or professional license.
+
+  Required model variables:
+  - nutritionistDisplayName: resolved display name (may be null)
+  - nutritionistProfile: NutritionistProfile entity (may be null)
+-->
+<p th:fragment="credentials"
+   th:if="${nutritionistDisplayName != null
+           or (nutritionistProfile != null
+               and nutritionistProfile.cedulaProfesional != null
+               and !#strings.isEmpty(nutritionistProfile.cedulaProfesional))}">
+	<span th:if="${nutritionistDisplayName != null}" th:text="${nutritionistDisplayName}">Nombre del Nutriólogo</span>
+	<span th:if="${nutritionistDisplayName != null
+	              and nutritionistProfile != null
+	              and nutritionistProfile.cedulaProfesional != null
+	              and !#strings.isEmpty(nutritionistProfile.cedulaProfesional)}"> — </span>
+	<span th:if="${nutritionistProfile != null
+	              and nutritionistProfile.cedulaProfesional != null
+	              and !#strings.isEmpty(nutritionistProfile.cedulaProfesional)}">
+		Ced. Prof. <span th:text="${nutritionistProfile.cedulaProfesional}">0000000</span>
+	</span>
+</p>

--- a/src/main/resources/templates/sbadmin/reports/clinic-statistics-pdf.html
+++ b/src/main/resources/templates/sbadmin/reports/clinic-statistics-pdf.html
@@ -133,6 +133,7 @@
 	<!--
 		OPTIONAL MODEL VARIABLES:
 		- nutritionistProfile: NutritionistProfile entity (may be null)
+		- nutritionistDisplayName: resolved nutritionist name (may be null)
 		- logoBase64: Base64 Data URI string (may be null)
 	-->
 	<div class="header">
@@ -141,10 +142,7 @@
 				<td style="vertical-align: bottom;">
 					<h1>Estadísticas de la Clínica</h1>
 					<p>Minutriporcion - Reporte de Estadísticas Generales</p>
-					<p th:if="${nutritionistProfile != null and nutritionistProfile.cedulaProfesional != null
-					        and !#strings.isEmpty(nutritionistProfile.cedulaProfesional)}">
-						Ced. Prof. <span th:text="${nutritionistProfile.cedulaProfesional}">0000000</span>
-					</p>
+					<div th:replace="~{sbadmin/fragments/pdf-nutritionist-credentials :: credentials}"></div>
 					<p th:if="${startDate != null or endDate != null}">
 						Período:
 						<span th:if="${startDate != null}" th:text="${#dates.format(startDate, 'dd/MM/yyyy')}"></span>

--- a/src/main/resources/templates/sbadmin/reports/nutrition-analysis.html
+++ b/src/main/resources/templates/sbadmin/reports/nutrition-analysis.html
@@ -150,6 +150,7 @@
 	<!--
 		OPTIONAL MODEL VARIABLES:
 		- nutritionistProfile: NutritionistProfile entity (may be null)
+		- nutritionistDisplayName: resolved nutritionist name (may be null)
 		- logoBase64: Base64 Data URI string (may be null)
 	-->
 	<div class="header">
@@ -160,10 +161,7 @@
 					<p th:if="${analysis != null and analysis.dieta != null}">
 						<strong>Dieta:</strong> <span th:text="${analysis.dieta.nombre}"></span>
 					</p>
-					<p th:if="${nutritionistProfile != null and nutritionistProfile.cedulaProfesional != null
-					        and !#strings.isEmpty(nutritionistProfile.cedulaProfesional)}">
-						Ced. Prof. <span th:text="${nutritionistProfile.cedulaProfesional}">0000000</span>
-					</p>
+					<div th:replace="~{sbadmin/fragments/pdf-nutritionist-credentials :: credentials}"></div>
 					<p th:if="${reportDate != null}">
 						<strong>Fecha del Reporte:</strong>
 						<span th:text="${#dates.format(reportDate, 'dd/MM/yyyy HH:mm')}"></span>

--- a/src/main/resources/templates/sbadmin/reports/patient-progress.html
+++ b/src/main/resources/templates/sbadmin/reports/patient-progress.html
@@ -180,6 +180,7 @@
 	<!--
 		OPTIONAL MODEL VARIABLES:
 		- nutritionistProfile: NutritionistProfile entity (may be null)
+		- nutritionistDisplayName: resolved nutritionist name (may be null)
 		- logoBase64: Base64 Data URI string (may be null)
 	-->
 	<div class="header">
@@ -188,10 +189,7 @@
 				<td style="vertical-align: bottom;">
 					<h1>Reporte de Progreso del Paciente</h1>
 					<p>Minutriporcion - Consulta Nutricional</p>
-					<p th:if="${nutritionistProfile != null and nutritionistProfile.cedulaProfesional != null
-					        and !#strings.isEmpty(nutritionistProfile.cedulaProfesional)}">
-						Ced. Prof. <span th:text="${nutritionistProfile.cedulaProfesional}">0000000</span>
-					</p>
+					<div th:replace="~{sbadmin/fragments/pdf-nutritionist-credentials :: credentials}"></div>
 				</td>
 				<td th:if="${logoBase64 != null}" style="text-align: right; vertical-align: bottom; width: 160px;">
 					<img th:src="${logoBase64}" alt="Logo" style="max-height: 70px; max-width: 150px;" />

--- a/src/test/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCalculationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCalculationServiceTest.java
@@ -17,8 +17,8 @@ class PhysiologicalStressCalculationServiceTest {
 
 	@Test
 	void calculateAspenMultiplierStressOnGet() {
-		final StressContext context = StressContext.fromValues(true, PhysiologicalStressType.TRAUMA, StressFormulaTable.ASPEN,
-				StressIncrementMode.MULTIPLIER_GET, null, null, null, null);
+		final StressContext context = StressContext.fromValues(true, PhysiologicalStressType.TRAUMA,
+				StressFormulaTable.ASPEN, StressIncrementMode.MULTIPLIER_GET, null, null, null, null);
 		final Double stressKcal = PhysiologicalStressCalculationService.calculateStressKcal(context, 1500.0, 2000.0,
 				null);
 		assertThat(stressKcal).isCloseTo(800.0, org.assertj.core.data.Offset.offset(0.01));
@@ -26,8 +26,8 @@ class PhysiologicalStressCalculationServiceTest {
 
 	@Test
 	void calculateFixedKcalStress() {
-		final StressContext context = StressContext.fromValues(true, PhysiologicalStressType.OTHER, StressFormulaTable.CUSTOM,
-				StressIncrementMode.FIXED_KCAL, 450.0, null, null, null);
+		final StressContext context = StressContext.fromValues(true, PhysiologicalStressType.OTHER,
+				StressFormulaTable.CUSTOM, StressIncrementMode.FIXED_KCAL, 450.0, null, null, null);
 		assertThat(PhysiologicalStressCalculationService.calculateStressKcal(context, 1500.0, 2000.0, null))
 			.isEqualTo(450.0);
 	}
@@ -43,8 +43,8 @@ class PhysiologicalStressCalculationServiceTest {
 
 	@Test
 	void calculateStressUsesCustomFactorOverride() {
-		final StressContext context = StressContext.fromValues(true, PhysiologicalStressType.OTHER, StressFormulaTable.LONG,
-				StressIncrementMode.MULTIPLIER_BMR, 1.50, null, null, null);
+		final StressContext context = StressContext.fromValues(true, PhysiologicalStressType.OTHER,
+				StressFormulaTable.LONG, StressIncrementMode.MULTIPLIER_BMR, 1.50, null, null, null);
 		assertThat(PhysiologicalStressCalculationService.calculateStressKcal(context, 1000.0, 1500.0, null))
 			.isEqualTo(500.0);
 	}
@@ -56,8 +56,8 @@ class PhysiologicalStressCalculationServiceTest {
 
 	@Test
 	void inactiveStressReturnsNull() {
-		final StressContext context = StressContext.fromValues(false, PhysiologicalStressType.FEVER, StressFormulaTable.LONG,
-				StressIncrementMode.MULTIPLIER_BMR, null, null, null, null);
+		final StressContext context = StressContext.fromValues(false, PhysiologicalStressType.FEVER,
+				StressFormulaTable.LONG, StressIncrementMode.MULTIPLIER_BMR, null, null, null, null);
 		assertThat(PhysiologicalStressCalculationService.calculateStressKcal(context, 1500.0, 2000.0, null)).isNull();
 	}
 

--- a/src/test/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCatalogTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/calculation/PhysiologicalStressCatalogTest.java
@@ -14,12 +14,14 @@ class PhysiologicalStressCatalogTest {
 	@Test
 	void defaultLongMultiplierForMajorSurgery() {
 		assertThat(PhysiologicalStressCatalog.defaultMultiplier(PhysiologicalStressType.MAJOR_SURGERY,
-				StressFormulaTable.LONG)).isEqualTo(1.20);
+				StressFormulaTable.LONG))
+			.isEqualTo(1.20);
 	}
 
 	@Test
 	void defaultAspenMultiplierForBurns() {
-		assertThat(PhysiologicalStressCatalog.defaultMultiplier(PhysiologicalStressType.BURNS, StressFormulaTable.ASPEN))
+		assertThat(
+				PhysiologicalStressCatalog.defaultMultiplier(PhysiologicalStressType.BURNS, StressFormulaTable.ASPEN))
 			.isEqualTo(1.80);
 	}
 

--- a/src/test/java/com/nutriconsultas/profile/NutritionistBrandingHelperTest.java
+++ b/src/test/java/com/nutriconsultas/profile/NutritionistBrandingHelperTest.java
@@ -1,0 +1,59 @@
+package com.nutriconsultas.profile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+/**
+ * Unit tests for {@link NutritionistBrandingHelper}.
+ */
+public class NutritionistBrandingHelperTest {
+
+	@Test
+	public void resolveDisplayNamePrefersProfileDisplayName() {
+		final NutritionistProfile profile = new NutritionistProfile();
+		profile.setDisplayName("Lic. María García");
+
+		assertThat(NutritionistBrandingHelper.resolveDisplayName(profile, "Auth0 Name")).isEqualTo("Lic. María García");
+	}
+
+	@Test
+	public void resolveDisplayNameFallsBackToOAuthName() {
+		final NutritionistProfile profile = new NutritionistProfile();
+
+		assertThat(NutritionistBrandingHelper.resolveDisplayName(profile, "Auth0 Name")).isEqualTo("Auth0 Name");
+	}
+
+	@Test
+	public void resolveDisplayNameReturnsNullWhenNoSourceAvailable() {
+		assertThat(NutritionistBrandingHelper.resolveDisplayName(null, null)).isNull();
+		assertThat(NutritionistBrandingHelper.resolveDisplayName(new NutritionistProfile(), "  ")).isNull();
+	}
+
+	@Test
+	public void resolveOAuthDisplayNameUsesNameClaim() {
+		final OidcUser principal = createOidcUser("María García López", "auth0|123");
+
+		assertThat(NutritionistBrandingHelper.resolveOAuthDisplayName(principal)).isEqualTo("María García López");
+	}
+
+	@Test
+	public void resolveOAuthDisplayNameReturnsNullForNullPrincipal() {
+		assertThat(NutritionistBrandingHelper.resolveOAuthDisplayName(null)).isNull();
+	}
+
+	private OidcUser createOidcUser(final String name, final String subject) {
+		final Map<String, Object> claims = new HashMap<>();
+		claims.put("sub", subject);
+		claims.put("name", name);
+		final OidcIdToken idToken = new OidcIdToken("token", null, null, claims);
+		return new DefaultOidcUser(null, idToken);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/reports/PatientReportServiceTest.java
+++ b/src/test/java/com/nutriconsultas/reports/PatientReportServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -15,11 +16,13 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
 
 import com.nutriconsultas.calendar.CalendarEvent;
 import com.nutriconsultas.calendar.CalendarEventService;
@@ -33,6 +36,7 @@ import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
 import com.nutriconsultas.paciente.PacienteDietaStatus;
 import com.nutriconsultas.paciente.PacienteService;
+import com.nutriconsultas.profile.NutritionistProfile;
 import com.nutriconsultas.profile.NutritionistProfileService;
 
 import lombok.extern.slf4j.Slf4j;
@@ -263,6 +267,31 @@ public class PatientReportServiceTest {
 
 		assertThat(pdfBytes).isNotNull();
 		assertThat(pdfBytes.length).isGreaterThan(0);
+	}
+
+	@Test
+	public void testGenerateReportIncludesResolvedNutritionistDisplayName() {
+		final NutritionistProfile profile = new NutritionistProfile();
+		profile.setUserId("user123");
+		profile.setDisplayName("Lic. María García López");
+		profile.setCedulaProfesional("12345678");
+		when(nutritionistProfileService.getOrCreateProfile("user123")).thenReturn(profile);
+
+		when(pacienteService.findByIdAndUserId(1L, "user123")).thenReturn(paciente);
+		when(calendarEventService.findByPacienteId(1L)).thenReturn(new ArrayList<>());
+		when(anthropometricMeasurementService.findByPacienteId(1L)).thenReturn(new ArrayList<>());
+		when(clinicalExamService.findByPacienteId(1L)).thenReturn(new ArrayList<>());
+		when(pacienteDietaRepository.findByPacienteIdOrderByStartDateDesc(1L)).thenReturn(new ArrayList<>());
+		when(templateEngine.process(eq("sbadmin/reports/patient-progress"), any(Context.class)))
+			.thenReturn("<html><body>Test Report</body></html>");
+
+		reportService.generateReport(1L, "user123", null, null);
+
+		final ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+		verify(templateEngine).process(eq("sbadmin/reports/patient-progress"), contextCaptor.capture());
+		assertThat(contextCaptor.getValue().getVariable("nutritionistDisplayName"))
+			.isEqualTo("Lic. María García López");
+		assertThat(contextCaptor.getValue().getVariable("nutritionistProfile")).isSameAs(profile);
 	}
 
 }


### PR DESCRIPTION
## Summary
- Add `NutritionistBrandingHelper` to resolve nutritionist display name (profile `displayName` → Auth0 `name` claim → omit).
- Introduce shared Thymeleaf fragment `pdf-nutritionist-credentials` for consistent PDF headers.
- Apply the header to patient progress, nutrition analysis, clinic statistics, and diet PDFs.
- Include unit tests and template validator mocks for the resolved display name.

## Test plan
- [x] `mvn test -Dtest=NutritionistBrandingHelperTest,PatientReportServiceTest,ThymeleafTemplateValidationTest`
- [ ] Generate patient progress PDF and verify name + cédula in header when profile is configured
- [ ] Verify header shows only name when cédula is missing, and only cédula when display name is missing
- [ ] Verify Auth0 name fallback when profile display name is blank

Closes #127

Made with [Cursor](https://cursor.com)