### PR TITLE
feat(calendar): autocompletar % grasa desde antropométricos en wizard (#154)

### DIFF
--- a/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurementService.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurementService.java
@@ -1,6 +1,7 @@
 package com.nutriconsultas.clinical.exam;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.lang.NonNull;
 
@@ -15,5 +16,7 @@ public interface AnthropometricMeasurementService {
 	void deleteById(@NonNull Long id);
 
 	List<AnthropometricMeasurement> findByPacienteId(@NonNull Long pacienteId);
+
+	Optional<LatestBodyFatResult> findLatestBodyFatForPatient(@NonNull Long pacienteId, @NonNull String userId);
 
 }

--- a/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurementServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurementServiceImpl.java
@@ -1,6 +1,7 @@
 package com.nutriconsultas.clinical.exam;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.NonNull;
@@ -16,6 +17,8 @@ import com.nutriconsultas.paciente.calculation.PhysicalActivityLevel;
 import com.nutriconsultas.util.LogRedaction;
 
 import com.nutriconsultas.paciente.metrics.BodyMetricSource;
+
+import java.time.Instant;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -118,6 +121,37 @@ public class AnthropometricMeasurementServiceImpl implements AnthropometricMeasu
 	public List<AnthropometricMeasurement> findByPacienteId(@NonNull final Long pacienteId) {
 		log.debug("Finding anthropometric measurements for paciente id: {}", pacienteId);
 		return repository.findByPacienteId(pacienteId);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Optional<LatestBodyFatResult> findLatestBodyFatForPatient(@NonNull final Long pacienteId,
+			@NonNull final String userId) {
+		log.debug("Finding latest body fat for paciente id {}", pacienteId);
+		final Paciente paciente = pacienteRepository.findByIdAndUserId(pacienteId, userId).orElse(null);
+		if (paciente == null) {
+			return Optional.empty();
+		}
+		return repository.findFirstByPacienteIdOrderByMeasurementDateTimeDescIdDesc(pacienteId)
+			.flatMap(this::resolveLatestBodyFat);
+	}
+
+	private Optional<LatestBodyFatResult> resolveLatestBodyFat(final AnthropometricMeasurement measurement) {
+		final Instant measurementDate = measurement.getMeasurementDateTime() != null
+				? measurement.getMeasurementDateTime().toInstant() : null;
+		if (measurement.getPorcentajeGrasaCorporal() != null) {
+			return Optional.of(new LatestBodyFatResult(measurement.getPorcentajeGrasaCorporal(), measurementDate,
+					BodyFatSource.PORCENTAJE));
+		}
+		if (measurement.getBioimpedance() != null && measurement.getBioimpedance().getBodyFatPercentage() != null) {
+			return Optional.of(new LatestBodyFatResult(measurement.getBioimpedance().getBodyFatPercentage(),
+					measurementDate, BodyFatSource.BIOIMPEDANCE));
+		}
+		if (measurement.getIndiceGrasaCorporal() != null) {
+			return Optional.of(new LatestBodyFatResult(measurement.getIndiceGrasaCorporal(), measurementDate,
+					BodyFatSource.INDICE));
+		}
+		return Optional.empty();
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/clinical/exam/BodyFatSource.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/BodyFatSource.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.clinical.exam;
+
+public enum BodyFatSource {
+
+	PORCENTAJE, BIOIMPEDANCE, INDICE
+
+}

--- a/src/main/java/com/nutriconsultas/clinical/exam/LatestBodyFatResult.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/LatestBodyFatResult.java
@@ -1,0 +1,6 @@
+package com.nutriconsultas.clinical.exam;
+
+import java.time.Instant;
+
+public record LatestBodyFatResult(Double bodyFatPercentage, Instant measurementDate, BodyFatSource source) {
+}

--- a/src/main/java/com/nutriconsultas/paciente/AnthropometricMeasurementRestController.java
+++ b/src/main/java/com/nutriconsultas/paciente/AnthropometricMeasurementRestController.java
@@ -17,12 +17,17 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.NonNull;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import com.nutriconsultas.clinical.exam.LatestBodyFatResult;
 import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
 import com.nutriconsultas.clinical.exam.AnthropometricMeasurementService;
 import com.nutriconsultas.controller.AbstractGridController;
@@ -173,6 +178,23 @@ public class AnthropometricMeasurementRestController extends AbstractGridControl
 						&& new SimpleDateFormat("dd MMM yyyy HH:mm").format(row.getMeasurementDateTime())
 							.toLowerCase()
 							.contains(lowerValue));
+	}
+
+	@GetMapping("/latest-body-fat")
+	public ResponseEntity<?> getLatestBodyFat(@PathVariable @NonNull final Long id,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = principal != null ? principal.getSubject() : null;
+		if (userId == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "No autenticado"));
+		}
+		final java.util.Optional<LatestBodyFatResult> result = anthropometricMeasurementService
+			.findLatestBodyFatForPatient(id, userId);
+		if (result.isEmpty()) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND)
+				.body(Map.of("error", "No hay porcentaje de grasa disponible en antropométricos"));
+		}
+		log.debug("Returning latest body fat for paciente id {}", id);
+		return ResponseEntity.ok(result.get());
 	}
 
 	@DeleteMapping("/{measurementId}")

