### PR TITLE
feat(anthropometric): registrar método de obtención de composición corporal (#161)

### DIFF
--- a/docs/schema/body-composition-metodo-obtencion.md
+++ b/docs/schema/body-composition-metodo-obtencion.md
@@ -1,0 +1,24 @@
+# DDL: método de obtención de composición corporal (#161)
+
+Hibernate `ddl-auto=update` aplica estos cambios en desarrollo. Para producción con Liquibase (#46), usar como referencia tras #156.
+
+```sql
+-- body_composition (entidad BodyComposition)
+ALTER TABLE body_composition
+  ADD COLUMN IF NOT EXISTS metodo_obtencion VARCHAR(30);
+
+-- body_metric_record (timeline agregado)
+ALTER TABLE body_metric_record
+  ADD COLUMN IF NOT EXISTS metodo_obtencion_composicion VARCHAR(30);
+```
+
+Valores permitidos (`MetodoObtencionComposicionCorporal`):
+
+- `MANUAL`
+- `BIOIMPEDANCIA`
+- `PLIEGUES`
+- `DEURENBERG`
+- `DEXA`
+- `OTRO`
+
+Registros existentes quedan con `NULL` (sin método registrado).

--- a/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurement.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurement.java
@@ -26,6 +26,7 @@ import com.nutriconsultas.clinical.exam.anthropometric.BodyMass;
 import com.nutriconsultas.clinical.exam.anthropometric.Bioimpedance;
 import com.nutriconsultas.clinical.exam.anthropometric.Circumferences;
 import com.nutriconsultas.clinical.exam.anthropometric.Diameters;
+import com.nutriconsultas.clinical.exam.anthropometric.MetodoObtencionComposicionCorporal;
 import com.nutriconsultas.clinical.exam.anthropometric.Skinfolds;
 import com.nutriconsultas.paciente.NivelPeso;
 import com.nutriconsultas.paciente.Paciente;
@@ -335,6 +336,17 @@ public class AnthropometricMeasurement {
 			bodyComposition = new BodyComposition();
 		}
 		bodyComposition.setSomatocartaY(somatocartaY);
+	}
+
+	public MetodoObtencionComposicionCorporal getMetodoObtencion() {
+		return bodyComposition != null ? bodyComposition.getMetodoObtencion() : null;
+	}
+
+	public void setMetodoObtencion(final MetodoObtencionComposicionCorporal metodoObtencion) {
+		if (bodyComposition == null) {
+			bodyComposition = new BodyComposition();
+		}
+		bodyComposition.setMetodoObtencion(metodoObtencion);
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/BodyComposition.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/BodyComposition.java
@@ -2,6 +2,8 @@ package com.nutriconsultas.clinical.exam.anthropometric;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -48,5 +50,10 @@ public class BodyComposition {
 	/** Somatocarta Y: 2×mesomorphy - (ectomorphy + endomorphy). */
 	@Column(precision = 4)
 	private Double somatocartaY;
+
+	/** Clinical source for consolidated body fat / muscle values. */
+	@Enumerated(EnumType.STRING)
+	@Column(length = 30)
+	private MetodoObtencionComposicionCorporal metodoObtencion;
 
 }

--- a/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/BodyCompositionService.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/BodyCompositionService.java
@@ -33,47 +33,72 @@ public class BodyCompositionService {
 	public void applyToMeasurement(final AnthropometricMeasurement measurement, final Paciente paciente,
 			final Double imc) {
 		ensureBodyComposition(measurement);
+		final MetodoObtencionComposicionCorporal clinicalOverride = resolveClinicalOverride(measurement);
 
 		if (measurement.getPorcentajeGrasaCorporal() != null) {
 			syncFatFields(measurement, measurement.getPorcentajeGrasaCorporal());
 			applyMusclePercentageIfAbsent(measurement, measurement.getPorcentajeGrasaCorporal());
+			assignMethodIfAllowed(measurement, MetodoObtencionComposicionCorporal.MANUAL, clinicalOverride);
 			return;
 		}
 
 		if (measurement.getIndiceGrasaCorporal() != null) {
 			syncFatFields(measurement, measurement.getIndiceGrasaCorporal());
 			applyMusclePercentageIfAbsent(measurement, measurement.getIndiceGrasaCorporal());
+			assignMethodIfAllowed(measurement, MetodoObtencionComposicionCorporal.MANUAL, clinicalOverride);
 			return;
 		}
 
-		final Double calculatedFat = resolveCalculatedFatPercentage(measurement, paciente, imc);
-		if (calculatedFat != null) {
-			syncFatFields(measurement, calculatedFat);
-			applyMusclePercentageIfAbsent(measurement, calculatedFat);
+		final ResolvedFatPercentage resolvedFat = resolveCalculatedFatPercentage(measurement, paciente, imc);
+		if (resolvedFat.fatPercentage() != null) {
+			syncFatFields(measurement, resolvedFat.fatPercentage());
+			applyMusclePercentageIfAbsent(measurement, resolvedFat.fatPercentage());
+			assignMethodIfAllowed(measurement, resolvedFat.method(), clinicalOverride);
 		}
 	}
 
-	private Double resolveCalculatedFatPercentage(final AnthropometricMeasurement measurement, final Paciente paciente,
-			final Double imc) {
+	private MetodoObtencionComposicionCorporal resolveClinicalOverride(final AnthropometricMeasurement measurement) {
+		if (measurement.getBodyComposition() == null) {
+			return null;
+		}
+		final MetodoObtencionComposicionCorporal method = measurement.getBodyComposition().getMetodoObtencion();
+		if (method != null && method.isClinicalOverride()) {
+			return method;
+		}
+		return null;
+	}
+
+	private void assignMethodIfAllowed(final AnthropometricMeasurement measurement,
+			final MetodoObtencionComposicionCorporal autoMethod,
+			final MetodoObtencionComposicionCorporal clinicalOverride) {
+		if (clinicalOverride != null) {
+			measurement.getBodyComposition().setMetodoObtencion(clinicalOverride);
+			return;
+		}
+		measurement.getBodyComposition().setMetodoObtencion(autoMethod);
+	}
+
+	private ResolvedFatPercentage resolveCalculatedFatPercentage(final AnthropometricMeasurement measurement,
+			final Paciente paciente, final Double imc) {
 		final Double bioimpedanceFat = resolveBioimpedanceFatPercentage(measurement);
 		if (bioimpedanceFat != null) {
 			log.debug("Using bioimpedance body fat percentage for measurement");
-			return bioimpedanceFat;
+			return new ResolvedFatPercentage(bioimpedanceFat, MetodoObtencionComposicionCorporal.BIOIMPEDANCIA);
 		}
 
 		final Double skinfoldFat = calculateSkinfoldFatPercentage(measurement, paciente);
 		if (skinfoldFat != null) {
 			log.debug("Using Jackson-Pollock skinfold body fat percentage for measurement");
-			return skinfoldFat;
+			return new ResolvedFatPercentage(skinfoldFat, MetodoObtencionComposicionCorporal.PLIEGUES);
 		}
 
 		final Double deurenbergFat = calculateDeurenbergFatPercentage(imc, paciente);
 		if (deurenbergFat != null) {
 			log.debug("Using Deurenberg body fat percentage for measurement");
-			return deurenbergFat;
+			return new ResolvedFatPercentage(deurenbergFat, MetodoObtencionComposicionCorporal.DEURENBERG);
 		}
 
-		return null;
+		return new ResolvedFatPercentage(null, null);
 	}
 
 	private Double resolveBioimpedanceFatPercentage(final AnthropometricMeasurement measurement) {
@@ -148,6 +173,9 @@ public class BodyCompositionService {
 			return null;
 		}
 		return Period.between(birthDate, currentDate).getYears();
+	}
+
+	private record ResolvedFatPercentage(Double fatPercentage, MetodoObtencionComposicionCorporal method) {
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/MetodoObtencionComposicionCorporal.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/MetodoObtencionComposicionCorporal.java
@@ -1,0 +1,25 @@
+package com.nutriconsultas.clinical.exam.anthropometric;
+
+/**
+ * Clinical source used to obtain consolidated body fat / muscle composition values.
+ */
+public enum MetodoObtencionComposicionCorporal {
+
+	MANUAL("Manual"), BIOIMPEDANCIA("Bioimpedancia"), PLIEGUES("Pliegues (Jackson-Pollock)"),
+	DEURENBERG("Deurenberg (estimado)"), DEXA("DEXA"), OTRO("Otro");
+
+	private final String displayName;
+
+	MetodoObtencionComposicionCorporal(final String displayName) {
+		this.displayName = displayName;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
+	public boolean isClinicalOverride() {
+		return this == DEXA || this == OTRO;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -204,6 +204,7 @@ public class PacienteController extends AbstractAuthorizedController {
 					: latest.getBodyFatIndex();
 			model.addAttribute("ultimoPorcentajeGrasaCorporal", ultimoPorcentajeGrasa);
 			model.addAttribute("ultimoIndiceGrasaCorporal", ultimoPorcentajeGrasa);
+			model.addAttribute("ultimoMetodoObtencionComposicion", latest.getMetodoObtencionComposicion());
 		});
 		addLatestMuscleMassToModel(id, model);
 		// Calculate age and check if patient is under 18 for growth table display

--- a/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
@@ -43,6 +43,7 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 		variables.put("ultimoNivelPeso", null);
 		variables.put("ultimoPorcentajeGrasaCorporal", null);
 		variables.put("ultimoIndiceGrasaCorporal", null);
+		variables.put("ultimoMetodoObtencionComposicion", null);
 		variables.put("ultimoPorcentajeMasaMuscular", null);
 		variables.put("isEligibleForPregnancy", false);
 		variables.put("isUnder18", false);

--- a/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecord.java
+++ b/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecord.java
@@ -22,6 +22,7 @@ import lombok.NoArgsConstructor;
 
 import com.nutriconsultas.paciente.NivelPeso;
 import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.clinical.exam.anthropometric.MetodoObtencionComposicionCorporal;
 
 /**
  * Centralized body metric history for a patient (IMC, grasa corporal, peso/talla).
@@ -77,6 +78,10 @@ public class BodyMetricRecord {
 
 	@Column(precision = 3)
 	private Double bodyFatPercentage;
+
+	@Enumerated(EnumType.STRING)
+	@Column(length = 30)
+	private MetodoObtencionComposicionCorporal metodoObtencionComposicion;
 
 	@Column(precision = 7)
 	private Double bmr;

--- a/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordServiceImpl.java
@@ -21,6 +21,7 @@ import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
 import com.nutriconsultas.clinical.exam.AnthropometricMeasurementRepository;
 import com.nutriconsultas.clinical.exam.ClinicalExam;
 import com.nutriconsultas.clinical.exam.ClinicalExamRepository;
+import com.nutriconsultas.clinical.exam.anthropometric.MetodoObtencionComposicionCorporal;
 import com.nutriconsultas.paciente.NivelPeso;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
@@ -64,8 +65,8 @@ public class BodyMetricRecordServiceImpl implements BodyMetricRecordService {
 		}
 		upsertRecord(new BodyMetricUpsertData(event.getPaciente(), event.getEventDateTime(),
 				BodyMetricSource.CONSULTATION, event.getId(), event.getPeso(), event.getEstatura(), event.getImc(),
-				event.getNivelPeso(), event.getIndiceGrasaCorporal(), null, event.getBmrUsed(), event.getGetKcal(),
-				event.getTefKcal(), event.getTotalAdjustedKcal()));
+				event.getNivelPeso(), event.getIndiceGrasaCorporal(), null, null, event.getBmrUsed(),
+				event.getGetKcal(), event.getTefKcal(), event.getTotalAdjustedKcal()));
 	}
 
 	@Override
@@ -78,8 +79,8 @@ public class BodyMetricRecordServiceImpl implements BodyMetricRecordService {
 		upsertRecord(new BodyMetricUpsertData(measurement.getPaciente(), measurement.getMeasurementDateTime(),
 				BodyMetricSource.ANTHROPOMETRIC, measurement.getId(), measurement.getPeso(), measurement.getEstatura(),
 				measurement.getImc(), measurement.getNivelPeso(), measurement.getIndiceGrasaCorporal(),
-				measurement.getPorcentajeGrasaCorporal(), measurement.getBmrUsed(), measurement.getGetKcal(),
-				measurement.getTefKcal(), measurement.getTotalAdjustedKcal()));
+				measurement.getPorcentajeGrasaCorporal(), measurement.getMetodoObtencion(), measurement.getBmrUsed(),
+				measurement.getGetKcal(), measurement.getTefKcal(), measurement.getTotalAdjustedKcal()));
 	}
 
 	@Override
@@ -90,7 +91,7 @@ public class BodyMetricRecordServiceImpl implements BodyMetricRecordService {
 		}
 		upsertRecord(new BodyMetricUpsertData(exam.getPaciente(), exam.getExamDateTime(),
 				BodyMetricSource.CLINICAL_EXAM, exam.getId(), exam.getPeso(), exam.getEstatura(), exam.getImc(),
-				exam.getNivelPeso(), exam.getIndiceGrasaCorporal(), null, null, null, null, null));
+				exam.getNivelPeso(), exam.getIndiceGrasaCorporal(), null, null, null, null, null, null));
 	}
 
 	@Override
@@ -194,6 +195,7 @@ public class BodyMetricRecordServiceImpl implements BodyMetricRecordService {
 		record.setNivelPeso(data.nivelPeso());
 		record.setBodyFatIndex(data.bodyFatIndex());
 		record.setBodyFatPercentage(data.bodyFatPercentage());
+		record.setMetodoObtencionComposicion(data.metodoObtencionComposicion());
 		record.setBmr(data.bmr());
 		record.setGetKcal(data.getKcal());
 		record.setTefKcal(data.tefKcal());
@@ -203,7 +205,8 @@ public class BodyMetricRecordServiceImpl implements BodyMetricRecordService {
 
 	private record BodyMetricUpsertData(Paciente paciente, java.util.Date recordedAt, BodyMetricSource source,
 			Long sourceId, Double weight, Double height, Double imc, NivelPeso nivelPeso, Double bodyFatIndex,
-			Double bodyFatPercentage, Double bmr, Double getKcal, Double tefKcal, Double totalAdjustedKcal) {
+			Double bodyFatPercentage, MetodoObtencionComposicionCorporal metodoObtencionComposicion, Double bmr,
+			Double getKcal, Double tefKcal, Double totalAdjustedKcal) {
 	}
 
 	private boolean hasBodyMetricData(final Double weight, final Double height, final Double imc,

--- a/src/main/java/com/nutriconsultas/reports/ReportTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/reports/ReportTemplateValidator.java
@@ -10,6 +10,7 @@ import com.nutriconsultas.calendar.EventStatus;
 import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
 import com.nutriconsultas.clinical.exam.ClinicalExam;
 import com.nutriconsultas.clinical.exam.anthropometric.BodyComposition;
+import com.nutriconsultas.clinical.exam.anthropometric.MetodoObtencionComposicionCorporal;
 import com.nutriconsultas.clinical.exam.anthropometric.BodyMass;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteDieta;
@@ -151,6 +152,9 @@ public class ReportTemplateValidator extends BaseTemplateValidator {
 		bodyComposition.setEctomorphy(2.8);
 		bodyComposition.setSomatocartaX(-0.4);
 		bodyComposition.setSomatocartaY(3.0);
+		bodyComposition.setPorcentajeGrasaCorporal(22.5);
+		bodyComposition.setPorcentajeMasaMuscular(45.0);
+		bodyComposition.setMetodoObtencion(MetodoObtencionComposicionCorporal.BIOIMPEDANCIA);
 		measurement.setBodyComposition(bodyComposition);
 		measurements.add(measurement);
 		return measurements;

--- a/src/main/resources/templates/sbadmin/pacientes/body-composition-fields.html
+++ b/src/main/resources/templates/sbadmin/pacientes/body-composition-fields.html
@@ -7,6 +7,7 @@
   <h5 class="mb-3">Composición Corporal</h5>
   <p class="text-muted small mb-3">
     Opcional. Al guardar se calcula automáticamente si hay peso/estatura, pliegues completos o % grasa de bioimpedancia.
+    Puede indicar el método clínico (p. ej. DEXA externo) para trazabilidad.
   </p>
   <div class="row">
     <div class="col-md-4">
@@ -37,19 +38,36 @@
       </div>
     </div>
   </div>
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <label>Método de obtención</label>
+        <select th:field="*{bodyComposition.metodoObtencion}" class="form-control">
+          <option value="">Automático (según datos ingresados)</option>
+          <option th:each="metodo : ${T(com.nutriconsultas.clinical.exam.anthropometric.MetodoObtencionComposicionCorporal).values()}"
+                  th:value="${metodo}" th:text="${metodo.displayName}">Manual</option>
+        </select>
+        <small class="form-text text-muted">DEXA u Otro se conserva al guardar aunque el % se recalcule.</small>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div th:fragment="bodyCompositionDisplay(measurement)">
   <div th:with="fatPct=${measurement.porcentajeGrasaCorporal != null ? measurement.porcentajeGrasaCorporal : (measurement.bioimpedance != null ? measurement.bioimpedance.bodyFatPercentage : null)},
                 fatIdx=${measurement.indiceGrasaCorporal},
-                musclePct=${measurement.porcentajeMasaMuscular != null ? measurement.porcentajeMasaMuscular : null}"
+                musclePct=${measurement.porcentajeMasaMuscular != null ? measurement.porcentajeMasaMuscular : null},
+                metodo=${measurement.metodoObtencion}"
        th:if="${fatPct != null || fatIdx != null || musclePct != null}">
     <hr class="my-3">
     <h5 class="mb-3">Composición Corporal</h5>
     <div class="row">
       <div class="col-md-4" th:if="${fatPct != null}">
         <p><strong>% Grasa Corporal:</strong>
-          <span th:text="${#numbers.formatDecimal(fatPct, 1, 1)} + '%'">-</span></p>
+          <span th:text="${#numbers.formatDecimal(fatPct, 1, 1)} + '%'">-</span>
+          <span th:if="${metodo != null}" class="text-muted small">
+            (<span th:text="${metodo.displayName}">-</span>)
+          </span></p>
       </div>
       <div class="col-md-4" th:if="${fatIdx != null}">
         <p><strong>Índice de Grasa Corporal:</strong>
@@ -58,6 +76,10 @@
       <div class="col-md-4" th:if="${musclePct != null}">
         <p><strong>% Masa Muscular:</strong>
           <span th:text="${#numbers.formatDecimal(musclePct, 1, 1)} + '%'">-</span></p>
+      </div>
+      <div class="col-md-12" th:if="${metodo != null && fatPct == null}">
+        <p><strong>Método de obtención:</strong>
+          <span th:text="${metodo.displayName}">-</span></p>
       </div>
     </div>
   </div>

--- a/src/main/resources/templates/sbadmin/pacientes/perfil.html
+++ b/src/main/resources/templates/sbadmin/pacientes/perfil.html
@@ -76,6 +76,9 @@
                       <i class="fas fa-percentage fa-lg" style="color: #e67e22;"></i>
                       <p class="mb-0" th:if="${ultimoPorcentajeGrasaCorporal != null}">
                         % Grasa: [[(${#numbers.formatDecimal(ultimoPorcentajeGrasaCorporal,1,'COMMA',1,'POINT')})]]%
+                        <span th:if="${ultimoMetodoObtencionComposicion != null}" class="text-muted small">
+                          ([[${ultimoMetodoObtencionComposicion.displayName}]])
+                        </span>
                       </p>
                       <p class="mb-0 text-muted" th:if="${ultimoPorcentajeGrasaCorporal == null}">% Grasa: sin dato</p>
                     </li>

--- a/src/main/resources/templates/sbadmin/reports/patient-progress.html
+++ b/src/main/resources/templates/sbadmin/reports/patient-progress.html
@@ -355,6 +355,7 @@
 					<th>Estatura (m)</th>
 					<th>IMC</th>
 					<th>% Grasa</th>
+					<th>Método</th>
 					<th>% Masa muscular</th>
 					<th>Somatotipo</th>
 				</tr>
@@ -367,6 +368,7 @@
 					<td th:text="${measurement.estatura != null ? (#numbers.formatDecimal(measurement.estatura, 2, 2) + ' m') : 'N/A'}"></td>
 					<td th:text="${measurement.bodyMass != null && measurement.bodyMass.imc != null ? #numbers.formatDecimal(measurement.bodyMass.imc, 1, 2) : 'N/A'}"></td>
 					<td th:text="${measurement.porcentajeGrasaCorporal != null ? (#numbers.formatDecimal(measurement.porcentajeGrasaCorporal, 1, 1) + '%') : 'N/A'}"></td>
+					<td th:text="${measurement.metodoObtencion != null ? measurement.metodoObtencion.displayName : 'N/A'}"></td>
 					<td th:text="${measurement.porcentajeMasaMuscular != null ? (#numbers.formatDecimal(measurement.porcentajeMasaMuscular, 1, 1) + '%') : 'N/A'}"></td>
 					<td th:text="${measurement.endomorphy != null ? (#numbers.formatDecimal(measurement.endomorphy,1,1) + '-' + #numbers.formatDecimal(measurement.mesomorphy,1,1) + '-' + #numbers.formatDecimal(measurement.ectomorphy,1,1)) : 'N/A'}"></td>
 				</tr>

--- a/src/test/java/com/nutriconsultas/clinical/exam/anthropometric/BodyCompositionServiceTest.java
+++ b/src/test/java/com/nutriconsultas/clinical/exam/anthropometric/BodyCompositionServiceTest.java
@@ -54,6 +54,7 @@ class BodyCompositionServiceTest {
 		assertThat(measurement.getPorcentajeGrasaCorporal()).isEqualTo(18.5);
 		assertThat(measurement.getIndiceGrasaCorporal()).isEqualTo(18.5);
 		assertThat(measurement.getPorcentajeMasaMuscular()).isEqualTo(80.0);
+		assertThat(measurement.getMetodoObtencion()).isEqualTo(MetodoObtencionComposicionCorporal.MANUAL);
 		verify(bodyFatCalculatorService, never()).calculateBodyFatPercentage(any(), any(), any());
 	}
 
@@ -69,6 +70,7 @@ class BodyCompositionServiceTest {
 		assertThat(measurement.getPorcentajeGrasaCorporal()).isEqualTo(24.0);
 		assertThat(measurement.getIndiceGrasaCorporal()).isEqualTo(24.0);
 		assertThat(measurement.getPorcentajeMasaMuscular()).isEqualTo(76.0);
+		assertThat(measurement.getMetodoObtencion()).isEqualTo(MetodoObtencionComposicionCorporal.BIOIMPEDANCIA);
 		verify(bodyFatCalculatorService, never()).calculateBodyFatPercentage(any(), any(), any());
 	}
 
@@ -86,6 +88,7 @@ class BodyCompositionServiceTest {
 
 		assertThat(measurement.getPorcentajeGrasaCorporal()).isEqualTo(19.0);
 		assertThat(measurement.getPorcentajeMasaMuscular()).isEqualTo(80.0);
+		assertThat(measurement.getMetodoObtencion()).isEqualTo(MetodoObtencionComposicionCorporal.PLIEGUES);
 		verify(bodyFatCalculatorService).calculateBodyFatFromSkinfolds(10.0, 15.0, 12.0, 30, "M");
 		verify(bodyFatCalculatorService, never()).calculateBodyFatPercentage(any(), any(), any());
 	}
@@ -100,6 +103,7 @@ class BodyCompositionServiceTest {
 		assertThat(measurement.getPorcentajeGrasaCorporal()).isEqualTo(16.5);
 		assertThat(measurement.getIndiceGrasaCorporal()).isEqualTo(16.5);
 		assertThat(measurement.getPorcentajeMasaMuscular()).isEqualTo(80.0);
+		assertThat(measurement.getMetodoObtencion()).isEqualTo(MetodoObtencionComposicionCorporal.DEURENBERG);
 		verify(bodyFatCalculatorService).calculateBodyFatPercentage(22.86, 30, "M");
 	}
 
@@ -124,6 +128,33 @@ class BodyCompositionServiceTest {
 		assertThat(measurement.getPorcentajeGrasaCorporal()).isNull();
 		assertThat(measurement.getIndiceGrasaCorporal()).isNull();
 		assertThat(measurement.getPorcentajeMasaMuscular()).isNull();
+		assertThat(measurement.getMetodoObtencion()).isNull();
+	}
+
+	@Test
+	void applyToMeasurementPreservesDexaOverrideWhenBioimpedanceRecalculatesFat() {
+		final AnthropometricMeasurement measurement = createMeasurementWithWeight(70.0, 1.75);
+		final Bioimpedance bioimpedance = new Bioimpedance();
+		bioimpedance.setBodyFatPercentage(24.0);
+		measurement.setBioimpedance(bioimpedance);
+		measurement.setMetodoObtencion(MetodoObtencionComposicionCorporal.DEXA);
+
+		service.applyToMeasurement(measurement, paciente, 22.86);
+
+		assertThat(measurement.getPorcentajeGrasaCorporal()).isEqualTo(24.0);
+		assertThat(measurement.getMetodoObtencion()).isEqualTo(MetodoObtencionComposicionCorporal.DEXA);
+	}
+
+	@Test
+	void applyToMeasurementPreservesOtroOverrideWithManualFatEntry() {
+		final AnthropometricMeasurement measurement = createMeasurementWithWeight(70.0, 1.75);
+		measurement.setPorcentajeGrasaCorporal(21.0);
+		measurement.setMetodoObtencion(MetodoObtencionComposicionCorporal.OTRO);
+
+		service.applyToMeasurement(measurement, paciente, 22.86);
+
+		assertThat(measurement.getPorcentajeGrasaCorporal()).isEqualTo(21.0);
+		assertThat(measurement.getMetodoObtencion()).isEqualTo(MetodoObtencionComposicionCorporal.OTRO);
 	}
 
 	private AnthropometricMeasurement createMeasurementWithWeight(final Double weight, final Double height) {

--- a/src/test/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordServiceTest.java
@@ -26,6 +26,7 @@ import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
 import com.nutriconsultas.clinical.exam.AnthropometricMeasurementRepository;
 import com.nutriconsultas.clinical.exam.ClinicalExamRepository;
 import com.nutriconsultas.clinical.exam.anthropometric.BodyMass;
+import com.nutriconsultas.clinical.exam.anthropometric.MetodoObtencionComposicionCorporal;
 import com.nutriconsultas.paciente.NivelPeso;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
@@ -85,6 +86,7 @@ class BodyMetricRecordServiceTest {
 		measurement.setMeasurementDateTime(new Date());
 		measurement.setPorcentajeGrasaCorporal(20.5);
 		measurement.setIndiceGrasaCorporal(20.5);
+		measurement.setMetodoObtencion(MetodoObtencionComposicionCorporal.BIOIMPEDANCIA);
 
 		when(repository.findBySourceAndSourceId(BodyMetricSource.ANTHROPOMETRIC, 10L)).thenReturn(Optional.empty());
 		when(repository.save(any(BodyMetricRecord.class))).thenAnswer(invocation -> {
@@ -99,6 +101,8 @@ class BodyMetricRecordServiceTest {
 		verify(repository).save(captor.capture());
 		assertThat(captor.getValue().getBodyFatPercentage()).isEqualTo(20.5);
 		assertThat(captor.getValue().getBodyFatIndex()).isEqualTo(20.5);
+		assertThat(captor.getValue().getMetodoObtencionComposicion())
+			.isEqualTo(MetodoObtencionComposicionCorporal.BIOIMPEDANCIA);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Adds `MetodoObtencionComposicionCorporal` enum and persists `metodoObtencion` on `BodyComposition` with auto-assignment from the existing body-fat precedence (manual → bioimpedancia → pliegues → Deurenberg).
- Preserves clinical overrides (`DEXA`, `OTRO`) on save; exposes method in anthropometric UI, patient profile, progress PDF, and `BodyMetricRecord` timeline.
- Includes service/timeline tests, template validator updates, and DDL notes in `docs/schema/body-composition-metodo-obtencion.md`.

Closes #161

## Test plan
- [x] `BodyCompositionServiceTest` — auto-assignment per source + DEXA/OTRO override preservation
- [x] `BodyMetricRecordServiceTest` — timeline sync persists method
- [x] `ThymeleafTemplateValidationTest` — templates validate
- [ ] Manual: save anthropometric with bioimpedance → method shows Bioimpedancia
- [ ] Manual: override method to DEXA → persists after re-save
- [ ] Manual: patient profile and progress PDF show method next to % grasa


Made with [Cursor](https://cursor.com)