### PR TITLE
feat(mobile-api): add senderDisplayName to message DTOs (#116)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -10,7 +10,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) | Canonical cross-repo contract — §F8 schema/enum map, per-issue corrected scope |
 | [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) | Endpoint request/response specs (#91–#99) with field mappings |
 
-**Current next issue:** [#116 — Additive: senderDisplayName in message DTOs](https://github.com/diego-torres/nutriconsultas/issues/116) — **NEXT** (additive). ~~#115~~ PHI audit done ([PR #168](https://github.com/diego-torres/nutriconsultas/pull/168)).
+**Current next issue:** [#114 — Nutritionist reply to patient messages](https://github.com/diego-torres/nutriconsultas/issues/114) — **NEXT** (web/backend). ~~#116~~ `senderDisplayName` in-progress (branch `mobile-api/116-sender-display-name`).
 
 ---
 
@@ -22,7 +22,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | **API surface** | All mobile endpoints live under `/rest/mobile/patient/` as plain JSON (not DataTables-shaped like the admin `*RestController`s). |
 | **Identity (security-critical)** | JWT `sub` → **`Paciente.patientAuthSub`** (#107 ✓ PR #117). **Never `Paciente.userId`** — that is the NUTRITIONIST's Auth0 sub / tenant owner (ALIGNMENT-SPEC §F2). `PatientLinkageFilter` returns **403** if no linked `Paciente`. |
 | **Ownership / IDOR** | Return only the authenticated patient's rows. On an ownership miss prefer **404** (not 403) so existence isn't leaked (esp. #92). Never return cross-tenant data. |
-| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **OpenAPI #112 done** (PR #164). **PHI audit #115 done**. **NEXT:** #116 `senderDisplayName`. Requires `AUTH_AUDIENCE` env var. |
+| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **OpenAPI #112 done** (PR #164). **PHI audit #115 done**. **#116 in-progress** (`senderDisplayName`, branch `mobile-api/116-sender-display-name`). **NEXT:** #114 (nutritionist reply). Requires `AUTH_AUDIENCE` env var. |
 | **DTO envelope** | `ApiResponse<T>`; lists in `PagedResponse<T>` or `CursorPagedResponse<T>` (messages); ISO-8601 date strings. See #110. |
 | **Schema ground truth** | ALIGNMENT-SPEC §F8 field-name map (`nombre→dietaName`, `energia→totalKcal`, `lipidos→totalGrasas`, `hidratosDeCarbono→totalCarbohidratos`, `Ingesta.nombre→tipo`); enums `EventStatus`/`PacienteDietaStatus` (no INACTIVE)/`NivelPeso`. Serialization aliases only — **no DB schema changes** for field renames. |
 | **PHI & logging** | No patient names/emails/DOB in unstructured logs. `LogRedaction` + `PhiLogTurboFilter`; CI runs `scripts/audit-logging.sh` and `scripts/audit-mobile-logging.sh` (#115 done). |
@@ -322,13 +322,13 @@ gh pr create ...
 
 | Field | Value |
 |-------|-------|
-| **Next issue** | [#116 — senderDisplayName in message DTOs](https://github.com/diego-torres/nutriconsultas/issues/116) |
+| **Next issue** | [#114 — Nutritionist reply to patient messages](https://github.com/diego-torres/nutriconsultas/issues/114) |
 | **Status** | **NEXT** |
-| **Phase** | Additive (optional) |
+| **Phase** | Web/backend (feeds #96 thread) |
 | **Depends on** | #96 |
 | **Blocks** | — |
-| **Just completed** | [#115](https://github.com/diego-torres/nutriconsultas/issues/115) — [PR #168](https://github.com/diego-torres/nutriconsultas/pull/168): PHI log redaction audit (merged to `main`) |
-| **In scope for #116** | Add `senderDisplayName` from `NutritionistProfile` to message DTOs |
+| **Just completed** | [#116](https://github.com/diego-torres/nutriconsultas/issues/116) — branch `mobile-api/116-sender-display-name`: `senderDisplayName` on `PatientMessageSummaryDto` (pending PR) |
+| **In scope for #114** | Nutritionist web UI + backend to reply in patient message thread |
 
 ### Upcoming gates
 
@@ -338,14 +338,14 @@ gh pr create ...
 | Auth linkage (tenant) | #108 (tenant config; prod audience deployed #118) | Before full Auth0 tenant hardening |
 | Endpoints | ~~#91–#99~~ ✓ | **Done** (PR #153) |
 | Cross-cutting | ~~#111~~ ✓, ~~#112~~ ✓ (OpenAPI), ~~#115~~ ✓ (PHI audit) | **Done** |
-| Hardening / additive | ~~#113~~ ✓, **#116** (senderDisplayName), #114 (nutritionist reply) | **#116 is NEXT** |
+| Hardening / additive | ~~#113~~ ✓, **#116** in-progress (`senderDisplayName`), **#114** (nutritionist reply) | **#114 is NEXT** (after #116 PR merges) |
 | Schema / Liquibase | **#156** (`Paciente` refactor) → **#46** (Liquibase baseline) → **#132–#141** (invitation onboarding) | **#156 before any Liquibase cut**; invitation epic not active sprint |
 
 ### Status snapshot (2026-06-15)
 
 **Patient mobile API on `main`:** JWT resource server (#107), DTO envelope (#110), patient linkage (#109), visits (#91/#92), diet plans (#93–#95), messages list/send (#96/#97 with HTTP 201 + rate limit), progress snapshot (#98) + measurements time series (#99, PR #153), localized API errors (#111), Resilience4j write throttling (#113), **OpenAPI spec (#112, PR #164)**. Dashboard IMC gauge (#106) done for web tablero.
 
-**Next:** #116 `senderDisplayName`, then web #114.
+**Next:** #114 nutritionist reply (web). #116 `senderDisplayName` in-progress on branch `mobile-api/116-sender-display-name`.
 
 **GitHub drift (close when convenient):** #97 and #111 are **done on `main`** but still **open on GitHub** (implemented in PRs #147, #151).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -561,7 +561,7 @@ Issue registry: [`ISSUE.md`](ISSUE.md). Agent workflow: [`AGENT-WORKFLOW.md`](AG
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 
-**Next:** [#116](https://github.com/diego-torres/nutriconsultas/issues/116) `senderDisplayName`. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). Open cross-cutting: web #114 (nutritionist reply).
+**Next:** [#114](https://github.com/diego-torres/nutriconsultas/issues/114) nutritionist reply (web). ~~#116~~ `senderDisplayName` **in-progress** (branch `mobile-api/116-sender-display-name`). ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164).
 
 **Schema gate (pre-Liquibase):** [#156](https://github.com/diego-torres/nutriconsultas/issues/156) `Paciente` decomposition must land before [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46); mobile `#98`/`#99` DTO contracts unchanged. See [`ISSUE.md`](ISSUE.md) Integration prerequisites.
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-15 — #115 PHI audit **done** (merged [PR #168](https://github.com/diego-torres/nutriconsultas/pull/168)). **NEXT:** #116.
+**Last updated:** 2026-06-15 — #116 `senderDisplayName` **in-progress** (branch `mobile-api/116-sender-display-name`). **NEXT:** #114.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -49,7 +49,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 (#107, #109, #110) is **done**. Patient linkage (#109) is **done**. Endpoints **#91–#99 are done** on `main` (PR #153). OpenAPI (#112, PR #164) is **done**. **#115 PHI audit done** (PR #168). **NEXT:** #116.
+Phase 0 (#107, #109, #110) is **done**. Patient linkage (#109) is **done**. Endpoints **#91–#99 are done** on `main` (PR #153). OpenAPI (#112, PR #164) is **done**. **#115 PHI audit done** (PR #168). **#116 in-progress** (branch `mobile-api/116-sender-display-name`). **NEXT:** #114.
 
 ---
 
@@ -118,8 +118,8 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 | # | Title | URL | State | Notes |
 |---|-------|-----|-------|-------|
 | 113 | Rate limiting on patient write endpoints (Resilience4j) | https://github.com/diego-torres/nutriconsultas/issues/113 | **done** | Merged PR #151: 10/min per `patientAuthSub` on POST #97; 429 + `Retry-After: 60`; localized via #111 |
-| 116 | Additive: `senderDisplayName` in message DTOs from `NutritionistProfile` | https://github.com/diego-torres/nutriconsultas/issues/116 | **NEXT** | Additive to #96 DTO; **non-blocking** for mobile #19. Source `NutritionistProfile.displayName`. |
-| 114 | Nutritionist reply to patient messages | https://github.com/diego-torres/nutriconsultas/issues/114 | open | **Web/backend only** — not a mobile-app endpoint; writes into the same thread #96 reads. |
+| 116 | Additive: `senderDisplayName` in message DTOs from `NutritionistProfile` | https://github.com/diego-torres/nutriconsultas/issues/116 | **in-progress** | Branch `mobile-api/116-sender-display-name`: optional `senderDisplayName` on `PatientMessageSummaryDto` when `senderRole=NUTRITIONIST`; sourced from `NutritionistProfile.displayName`; OpenAPI updated. |
+| 114 | Nutritionist reply to patient messages | https://github.com/diego-torres/nutriconsultas/issues/114 | **NEXT** | **Web/backend only** — not a mobile-app endpoint; writes into the same thread #96 reads. |
 | 106 | `[Dashboard]` IMC gauge with color bands (anthropometric tablero) | https://github.com/diego-torres/nutriconsultas/issues/106 | **done** | Web dashboard; shares `NivelPeso` color-band logic the mobile `ImcGauge` (mobile #21) mirrors. Not a `/rest/mobile/**` endpoint. |
 
 ---
@@ -167,7 +167,7 @@ Each mobile feature consumes these backend endpoints. Two-way linking with the m
 | 96, 97 | Mensajes | mobile #19, #14, #6 | Read + patient send |
 | 98, 99 | Progreso | mobile #16/#20, #15, #8 | Read-only |
 | 107, 108, 109 | Auth / linkage | mobile #5, #7, #13, #22 | Auth |
-| 116 | `senderDisplayName` (optional) | mobile #19 | Read-only (additive) |
+| 116 | `senderDisplayName` (optional) | mobile #19 | Read-only (additive) | **in-progress** — branch `mobile-api/116-sender-display-name` |
 | 114 | nutritionist reply | — (web only; feeds #96) | — |
 | 156 | `Paciente` internal refactor (pre-Liquibase) | — (backend only) | — | No mobile JSON change; `#98`/`#99` regression required per PR |
 | 132–141 | Invitation onboarding | mobile (future) | Auth + profile | Replaces #109 manual linkage for new patients; gated by #156 |

--- a/docs/api/openapi-mobile.yaml
+++ b/docs/api/openapi-mobile.yaml
@@ -458,6 +458,10 @@ components:
           type: string
         read:
           type: boolean
+        senderDisplayName:
+          type: string
+          description: Nutritionist display name when senderRole is NUTRITIONIST; omitted otherwise
+          nullable: true
     ApiResponsePagedResponseVisitSummaryDto:
       type: object
       properties:

--- a/docs/mobile-api/ALIGNMENT-SPEC.md
+++ b/docs/mobile-api/ALIGNMENT-SPEC.md
@@ -160,7 +160,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 - **Phase 0 DONE:** #107 (PR #117), #109 (PR #142), #110 (DTO envelope).
 - **Endpoints on `main`:** #91–#99 (visits, diet plans + PDF, messages, progress snapshot + measurements time series); #96/#97 messaging with HTTP 201 + Resilience4j 10/min (#113, PR #151).
 - **i18n (#111) DONE** (PR #151): `LocaleContextFilter`, `MobileApiErrorResponses`, localized 403/404/400/429.
-- **Cross-cutting NEXT:** #116 `senderDisplayName`. ~~#115~~ PHI log redaction audit **done** (PR #168, `docs/mobile-api/PHI-LOGGING-AUDIT.md`). ~~#112~~ OpenAPI spec **done** (PR #164, `docs/api/openapi-mobile.yaml`).
+- **Cross-cutting:** ~~#116~~ `senderDisplayName` **in-progress** (branch `mobile-api/116-sender-display-name`: optional field on `PatientMessageSummaryDto` when `senderRole=NUTRITIONIST`). ~~#115~~ PHI log redaction audit **done** (PR #168, `docs/mobile-api/PHI-LOGGING-AUDIT.md`). ~~#112~~ OpenAPI spec **done** (PR #164, `docs/api/openapi-mobile.yaml`). **NEXT:** #114 nutritionist reply (web).
 - `deltaPeso`/`deltaImc` are computed-at-query, not stored.
 - Progress `grasa` ambiguity: prefer `bodyComposition.porcentajeGrasaCorporal` (patient-facing %) over `indiceGrasaCorporal`.
 - Template dietas (seed `system:template-dietas`) have 4 ingestas incl. Colación — contract examples show only 3.
@@ -168,7 +168,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 ### F8.4 — NutritionistProfile (NEW entity, 228bbc3)
 `userId` (unique, nutritionist sub), `displayName`, `cedulaProfesional`, `logoExtension`, `registro`.
 - #95 PDF endpoint now serves branded PDFs transparently (no scope change).
-- Optional additive: `senderDisplayName` in message DTOs (#96) from `NutritionistProfile.displayName` — track as separate issue.
+- **#116 DONE (pending PR):** optional `senderDisplayName` in `PatientMessageSummaryDto` when `senderRole=NUTRITIONIST`; sourced from `NutritionistProfile.displayName` via `NutritionistBrandingHelper`; omitted for patient messages or when profile has no display name.
 
 ### F8.5 — Design source of truth
 Canonical visual design: `mobile/.claude/MiNutriporcion-2/` (light editorial palette per JSX + 01-p-dashboard.png; the dark welcome/login screenshots are an OLD iteration — ignore).

--- a/docs/mobile-api/MOBILE-E2E-STATUS.md
+++ b/docs/mobile-api/MOBILE-E2E-STATUS.md
@@ -212,4 +212,4 @@ Optional backend script (requires access token from the app):
 
 ---
 
-*Updated 2026-06-15: #115 PHI audit done (PR #168); **NEXT:** #116.*
+*Updated 2026-06-15: #116 `senderDisplayName` in-progress (branch `mobile-api/116-sender-display-name`); **NEXT:** #114.*

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -4,11 +4,11 @@ Canonical cross-repo contracts for the `[Mobile API]` track, vendored into this 
 
 | File | What it is |
 |------|-----------|
-| `ALIGNMENT-SPEC.md` | Source-of-truth contract for all agents. §F8 = backend↔mobile field/enum map. Phase 0 + endpoints **#91–#99 done** on `main`. **OpenAPI #112 done** — `docs/api/openapi-mobile.yaml` ([PR #164](https://github.com/diego-torres/nutriconsultas/pull/164)). **PHI audit #115** — `docs/mobile-api/PHI-LOGGING-AUDIT.md`. **NEXT:** #116. Invitation **#132–#141** deferred (see §F8.6). |
-| `mobile-api-roadmap-v2.md` | Per-endpoint (#91–#99) request/response JSON and field mappings. All endpoints **done**; OpenAPI **#112 done**; PHI audit **#115**; **NEXT:** #116. |
+| `ALIGNMENT-SPEC.md` | Source-of-truth contract for all agents. §F8 = backend↔mobile field/enum map. Phase 0 + endpoints **#91–#99 done** on `main`. **OpenAPI #112 done** — `docs/api/openapi-mobile.yaml` ([PR #164](https://github.com/diego-torres/nutriconsultas/pull/164)). **PHI audit #115** — `docs/mobile-api/PHI-LOGGING-AUDIT.md`. **#116 in-progress** (`senderDisplayName`). **NEXT:** #114. Invitation **#132–#141** deferred (see §F8.6). |
+| `mobile-api-roadmap-v2.md` | Per-endpoint (#91–#99) request/response JSON and field mappings. All endpoints **done**; OpenAPI **#112 done**; PHI audit **#115**; **#116 in-progress**; **NEXT:** #114. |
 | `PHI-LOGGING-AUDIT.md` | Completed PHI logging audit checklist for `/rest/mobile/**` (#115). |
 
-**Last synced:** 2026-06-15 (#115 PHI audit done, PR #168; **NEXT:** #116).
+**Last synced:** 2026-06-15 (#116 `senderDisplayName` in-progress, branch `mobile-api/116-sender-display-name`; **NEXT:** #114).
 
 **Provenance / drift:** these are synced copies of the workspace-root originals
 (`/Users/joelmartinez/Documents/Work/ALIGNMENT-SPEC.md` and `mobile-api-roadmap-v2.md`),

--- a/docs/mobile-api/mobile-api-roadmap-v2.md
+++ b/docs/mobile-api/mobile-api-roadmap-v2.md
@@ -14,7 +14,7 @@
 
 > **State verification (2026-06-11):**
 >
-> - **Backend schema (2026-06-15):** Phase 0 **done** (#107, #109, #110). **All endpoints #91–#99 on `main`**. **#112 OpenAPI done** (PR #164). **#115 PHI audit done** (PR #168). **#96/#97** messaging (POST **201**, Resilience4j **10/min** — #113). **#111** localized errors. **NEXT:** #116 `senderDisplayName`; #106 dashboard IMC gauge **done**.
+> - **Backend schema (2026-06-15):** Phase 0 **done** (#107, #109, #110). **All endpoints #91–#99 on `main`**. **#112 OpenAPI done** (PR #164). **#115 PHI audit done** (PR #168). **#96/#97** messaging (POST **201**, Resilience4j **10/min** — #113). **#111** localized errors. **#116 in-progress** (`senderDisplayName` on `PatientMessageSummaryDto`); **NEXT:** #114; #106 dashboard IMC gauge **done**.
 > - **DTO field-name map (authoritative — ALIGNMENT-SPEC §F8):** `Dieta.nombre→dietaName`, `energia→totalKcal`, `proteina→totalProteina`, `lipidos→totalGrasas`, `hidratosDeCarbono→totalCarbohidratos`; `Ingesta.nombre→tipo`; `PlatilloIngesta.name/portions/energia→nombre/porciones/kcal`, `hidratosDeCarbono→carbohidratos`, `lipidos→grasas` (same for `AlimentoIngesta`). Enums: `EventStatus = SCHEDULED/COMPLETED/CANCELLED`; `PacienteDietaStatus = ACTIVE/COMPLETED/CANCELLED` (no INACTIVE); `NivelPeso = BAJO/NORMAL/ALTO/SOBREPESO` (translate to `imcLabel` server-side). `deltaPeso`/`deltaImc` are computed, not stored.
 > - **Mobile redesign branch state (style/editorial-redesign):** Auth dedup complete — `AuthFlowController` + login/signup/welcome screens canonical; PR #48's `AuthController`/`LoginView` retired (commit 3427612); `flutter analyze` clean, 146/146 tests pass. Canonical design source: `.claude/MiNutriporcion-2/` (light editorial palette; dark welcome/login PNGs are OLD, ignore). Mobile issues #13/#21/#31 done; #32/#33 in flight on branch.
 
@@ -395,8 +395,8 @@ All nine endpoints will return DTOs. Without a shared convention, the Flutter `m
 | **93** | `GET /rest/mobile/patient/diet-plans` | Diet list | No | Add `active` filter param; map status enum to locale string. `PacienteDietaStatus = ACTIVE/COMPLETED/CANCELLED` (no INACTIVE). Field names per ALIGNMENT-SPEC §F8 map (e.g., `nombre→dietaName`, `energia→totalKcal`, `lipidos→totalGrasas`, `hidratosDeCarbono→totalCarbohidratos`). |
 | **94** | `GET /rest/mobile/patient/diet-plans/{assignmentId}` | Diet JSON | No | Strip nutritionist-internal fields before serializing; define DTO tree. Field names per ALIGNMENT-SPEC §F8 map (e.g., `nombre→dietaName`, `energia→totalKcal`, `lipidos→grasas`, `hidratosDeCarbono→carbohidratos`). |
 | **95** | `GET .../diet-plans/{assignmentId}/pdf` | Diet PDF | No | `Content-Disposition: attachment`, ownership check before calling service |
-| **96** | `GET /rest/mobile/patient/messages` | Message thread | Yes | Cursor pagination (not offset); no message body in INFO logs. **Greenfield — no message entity exists yet.** Optional: include `senderDisplayName` from `NutritionistProfile.displayName` (#116, additive). |
-| **97** | `POST /rest/mobile/patient/messages` | Send message | Yes | `senderRole=PATIENT` derived from JWT only; `@Valid`; rate limiter. **Greenfield — no message entity exists yet.** Optional `senderDisplayName` support via #116. |
+| **96** | `GET /rest/mobile/patient/messages` | Message thread | Yes | Cursor pagination (not offset); no message body in INFO logs. Optional `senderDisplayName` from `NutritionistProfile.displayName` when `senderRole=NUTRITIONIST` (#116, in-progress). |
+| **97** | `POST /rest/mobile/patient/messages` | Send message | Yes | `senderRole=PATIENT` derived from JWT only; `@Valid`; rate limiter. Patient messages omit `senderDisplayName` (#116). |
 | **98** | `GET /rest/mobile/patient/progress` | Progress snapshot | No | Aggregate in service layer; delta = latest minus previous measurement. Use `porcentajeGrasaCorporal` for body fat % (recommended over `grasa`); `deltaPeso`/`deltaImc` are computed, not stored. |
 | **99** | `GET /rest/mobile/patient/progress/measurements` | Time series | No | `from`/`to` ISO-8601 params; cap at 365 data points. Use `porcentajeGrasaCorporal` for body fat % series. |
 
@@ -618,14 +618,14 @@ flowchart TD
 
 ### #96 — List messages / FL-7a
 
-- **Backend:** Cursor pagination (`?after=<lastMessageId>&limit=20`); never log body at INFO. Entity: `PatientNutritionistMessage { id, pacienteId, senderRole, body, sentAt, readAt }`. **Greenfield — no message entity exists yet (verified at 228bbc3).** Optional: include `senderDisplayName` from `NutritionistProfile.displayName` via backend #116 (additive, non-blocking).
+- **Backend:** Cursor pagination (`?after=<lastMessageId>&limit=20`); never log body at INFO. Response item: `{ id, sentAt, senderRole, body, read, senderDisplayName? }`. `senderDisplayName` present when `senderRole=NUTRITIONIST` and `NutritionistProfile.displayName` is set (#116).
 - **Flutter:** `MessageController`, `MessagePage` with `ListView.builder` (reverse: true), real-time polling every 30s (Phase 1); push notifications in FL-9.
 
 ---
 
 ### #97 — Send message / FL-7b
 
-- **Backend:** `senderRole=PATIENT` derived from JWT, never from request body. `@Valid` + `@Size(max=2000)`. Rate limit: `@RateLimiter(name="patientMessage")` — 10 messages/minute per patient. **Greenfield — no message entity exists yet (verified at 228bbc3).** Optional `senderDisplayName` response field via #116.
+- **Backend:** `senderRole=PATIENT` derived from JWT, never from request body. `@Valid` + `@Size(max=2000)`. Rate limit: `@RateLimiter(name="patientMessage")` — 10 messages/minute per patient. Response omits `senderDisplayName` for patient-authored messages.
 - **Flutter:** `MessageInputBar` widget, optimistic UI (add to list immediately, revert on error).
 
 ---

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageService.java
@@ -1,6 +1,10 @@
 package com.nutriconsultas.mobile;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -13,6 +17,8 @@ import com.nutriconsultas.message.PatientMessageRepository;
 import com.nutriconsultas.mobile.dto.CursorPagedResponse;
 import com.nutriconsultas.mobile.dto.PatientMessageSummaryDto;
 import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.profile.NutritionistBrandingHelper;
+import com.nutriconsultas.profile.NutritionistProfileRepository;
 import com.nutriconsultas.util.LogRedaction;
 
 import lombok.extern.slf4j.Slf4j;
@@ -27,11 +33,15 @@ public class MobilePatientMessageService {
 
 	private final PatientMessageRepository patientMessageRepository;
 
+	private final NutritionistProfileRepository nutritionistProfileRepository;
+
 	private final PatientWriteRateLimiter patientWriteRateLimiter;
 
 	public MobilePatientMessageService(final PatientMessageRepository patientMessageRepository,
+			final NutritionistProfileRepository nutritionistProfileRepository,
 			final PatientWriteRateLimiter patientWriteRateLimiter) {
 		this.patientMessageRepository = patientMessageRepository;
+		this.nutritionistProfileRepository = nutritionistProfileRepository;
 		this.patientWriteRateLimiter = patientWriteRateLimiter;
 	}
 
@@ -44,8 +54,10 @@ public class MobilePatientMessageService {
 				PageRequest.of(0, safeSize + 1));
 		final boolean hasMore = fetched.size() > safeSize;
 		final List<PatientMessage> page = hasMore ? fetched.subList(0, safeSize) : fetched;
+		final Map<String, String> nutritionistDisplayNames = resolveNutritionistDisplayNames(page);
 		final List<PatientMessageSummaryDto> summaries = page.stream()
-			.map(PatientMessageSummaryDto::fromEntity)
+			.map(message -> PatientMessageSummaryDto.fromEntity(message,
+					nutritionistDisplayNames.get(message.getNutritionistUserId())))
 			.toList();
 		final String nextCursor = hasMore && !page.isEmpty() ? String.valueOf(page.get(page.size() - 1).getId()) : null;
 		if (log.isDebugEnabled()) {
@@ -71,7 +83,21 @@ public class MobilePatientMessageService {
 		if (log.isInfoEnabled()) {
 			log.info("Patient sent message: {}", LogRedaction.redactPatientMessage(saved.getId()));
 		}
-		return PatientMessageSummaryDto.fromEntity(saved);
+		return PatientMessageSummaryDto.fromEntity(saved, null);
+	}
+
+	private Map<String, String> resolveNutritionistDisplayNames(final List<PatientMessage> messages) {
+		final Set<String> nutritionistUserIds = messages.stream()
+			.filter(message -> message.getSenderRole() == MessageSenderRole.NUTRITIONIST)
+			.map(PatientMessage::getNutritionistUserId)
+			.collect(Collectors.toSet());
+		final Map<String, String> displayNames = new HashMap<>();
+		for (final String userId : nutritionistUserIds) {
+			nutritionistProfileRepository.findByUserId(userId)
+				.map(profile -> NutritionistBrandingHelper.resolveDisplayName(profile, null))
+				.ifPresent(name -> displayNames.put(userId, name));
+		}
+		return displayNames;
 	}
 
 	private Long parseCursor(final String cursor) {

--- a/src/main/java/com/nutriconsultas/mobile/dto/PatientMessageSummaryDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/PatientMessageSummaryDto.java
@@ -2,15 +2,20 @@ package com.nutriconsultas.mobile.dto;
 
 import java.time.Instant;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.nutriconsultas.message.MessageSenderRole;
 import com.nutriconsultas.message.PatientMessage;
 
-public record PatientMessageSummaryDto(Long id, Instant sentAt, MessageSenderRole senderRole, String body,
-		boolean read) {
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record PatientMessageSummaryDto(Long id, Instant sentAt, MessageSenderRole senderRole, String body, boolean read,
+		String senderDisplayName) {
 
-	public static PatientMessageSummaryDto fromEntity(final PatientMessage message) {
+	public static PatientMessageSummaryDto fromEntity(final PatientMessage message,
+			final String nutritionistDisplayName) {
+		final String senderDisplayName = message.getSenderRole() == MessageSenderRole.NUTRITIONIST
+				? nutritionistDisplayName : null;
 		return new PatientMessageSummaryDto(message.getId(), message.getSentAt(), message.getSenderRole(),
-				message.getBody(), message.isReadByPatient());
+				message.getBody(), message.isReadByPatient(), senderDisplayName);
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageControllerTest.java
@@ -41,7 +41,7 @@ class MobilePatientMessageControllerTest {
 		final Paciente paciente = new Paciente();
 		paciente.setId(5L);
 		final PatientMessageSummaryDto summary = new PatientMessageSummaryDto(1L, Instant.parse("2026-06-01T12:00:00Z"),
-				MessageSenderRole.PATIENT, "Hola", true);
+				MessageSenderRole.PATIENT, "Hola", true, null);
 		final CursorPagedResponse<PatientMessageSummaryDto> page = CursorPagedResponse.of(List.of(summary), null);
 		final Jwt jwt = jwtWithSub(PATIENT_SUB);
 
@@ -62,7 +62,7 @@ class MobilePatientMessageControllerTest {
 		final Paciente paciente = new Paciente();
 		paciente.setId(5L);
 		final PatientMessageSummaryDto sent = new PatientMessageSummaryDto(9L, Instant.parse("2026-06-01T12:00:00Z"),
-				MessageSenderRole.PATIENT, "Hola doctor", true);
+				MessageSenderRole.PATIENT, "Hola doctor", true, null);
 		final Jwt jwt = jwtWithSub(PATIENT_SUB);
 
 		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageIntegrationTest.java
@@ -24,6 +24,8 @@ import com.nutriconsultas.message.PatientMessage;
 import com.nutriconsultas.message.PatientMessageRepository;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.profile.NutritionistProfile;
+import com.nutriconsultas.profile.NutritionistProfileRepository;
 
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 
@@ -42,6 +44,9 @@ class MobilePatientMessageIntegrationTest {
 
 	@Autowired
 	private PatientMessageRepository patientMessageRepository;
+
+	@Autowired
+	private NutritionistProfileRepository nutritionistProfileRepository;
 
 	@Autowired
 	private RateLimiterRegistry rateLimiterRegistry;
@@ -66,6 +71,11 @@ class MobilePatientMessageIntegrationTest {
 		message.setReadByPatient(false);
 		message.setReadByNutritionist(true);
 		patientMessageRepository.saveAndFlush(message);
+		final NutritionistProfile profile = nutritionistProfileRepository.findByUserId(linkedPaciente.getUserId())
+			.orElseGet(NutritionistProfile::new);
+		profile.setUserId(linkedPaciente.getUserId());
+		profile.setDisplayName("Lic. Nutri Minutriporcion");
+		nutritionistProfileRepository.saveAndFlush(profile);
 	}
 
 	@Test
@@ -74,6 +84,7 @@ class MobilePatientMessageIntegrationTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.content").isArray())
 			.andExpect(jsonPath("$.data.content[0].senderRole").value("NUTRITIONIST"))
+			.andExpect(jsonPath("$.data.content[0].senderDisplayName").value("Lic. Nutri Minutriporcion"))
 			.andExpect(jsonPath("$.data.content[0].body").value("Bienvenido a tu consultorio digital"))
 			.andExpect(jsonPath("$.data.content[0].read").value(false))
 			.andExpect(jsonPath("$.timestamp").exists());

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageServiceTest.java
@@ -25,6 +25,10 @@ import com.nutriconsultas.message.PatientMessageRepository;
 import com.nutriconsultas.mobile.dto.CursorPagedResponse;
 import com.nutriconsultas.mobile.dto.PatientMessageSummaryDto;
 import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.profile.NutritionistProfile;
+import com.nutriconsultas.profile.NutritionistProfileRepository;
+
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 class MobilePatientMessageServiceTest {
@@ -36,6 +40,9 @@ class MobilePatientMessageServiceTest {
 	private PatientMessageRepository patientMessageRepository;
 
 	@Mock
+	private NutritionistProfileRepository nutritionistProfileRepository;
+
+	@Mock
 	private PatientWriteRateLimiter patientWriteRateLimiter;
 
 	@Test
@@ -43,6 +50,7 @@ class MobilePatientMessageServiceTest {
 		final PatientMessage message = sampleMessage(42L, "Hola nutrióloga");
 		when(patientMessageRepository.findThreadForPatient(eq(5L), isNull(), org.mockito.ArgumentMatchers.any()))
 			.thenReturn(List.of(message));
+		when(nutritionistProfileRepository.findByUserId("auth0|nutritionist")).thenReturn(Optional.empty());
 
 		final CursorPagedResponse<PatientMessageSummaryDto> page = service.listMessages(5L, null, 20);
 
@@ -65,6 +73,7 @@ class MobilePatientMessageServiceTest {
 				assertThat(pageable.getPageSize()).isEqualTo(3);
 				return List.of(first, second, extra);
 			});
+		when(nutritionistProfileRepository.findByUserId("auth0|nutritionist")).thenReturn(Optional.empty());
 
 		final CursorPagedResponse<PatientMessageSummaryDto> page = service.listMessages(5L, null, 2);
 
@@ -74,7 +83,34 @@ class MobilePatientMessageServiceTest {
 	}
 
 	@Test
-	void sendMessage_persistsPatientMessageWithNutritionistTenant() throws Exception {
+	void listMessages_includesSenderDisplayNameForNutritionistMessages() {
+		final PatientMessage message = sampleMessage(42L, "Hola nutrióloga");
+		final NutritionistProfile profile = new NutritionistProfile();
+		profile.setUserId("auth0|nutritionist");
+		profile.setDisplayName("Lic. Ana López");
+		when(patientMessageRepository.findThreadForPatient(eq(5L), isNull(), org.mockito.ArgumentMatchers.any()))
+			.thenReturn(List.of(message));
+		when(nutritionistProfileRepository.findByUserId("auth0|nutritionist")).thenReturn(Optional.of(profile));
+
+		final CursorPagedResponse<PatientMessageSummaryDto> page = service.listMessages(5L, null, 20);
+
+		assertThat(page.content().get(0).senderDisplayName()).isEqualTo("Lic. Ana López");
+	}
+
+	@Test
+	void listMessages_omitsSenderDisplayNameWhenNoNutritionistProfile() {
+		final PatientMessage message = sampleMessage(42L, "Hola nutrióloga");
+		when(patientMessageRepository.findThreadForPatient(eq(5L), isNull(), org.mockito.ArgumentMatchers.any()))
+			.thenReturn(List.of(message));
+		when(nutritionistProfileRepository.findByUserId("auth0|nutritionist")).thenReturn(Optional.empty());
+
+		final CursorPagedResponse<PatientMessageSummaryDto> page = service.listMessages(5L, null, 20);
+
+		assertThat(page.content().get(0).senderDisplayName()).isNull();
+	}
+
+	@Test
+	void sendMessage_doesNotIncludeSenderDisplayNameForPatientMessages() throws Exception {
 		final Paciente paciente = new Paciente();
 		paciente.setId(5L);
 		paciente.setUserId("auth0|nutritionist-owner");
@@ -100,6 +136,7 @@ class MobilePatientMessageServiceTest {
 		assertThat(sent.senderRole()).isEqualTo(MessageSenderRole.PATIENT);
 		assertThat(sent.body()).isEqualTo("Hola doctor");
 		assertThat(sent.read()).isTrue();
+		assertThat(sent.senderDisplayName()).isNull();
 		final ArgumentCaptor<PatientMessage> captor = ArgumentCaptor.forClass(PatientMessage.class);
 		verify(patientMessageRepository).save(captor.capture());
 		assertThat(captor.getValue().getSenderRole()).isEqualTo(MessageSenderRole.PATIENT);


### PR DESCRIPTION
## Summary
- Adds optional `senderDisplayName` to `PatientMessageSummaryDto` when `senderRole=NUTRITIONIST`, sourced from `NutritionistProfile.displayName` via `NutritionistBrandingHelper`
- Updates `MobilePatientMessageService` to resolve nutritionist display names per thread page (graceful omission when no profile or blank display name)
- Updates OpenAPI schema, unit/integration tests, and issue registries (`ISSUE.md`, `AGENT-WORKFLOW.md`)

Fixes #116

## Test plan
- [x] `MobilePatientMessageServiceTest` — with/without `NutritionistProfile`, patient send omits field
- [x] `MobilePatientMessageIntegrationTest` — E2E JSON includes `senderDisplayName` for nutritionist messages
- [x] Pre-commit checkstyle passed on commit


Made with [Cursor](https://cursor.com)