--- a/src/main/resources/templates/sbadmin/calendar/listado.html
+++ b/src/main/resources/templates/sbadmin/calendar/listado.html
@@ -739,6 +739,41 @@
           }
         }
 
+        function fillBodyFatFromLatestAnthropometric(pacienteId) {
+          const feedback = $('#summaryNotesWizardModal #bodyFatAutofillFeedback');
+          feedback.text('');
+          if (!pacienteId) {
+            alert('No se encontró el paciente de la cita.');
+            return;
+          }
+          const btn = $('#summaryNotesWizardModal #useLatestBodyFatBtn');
+          btn.prop('disabled', true);
+          $.get('/rest/pacientes/' + pacienteId + '/antropometricos/latest-body-fat')
+            .done(function(data) {
+              if (data.bodyFatPercentage != null) {
+                $('#summaryNotesWizardModal #indiceGrasaCorporalInput').val(data.bodyFatPercentage);
+                if (data.measurementDate) {
+                  const dateStr = new Date(data.measurementDate).toLocaleDateString('es-ES', {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric'
+                  });
+                  feedback.text('Medición del ' + dateStr);
+                }
+              }
+            })
+            .fail(function(xhr) {
+              let msg = 'No hay porcentaje de grasa disponible en antropométricos.';
+              if (xhr.responseJSON && xhr.responseJSON.error) {
+                msg = xhr.responseJSON.error;
+              }
+              alert(msg);
+            })
+            .always(function() {
+              btn.prop('disabled', false);
+            });
+        }
+
         function showSummaryNotesWizard(eventId) {
           const props = window.currentEventWizardProps || {};
           const eventData = {
@@ -821,8 +856,13 @@
           wizardHtml += '</div>';
           wizardHtml += '<div class="col-md-6">';
           wizardHtml += '<div class="form-group">';
-          wizardHtml += '<label>Índice de Grasa Corporal (%):</label>';
+          wizardHtml += '<label>Porcentaje de grasa corporal (%):</label>';
+          wizardHtml += '<div class="input-group">';
           wizardHtml += '<input type="number" class="form-control" name="indiceGrasaCorporal" id="indiceGrasaCorporalInput" step="0.01" min="0" max="100" placeholder="Ej: 25.5">';
+          wizardHtml += '<div class="input-group-append">';
+          wizardHtml += '<button type="button" class="btn btn-outline-secondary" id="useLatestBodyFatBtn" title="Usar el último porcentaje de grasa de antropométricos">Usar último registro</button>';
+          wizardHtml += '</div></div>';
+          wizardHtml += '<small id="bodyFatAutofillFeedback" class="form-text text-muted"></small>';
           wizardHtml += '</div>';
           wizardHtml += '</div>';
           wizardHtml += '</div>';
@@ -1019,6 +1059,9 @@
             }
             updateWizardGetPreview();
             updateWizardUI();
+            $('#summaryNotesWizardModal #useLatestBodyFatBtn').off('click').on('click', function() {
+              fillBodyFatFromLatestAnthropometric((window.currentEventWizardProps || {}).pacienteId);
+            });
           });
 
           $('#summaryNotesWizardModal').on('change input', '#wizardActivityLevel, #wizardBmrFormula, #wizardCustomFactor, #pesoInput, #estaturaInput', function() {
@@ -1098,7 +1141,7 @@
             if (formData.peso) summary += 'Peso: ' + formData.peso + ' kg\n';
             if (formData.estatura) summary += 'Estatura: ' + formData.estatura + ' m\n';
             if (formData.imc) summary += 'IMC: ' + formData.imc + '\n';
-            if (formData.indiceGrasaCorporal) summary += 'Índice de Grasa Corporal: ' + formData.indiceGrasaCorporal + '%\n';
+            if (formData.indiceGrasaCorporal) summary += 'Porcentaje de grasa corporal: ' + formData.indiceGrasaCorporal + '%\n';
             if (formData.sistolica || formData.diastolica) {
               summary += 'Presión Arterial: ' + (formData.sistolica || '') + '/' + (formData.diastolica || '') + ' mmHg\n';
             }

--- a/src/main/resources/templates/sbadmin/calendar/ver.html
+++ b/src/main/resources/templates/sbadmin/calendar/ver.html
@@ -104,7 +104,7 @@
                           <div th:replace="~{sbadmin/pacientes/imc-gauge :: imcGauge(${event.imc}, ${event.nivelPeso})}"></div>
                         </div>
                         <div class="col-md-3" th:if="${event.indiceGrasaCorporal != null}">
-                          <p><strong>Índice Grasa Corporal:</strong> <span th:text="${#numbers.formatDecimal(event.indiceGrasaCorporal, 2, 2)} + '%'">-</span></p>
+                          <p><strong>Porcentaje de grasa corporal:</strong> <span th:text="${#numbers.formatDecimal(event.indiceGrasaCorporal, 2, 2)} + '%'">-</span></p>
                         </div>
                         <div class="col-md-3" th:if="${event.getKcal != null}">
                           <p><strong>GET:</strong> <span th:text="${#numbers.formatDecimal(event.getKcal, 1, 0)} + ' kcal/día'">-</span></p>
@@ -454,8 +454,44 @@
         }
       }
       
