### PR TITLE
feat(mobile-api): PHI log redaction audit for /rest/mobile/** (#115)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -49,6 +49,8 @@ jobs:
       run: mvn -B test -Dtest=ThymeleafTemplateValidationTest
     - name: Check Logging Security
       run: bash scripts/audit-logging.sh
+    - name: Check Mobile PHI Logging (#115)
+      run: bash scripts/audit-mobile-logging.sh
     - name: Upload Checkstyle results
       uses: actions/upload-artifact@v7
       if: always()

--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -10,7 +10,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) | Canonical cross-repo contract — §F8 schema/enum map, per-issue corrected scope |
 | [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) | Endpoint request/response specs (#91–#99) with field mappings |
 
-**Current next issue:** [#115 — PHI log redaction audit for all mobile controllers](https://github.com/diego-torres/nutriconsultas/issues/115) — **NEXT** (P1 cross-cutting). #112 OpenAPI merged ([PR #164](https://github.com/diego-torres/nutriconsultas/pull/164)).
+**Current next issue:** [#116 — Additive: senderDisplayName in message DTOs](https://github.com/diego-torres/nutriconsultas/issues/116) — **NEXT** (additive). #115 PHI audit merged.
 
 ---
 
@@ -22,10 +22,10 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | **API surface** | All mobile endpoints live under `/rest/mobile/patient/` as plain JSON (not DataTables-shaped like the admin `*RestController`s). |
 | **Identity (security-critical)** | JWT `sub` → **`Paciente.patientAuthSub`** (#107 ✓ PR #117). **Never `Paciente.userId`** — that is the NUTRITIONIST's Auth0 sub / tenant owner (ALIGNMENT-SPEC §F2). `PatientLinkageFilter` returns **403** if no linked `Paciente`. |
 | **Ownership / IDOR** | Return only the authenticated patient's rows. On an ownership miss prefer **404** (not 403) so existence isn't leaked (esp. #92). Never return cross-tenant data. |
-| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **OpenAPI #112 done** (PR #164). Cross-cutting **NEXT:** #115 PHI audit. Requires `AUTH_AUDIENCE` env var. |
+| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **OpenAPI #112 done** (PR #164). **PHI audit #115 done**. **NEXT:** #116 `senderDisplayName`. Requires `AUTH_AUDIENCE` env var. |
 | **DTO envelope** | `ApiResponse<T>`; lists in `PagedResponse<T>` or `CursorPagedResponse<T>` (messages); ISO-8601 date strings. See #110. |
 | **Schema ground truth** | ALIGNMENT-SPEC §F8 field-name map (`nombre→dietaName`, `energia→totalKcal`, `lipidos→totalGrasas`, `hidratosDeCarbono→totalCarbohidratos`, `Ingesta.nombre→tipo`); enums `EventStatus`/`PacienteDietaStatus` (no INACTIVE)/`NivelPeso`. Serialization aliases only — **no DB schema changes** for field renames. |
-| **PHI & logging** | No patient names/emails/DOB in unstructured logs. Follow `util/LogRedaction`; CI runs `scripts/audit-logging.sh` (#115). |
+| **PHI & logging** | No patient names/emails/DOB in unstructured logs. `LogRedaction` + `PhiLogTurboFilter`; CI runs `scripts/audit-logging.sh` and `scripts/audit-mobile-logging.sh` (#115 done). |
 | **Existing code to reuse** | Visits → `calendar/CalendarEventService`; Diet → `PacienteDietaService` + `dieta/` + PDF (#95); Progress → `BodyMetricRecordService` + anthropometrics (#98/#99); Messages → `PatientMessage` entity + mobile/admin controllers (#96/#97). |
 | **`Paciente` / Liquibase order** | [#156](https://github.com/diego-torres/nutriconsultas/issues/156) (projections + `@Embeddable`, optional satellite tables) must complete **before** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46). Mobile `#98`/`#99` DTOs stay stable — refactor maps in the service layer only. Do not add #132 onboarding columns to the monolithic entity until #156 Phase B lands. |
 
@@ -322,13 +322,13 @@ gh pr create ...
 
 | Field | Value |
 |-------|-------|
-| **Next issue** | [#115 — PHI log redaction audit](https://github.com/diego-torres/nutriconsultas/issues/115) |
+| **Next issue** | [#116 — senderDisplayName in message DTOs](https://github.com/diego-torres/nutriconsultas/issues/116) |
 | **Status** | **NEXT** |
-| **Phase** | Cross-cutting (P1) |
-| **Depends on** | #110 |
+| **Phase** | Additive (optional) |
+| **Depends on** | #96 |
 | **Blocks** | — |
-| **Just completed** | [#112](https://github.com/diego-torres/nutriconsultas/issues/112) — [PR #164](https://github.com/diego-torres/nutriconsultas/pull/164): OpenAPI 3.1 + `docs/api/openapi-mobile.yaml` |
-| **In scope for #115** | Audit `/rest/mobile/**` logging; enforce `LogRedaction`; CI `scripts/audit-logging.sh` |
+| **Just completed** | [#115](https://github.com/diego-torres/nutriconsultas/issues/115) — PHI log redaction audit: `PhiLogTurboFilter`, `scripts/audit-mobile-logging.sh`, `docs/mobile-api/PHI-LOGGING-AUDIT.md` |
+| **In scope for #116** | Add `senderDisplayName` from `NutritionistProfile` to message DTOs |
 
 ### Upcoming gates
 
@@ -337,15 +337,15 @@ gh pr create ...
 | Phase 0 foundation | ~~#107~~ ✓, ~~#109~~ ✓, ~~#110~~ ✓ | **Done** |
 | Auth linkage (tenant) | #108 (tenant config; prod audience deployed #118) | Before full Auth0 tenant hardening |
 | Endpoints | ~~#91–#99~~ ✓ | **Done** (PR #153) |
-| Cross-cutting | ~~#111~~ ✓, ~~#112~~ ✓ (OpenAPI), **#115** (PHI audit) | **#115 is NEXT** |
-| Hardening / additive | ~~#113~~ ✓, #116 (senderDisplayName), #114 (nutritionist reply) | With/after owning feature |
+| Cross-cutting | ~~#111~~ ✓, ~~#112~~ ✓ (OpenAPI), ~~#115~~ ✓ (PHI audit) | **Done** |
+| Hardening / additive | ~~#113~~ ✓, **#116** (senderDisplayName), #114 (nutritionist reply) | **#116 is NEXT** |
 | Schema / Liquibase | **#156** (`Paciente` refactor) → **#46** (Liquibase baseline) → **#132–#141** (invitation onboarding) | **#156 before any Liquibase cut**; invitation epic not active sprint |
 
 ### Status snapshot (2026-06-15)
 
 **Patient mobile API on `main`:** JWT resource server (#107), DTO envelope (#110), patient linkage (#109), visits (#91/#92), diet plans (#93–#95), messages list/send (#96/#97 with HTTP 201 + rate limit), progress snapshot (#98) + measurements time series (#99, PR #153), localized API errors (#111), Resilience4j write throttling (#113), **OpenAPI spec (#112, PR #164)**. Dashboard IMC gauge (#106) done for web tablero.
 
-**Next:** #115 PHI log redaction audit, then additive #116 / web #114.
+**Next:** #116 `senderDisplayName`, then web #114.
 
 **GitHub drift (close when convenient):** #97 and #111 are **done on `main`** but still **open on GitHub** (implemented in PRs #147, #151).
 

--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -327,7 +327,7 @@ gh pr create ...
 | **Phase** | Additive (optional) |
 | **Depends on** | #96 |
 | **Blocks** | — |
-| **Just completed** | [#115](https://github.com/diego-torres/nutriconsultas/issues/115) — PHI log redaction audit: `PhiLogTurboFilter`, `scripts/audit-mobile-logging.sh`, `docs/mobile-api/PHI-LOGGING-AUDIT.md` |
+| **Just completed** | [#115](https://github.com/diego-torres/nutriconsultas/issues/115) — [PR #168](https://github.com/diego-torres/nutriconsultas/pull/168): PHI log redaction audit (in review) |
 | **In scope for #116** | Add `senderDisplayName` from `NutritionistProfile` to message DTOs |
 
 ### Upcoming gates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -561,7 +561,7 @@ Issue registry: [`ISSUE.md`](ISSUE.md). Agent workflow: [`AGENT-WORKFLOW.md`](AG
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 
-**Next:** [#115](https://github.com/diego-torres/nutriconsultas/issues/115) PHI log redaction audit. ~~#112~~ OpenAPI **done** (PR #164). Open cross-cutting: #116 (`senderDisplayName`), web #114 (nutritionist reply).
+**Next:** [#116](https://github.com/diego-torres/nutriconsultas/issues/116) `senderDisplayName`. ~~#115~~ PHI audit **in progress**. ~~#112~~ OpenAPI **done** (PR #164). Open cross-cutting: web #114 (nutritionist reply).
 
 **Schema gate (pre-Liquibase):** [#156](https://github.com/diego-torres/nutriconsultas/issues/156) `Paciente` decomposition must land before [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46); mobile `#98`/`#99` DTO contracts unchanged. See [`ISSUE.md`](ISSUE.md) Integration prerequisites.
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-15 — #112 OpenAPI **done** ([PR #164](https://github.com/diego-torres/nutriconsultas/pull/164) merged). **NEXT:** [#115](https://github.com/diego-torres/nutriconsultas/issues/115) PHI audit.
+**Last updated:** 2026-06-15 — #115 PHI audit **in progress** on branch `mobile-api/115-phi-audit`.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -49,7 +49,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 (#107, #109, #110) is **done**. Patient linkage (#109) is **done**. Endpoints **#91–#99 are done** on `main` (PR #153). OpenAPI (#112, PR #164) is **done**. **NEXT:** #115 (PHI log redaction audit).
+Phase 0 (#107, #109, #110) is **done**. Patient linkage (#109) is **done**. Endpoints **#91–#99 are done** on `main` (PR #153). OpenAPI (#112, PR #164) is **done**. **#115 PHI audit in progress** on `mobile-api/115-phi-audit`.
 
 ---
 
@@ -75,7 +75,7 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | 111 | Accept-Language filter + MessageSource i18n for REST errors | https://github.com/diego-torres/nutriconsultas/issues/111 | **done** | 110 | Merged PR #151: `LocaleContextFilter`, `MobileApiErrorResponses`, `MobileApiExceptionHandler` (403/404/400/429). GitHub issue still open — close when convenient. |
-| 115 | PHI log redaction audit for all mobile controllers | https://github.com/diego-torres/nutriconsultas/issues/115 | **NEXT** | 110 | Audit every `/rest/mobile/**` controller against `util/LogRedaction`; CI gate `scripts/audit-logging.sh`. No names/emails/DOB at INFO. |
+| 115 | PHI log redaction audit for all mobile controllers | https://github.com/diego-torres/nutriconsultas/issues/115 | **in-progress** | 110 | `PhiLogTurboFilter`, `scripts/audit-mobile-logging.sh`, `docs/mobile-api/PHI-LOGGING-AUDIT.md`; branch `mobile-api/115-phi-audit`. |
 | 112 | OpenAPI spec for `/rest/mobile/patient/**` | https://github.com/diego-torres/nutriconsultas/issues/112 | **done** | 110, endpoints | Merged [PR #164](https://github.com/diego-torres/nutriconsultas/pull/164): springdoc + `docs/api/openapi-mobile.yaml`. |
 
 ---
@@ -118,7 +118,7 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 | # | Title | URL | State | Notes |
 |---|-------|-----|-------|-------|
 | 113 | Rate limiting on patient write endpoints (Resilience4j) | https://github.com/diego-torres/nutriconsultas/issues/113 | **done** | Merged PR #151: 10/min per `patientAuthSub` on POST #97; 429 + `Retry-After: 60`; localized via #111 |
-| 116 | Additive: `senderDisplayName` in message DTOs from `NutritionistProfile` | https://github.com/diego-torres/nutriconsultas/issues/116 | open | Additive to #96 DTO; **non-blocking** for mobile #19. Source `NutritionistProfile.displayName`. |
+| 116 | Additive: `senderDisplayName` in message DTOs from `NutritionistProfile` | https://github.com/diego-torres/nutriconsultas/issues/116 | **NEXT** | Additive to #96 DTO; **non-blocking** for mobile #19. Source `NutritionistProfile.displayName`. |
 | 114 | Nutritionist reply to patient messages | https://github.com/diego-torres/nutriconsultas/issues/114 | open | **Web/backend only** — not a mobile-app endpoint; writes into the same thread #96 reads. |
 | 106 | `[Dashboard]` IMC gauge with color bands (anthropometric tablero) | https://github.com/diego-torres/nutriconsultas/issues/106 | **done** | Web dashboard; shares `NivelPeso` color-band logic the mobile `ImcGauge` (mobile #21) mirrors. Not a `/rest/mobile/**` endpoint. |
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-15 — #115 PHI audit **in progress** on branch `mobile-api/115-phi-audit`.
+**Last updated:** 2026-06-15 — #115 PHI audit **in progress** → [PR #168](https://github.com/diego-torres/nutriconsultas/pull/168).
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -75,7 +75,7 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | 111 | Accept-Language filter + MessageSource i18n for REST errors | https://github.com/diego-torres/nutriconsultas/issues/111 | **done** | 110 | Merged PR #151: `LocaleContextFilter`, `MobileApiErrorResponses`, `MobileApiExceptionHandler` (403/404/400/429). GitHub issue still open — close when convenient. |
-| 115 | PHI log redaction audit for all mobile controllers | https://github.com/diego-torres/nutriconsultas/issues/115 | **in-progress** | 110 | `PhiLogTurboFilter`, `scripts/audit-mobile-logging.sh`, `docs/mobile-api/PHI-LOGGING-AUDIT.md`; branch `mobile-api/115-phi-audit`. |
+| 115 | PHI log redaction audit for all mobile controllers | https://github.com/diego-torres/nutriconsultas/issues/115 | **in-progress** | 110 | [PR #168](https://github.com/diego-torres/nutriconsultas/pull/168): `PhiLogTurboFilter`, `scripts/audit-mobile-logging.sh`, `docs/mobile-api/PHI-LOGGING-AUDIT.md`. |
 | 112 | OpenAPI spec for `/rest/mobile/patient/**` | https://github.com/diego-torres/nutriconsultas/issues/112 | **done** | 110, endpoints | Merged [PR #164](https://github.com/diego-torres/nutriconsultas/pull/164): springdoc + `docs/api/openapi-mobile.yaml`. |
 
 ---

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 Backend REST endpoints for the Flutter patient app live under `/rest/mobile/patient/**`. Issue tracking and endpoint status: [`ISSUE.md`](ISSUE.md). Agent workflow: [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md). Contract docs: [`docs/mobile-api/`](docs/mobile-api/).
 
-**On `main` (2026-06-15):** Phase 0 auth (#107, #109, #110); all patient endpoints #91–#99; localized API errors (#111); rate limit (#113); **OpenAPI #112** (PR #164, `docs/api/openapi-mobile.yaml`). **Next:** #115 PHI audit.
+**On `main` (2026-06-15):** Phase 0 auth (#107, #109, #110); all patient endpoints #91–#99; localized API errors (#111); rate limit (#113); **OpenAPI #112** (PR #164); **PHI audit #115** (in progress). **Next:** #116 `senderDisplayName`.
 
 ## AWS (production infrastructure)
 

--- a/docs/mobile-api/ALIGNMENT-SPEC.md
+++ b/docs/mobile-api/ALIGNMENT-SPEC.md
@@ -160,7 +160,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 - **Phase 0 DONE:** #107 (PR #117), #109 (PR #142), #110 (DTO envelope).
 - **Endpoints on `main`:** #91–#99 (visits, diet plans + PDF, messages, progress snapshot + measurements time series); #96/#97 messaging with HTTP 201 + Resilience4j 10/min (#113, PR #151).
 - **i18n (#111) DONE** (PR #151): `LocaleContextFilter`, `MobileApiErrorResponses`, localized 403/404/400/429.
-- **Cross-cutting NEXT:** #115 PHI log redaction audit. ~~#112~~ OpenAPI spec **done** (PR #164, `docs/api/openapi-mobile.yaml`).
+- **Cross-cutting NEXT:** #116 `senderDisplayName`. ~~#115~~ PHI log redaction audit **in progress** (`docs/mobile-api/PHI-LOGGING-AUDIT.md`). ~~#112~~ OpenAPI spec **done** (PR #164, `docs/api/openapi-mobile.yaml`).
 - `deltaPeso`/`deltaImc` are computed-at-query, not stored.
 - Progress `grasa` ambiguity: prefer `bodyComposition.porcentajeGrasaCorporal` (patient-facing %) over `indiceGrasaCorporal`.
 - Template dietas (seed `system:template-dietas`) have 4 ingestas incl. Colación — contract examples show only 3.

--- a/docs/mobile-api/MOBILE-E2E-STATUS.md
+++ b/docs/mobile-api/MOBILE-E2E-STATUS.md
@@ -212,4 +212,4 @@ Optional backend script (requires access token from the app):
 
 ---
 
-*Updated 2026-06-15: #112 OpenAPI merged (PR #164); **NEXT:** #115 PHI audit.*
+*Updated 2026-06-15: #115 PHI audit in progress; **NEXT:** #116.*

--- a/docs/mobile-api/PHI-LOGGING-AUDIT.md
+++ b/docs/mobile-api/PHI-LOGGING-AUDIT.md
@@ -1,0 +1,43 @@
+# Mobile API PHI logging audit (#115)
+
+Audit completed **2026-06-15** on branch `mobile-api/115-phi-audit`.
+
+## Policy
+
+- No patient names, emails, phone numbers, DOB, measurements, message bodies, or raw Auth0 `sub` values in unstructured logs at **INFO** or above.
+- Use `com.nutriconsultas.util.LogRedaction` for all patient-related identifiers in log statements.
+- Defense in depth: `PhiLogTurboFilter` (configured in `logback-spring.xml`) denies INFO+ mobile log lines that match email or unredacted Auth0 sub patterns.
+
+## Checklist
+
+| Area | Issue | Status | Notes |
+|------|-------|--------|-------|
+| Visits | #91, #92 | ✓ | `MobilePatientVisitController` / `MobilePatientVisitService` — patient ID via `LogRedaction.redactPaciente`, visit ID via `LogRedaction.redactCalendarEvent` |
+| Diet plans | #93, #94, #95 | ✓ | `MobilePatientDietPlanController` / `MobilePatientDietPlanService` — assignment ID via `LogRedaction.redactPacienteDieta`; no plan content or notes logged |
+| Messages | #96, #97 | ✓ | `MobilePatientMessageController` / `MobilePatientMessageService` — only `PatientMessage[id=…]` at INFO; message body never logged |
+| Progress | #98, #99 | ✓ | `MobilePatientProgressController` / `MobilePatientProgressService` — patient ID only; no raw BMI/weight values in logs |
+| Auth resolver | #107 | ✓ | `PatientAuthService`, `PatientLinkageFilter`, `PatientAuthLinkageService` — `sub` redacted via `LogRedaction.redactUserId` |
+| Exception handler | — | ✓ | `MobileApiExceptionHandler` — generic messages only, no request payloads |
+
+## CI gates
+
+| Gate | Command |
+|------|---------|
+| Repo-wide logging audit | `bash scripts/audit-logging.sh` |
+| Mobile package audit (#115) | `bash scripts/audit-mobile-logging.sh` |
+| Automated tests | `MobilePackageLoggingAuditTest`, `MobilePhiLoggingIntegrationTest`, `PhiLogTurboFilterTest` |
+
+## Safe logging examples
+
+```java
+log.debug("Mobile list visits for patient {}", LogRedaction.redactPaciente(paciente.getId()));
+log.info("Patient sent message: {}", LogRedaction.redactPatientMessage(saved.getId()));
+log.info("Linked mobile Auth0 account for patient {} sub={}",
+    LogRedaction.redactPaciente(saved.getId()), LogRedaction.redactUserId(patientAuthSub));
+```
+
+## Related
+
+- `docs/LOGGING_SECURITY.md` — project-wide logging security guide
+- `README_LOGGING_SECURITY.md` — quick reference
+- Issue [#141](https://github.com/diego-torres/nutriconsultas/issues/141) — invitation token logging (future; never log raw tokens)

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -4,10 +4,11 @@ Canonical cross-repo contracts for the `[Mobile API]` track, vendored into this 
 
 | File | What it is |
 |------|-----------|
-| `ALIGNMENT-SPEC.md` | Source-of-truth contract for all agents. §F8 = backend↔mobile field/enum map. Phase 0 + endpoints **#91–#99 done** on `main`. **OpenAPI #112 done** — `docs/api/openapi-mobile.yaml` ([PR #164](https://github.com/diego-torres/nutriconsultas/pull/164)). **NEXT:** #115. Invitation **#132–#141** deferred (see §F8.6). |
-| `mobile-api-roadmap-v2.md` | Per-endpoint (#91–#99) request/response JSON and field mappings. All endpoints **done**; OpenAPI **#112 done**; **NEXT:** #115. |
+| `ALIGNMENT-SPEC.md` | Source-of-truth contract for all agents. §F8 = backend↔mobile field/enum map. Phase 0 + endpoints **#91–#99 done** on `main`. **OpenAPI #112 done** — `docs/api/openapi-mobile.yaml` ([PR #164](https://github.com/diego-torres/nutriconsultas/pull/164)). **PHI audit #115** — `docs/mobile-api/PHI-LOGGING-AUDIT.md`. **NEXT:** #116. Invitation **#132–#141** deferred (see §F8.6). |
+| `mobile-api-roadmap-v2.md` | Per-endpoint (#91–#99) request/response JSON and field mappings. All endpoints **done**; OpenAPI **#112 done**; PHI audit **#115**; **NEXT:** #116. |
+| `PHI-LOGGING-AUDIT.md` | Completed PHI logging audit checklist for `/rest/mobile/**` (#115). |
 
-**Last synced:** 2026-06-15 (#112 merged PR #164; **NEXT:** #115).
+**Last synced:** 2026-06-15 (#115 PHI audit in progress; **NEXT:** #116).
 
 **Provenance / drift:** these are synced copies of the workspace-root originals
 (`/Users/joelmartinez/Documents/Work/ALIGNMENT-SPEC.md` and `mobile-api-roadmap-v2.md`),

--- a/docs/mobile-api/mobile-api-roadmap-v2.md
+++ b/docs/mobile-api/mobile-api-roadmap-v2.md
@@ -14,7 +14,7 @@
 
 > **State verification (2026-06-11):**
 >
-> - **Backend schema (2026-06-15):** Phase 0 **done** (#107, #109, #110). **All endpoints #91–#99 on `main`**. **#112 OpenAPI done** (PR #164, `docs/api/openapi-mobile.yaml`). **#96/#97** messaging (POST **201**, Resilience4j **10/min** — #113). **#111** localized errors. **NEXT:** #115 PHI audit. #116 optional `senderDisplayName`; #106 dashboard IMC gauge **done**.
+> - **Backend schema (2026-06-15):** Phase 0 **done** (#107, #109, #110). **All endpoints #91–#99 on `main`**. **#112 OpenAPI done** (PR #164). **#115 PHI audit in progress**. **#96/#97** messaging (POST **201**, Resilience4j **10/min** — #113). **#111** localized errors. **NEXT:** #116 `senderDisplayName`; #106 dashboard IMC gauge **done**.
 > - **DTO field-name map (authoritative — ALIGNMENT-SPEC §F8):** `Dieta.nombre→dietaName`, `energia→totalKcal`, `proteina→totalProteina`, `lipidos→totalGrasas`, `hidratosDeCarbono→totalCarbohidratos`; `Ingesta.nombre→tipo`; `PlatilloIngesta.name/portions/energia→nombre/porciones/kcal`, `hidratosDeCarbono→carbohidratos`, `lipidos→grasas` (same for `AlimentoIngesta`). Enums: `EventStatus = SCHEDULED/COMPLETED/CANCELLED`; `PacienteDietaStatus = ACTIVE/COMPLETED/CANCELLED` (no INACTIVE); `NivelPeso = BAJO/NORMAL/ALTO/SOBREPESO` (translate to `imcLabel` server-side). `deltaPeso`/`deltaImc` are computed, not stored.
 > - **Mobile redesign branch state (style/editorial-redesign):** Auth dedup complete — `AuthFlowController` + login/signup/welcome screens canonical; PR #48's `AuthController`/`LoginView` retired (commit 3427612); `flutter analyze` clean, 146/146 tests pass. Canonical design source: `.claude/MiNutriporcion-2/` (light editorial palette; dark welcome/login PNGs are OLD, ignore). Mobile issues #13/#21/#31 done; #32/#33 in flight on branch.
 
@@ -368,7 +368,7 @@ See Phase 0.
 |---------|--------|--------|
 | OpenAPI doc | Missing | Add `springdoc-openapi-starter-webmvc-ui`, annotate mobile controllers |
 | Rate limiting | Missing | Resilience4j `@RateLimiter` on `POST /messages`; 10 req/min per patient |
-| PHI-safe logging | Pattern exists | Apply `LogRedaction` to all mobile controllers before first deploy |
+| PHI-safe logging | Done (#115) | `LogRedaction` + `PhiLogTurboFilter`; see `docs/mobile-api/PHI-LOGGING-AUDIT.md` |
 | CORS | Unknown | Confirm WebView-only vs native HTTP; add `@CrossOrigin` or `CorsConfigurationSource` bean for `/rest/mobile/**` if native |
 | `Accept-Language` | Missing | `LocaleContextFilter` for `/rest/mobile/**` (see G3) |
 | Pagination defaults | Missing | Standard `page`/`size` params with `maxSize` cap — apply consistently to all list endpoints |

--- a/scripts/audit-mobile-logging.sh
+++ b/scripts/audit-mobile-logging.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Strict PHI logging audit for the patient mobile API package (#115).
+# Scans only src/main/java/com/nutriconsultas/mobile for unsafe log patterns.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+VIOLATIONS=0
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MOBILE_SRC="$PROJECT_ROOT/src/main/java/com/nutriconsultas/mobile"
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Mobile API PHI Logging Audit (#115)${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+if [ ! -d "$MOBILE_SRC" ]; then
+  echo -e "${RED}✗ Mobile source directory not found: $MOBILE_SRC${NC}"
+  exit 1
+fi
+
+JAVA_FILES=$(find "$MOBILE_SRC" -name "*.java" -type f | sort)
+FILE_COUNT=$(echo "$JAVA_FILES" | wc -l | tr -d ' ')
+echo -e "${YELLOW}Scanning ${FILE_COUNT} mobile Java file(s)...${NC}"
+echo ""
+
+report_violation() {
+  local file="$1"
+  local line="$2"
+  local content="$3"
+  local reason="$4"
+  echo -e "${RED}✗ VIOLATION in ${file}:${NC}"
+  echo -e "  ${RED}${reason}${NC}"
+  echo -e "    ${YELLOW}Line ${line}:${NC} ${content}"
+  echo ""
+  VIOLATIONS=$((VIOLATIONS + 1))
+}
+
+while IFS= read -r file; do
+  if [[ "$file" == *"PhiLogTurboFilter.java" ]]; then
+    continue
+  fi
+
+  line_number=0
+  while IFS= read -r line; do
+    line_number=$((line_number + 1))
+
+    if [[ "$line" =~ ^[[:space:]]*// ]] || [[ "$line" =~ ^[[:space:]]*\* ]]; then
+      continue
+    fi
+
+    if echo "$line" | grep -qE 'log\.(info|debug|warn|error|trace)\('; then
+      if echo "$line" | grep -qE '\b(body|getBody\(\)|request\.body\(\))\b' \
+          && ! echo "$line" | grep -q 'LogRedaction'; then
+        report_violation "$file" "$line_number" "$line" "Message body must never appear in log statements"
+      fi
+
+      if echo "$line" | grep -qE 'log\.(info|warn|error)\(' \
+          && echo "$line" | grep -qE '\b(getEmail|getNombre|getTelefono|getDireccion|getFechaNacimiento)\b' \
+          && ! echo "$line" | grep -q 'LogRedaction'; then
+        report_violation "$file" "$line_number" "$line" "PHI accessor must not be logged at INFO+ without LogRedaction"
+      fi
+
+      if echo "$line" | grep -qE 'log\.(info|warn|error)\(' \
+          && echo "$line" | grep -qE '\bpatientAuthSub\b' \
+          && ! echo "$line" | grep -q 'LogRedaction\.redactUserId'; then
+        report_violation "$file" "$line_number" "$line" "Auth0 sub must use LogRedaction.redactUserId at INFO+"
+      fi
+
+      if echo "$line" | grep -qE 'log\.(info|debug|warn|error|trace)\([^)]*\{[^}]*\b(paciente|Paciente)\b[^}]*\}' \
+          && ! echo "$line" | grep -q 'LogRedaction'; then
+        report_violation "$file" "$line_number" "$line" "Paciente entity must be logged via LogRedaction"
+      fi
+
+      if echo "$line" | grep -qE 'log\.(info|debug|warn|error|trace)\([^)]*\{[^}]*\b(PatientMessage|CalendarEvent|ClinicalExam|AnthropometricMeasurement|PacienteDieta)\b[^}]*\}' \
+          && ! echo "$line" | grep -q 'LogRedaction'; then
+        report_violation "$file" "$line_number" "$line" "Patient-related entity must be logged via LogRedaction"
+      fi
+    fi
+  done < "$file"
+done <<< "$JAVA_FILES"
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Audit Summary${NC}"
+echo -e "${BLUE}========================================${NC}"
+
+if [ "$VIOLATIONS" -eq 0 ]; then
+  echo -e "${GREEN}✓ No mobile PHI logging violations found${NC}"
+  exit 0
+fi
+
+echo -e "${RED}✗ ${VIOLATIONS} violation(s) found${NC}"
+echo -e "${YELLOW}Use com.nutriconsultas.util.LogRedaction for all patient-related log output.${NC}"
+exit 1

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanController.java
@@ -71,7 +71,7 @@ public class MobilePatientDietPlanController extends AbstractMobilePatientContro
 			@Parameter(description = "PacienteDieta assignment identifier") @PathVariable final Long assignmentId) {
 		final Paciente paciente = getAuthenticatedPaciente(jwt);
 		if (log.isDebugEnabled()) {
-			log.debug("Mobile get diet plan {} for patient {}", assignmentId,
+			log.debug("Mobile get diet plan {} for patient {}", LogRedaction.redactPacienteDieta(assignmentId),
 					LogRedaction.redactPaciente(paciente.getId()));
 		}
 		final DietPlanDetailDto plan = mobilePatientDietPlanService.getDietPlanDetail(paciente.getId(), assignmentId);
@@ -89,7 +89,7 @@ public class MobilePatientDietPlanController extends AbstractMobilePatientContro
 			@Parameter(description = "PacienteDieta assignment identifier") @PathVariable final Long assignmentId) {
 		final Paciente paciente = getAuthenticatedPaciente(jwt);
 		if (log.isDebugEnabled()) {
-			log.debug("Mobile get diet plan PDF {} for patient {}", assignmentId,
+			log.debug("Mobile get diet plan PDF {} for patient {}", LogRedaction.redactPacienteDieta(assignmentId),
 					LogRedaction.redactPaciente(paciente.getId()));
 		}
 		final DietPlanPdfResult pdf = mobilePatientDietPlanService.generateDietPlanPdf(paciente.getId(), assignmentId);

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanService.java
@@ -63,8 +63,8 @@ public class MobilePatientDietPlanService {
 			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
 		initializeDietaTree(assignment.getDieta());
 		if (log.isDebugEnabled()) {
-			log.debug("Loaded mobile diet plan detail assignmentId={} for patient {}", assignmentId,
-					LogRedaction.redactPaciente(pacienteId));
+			log.debug("Loaded mobile diet plan detail assignmentId={} for patient {}",
+					LogRedaction.redactPacienteDieta(assignmentId), LogRedaction.redactPaciente(pacienteId));
 		}
 		return DietPlanDetailDto.fromEntity(assignment);
 	}
@@ -77,8 +77,8 @@ public class MobilePatientDietPlanService {
 		final Dieta dieta = assignment.getDieta();
 		final String filename = (dieta != null && dieta.getNombre() != null ? dieta.getNombre() : "dieta") + ".pdf";
 		if (log.isDebugEnabled()) {
-			log.debug("Generated mobile diet plan PDF assignmentId={} for patient {}", assignmentId,
-					LogRedaction.redactPaciente(pacienteId));
+			log.debug("Generated mobile diet plan PDF assignmentId={} for patient {}",
+					LogRedaction.redactPacienteDieta(assignmentId), LogRedaction.redactPaciente(pacienteId));
 		}
 		return new DietPlanPdfResult(pdfBytes, filename);
 	}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageService.java
@@ -68,7 +68,9 @@ public class MobilePatientMessageService {
 		message.setSenderRole(MessageSenderRole.PATIENT);
 		message.setBody(body.trim());
 		final PatientMessage saved = patientMessageRepository.save(message);
-		log.info("Patient sent message: {}", LogRedaction.redactPatientMessage(saved.getId()));
+		if (log.isInfoEnabled()) {
+			log.info("Patient sent message: {}", LogRedaction.redactPatientMessage(saved.getId()));
+		}
 		return PatientMessageSummaryDto.fromEntity(saved);
 	}
 

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitController.java
@@ -69,7 +69,8 @@ public class MobilePatientVisitController extends AbstractMobilePatientControlle
 			@Parameter(description = "Visit identifier") @PathVariable final Long visitId) {
 		final Paciente paciente = getAuthenticatedPaciente(jwt);
 		if (log.isDebugEnabled()) {
-			log.debug("Mobile get visit {} for patient {}", visitId, LogRedaction.redactPaciente(paciente.getId()));
+			log.debug("Mobile get visit {} for patient {}", LogRedaction.redactCalendarEvent(visitId),
+					LogRedaction.redactPaciente(paciente.getId()));
 		}
 		final VisitDetailDto visit = mobilePatientVisitService.getVisitDetail(paciente.getId(), visitId);
 		return ApiResponse.ok(visit);

--- a/src/main/java/com/nutriconsultas/mobile/logging/PhiLogTurboFilter.java
+++ b/src/main/java/com/nutriconsultas/mobile/logging/PhiLogTurboFilter.java
@@ -1,0 +1,55 @@
+package com.nutriconsultas.mobile.logging;
+
+import java.util.regex.Pattern;
+
+import org.slf4j.Marker;
+import org.slf4j.helpers.MessageFormatter;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.core.spi.FilterReply;
+
+/**
+ * Defense-in-depth filter for the mobile API package. Blocks log lines at INFO and above
+ * when the formatted message appears to contain email addresses or unredacted Auth0
+ * subject identifiers.
+ */
+public final class PhiLogTurboFilter extends TurboFilter {
+
+	private static final String MOBILE_LOGGER_PREFIX = "com.nutriconsultas.mobile";
+
+	private static final Pattern EMAIL = Pattern.compile("[\\w.+-]+@[\\w.-]+\\.[A-Za-z]{2,}");
+
+	private static final Pattern RAW_AUTH0_SUB = Pattern.compile("auth0\\|[^\\s\\[.]{8,}");
+
+	@Override
+	public FilterReply decide(final Marker marker, final Logger logger, final Level level, final String format,
+			final Object[] params, final Throwable throwable) {
+		if (level == null || !level.isGreaterOrEqual(Level.INFO)) {
+			return FilterReply.NEUTRAL;
+		}
+		if (logger == null || !logger.getName().startsWith(MOBILE_LOGGER_PREFIX)) {
+			return FilterReply.NEUTRAL;
+		}
+		final String message = buildMessage(format, params, throwable);
+		if (message == null || message.isEmpty()) {
+			return FilterReply.NEUTRAL;
+		}
+		if (EMAIL.matcher(message).find()) {
+			return FilterReply.DENY;
+		}
+		if (RAW_AUTH0_SUB.matcher(message).find() && !message.contains("REDACTED")) {
+			return FilterReply.DENY;
+		}
+		return FilterReply.NEUTRAL;
+	}
+
+	private static String buildMessage(final String format, final Object[] params, final Throwable throwable) {
+		if (format == null) {
+			return throwable != null ? throwable.getMessage() : null;
+		}
+		return MessageFormatter.arrayFormat(format, params, throwable).getMessage();
+	}
+
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+  <turboFilter class="com.nutriconsultas.mobile.logging.PhiLogTurboFilter" />
   <include resource="org/springframework/boot/logging/logback/defaults.xml" />
-	<property name="LOG_FILE" value="${LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}/}spring.log}"/>
-	<include resource="org/springframework/boot/logging/logback/file-appender.xml" />
+  <property name="LOG_FILE" value="${LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}/}spring.log}" />
+  <include resource="org/springframework/boot/logging/logback/file-appender.xml" />
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>

--- a/src/test/java/com/nutriconsultas/mobile/MobilePackageLoggingAuditTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePackageLoggingAuditTest.java
@@ -1,0 +1,86 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Static audit for PHI-safe logging in the mobile API package (#115).
+ */
+class MobilePackageLoggingAuditTest {
+
+	private static final Path MOBILE_SRC = Path.of("src", "main", "java", "com", "nutriconsultas", "mobile");
+
+	private static final Pattern LOG_STATEMENT = Pattern.compile("log\\.(info|debug|warn|error|trace)\\(");
+
+	private static final Pattern BODY_IN_LOG = Pattern.compile("\\b(body|getBody\\(\\)|request\\.body\\(\\))\\b");
+
+	private static final Pattern PACIENTE_PLACEHOLDER = Pattern
+		.compile("log\\.(info|debug|warn|error|trace)\\([^)]*\\{[^}]*\\b(paciente|Paciente)\\b");
+
+	private static final Pattern ENTITY_PLACEHOLDER = Pattern.compile(
+			"log\\.(info|debug|warn|error|trace)\\([^)]*\\{[^}]*\\b(PatientMessage|CalendarEvent|ClinicalExam|AnthropometricMeasurement|PacienteDieta)\\b");
+
+	private static final Pattern INFO_PHI_ACCESSOR = Pattern.compile(
+			"log\\.(info|warn|error)\\([^)]*\\b(getEmail|getNombre|getTelefono|getDireccion|getFechaNacimiento)\\b");
+
+	private static final Pattern INFO_RAW_SUB = Pattern
+		.compile("log\\.(info|warn|error)\\([^)]*\\bpatientAuthSub\\b(?!.*LogRedaction\\.redactUserId)");
+
+	@Test
+	void mobilePackageHasNoPhiLoggingViolations() throws IOException {
+		assertThat(Files.isDirectory(MOBILE_SRC)).as("mobile source directory").isTrue();
+
+		final List<String> violations = new ArrayList<>();
+		try (Stream<Path> paths = Files.walk(MOBILE_SRC)) {
+			paths.filter(path -> path.toString().endsWith(".java"))
+				.filter(path -> !path.getFileName().toString().equals("PhiLogTurboFilter.java"))
+				.forEach(path -> scanFile(path, violations));
+		}
+
+		assertThat(violations).as("mobile PHI logging violations:\n%s", String.join("\n", violations)).isEmpty();
+	}
+
+	private static void scanFile(final Path file, final List<String> violations) {
+		try {
+			final List<String> lines = Files.readAllLines(file);
+			for (int index = 0; index < lines.size(); index++) {
+				final String line = lines.get(index).trim();
+				if (line.startsWith("//") || line.startsWith("*")) {
+					continue;
+				}
+				if (!LOG_STATEMENT.matcher(line).find()) {
+					continue;
+				}
+				final String location = file + ":" + (index + 1);
+				if (BODY_IN_LOG.matcher(line).find() && !line.contains("LogRedaction")) {
+					violations.add(location + " — message body must not be logged");
+				}
+				if (PACIENTE_PLACEHOLDER.matcher(line).find() && !line.contains("LogRedaction")) {
+					violations.add(location + " — Paciente must use LogRedaction");
+				}
+				if (ENTITY_PLACEHOLDER.matcher(line).find() && !line.contains("LogRedaction")) {
+					violations.add(location + " — patient entity must use LogRedaction");
+				}
+				if (INFO_PHI_ACCESSOR.matcher(line).find() && !line.contains("LogRedaction")) {
+					violations.add(location + " — PHI accessor must not be logged at INFO+");
+				}
+				if (INFO_RAW_SUB.matcher(line).find()) {
+					violations.add(location + " — patientAuthSub must use LogRedaction.redactUserId at INFO+");
+				}
+			}
+		}
+		catch (IOException ex) {
+			violations.add(file + " — could not read file: " + ex.getMessage());
+		}
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePhiLoggingIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePhiLoggingIntegrationTest.java
@@ -1,0 +1,97 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.concurrent.Callable;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.message.PatientMessage;
+import com.nutriconsultas.message.PatientMessageRepository;
+import com.nutriconsultas.paciente.Paciente;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+class MobilePhiLoggingIntegrationTest {
+
+	private static final String PHI_MESSAGE_BODY = "PHI-LEAK-TEST-secret-message-body-xyz789";
+
+	private static final String PATIENT_SUB = "auth0|mobile-phi-logging-integration-patient-sub";
+
+	@InjectMocks
+	private MobilePatientMessageService service;
+
+	@Mock
+	private PatientMessageRepository patientMessageRepository;
+
+	@Mock
+	private PatientWriteRateLimiter patientWriteRateLimiter;
+
+	private ListAppender<ILoggingEvent> logAppender;
+
+	private Logger serviceLogger;
+
+	@BeforeEach
+	void attachLogAppender() {
+		serviceLogger = (Logger) LoggerFactory.getLogger(MobilePatientMessageService.class);
+		logAppender = new ListAppender<>();
+		logAppender.start();
+		serviceLogger.addAppender(logAppender);
+		serviceLogger.setLevel(Level.DEBUG);
+	}
+
+	@AfterEach
+	void detachLogAppender() {
+		if (serviceLogger != null && logAppender != null) {
+			serviceLogger.detachAppender(logAppender);
+		}
+	}
+
+	@Test
+	void sendMessage_doesNotLogMessageBodyOrRawAuthSub() throws Exception {
+		final Paciente paciente = new Paciente();
+		paciente.setId(12L);
+		paciente.setUserId("auth0|nutritionist-owner");
+		paciente.setPatientAuthSub(PATIENT_SUB);
+		when(patientWriteRateLimiter.execute(eq(PatientWriteRateLimiter.PATIENT_MESSAGES), eq(PATIENT_SUB),
+				any(Callable.class)))
+			.thenAnswer(invocation -> {
+				final Callable<?> callable = invocation.getArgument(2);
+				return callable.call();
+			});
+		when(patientMessageRepository.save(any(PatientMessage.class))).thenAnswer(invocation -> {
+			final PatientMessage saved = invocation.getArgument(0);
+			saved.setId(501L);
+			saved.setSentAt(Instant.parse("2026-06-15T12:00:00Z"));
+			saved.setReadByPatient(true);
+			saved.setReadByNutritionist(false);
+			return saved;
+		});
+
+		service.sendMessage(paciente, PHI_MESSAGE_BODY);
+
+		assertThat(logAppender.list).isNotEmpty();
+		for (final ILoggingEvent event : logAppender.list) {
+			final String formatted = event.getFormattedMessage();
+			assertThat(formatted).doesNotContain(PHI_MESSAGE_BODY);
+			assertThat(formatted).doesNotContain(PATIENT_SUB);
+			assertThat(formatted).contains("PatientMessage[id=501]");
+		}
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/logging/PhiLogTurboFilterTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/logging/PhiLogTurboFilterTest.java
@@ -1,0 +1,75 @@
+package com.nutriconsultas.mobile.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.spi.FilterReply;
+
+class PhiLogTurboFilterTest {
+
+	private final PhiLogTurboFilter filter = new PhiLogTurboFilter();
+
+	private final Logger mobileLogger = logger("com.nutriconsultas.mobile.MobilePatientMessageService");
+
+	private final Logger otherLogger = logger("com.nutriconsultas.paciente.PacienteService");
+
+	private static Logger logger(final String name) {
+		final LoggerContext context = new LoggerContext();
+		return context.getLogger(name);
+	}
+
+	@Test
+	void deniesInfoLogsWithEmailInMobilePackage() {
+		filter.start();
+
+		final FilterReply reply = filter.decide(null, mobileLogger, Level.INFO, "Patient email is {}",
+				new Object[] { "patient@example.com" }, null);
+
+		assertThat(reply).isEqualTo(FilterReply.DENY);
+	}
+
+	@Test
+	void deniesInfoLogsWithRawAuth0SubInMobilePackage() {
+		filter.start();
+
+		final FilterReply reply = filter.decide(null, mobileLogger, Level.INFO, "Linked sub={}",
+				new Object[] { "auth0|abcdefghijklmnopqrstuvwxyz" }, null);
+
+		assertThat(reply).isEqualTo(FilterReply.DENY);
+	}
+
+	@Test
+	void allowsRedactedAuth0SubAtInfo() {
+		filter.start();
+
+		final FilterReply reply = filter.decide(null, mobileLogger, Level.INFO, "Linked sub={}",
+				new Object[] { "userId[auth0|...REDACTED]" }, null);
+
+		assertThat(reply).isEqualTo(FilterReply.NEUTRAL);
+	}
+
+	@Test
+	void allowsDebugLogsEvenWithSensitivePatterns() {
+		filter.start();
+
+		final FilterReply reply = filter.decide(null, mobileLogger, Level.DEBUG, "Patient email is {}",
+				new Object[] { "patient@example.com" }, null);
+
+		assertThat(reply).isEqualTo(FilterReply.NEUTRAL);
+	}
+
+	@Test
+	void neutralForNonMobileLoggers() {
+		filter.start();
+
+		final FilterReply reply = filter.decide(null, otherLogger, Level.INFO, "Patient email is {}",
+				new Object[] { "patient@example.com" }, null);
+
+		assertThat(reply).isEqualTo(FilterReply.NEUTRAL);
+	}
+
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+  <turboFilter class="com.nutriconsultas.mobile.logging.PhiLogTurboFilter" />
   <include resource="org/springframework/boot/logging/logback/defaults.xml" />
 	<property name="LOG_FILE" value="/tmp/minutriporcion.log}"/>
 	<include resource="org/springframework/boot/logging/logback/file-appender.xml" />


### PR DESCRIPTION
## Summary
- Audits all `/rest/mobile/**` controllers and services for PHI-safe logging using existing `LogRedaction` helpers
- Adds `PhiLogTurboFilter` (logback) to deny INFO+ mobile log lines matching email or unredacted Auth0 `sub` patterns
- Adds `scripts/audit-mobile-logging.sh` CI gate plus static (`MobilePackageLoggingAuditTest`), integration (`MobilePhiLoggingIntegrationTest`), and filter unit tests
- Documents completed checklist in `docs/mobile-api/PHI-LOGGING-AUDIT.md` and advances registry **NEXT** to #116

Closes #115

## Test plan
- [x] `bash scripts/audit-mobile-logging.sh`
- [x] `bash scripts/audit-logging.sh`
- [x] `./lint.sh`
- [x] `mvn -B verify` (707 tests)


Made with [Cursor](https://cursor.com)