### PR TITLE
feat(anthropometric): captura y visualización de masa ósea (#162)

### DIFF
--- a/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurement.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/AnthropometricMeasurement.java
@@ -283,6 +283,28 @@ public class AnthropometricMeasurement {
 		bodyComposition.setPorcentajeMasaMuscular(porcentajeMasaMuscular);
 	}
 
+	public Double getMasaOseaKg() {
+		return bodyComposition != null ? bodyComposition.getMasaOseaKg() : null;
+	}
+
+	public void setMasaOseaKg(final Double masaOseaKg) {
+		if (bodyComposition == null) {
+			bodyComposition = new BodyComposition();
+		}
+		bodyComposition.setMasaOseaKg(masaOseaKg);
+	}
+
+	public Double getPorcentajeMasaOsea() {
+		return bodyComposition != null ? bodyComposition.getPorcentajeMasaOsea() : null;
+	}
+
+	public void setPorcentajeMasaOsea(final Double porcentajeMasaOsea) {
+		if (bodyComposition == null) {
+			bodyComposition = new BodyComposition();
+		}
+		bodyComposition.setPorcentajeMasaOsea(porcentajeMasaOsea);
+	}
+
 	public Double getEndomorphy() {
 		return bodyComposition != null ? bodyComposition.getEndomorphy() : null;
 	}

--- a/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/Bioimpedance.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/Bioimpedance.java
@@ -49,6 +49,12 @@ public class Bioimpedance {
 	private Double skeletalMuscleMass; // Masa muscular esquelética (kg)
 
 	@Column(precision = 5)
+	private Double boneMass; // Masa ósea (kg)
+
+	@Column(precision = 3)
+	private Double boneMassPercentage; // Masa ósea (%)
+
+	@Column(precision = 5)
 	private Double totalBodyWaterLiters; // Agua corporal total (L)
 
 	@Column(precision = 3)

--- a/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/BodyComposition.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/BodyComposition.java
@@ -31,6 +31,12 @@ public class BodyComposition {
 	@Column(precision = 3)
 	private Double porcentajeMasaMuscular;
 
+	@Column(precision = 5)
+	private Double masaOseaKg;
+
+	@Column(precision = 3)
+	private Double porcentajeMasaOsea;
+
 	/** Heath-Carter endomorphy rating (adults). */
 	@Column(precision = 4)
 	private Double endomorphy;

--- a/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/BodyCompositionService.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/anthropometric/BodyCompositionService.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
  * <p>
  * Precedence: manual {@code porcentajeGrasaCorporal} / {@code indiceGrasaCorporal},
  * bioimpedance {@code bodyFatPercentage}, Jackson-Pollock skinfolds, Deurenberg estimate.
+ * Bone mass: bioimpedance over manual {@code masaOseaKg} / {@code porcentajeMasaOsea}.
  */
 @Service
 @Slf4j
@@ -34,27 +35,90 @@ public class BodyCompositionService {
 			final Double imc) {
 		ensureBodyComposition(measurement);
 		final MetodoObtencionComposicionCorporal clinicalOverride = resolveClinicalOverride(measurement);
+		final Double resolvedFat = resolveFatPercentage(measurement, paciente, imc, clinicalOverride);
 
+		consolidateBoneMass(measurement);
+
+		if (resolvedFat != null) {
+			applyMusclePercentageIfAbsent(measurement, resolvedFat);
+		}
+	}
+
+	private Double resolveFatPercentage(final AnthropometricMeasurement measurement, final Paciente paciente,
+			final Double imc, final MetodoObtencionComposicionCorporal clinicalOverride) {
 		if (measurement.getPorcentajeGrasaCorporal() != null) {
 			syncFatFields(measurement, measurement.getPorcentajeGrasaCorporal());
-			applyMusclePercentageIfAbsent(measurement, measurement.getPorcentajeGrasaCorporal());
 			assignMethodIfAllowed(measurement, MetodoObtencionComposicionCorporal.MANUAL, clinicalOverride);
-			return;
+			return measurement.getPorcentajeGrasaCorporal();
 		}
 
 		if (measurement.getIndiceGrasaCorporal() != null) {
 			syncFatFields(measurement, measurement.getIndiceGrasaCorporal());
-			applyMusclePercentageIfAbsent(measurement, measurement.getIndiceGrasaCorporal());
 			assignMethodIfAllowed(measurement, MetodoObtencionComposicionCorporal.MANUAL, clinicalOverride);
-			return;
+			return measurement.getIndiceGrasaCorporal();
 		}
 
 		final ResolvedFatPercentage resolvedFat = resolveCalculatedFatPercentage(measurement, paciente, imc);
 		if (resolvedFat.fatPercentage() != null) {
 			syncFatFields(measurement, resolvedFat.fatPercentage());
-			applyMusclePercentageIfAbsent(measurement, resolvedFat.fatPercentage());
 			assignMethodIfAllowed(measurement, resolvedFat.method(), clinicalOverride);
+			return resolvedFat.fatPercentage();
 		}
+
+		return null;
+	}
+
+	private void consolidateBoneMass(final AnthropometricMeasurement measurement) {
+		final Double weight = measurement.getPeso();
+		final ResolvedBoneMass resolved = resolveBoneMass(measurement, weight);
+		if (resolved == null) {
+			return;
+		}
+		measurement.setMasaOseaKg(resolved.masaOseaKg());
+		measurement.setPorcentajeMasaOsea(resolved.porcentajeMasaOsea());
+	}
+
+	private ResolvedBoneMass resolveBoneMass(final AnthropometricMeasurement measurement, final Double weight) {
+		final Bioimpedance bioimpedance = measurement.getBioimpedance();
+		if (bioimpedance != null) {
+			final ResolvedBoneMass fromBio = deriveBoneMass(bioimpedance.getBoneMass(),
+					bioimpedance.getBoneMassPercentage(), weight);
+			if (fromBio != null) {
+				log.debug("Using bioimpedance bone mass for measurement");
+				return fromBio;
+			}
+		}
+
+		return deriveBoneMass(measurement.getMasaOseaKg(), measurement.getPorcentajeMasaOsea(), weight);
+	}
+
+	private ResolvedBoneMass deriveBoneMass(final Double masaOseaKg, final Double porcentajeMasaOsea,
+			final Double weight) {
+		if (masaOseaKg != null && porcentajeMasaOsea != null) {
+			return new ResolvedBoneMass(masaOseaKg, porcentajeMasaOsea);
+		}
+		if (masaOseaKg != null && weight != null && weight > 0) {
+			final double percentage = (masaOseaKg / weight) * 100.0;
+			return new ResolvedBoneMass(masaOseaKg, percentage);
+		}
+		if (porcentajeMasaOsea != null && weight != null && weight > 0) {
+			final double kg = (porcentajeMasaOsea / 100.0) * weight;
+			return new ResolvedBoneMass(kg, porcentajeMasaOsea);
+		}
+		if (masaOseaKg != null) {
+			return new ResolvedBoneMass(masaOseaKg, null);
+		}
+		if (porcentajeMasaOsea != null) {
+			return new ResolvedBoneMass(null, porcentajeMasaOsea);
+		}
+		return null;
+	}
+
+	private Double resolveWaterPercentage(final AnthropometricMeasurement measurement) {
+		if (measurement.getBioimpedance() == null) {
+			return null;
+		}
+		return measurement.getBioimpedance().getTotalBodyWaterPercentage();
 	}
 
 	private MetodoObtencionComposicionCorporal resolveClinicalOverride(final AnthropometricMeasurement measurement) {
@@ -146,7 +210,18 @@ public class BodyCompositionService {
 		if (measurement.getPorcentajeMasaMuscular() != null || fatPercentage == null) {
 			return;
 		}
-		final double muscleMassPercentage = 100.0 - fatPercentage;
+		final Double bonePercentage = measurement.getPorcentajeMasaOsea();
+		final Double waterPercentage = resolveWaterPercentage(measurement);
+		double muscleMassPercentage;
+		if (bonePercentage != null && waterPercentage != null) {
+			muscleMassPercentage = 100.0 - fatPercentage - bonePercentage - waterPercentage;
+		}
+		else if (bonePercentage != null) {
+			muscleMassPercentage = 100.0 - fatPercentage - bonePercentage;
+		}
+		else {
+			muscleMassPercentage = 100.0 - fatPercentage;
+		}
 		final double clamped = Math.max(20.0, Math.min(80.0, muscleMassPercentage));
 		measurement.setPorcentajeMasaMuscular(clamped);
 	}
@@ -176,6 +251,9 @@ public class BodyCompositionService {
 	}
 
 	private record ResolvedFatPercentage(Double fatPercentage, MetodoObtencionComposicionCorporal method) {
+	}
+
+	private record ResolvedBoneMass(Double masaOseaKg, Double porcentajeMasaOsea) {
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -207,6 +207,7 @@ public class PacienteController extends AbstractAuthorizedController {
 			model.addAttribute("ultimoMetodoObtencionComposicion", latest.getMetodoObtencionComposicion());
 		});
 		addLatestMuscleMassToModel(id, model);
+		addLatestBoneMassToModel(id, model);
 		// Calculate age and check if patient is under 18 for growth table display
 		final Integer age = calculateAge(paciente.getDob());
 		final boolean isUnder18 = age != null && age < 18;
@@ -1354,6 +1355,18 @@ public class PacienteController extends AbstractAuthorizedController {
 				.thenComparing(AnthropometricMeasurement::getId, Comparator.nullsLast(Comparator.naturalOrder())))
 			.ifPresent(
 					latest -> model.addAttribute("ultimoPorcentajeMasaMuscular", latest.getPorcentajeMasaMuscular()));
+	}
+
+	private void addLatestBoneMassToModel(final Long pacienteId, final Model model) {
+		anthropometricMeasurementService.findByPacienteId(pacienteId)
+			.stream()
+			.filter(measurement -> measurement.getMasaOseaKg() != null || measurement.getPorcentajeMasaOsea() != null)
+			.max(Comparator.comparing(AnthropometricMeasurement::getMeasurementDateTime)
+				.thenComparing(AnthropometricMeasurement::getId, Comparator.nullsLast(Comparator.naturalOrder())))
+			.ifPresent(latest -> {
+				model.addAttribute("ultimaMasaOseaKg", latest.getMasaOseaKg());
+				model.addAttribute("ultimoPorcentajeMasaOsea", latest.getPorcentajeMasaOsea());
+			});
 	}
 
 	/**

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -206,8 +206,7 @@ public class PacienteController extends AbstractAuthorizedController {
 			model.addAttribute("ultimoIndiceGrasaCorporal", ultimoPorcentajeGrasa);
 			model.addAttribute("ultimoMetodoObtencionComposicion", latest.getMetodoObtencionComposicion());
 		});
-		addLatestMuscleMassToModel(id, model);
-		addLatestBoneMassToModel(id, model);
+		addLatestCompositionMetricsToModel(id, model);
 		// Calculate age and check if patient is under 18 for growth table display
 		final Integer age = calculateAge(paciente.getDob());
 		final boolean isUnder18 = age != null && age < 18;
@@ -1347,22 +1346,22 @@ public class PacienteController extends AbstractAuthorizedController {
 		return new BmiCalculationResult(imc, np, bodyFatPercentage);
 	}
 
-	private void addLatestMuscleMassToModel(final Long pacienteId, final Model model) {
-		anthropometricMeasurementService.findByPacienteId(pacienteId)
-			.stream()
+	private void addLatestCompositionMetricsToModel(final Long pacienteId, final Model model) {
+		final List<AnthropometricMeasurement> measurements = anthropometricMeasurementService
+			.findByPacienteId(pacienteId);
+		final Comparator<AnthropometricMeasurement> byRecency = Comparator
+			.comparing(AnthropometricMeasurement::getMeasurementDateTime)
+			.thenComparing(AnthropometricMeasurement::getId, Comparator.nullsLast(Comparator.naturalOrder()));
+
+		measurements.stream()
 			.filter(measurement -> measurement.getPorcentajeMasaMuscular() != null)
-			.max(Comparator.comparing(AnthropometricMeasurement::getMeasurementDateTime)
-				.thenComparing(AnthropometricMeasurement::getId, Comparator.nullsLast(Comparator.naturalOrder())))
+			.max(byRecency)
 			.ifPresent(
 					latest -> model.addAttribute("ultimoPorcentajeMasaMuscular", latest.getPorcentajeMasaMuscular()));
-	}
 
-	private void addLatestBoneMassToModel(final Long pacienteId, final Model model) {
-		anthropometricMeasurementService.findByPacienteId(pacienteId)
-			.stream()
+		measurements.stream()
 			.filter(measurement -> measurement.getMasaOseaKg() != null || measurement.getPorcentajeMasaOsea() != null)
-			.max(Comparator.comparing(AnthropometricMeasurement::getMeasurementDateTime)
-				.thenComparing(AnthropometricMeasurement::getId, Comparator.nullsLast(Comparator.naturalOrder())))
+			.max(byRecency)
 			.ifPresent(latest -> {
 				model.addAttribute("ultimaMasaOseaKg", latest.getMasaOseaKg());
 				model.addAttribute("ultimoPorcentajeMasaOsea", latest.getPorcentajeMasaOsea());

--- a/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
@@ -45,6 +45,8 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 		variables.put("ultimoIndiceGrasaCorporal", null);
 		variables.put("ultimoMetodoObtencionComposicion", null);
 		variables.put("ultimoPorcentajeMasaMuscular", null);
+		variables.put("ultimaMasaOseaKg", null);
+		variables.put("ultimoPorcentajeMasaOsea", null);
 		variables.put("isEligibleForPregnancy", false);
 		variables.put("isUnder18", false);
 		variables.put("suggestedStressTypes", List.of());

--- a/src/main/java/com/nutriconsultas/reports/ReportTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/reports/ReportTemplateValidator.java
@@ -154,6 +154,8 @@ public class ReportTemplateValidator extends BaseTemplateValidator {
 		bodyComposition.setSomatocartaY(3.0);
 		bodyComposition.setPorcentajeGrasaCorporal(22.5);
 		bodyComposition.setPorcentajeMasaMuscular(45.0);
+		bodyComposition.setMasaOseaKg(2.8);
+		bodyComposition.setPorcentajeMasaOsea(4.0);
 		bodyComposition.setMetodoObtencion(MetodoObtencionComposicionCorporal.BIOIMPEDANCIA);
 		measurement.setBodyComposition(bodyComposition);
 		measurements.add(measurement);

--- a/src/main/resources/templates/sbadmin/pacientes/antropometricos.html
+++ b/src/main/resources/templates/sbadmin/pacientes/antropometricos.html
@@ -216,6 +216,20 @@
                                 <span th:if="${#fields.hasErrors('bioimpedance.skeletalMuscleMass')}" th:errors="*{bioimpedance.skeletalMuscleMass}"></span>
                               </div>
                             </div>
+                            <div class="col-md-4">
+                              <div class="form-group">
+                                <label>Masa Ósea (kg)</label>
+                                <input type="number" step="0.01" th:field="*{bioimpedance.boneMass}" class="form-control">
+                                <span th:if="${#fields.hasErrors('bioimpedance.boneMass')}" th:errors="*{bioimpedance.boneMass}"></span>
+                              </div>
+                            </div>
+                            <div class="col-md-4">
+                              <div class="form-group">
+                                <label>% Masa Ósea</label>
+                                <input type="number" step="0.1" th:field="*{bioimpedance.boneMassPercentage}" class="form-control" min="0" max="100">
+                                <span th:if="${#fields.hasErrors('bioimpedance.boneMassPercentage')}" th:errors="*{bioimpedance.boneMassPercentage}"></span>
+                              </div>
+                            </div>
                           </div>
                           <hr class="my-4">
                           <h5 class="mb-3">Agua Corporal</h5>

--- a/src/main/resources/templates/sbadmin/pacientes/body-composition-fields.html
+++ b/src/main/resources/templates/sbadmin/pacientes/body-composition-fields.html
@@ -39,6 +39,26 @@
     </div>
   </div>
   <div class="row">
+    <div class="col-md-4">
+      <div class="form-group">
+        <label>Masa Ósea (kg)</label>
+        <input type="number" step="0.01" th:field="*{bodyComposition.masaOseaKg}" class="form-control"
+               min="0" placeholder="Ej: 2.8">
+        <span th:if="${#fields.hasErrors('bodyComposition.masaOseaKg')}"
+              th:errors="*{bodyComposition.masaOseaKg}"></span>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="form-group">
+        <label>% Masa Ósea</label>
+        <input type="number" step="0.1" th:field="*{bodyComposition.porcentajeMasaOsea}" class="form-control"
+               min="0" max="100" placeholder="Ej: 4.0">
+        <span th:if="${#fields.hasErrors('bodyComposition.porcentajeMasaOsea')}"
+              th:errors="*{bodyComposition.porcentajeMasaOsea}"></span>
+      </div>
+    </div>
+  </div>
+  <div class="row">
     <div class="col-md-6">
       <div class="form-group">
         <label>Método de obtención</label>
@@ -57,8 +77,10 @@
   <div th:with="fatPct=${measurement.porcentajeGrasaCorporal != null ? measurement.porcentajeGrasaCorporal : (measurement.bioimpedance != null ? measurement.bioimpedance.bodyFatPercentage : null)},
                 fatIdx=${measurement.indiceGrasaCorporal},
                 musclePct=${measurement.porcentajeMasaMuscular != null ? measurement.porcentajeMasaMuscular : null},
+                boneKg=${measurement.masaOseaKg},
+                bonePct=${measurement.porcentajeMasaOsea},
                 metodo=${measurement.metodoObtencion}"
-       th:if="${fatPct != null || fatIdx != null || musclePct != null}">
+       th:if="${fatPct != null || fatIdx != null || musclePct != null || boneKg != null || bonePct != null}">
     <hr class="my-3">
     <h5 class="mb-3">Composición Corporal</h5>
     <div class="row">
@@ -76,6 +98,17 @@
       <div class="col-md-4" th:if="${musclePct != null}">
         <p><strong>% Masa Muscular:</strong>
           <span th:text="${#numbers.formatDecimal(musclePct, 1, 1)} + '%'">-</span></p>
+      </div>
+      <div class="col-md-4" th:if="${boneKg != null}">
+        <p><strong>Masa Ósea:</strong>
+          <span th:text="${#numbers.formatDecimal(boneKg, 1, 2)} + ' kg'">-</span>
+          <span th:if="${bonePct != null}" class="text-muted small">
+            (<span th:text="${#numbers.formatDecimal(bonePct, 1, 1)} + '%'">-</span>)
+          </span></p>
+      </div>
+      <div class="col-md-4" th:if="${boneKg == null && bonePct != null}">
+        <p><strong>% Masa Ósea:</strong>
+          <span th:text="${#numbers.formatDecimal(bonePct, 1, 1)} + '%'">-</span></p>
       </div>
       <div class="col-md-12" th:if="${metodo != null && fatPct == null}">
         <p><strong>Método de obtención:</strong>

--- a/src/main/resources/templates/sbadmin/pacientes/calculation-script.html
+++ b/src/main/resources/templates/sbadmin/pacientes/calculation-script.html
@@ -671,15 +671,48 @@
       return Math.max(5.0, Math.min(50.0, bodyFatPercentage));
     }
 
-    function calculateMuscleMassPercentage(bodyFatPercentage) {
+    function calculateMuscleMassPercentage(bodyFatPercentage, bonePercentage, waterPercentage) {
       if (bodyFatPercentage === null || bodyFatPercentage === undefined) {
         return null;
       }
-      // Simple approximation: 100% - body fat %
-      // Note: This doesn't account for bone mass, water, etc., but provides a reasonable estimate
-      const muscleMassPercentage = 100 - bodyFatPercentage;
-      // Clamp to reasonable range (20% to 80%)
+      let muscleMassPercentage;
+      if (bonePercentage !== null && bonePercentage !== undefined && waterPercentage !== null && waterPercentage !== undefined) {
+        muscleMassPercentage = 100 - bodyFatPercentage - bonePercentage - waterPercentage;
+      } else if (bonePercentage !== null && bonePercentage !== undefined) {
+        muscleMassPercentage = 100 - bodyFatPercentage - bonePercentage;
+      } else {
+        muscleMassPercentage = 100 - bodyFatPercentage;
+      }
       return Math.max(20.0, Math.min(80.0, muscleMassPercentage));
+    }
+
+    function resolveBonePercentageForCalculation() {
+      const bioBonePctField = document.querySelector('input[name*="bioimpedance.boneMassPercentage"]');
+      if (bioBonePctField && bioBonePctField.value) {
+        return parseFloat(bioBonePctField.value);
+      }
+      const manualBonePctField = document.querySelector('input[name*="bodyComposition.porcentajeMasaOsea"]');
+      if (manualBonePctField && manualBonePctField.value) {
+        return parseFloat(manualBonePctField.value);
+      }
+      const bioBoneKgField = document.querySelector('input[name*="bioimpedance.boneMass"]');
+      const manualBoneKgField = document.querySelector('input[name*="bodyComposition.masaOseaKg"]');
+      const weightField = document.querySelector('input[name*="bodyMass.weight"]');
+      const boneKg = (bioBoneKgField && bioBoneKgField.value) ? parseFloat(bioBoneKgField.value)
+        : ((manualBoneKgField && manualBoneKgField.value) ? parseFloat(manualBoneKgField.value) : null);
+      const weight = (weightField && weightField.value) ? parseFloat(weightField.value) : null;
+      if (boneKg !== null && weight !== null && weight > 0) {
+        return (boneKg / weight) * 100;
+      }
+      return null;
+    }
+
+    function resolveWaterPercentageForCalculation() {
+      const waterPctField = document.querySelector('input[name*="bioimpedance.totalBodyWaterPercentage"]');
+      if (waterPctField && waterPctField.value) {
+        return parseFloat(waterPctField.value);
+      }
+      return null;
     }
 
     // Update Body Composition calculations
@@ -694,7 +727,9 @@
       document.getElementById('body-fat-index-result').textContent = formatNumber(bodyFatPercentage);
       
       // Muscle Mass Percentage
-      const muscleMassPercentage = calculateMuscleMassPercentage(bodyFatPercentage);
+      const bonePercentage = resolveBonePercentageForCalculation();
+      const waterPercentage = resolveWaterPercentageForCalculation();
+      const muscleMassPercentage = calculateMuscleMassPercentage(bodyFatPercentage, bonePercentage, waterPercentage);
       document.getElementById('muscle-mass-percentage-result').textContent = formatNumber(muscleMassPercentage);
       
       // Update Índice de Grasa Corporal in BMI section

--- a/src/main/resources/templates/sbadmin/pacientes/perfil.html
+++ b/src/main/resources/templates/sbadmin/pacientes/perfil.html
@@ -90,6 +90,19 @@
                       <p class="mb-0 text-muted" th:if="${ultimoPorcentajeMasaMuscular == null}">% Masa muscular: sin dato</p>
                     </li>
                     <li class="list-group-item d-flex justify-content-between align-items-center p-3">
+                      <i class="fas fa-bone fa-lg" style="color: #adb5bd;"></i>
+                      <p class="mb-0" th:if="${ultimaMasaOseaKg != null}">
+                        Masa ósea: [[(${#numbers.formatDecimal(ultimaMasaOseaKg,1,'COMMA',2,'POINT')})]] kg
+                        <span th:if="${ultimoPorcentajeMasaOsea != null}" class="text-muted small">
+                          ([[(${#numbers.formatDecimal(ultimoPorcentajeMasaOsea,1,'COMMA',1,'POINT')})]]%)
+                        </span>
+                      </p>
+                      <p class="mb-0 text-muted" th:if="${ultimaMasaOseaKg == null && ultimoPorcentajeMasaOsea == null}">Masa ósea: sin dato</p>
+                      <p class="mb-0" th:if="${ultimaMasaOseaKg == null && ultimoPorcentajeMasaOsea != null}">
+                        Masa ósea: [[(${#numbers.formatDecimal(ultimoPorcentajeMasaOsea,1,'COMMA',1,'POINT')})]]%
+                      </p>
+                    </li>
+                    <li class="list-group-item d-flex justify-content-between align-items-center p-3">
                       <i class="fas fa-bolt fa-lg" style="color: #ff6b35;"></i>
                       <p class="mb-0" th:if="${paciente.getKcal != null}">
                         GET: [[(${#numbers.formatDecimal(paciente.getKcal,1,'COMMA',0,'POINT')})]] kcal/día

--- a/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
+++ b/src/main/resources/templates/sbadmin/pacientes/ver-antropometrico.html
@@ -154,8 +154,8 @@
                           <p><strong>Ángulo de fase (°):</strong> <span th:text="${#numbers.formatDecimal(measurement.bioimpedance.phaseAngle, 1, 1)}">-</span></p>
                         </div>
                       </div>
-                      <hr class="my-4" th:if="${measurement.bioimpedance != null && (measurement.bioimpedance.bodyFatPercentage != null || measurement.bioimpedance.fatMass != null || measurement.bioimpedance.fatFreeMass != null || measurement.bioimpedance.skeletalMuscleMass != null)}">
-                      <h5 class="mb-3" th:if="${measurement.bioimpedance != null && (measurement.bioimpedance.bodyFatPercentage != null || measurement.bioimpedance.fatMass != null || measurement.bioimpedance.fatFreeMass != null || measurement.bioimpedance.skeletalMuscleMass != null)}">Composición Corporal</h5>
+                      <hr class="my-4" th:if="${measurement.bioimpedance != null && (measurement.bioimpedance.bodyFatPercentage != null || measurement.bioimpedance.fatMass != null || measurement.bioimpedance.fatFreeMass != null || measurement.bioimpedance.skeletalMuscleMass != null || measurement.bioimpedance.boneMass != null || measurement.bioimpedance.boneMassPercentage != null)}">
+                      <h5 class="mb-3" th:if="${measurement.bioimpedance != null && (measurement.bioimpedance.bodyFatPercentage != null || measurement.bioimpedance.fatMass != null || measurement.bioimpedance.fatFreeMass != null || measurement.bioimpedance.skeletalMuscleMass != null || measurement.bioimpedance.boneMass != null || measurement.bioimpedance.boneMassPercentage != null)}">Composición Corporal</h5>
                       <div class="row">
                         <div class="col-md-4" th:if="${measurement.bioimpedance != null && measurement.bioimpedance.bodyFatPercentage != null}">
                           <p><strong>% Grasa Corporal:</strong> <span th:text="${#numbers.formatDecimal(measurement.bioimpedance.bodyFatPercentage, 1, 1)} + '%'">-</span></p>
@@ -168,6 +168,12 @@
                         </div>
                         <div class="col-md-4" th:if="${measurement.bioimpedance != null && measurement.bioimpedance.skeletalMuscleMass != null}">
                           <p><strong>Masa Muscular Esquelética (kg):</strong> <span th:text="${#numbers.formatDecimal(measurement.bioimpedance.skeletalMuscleMass, 1, 1)}">-</span></p>
+                        </div>
+                        <div class="col-md-4" th:if="${measurement.bioimpedance != null && measurement.bioimpedance.boneMass != null}">
+                          <p><strong>Masa Ósea (kg):</strong> <span th:text="${#numbers.formatDecimal(measurement.bioimpedance.boneMass, 1, 2)}">-</span></p>
+                        </div>
+                        <div class="col-md-4" th:if="${measurement.bioimpedance != null && measurement.bioimpedance.boneMassPercentage != null}">
+                          <p><strong>% Masa Ósea:</strong> <span th:text="${#numbers.formatDecimal(measurement.bioimpedance.boneMassPercentage, 1, 1)} + '%'">-</span></p>
                         </div>
                       </div>
                       <hr class="my-4" th:if="${measurement.bioimpedance != null && (measurement.bioimpedance.totalBodyWaterLiters != null || measurement.bioimpedance.totalBodyWaterPercentage != null || measurement.bioimpedance.intracellularWater != null || measurement.bioimpedance.extracellularWater != null || measurement.bioimpedance.ecwIcwRatio != null)}">

--- a/src/main/resources/templates/sbadmin/reports/patient-progress.html
+++ b/src/main/resources/templates/sbadmin/reports/patient-progress.html
@@ -357,6 +357,7 @@
 					<th>% Grasa</th>
 					<th>Método</th>
 					<th>% Masa muscular</th>
+					<th>Masa ósea</th>
 					<th>Somatotipo</th>
 				</tr>
 			</thead>
@@ -370,6 +371,7 @@
 					<td th:text="${measurement.porcentajeGrasaCorporal != null ? (#numbers.formatDecimal(measurement.porcentajeGrasaCorporal, 1, 1) + '%') : 'N/A'}"></td>
 					<td th:text="${measurement.metodoObtencion != null ? measurement.metodoObtencion.displayName : 'N/A'}"></td>
 					<td th:text="${measurement.porcentajeMasaMuscular != null ? (#numbers.formatDecimal(measurement.porcentajeMasaMuscular, 1, 1) + '%') : 'N/A'}"></td>
+					<td th:text="${measurement.masaOseaKg != null ? (#numbers.formatDecimal(measurement.masaOseaKg, 1, 2) + ' kg' + (measurement.porcentajeMasaOsea != null ? ' (' + #numbers.formatDecimal(measurement.porcentajeMasaOsea, 1, 1) + '%)' : '')) : (measurement.porcentajeMasaOsea != null ? (#numbers.formatDecimal(measurement.porcentajeMasaOsea, 1, 1) + '%') : 'N/A')}"></td>
 					<td th:text="${measurement.endomorphy != null ? (#numbers.formatDecimal(measurement.endomorphy,1,1) + '-' + #numbers.formatDecimal(measurement.mesomorphy,1,1) + '-' + #numbers.formatDecimal(measurement.ectomorphy,1,1)) : 'N/A'}"></td>
 				</tr>
 			</tbody>

--- a/src/test/java/com/nutriconsultas/clinical/exam/anthropometric/BodyCompositionServiceTest.java
+++ b/src/test/java/com/nutriconsultas/clinical/exam/anthropometric/BodyCompositionServiceTest.java
@@ -157,6 +157,73 @@ class BodyCompositionServiceTest {
 		assertThat(measurement.getMetodoObtencion()).isEqualTo(MetodoObtencionComposicionCorporal.OTRO);
 	}
 
+	@Test
+	void applyToMeasurementConsolidatesBoneMassFromBioimpedance() {
+		final AnthropometricMeasurement measurement = createMeasurementWithWeight(70.0, 1.75);
+		final Bioimpedance bioimpedance = new Bioimpedance();
+		bioimpedance.setBoneMass(2.8);
+		bioimpedance.setBoneMassPercentage(4.0);
+		measurement.setBioimpedance(bioimpedance);
+
+		service.applyToMeasurement(measurement, paciente, 22.86);
+
+		assertThat(measurement.getMasaOseaKg()).isEqualTo(2.8);
+		assertThat(measurement.getPorcentajeMasaOsea()).isEqualTo(4.0);
+	}
+
+	@Test
+	void applyToMeasurementPrefersBioimpedanceBoneMassOverManual() {
+		final AnthropometricMeasurement measurement = createMeasurementWithWeight(70.0, 1.75);
+		measurement.setMasaOseaKg(3.0);
+		measurement.setPorcentajeMasaOsea(5.0);
+		final Bioimpedance bioimpedance = new Bioimpedance();
+		bioimpedance.setBoneMass(2.5);
+		bioimpedance.setBoneMassPercentage(3.6);
+		measurement.setBioimpedance(bioimpedance);
+
+		service.applyToMeasurement(measurement, paciente, 22.86);
+
+		assertThat(measurement.getMasaOseaKg()).isEqualTo(2.5);
+		assertThat(measurement.getPorcentajeMasaOsea()).isEqualTo(3.6);
+	}
+
+	@Test
+	void applyToMeasurementDerivesBoneMassPercentageFromKg() {
+		final AnthropometricMeasurement measurement = createMeasurementWithWeight(70.0, 1.75);
+		measurement.setMasaOseaKg(3.5);
+
+		service.applyToMeasurement(measurement, paciente, 22.86);
+
+		assertThat(measurement.getMasaOseaKg()).isEqualTo(3.5);
+		assertThat(measurement.getPorcentajeMasaOsea()).isEqualTo(5.0);
+	}
+
+	@Test
+	void applyToMeasurementCalculatesMusclePercentageWithBoneAndWater() {
+		final AnthropometricMeasurement measurement = createMeasurementWithWeight(70.0, 1.75);
+		measurement.setPorcentajeGrasaCorporal(24.0);
+		measurement.setMasaOseaKg(2.8);
+		measurement.setPorcentajeMasaOsea(4.0);
+		final Bioimpedance bioimpedance = new Bioimpedance();
+		bioimpedance.setTotalBodyWaterPercentage(55.0);
+		measurement.setBioimpedance(bioimpedance);
+
+		service.applyToMeasurement(measurement, paciente, 22.86);
+
+		assertThat(measurement.getPorcentajeMasaMuscular()).isEqualTo(20.0);
+	}
+
+	@Test
+	void applyToMeasurementCalculatesMusclePercentageWithBoneOnly() {
+		final AnthropometricMeasurement measurement = createMeasurementWithWeight(70.0, 1.75);
+		measurement.setPorcentajeGrasaCorporal(20.0);
+		measurement.setPorcentajeMasaOsea(4.0);
+
+		service.applyToMeasurement(measurement, paciente, 22.86);
+
+		assertThat(measurement.getPorcentajeMasaMuscular()).isEqualTo(76.0);
+	}
+
 	private AnthropometricMeasurement createMeasurementWithWeight(final Double weight, final Double height) {
 		final AnthropometricMeasurement measurement = new AnthropometricMeasurement();
 		final BodyMass bodyMass = new BodyMass();


### PR DESCRIPTION
## Summary
- Añade campos de masa ósea (kg y %) en `BodyComposition` y `Bioimpedance`, con consolidación que prioriza bioimpedancia sobre entrada manual.
- Actualiza el cálculo de `% masa muscular` para restar grasa, hueso y agua cuando hay datos disponibles.
- Muestra masa ósea consolidada en formulario antropométrico, vista de lectura, perfil del paciente y PDF de progreso.

Resuelve #162 según decisiones del issue: registrar ambos valores según equipo, incluir hueso en el cálculo muscular y priorizar bioimpedancia.

## Test plan
- [x] `BodyCompositionServiceTest` (consolidación, precedencia bioimpedancia, cálculo muscular con hueso/agua)
- [x] `ThymeleafTemplateValidationTest`
- [x] `mvn checkstyle:check`
- [ ] Verificar captura manual en pestaña Masa corporal
- [ ] Verificar captura desde bioimpedancia y consolidación al guardar
- [ ] Verificar perfil y PDF con masa ósea presente/ausente


Made with [Cursor](https://cursor.com)