### PR TITLE
fix(calendar): correcciones wizard % grasa corporal (#154)

### DIFF
--- a/src/main/resources/templates/sbadmin/calendar/listado.html
+++ b/src/main/resources/templates/sbadmin/calendar/listado.html
@@ -739,6 +739,14 @@
           }
         }
 
+        function formatBodyFatPercent(value) {
+          const num = Number(value);
+          if (Number.isNaN(num)) {
+            return '';
+          }
+          return num.toFixed(2);
+        }
+
         function fillBodyFatFromLatestAnthropometric(pacienteId) {
           const feedback = $('#summaryNotesWizardModal #bodyFatAutofillFeedback');
           feedback.text('');
@@ -751,7 +759,7 @@
           $.get('/rest/pacientes/' + pacienteId + '/antropometricos/latest-body-fat')
             .done(function(data) {
               if (data.bodyFatPercentage != null) {
-                $('#summaryNotesWizardModal #indiceGrasaCorporalInput').val(data.bodyFatPercentage);
+                $('#summaryNotesWizardModal #indiceGrasaCorporalInput').val(formatBodyFatPercent(data.bodyFatPercentage));
                 if (data.measurementDate) {
                   const dateStr = new Date(data.measurementDate).toLocaleDateString('es-ES', {
                     year: 'numeric',
@@ -1036,7 +1044,7 @@
               $('#summaryNotesWizardModal #imcCalculado').val(eventData.imc);
             }
             if (eventData.indiceGrasaCorporal) {
-              $('#summaryNotesWizardModal #indiceGrasaCorporalInput').val(eventData.indiceGrasaCorporal);
+              $('#summaryNotesWizardModal #indiceGrasaCorporalInput').val(formatBodyFatPercent(eventData.indiceGrasaCorporal));
             }
             if (eventData.sistolica) {
               $('#summaryNotesWizardModal input[name="sistolica"]').val(eventData.sistolica);
@@ -1141,7 +1149,9 @@
             if (formData.peso) summary += 'Peso: ' + formData.peso + ' kg\n';
             if (formData.estatura) summary += 'Estatura: ' + formData.estatura + ' m\n';
             if (formData.imc) summary += 'IMC: ' + formData.imc + '\n';
-            if (formData.indiceGrasaCorporal) summary += 'Porcentaje de grasa corporal: ' + formData.indiceGrasaCorporal + '%\n';
+            if (formData.indiceGrasaCorporal) {
+              summary += 'Porcentaje de grasa corporal: ' + formatBodyFatPercent(formData.indiceGrasaCorporal) + '%\n';
+            }
             if (formData.sistolica || formData.diastolica) {
               summary += 'Presión Arterial: ' + (formData.sistolica || '') + '/' + (formData.diastolica || '') + ' mmHg\n';
             }
@@ -1246,7 +1256,9 @@
           if (peso) formData.peso = parseFloat(peso);
           if (estatura) formData.estatura = parseFloat(estatura);
           if (imc) formData.imc = parseFloat(imc);
-          if (indiceGrasaCorporal) formData.indiceGrasaCorporal = parseFloat(indiceGrasaCorporal);
+          if (indiceGrasaCorporal) {
+            formData.indiceGrasaCorporal = parseFloat(formatBodyFatPercent(indiceGrasaCorporal));
+          }
           if (sistolica) formData.sistolica = parseInt(sistolica);
           if (diastolica) formData.diastolica = parseInt(diastolica);
           if (indiceGlucemico) formData.indiceGlucemico = parseInt(indiceGlucemico);

--- a/src/main/resources/templates/sbadmin/calendar/ver.html
+++ b/src/main/resources/templates/sbadmin/calendar/ver.html
@@ -455,6 +455,14 @@
         }
       }
       
+      function formatBodyFatPercent(value) {
+        const num = Number(value);
+        if (Number.isNaN(num)) {
+          return '';
+        }
+        return num.toFixed(2);
+      }
+
       function fillBodyFatFromLatestAnthropometric(pacienteId) {
         const feedback = jQuery('#summaryNotesWizardModal #bodyFatAutofillFeedback');
         feedback.text('');
@@ -467,7 +475,7 @@
         jQuery.get('/rest/pacientes/' + pacienteId + '/antropometricos/latest-body-fat')
           .done(function(data) {
             if (data.bodyFatPercentage != null) {
-              jQuery('#summaryNotesWizardModal #indiceGrasaCorporalInput').val(data.bodyFatPercentage);
+              jQuery('#summaryNotesWizardModal #indiceGrasaCorporalInput').val(formatBodyFatPercent(data.bodyFatPercentage));
               if (data.measurementDate) {
                 const dateStr = new Date(data.measurementDate).toLocaleDateString('es-ES', {
                   year: 'numeric',
@@ -790,7 +798,7 @@
             jQuery('#summaryNotesWizardModal #imcCalculado').val(eventData.imc);
           }
           if (eventData.indiceGrasaCorporal) {
-            jQuery('#summaryNotesWizardModal #indiceGrasaCorporalInput').val(eventData.indiceGrasaCorporal);
+            jQuery('#summaryNotesWizardModal #indiceGrasaCorporalInput').val(formatBodyFatPercent(eventData.indiceGrasaCorporal));
           }
           if (eventData.sistolica) {
             jQuery('#summaryNotesWizardModal input[name="sistolica"]').val(eventData.sistolica);
@@ -899,7 +907,9 @@
           if (formData.peso) summary += 'Peso: ' + formData.peso + ' kg\n';
           if (formData.estatura) summary += 'Estatura: ' + formData.estatura + ' m\n';
           if (formData.imc) summary += 'IMC: ' + formData.imc + '\n';
-          if (formData.indiceGrasaCorporal) summary += 'Porcentaje de grasa corporal: ' + formData.indiceGrasaCorporal + '%\n';
+          if (formData.indiceGrasaCorporal) {
+            summary += 'Porcentaje de grasa corporal: ' + formatBodyFatPercent(formData.indiceGrasaCorporal) + '%\n';
+          }
           if (formData.sistolica || formData.diastolica) {
             summary += 'Presión Arterial: ' + (formData.sistolica || '') + '/' + (formData.diastolica || '') + ' mmHg\n';
           }
@@ -1007,7 +1017,9 @@
         if (peso) formData.peso = parseFloat(peso);
         if (estatura) formData.estatura = parseFloat(estatura);
         if (imc) formData.imc = parseFloat(imc);
-        if (indiceGrasaCorporal) formData.indiceGrasaCorporal = parseFloat(indiceGrasaCorporal);
+        if (indiceGrasaCorporal) {
+          formData.indiceGrasaCorporal = parseFloat(formatBodyFatPercent(indiceGrasaCorporal));
+        }
         if (sistolica) formData.sistolica = parseInt(sistolica);
         if (diastolica) formData.diastolica = parseInt(diastolica);
         if (indiceGlucemico) formData.indiceGlucemico = parseInt(indiceGlucemico);

--- a/src/main/resources/templates/sbadmin/calendar/ver.html
+++ b/src/main/resources/templates/sbadmin/calendar/ver.html
@@ -182,7 +182,7 @@
                     <div class="col-md-12">
                       <h6>Notas de Resumen</h6>
                       <button type="button" class="btn btn-info mb-3" id="btnShowWizard"
-                              th:attr="data-event-id=${event.id}, data-summary-notes=${event.summaryNotes != null ? event.summaryNotes : ''}"
+                              th:attr="data-event-id=${event.id}, data-paciente-id=${event.paciente.id}, data-summary-notes=${event.summaryNotes != null ? event.summaryNotes : ''}"
                               onclick="showSummaryNotesWizardFromButton(this)">
                         <i class="fas fa-edit"></i> 
                         <span th:text="${event.summaryNotes != null && !event.summaryNotes.isEmpty()} ? 'Editar Notas' : 'Agregar Notas'">Agregar Notas</span>
@@ -227,7 +227,7 @@
     <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
     <script th:src="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.js}"></script>
     
-    <script lang="javascript">
+    <script lang="javascript" th:inline="javascript">
       'use strict';
       
       // Wait for jQuery to be loaded
@@ -373,8 +373,9 @@
       // Function to show summary notes wizard from button
       function showSummaryNotesWizardFromButton(button) {
         const eventId = button.getAttribute('data-event-id');
+        const pacienteId = button.getAttribute('data-paciente-id');
         const currentNotes = button.getAttribute('data-summary-notes') || '';
-        showSummaryNotesWizard(eventId, currentNotes);
+        showSummaryNotesWizard(eventId, currentNotes, pacienteId);
       }
 
       const WIZARD_ACTIVITY_FACTORS = {
@@ -490,8 +491,8 @@
       }
 
       // Function to show summary notes wizard
-      function showSummaryNotesWizard(eventId, currentNotes) {
-        window.wizardPacienteId = /*[[${event.paciente.id}]]*/ null;
+      function showSummaryNotesWizard(eventId, currentNotes, pacienteId) {
+        window.wizardPacienteId = pacienteId ? parseInt(pacienteId, 10) : null;
         // Get event data from the page
         const eventData = {
           peso: /*[[${event.peso}]]*/ null,


### PR DESCRIPTION
## Summary
- Corrige `pacienteId` nulo en vista de cita (`/admin/calendario/{id}`) al usar **Usar último registro**.
- Formatea el % de grasa autocompletado a **2 decimales** en wizard y resumen.

Complementa #167 (ya en main) con fixes encontrados en pruebas manuales.

## Test plan
- [x] `mvn test -Dtest=AnthropometricMeasurementServiceTest,AnthropometricMeasurementRestControllerTest`
- [ ] En `/admin/calendario/{id}`, botón **Usar último registro** rellena el campo (sin alerta de paciente no encontrado).
- [ ] Valor autocompletado muestra máximo 2 decimales (p. ej. `24.57`).

Closes #154

Made with [Cursor](https://cursor.com)