+      function fillBodyFatFromLatestAnthropometric(pacienteId) {
+        const feedback = jQuery('#summaryNotesWizardModal #bodyFatAutofillFeedback');
+        feedback.text('');
+        if (!pacienteId) {
+          alert('No se encontró el paciente de la cita.');
+          return;
+        }
+        const btn = jQuery('#summaryNotesWizardModal #useLatestBodyFatBtn');
+        btn.prop('disabled', true);
+        jQuery.get('/rest/pacientes/' + pacienteId + '/antropometricos/latest-body-fat')
+          .done(function(data) {
+            if (data.bodyFatPercentage != null) {
+              jQuery('#summaryNotesWizardModal #indiceGrasaCorporalInput').val(data.bodyFatPercentage);
+              if (data.measurementDate) {
+                const dateStr = new Date(data.measurementDate).toLocaleDateString('es-ES', {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric'
+                });
+                feedback.text('Medición del ' + dateStr);
+              }
+            }
+          })
+          .fail(function(xhr) {
+            let msg = 'No hay porcentaje de grasa disponible en antropométricos.';
+            if (xhr.responseJSON && xhr.responseJSON.error) {
+              msg = xhr.responseJSON.error;
+            }
+            alert(msg);
+          })
+          .always(function() {
+            btn.prop('disabled', false);
+          });
+      }
+
       // Function to show summary notes wizard
       function showSummaryNotesWizard(eventId, currentNotes) {
+        window.wizardPacienteId = /*[[${event.paciente.id}]]*/ null;
         // Get event data from the page
         const eventData = {
           peso: /*[[${event.peso}]]*/ null,
@@ -536,8 +572,13 @@
         wizardHtml += '</div>';
         wizardHtml += '<div class="col-md-6">';
         wizardHtml += '<div class="form-group">';
-        wizardHtml += '<label>Índice de Grasa Corporal (%):</label>';
+        wizardHtml += '<label>Porcentaje de grasa corporal (%):</label>';
+        wizardHtml += '<div class="input-group">';
         wizardHtml += '<input type="number" class="form-control" name="indiceGrasaCorporal" id="indiceGrasaCorporalInput" step="0.01" min="0" max="100" placeholder="Ej: 25.5">';
+        wizardHtml += '<div class="input-group-append">';
+        wizardHtml += '<button type="button" class="btn btn-outline-secondary" id="useLatestBodyFatBtn" title="Usar el último porcentaje de grasa de antropométricos">Usar último registro</button>';
+        wizardHtml += '</div></div>';
+        wizardHtml += '<small id="bodyFatAutofillFeedback" class="form-text text-muted"></small>';
         wizardHtml += '</div>';
         wizardHtml += '</div>';
         wizardHtml += '</div>';
@@ -770,6 +811,9 @@
             jQuery('#wizardCustomFactorGroup').show();
           }
           updateWizardGetPreview();
+          jQuery('#summaryNotesWizardModal #useLatestBodyFatBtn').off('click').on('click', function() {
+            fillBodyFatFromLatestAnthropometric(window.wizardPacienteId);
+          });
         });
 
         jQuery('#summaryNotesWizardModal').on('change input', '#wizardActivityLevel, #wizardBmrFormula, #wizardCustomFactor, #pesoInput, #estaturaInput', function() {
@@ -854,7 +898,7 @@
           if (formData.peso) summary += 'Peso: ' + formData.peso + ' kg\n';
           if (formData.estatura) summary += 'Estatura: ' + formData.estatura + ' m\n';
           if (formData.imc) summary += 'IMC: ' + formData.imc + '\n';
-          if (formData.indiceGrasaCorporal) summary += 'Índice de Grasa Corporal: ' + formData.indiceGrasaCorporal + '%\n';
+          if (formData.indiceGrasaCorporal) summary += 'Porcentaje de grasa corporal: ' + formData.indiceGrasaCorporal + '%\n';
           if (formData.sistolica || formData.diastolica) {
             summary += 'Presión Arterial: ' + (formData.sistolica || '') + '/' + (formData.diastolica || '') + ' mmHg\n';
           }

--- a/src/test/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurementServiceTest.java
+++ b/src/test/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurementServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import com.nutriconsultas.paciente.NivelPeso;
 import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.clinical.exam.anthropometric.BodyMass;
 import com.nutriconsultas.clinical.exam.anthropometric.Circumferences;
 import com.nutriconsultas.clinical.exam.anthropometric.BodyComposition;
@@ -44,6 +45,9 @@ public class AnthropometricMeasurementServiceTest {
 
 	@Mock
 	private com.nutriconsultas.paciente.metrics.BodyMetricRecordService bodyMetricRecordService;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
 
 	private Paciente paciente;
 
@@ -336,6 +340,47 @@ public class AnthropometricMeasurementServiceTest {
 		assertThat(result).isEmpty();
 		verify(repository).findByPacienteId(999L);
 		log.info("finished testFindByPacienteIdReturnsEmptyList");
+	}
+
+	@Test
+	public void testFindLatestBodyFatForPatientUsesPorcentajeGrasaCorporal() {
+		paciente.setUserId("user-1");
+		when(pacienteRepository.findByIdAndUserId(1L, "user-1")).thenReturn(Optional.of(paciente));
+		when(repository.findFirstByPacienteIdOrderByMeasurementDateTimeDescIdDesc(1L))
+			.thenReturn(Optional.of(measurement));
+
+		final Optional<LatestBodyFatResult> result = service.findLatestBodyFatForPatient(1L, "user-1");
+
+		assertThat(result).isPresent();
+		assertThat(result.get().bodyFatPercentage()).isEqualTo(15.5);
+		assertThat(result.get().source()).isEqualTo(BodyFatSource.PORCENTAJE);
+	}
+
+	@Test
+	public void testFindLatestBodyFatForPatientUsesBioimpedanceWhenPorcentajeMissing() {
+		paciente.setUserId("user-1");
+		measurement.getBodyComposition().setPorcentajeGrasaCorporal(null);
+		final Bioimpedance bioimpedance = new Bioimpedance();
+		bioimpedance.setBodyFatPercentage(22.3);
+		measurement.setBioimpedance(bioimpedance);
+		when(pacienteRepository.findByIdAndUserId(1L, "user-1")).thenReturn(Optional.of(paciente));
+		when(repository.findFirstByPacienteIdOrderByMeasurementDateTimeDescIdDesc(1L))
+			.thenReturn(Optional.of(measurement));
+
+		final Optional<LatestBodyFatResult> result = service.findLatestBodyFatForPatient(1L, "user-1");
+
+		assertThat(result).isPresent();
+		assertThat(result.get().bodyFatPercentage()).isEqualTo(22.3);
+		assertThat(result.get().source()).isEqualTo(BodyFatSource.BIOIMPEDANCE);
+	}
+
+	@Test
+	public void testFindLatestBodyFatForPatientReturnsEmptyWhenPatientNotOwned() {
+		when(pacienteRepository.findByIdAndUserId(1L, "other-user")).thenReturn(Optional.empty());
+
+		final Optional<LatestBodyFatResult> result = service.findLatestBodyFatForPatient(1L, "other-user");
+
+		assertThat(result).isEmpty();
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/paciente/AnthropometricMeasurementRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/AnthropometricMeasurementRestControllerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,7 +20,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.test.context.ActiveProfiles;
+
+import com.nutriconsultas.clinical.exam.BodyFatSource;
+import com.nutriconsultas.clinical.exam.LatestBodyFatResult;
 
 import com.nutriconsultas.dataTables.paging.Direction;
 import com.nutriconsultas.dataTables.paging.Order;
@@ -188,6 +193,39 @@ public class AnthropometricMeasurementRestControllerTest {
 		assertThat(result.getBody().get("success")).isEqualTo(false);
 		verify(anthropometricMeasurementService).findById(1L);
 		log.info("Finished testDeleteMeasurementWrongPaciente");
+	}
+
+	@Test
+	public void testGetLatestBodyFatReturnsResult() {
+		final OidcUser principal = org.mockito.Mockito.mock(OidcUser.class);
+		when(principal.getSubject()).thenReturn("user-1");
+		final LatestBodyFatResult latest = new LatestBodyFatResult(24.5, new Date().toInstant(),
+				BodyFatSource.PORCENTAJE);
+		when(anthropometricMeasurementService.findLatestBodyFatForPatient(1L, "user-1"))
+			.thenReturn(Optional.of(latest));
+
+		final ResponseEntity<?> result = restController.getLatestBodyFat(1L, principal);
+
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(result.getBody()).isEqualTo(latest);
+	}
+
+	@Test
+	public void testGetLatestBodyFatReturnsNotFoundWhenMissing() {
+		final OidcUser principal = org.mockito.Mockito.mock(OidcUser.class);
+		when(principal.getSubject()).thenReturn("user-1");
+		when(anthropometricMeasurementService.findLatestBodyFatForPatient(1L, "user-1")).thenReturn(Optional.empty());
+
+		final ResponseEntity<?> result = restController.getLatestBodyFat(1L, principal);
+
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	public void testGetLatestBodyFatReturnsUnauthorizedWithoutPrincipal() {
+		final ResponseEntity<?> result = restController.getLatestBodyFat(1L, null);
+
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
 	}
 
 }


### PR DESCRIPTION
## Summary
- Renombra la etiqueta del wizard de notas a **Porcentaje de grasa corporal (%)** (UI y resumen generado).
- Agrega botón **Usar último registro** en calendario listado y ver cita para rellenar el campo desde la última medición antropométrica.
- Expone `GET /rest/pacientes/{id}/antropometricos/latest-body-fat` con filtro multi-tenant por `userId`.

## Test plan
- [ ] Abrir wizard de notas en calendario listado y ver cita; confirmar nueva etiqueta y botón.
- [ ] Con antropométrico previo con % grasa, clic en **Usar último registro** rellena el input y muestra fecha.
- [ ] Sin antropométricos o sin dato de grasa, muestra alerta clara (404) sin error 500.
- [ ] Usuario A no puede obtener datos de pacientes de usuario B.
- [x] `mvn test -Dtest=AnthropometricMeasurementServiceTest,AnthropometricMeasurementRestControllerTest`

Closes #154

Made with [Cursor](https://cursor.com)