### PR TITLE
test(mobile-api): verify nutritionist reply round-trip (#114)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -10,7 +10,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) | Canonical cross-repo contract — §F8 schema/enum map, per-issue corrected scope |
 | [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) | Endpoint request/response specs (#91–#99) with field mappings |
 
-**Current next issue:** [#114 — Nutritionist reply to patient messages](https://github.com/diego-torres/nutriconsultas/issues/114) — **NEXT** (web/backend). ~~#116~~ `senderDisplayName` in-progress (branch `mobile-api/116-sender-display-name`).
+**Current next issue:** [#156 — Paciente domain refactor](https://github.com/diego-torres/nutriconsultas/issues/156) — **NEXT** (integration prerequisite). ~~#114~~ nutritionist reply **done**. ~~#116~~ `senderDisplayName` **done** on `main`.
 
 ---
 
@@ -22,7 +22,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | **API surface** | All mobile endpoints live under `/rest/mobile/patient/` as plain JSON (not DataTables-shaped like the admin `*RestController`s). |
 | **Identity (security-critical)** | JWT `sub` → **`Paciente.patientAuthSub`** (#107 ✓ PR #117). **Never `Paciente.userId`** — that is the NUTRITIONIST's Auth0 sub / tenant owner (ALIGNMENT-SPEC §F2). `PatientLinkageFilter` returns **403** if no linked `Paciente`. |
 | **Ownership / IDOR** | Return only the authenticated patient's rows. On an ownership miss prefer **404** (not 403) so existence isn't leaked (esp. #92). Never return cross-tenant data. |
-| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **OpenAPI #112 done** (PR #164). **PHI audit #115 done**. **#116 in-progress** (`senderDisplayName`, branch `mobile-api/116-sender-display-name`). **NEXT:** #114 (nutritionist reply). Requires `AUTH_AUDIENCE` env var. |
+| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **OpenAPI #112 done** (PR #164). **PHI audit #115 done**. **#116 `senderDisplayName` done** on `main`. **#114 nutritionist reply done** on `main` (admin REST + web widget). **NEXT:** #156 (`Paciente` decomposition). Requires `AUTH_AUDIENCE` env var. |
 | **DTO envelope** | `ApiResponse<T>`; lists in `PagedResponse<T>` or `CursorPagedResponse<T>` (messages); ISO-8601 date strings. See #110. |
 | **Schema ground truth** | ALIGNMENT-SPEC §F8 field-name map (`nombre→dietaName`, `energia→totalKcal`, `lipidos→totalGrasas`, `hidratosDeCarbono→totalCarbohidratos`, `Ingesta.nombre→tipo`); enums `EventStatus`/`PacienteDietaStatus` (no INACTIVE)/`NivelPeso`. Serialization aliases only — **no DB schema changes** for field renames. |
 | **PHI & logging** | No patient names/emails/DOB in unstructured logs. `LogRedaction` + `PhiLogTurboFilter`; CI runs `scripts/audit-logging.sh` and `scripts/audit-mobile-logging.sh` (#115 done). |
@@ -322,13 +322,13 @@ gh pr create ...
 
 | Field | Value |
 |-------|-------|
-| **Next issue** | [#114 — Nutritionist reply to patient messages](https://github.com/diego-torres/nutriconsultas/issues/114) |
+| **Next issue** | [#156 — Paciente domain refactor](https://github.com/diego-torres/nutriconsultas/issues/156) |
 | **Status** | **NEXT** |
-| **Phase** | Web/backend (feeds #96 thread) |
-| **Depends on** | #96 |
-| **Blocks** | — |
-| **Just completed** | [#116](https://github.com/diego-torres/nutriconsultas/issues/116) — branch `mobile-api/116-sender-display-name`: `senderDisplayName` on `PatientMessageSummaryDto` (pending PR) |
-| **In scope for #114** | Nutritionist web UI + backend to reply in patient message thread |
+| **Phase** | Integration prerequisite (blocks #46 Liquibase, #132 onboarding) |
+| **Depends on** | #121 |
+| **Blocks** | #46, #132 |
+| **Just completed** | [#114](https://github.com/diego-torres/nutriconsultas/issues/114) — nutritionist reply (admin REST + web widget; `PatientMessageIntegrationTest` round-trip); [#116](https://github.com/diego-torres/nutriconsultas/issues/116) — `senderDisplayName` on `main` |
+| **In scope for #156** | Incremental `Paciente` decomposition (projections + `@Embeddable`); no mobile JSON contract changes |
 
 ### Upcoming gates
 
@@ -338,14 +338,14 @@ gh pr create ...
 | Auth linkage (tenant) | #108 (tenant config; prod audience deployed #118) | Before full Auth0 tenant hardening |
 | Endpoints | ~~#91–#99~~ ✓ | **Done** (PR #153) |
 | Cross-cutting | ~~#111~~ ✓, ~~#112~~ ✓ (OpenAPI), ~~#115~~ ✓ (PHI audit) | **Done** |
-| Hardening / additive | ~~#113~~ ✓, **#116** in-progress (`senderDisplayName`), **#114** (nutritionist reply) | **#114 is NEXT** (after #116 PR merges) |
-| Schema / Liquibase | **#156** (`Paciente` refactor) → **#46** (Liquibase baseline) → **#132–#141** (invitation onboarding) | **#156 before any Liquibase cut**; invitation epic not active sprint |
+| Hardening / additive | ~~#113~~ ✓, ~~#116~~ ✓ (`senderDisplayName`), ~~#114~~ ✓ (nutritionist reply) | **Done** |
+| Schema / Liquibase | **#156** (`Paciente` refactor) **NEXT** → **#46** (Liquibase baseline) → **#132–#141** (invitation onboarding) | **#156 before any Liquibase cut**; invitation epic not active sprint |
 
 ### Status snapshot (2026-06-15)
 
-**Patient mobile API on `main`:** JWT resource server (#107), DTO envelope (#110), patient linkage (#109), visits (#91/#92), diet plans (#93–#95), messages list/send (#96/#97 with HTTP 201 + rate limit), progress snapshot (#98) + measurements time series (#99, PR #153), localized API errors (#111), Resilience4j write throttling (#113), **OpenAPI spec (#112, PR #164)**. Dashboard IMC gauge (#106) done for web tablero.
+**Patient mobile API on `main`:** JWT resource server (#107), DTO envelope (#110), patient linkage (#109), visits (#91/#92), diet plans (#93–#95), messages list/send (#96/#97 with HTTP 201 + rate limit), progress snapshot (#98) + measurements time series (#99, PR #153), localized API errors (#111), Resilience4j write throttling (#113), **OpenAPI spec (#112, PR #164)**, **`senderDisplayName` (#116)**, **nutritionist reply (#114)**. Dashboard IMC gauge (#106) done for web tablero.
 
-**Next:** #114 nutritionist reply (web). #116 `senderDisplayName` in-progress on branch `mobile-api/116-sender-display-name`.
+**Next:** #156 `Paciente` domain refactor (integration prerequisite — blocks Liquibase #46 and onboarding #132).
 
 **GitHub drift (close when convenient):** #97 and #111 are **done on `main`** but still **open on GitHub** (implemented in PRs #147, #151).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -561,7 +561,7 @@ Issue registry: [`ISSUE.md`](ISSUE.md). Agent workflow: [`AGENT-WORKFLOW.md`](AG
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 
-**Next:** [#114](https://github.com/diego-torres/nutriconsultas/issues/114) nutritionist reply (web). ~~#116~~ `senderDisplayName` **in-progress** (branch `mobile-api/116-sender-display-name`). ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164).
+**Next:** [#156](https://github.com/diego-torres/nutriconsultas/issues/156) `Paciente` domain refactor. ~~#114~~ nutritionist reply **done**. ~~#116~~ `senderDisplayName` **done** on `main`. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164).
 
 **Schema gate (pre-Liquibase):** [#156](https://github.com/diego-torres/nutriconsultas/issues/156) `Paciente` decomposition must land before [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46); mobile `#98`/`#99` DTO contracts unchanged. See [`ISSUE.md`](ISSUE.md) Integration prerequisites.
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-15 — #116 `senderDisplayName` **in-progress** (branch `mobile-api/116-sender-display-name`). **NEXT:** #114.
+**Last updated:** 2026-06-15 — #114 nutritionist reply **done** (branch `mobile-api/114-nutritionist-reply`: integration test for admin→mobile loop). #116 `senderDisplayName` **done** on `main`. **NEXT:** #156.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -49,7 +49,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 (#107, #109, #110) is **done**. Patient linkage (#109) is **done**. Endpoints **#91–#99 are done** on `main` (PR #153). OpenAPI (#112, PR #164) is **done**. **#115 PHI audit done** (PR #168). **#116 in-progress** (branch `mobile-api/116-sender-display-name`). **NEXT:** #114.
+Phase 0 (#107, #109, #110) is **done**. Patient linkage (#109) is **done**. Endpoints **#91–#99 are done** on `main` (PR #153). OpenAPI (#112, PR #164) is **done**. **#115 PHI audit done** (PR #168). **#116 `senderDisplayName` done** on `main`. **#114 nutritionist reply done** on `main` (admin REST + web widget since PR #146; integration test on branch `mobile-api/114-nutritionist-reply`). **NEXT:** #156.
 
 ---
 
@@ -118,8 +118,8 @@ No `/rest/mobile/**` endpoint may be integrated until #107 **and** #110 are `don
 | # | Title | URL | State | Notes |
 |---|-------|-----|-------|-------|
 | 113 | Rate limiting on patient write endpoints (Resilience4j) | https://github.com/diego-torres/nutriconsultas/issues/113 | **done** | Merged PR #151: 10/min per `patientAuthSub` on POST #97; 429 + `Retry-After: 60`; localized via #111 |
-| 116 | Additive: `senderDisplayName` in message DTOs from `NutritionistProfile` | https://github.com/diego-torres/nutriconsultas/issues/116 | **in-progress** | Branch `mobile-api/116-sender-display-name`: optional `senderDisplayName` on `PatientMessageSummaryDto` when `senderRole=NUTRITIONIST`; sourced from `NutritionistProfile.displayName`; OpenAPI updated. |
-| 114 | Nutritionist reply to patient messages | https://github.com/diego-torres/nutriconsultas/issues/114 | **NEXT** | **Web/backend only** — not a mobile-app endpoint; writes into the same thread #96 reads. |
+| 116 | Additive: `senderDisplayName` in message DTOs from `NutritionistProfile` | https://github.com/diego-torres/nutriconsultas/issues/116 | **done** | On `main`: optional `senderDisplayName` on `PatientMessageSummaryDto` when `senderRole=NUTRITIONIST`; sourced from `NutritionistProfile.displayName`; OpenAPI updated. GitHub issue closed. |
+| 114 | Nutritionist reply to patient messages | https://github.com/diego-torres/nutriconsultas/issues/114 | **done** | **Web/backend only** — `POST /rest/patient-messages/thread/{pacienteId}` + floating admin widget (`patient-messages-widget`); `senderRole=NUTRITIONIST` server-side; feeds #96 thread. Integration test: `PatientMessageIntegrationTest`. |
 | 106 | `[Dashboard]` IMC gauge with color bands (anthropometric tablero) | https://github.com/diego-torres/nutriconsultas/issues/106 | **done** | Web dashboard; shares `NivelPeso` color-band logic the mobile `ImcGauge` (mobile #21) mirrors. Not a `/rest/mobile/**` endpoint. |
 
 ---
@@ -130,7 +130,7 @@ Schema-affecting work must respect mobile DTO contracts (§F8). These issues are
 
 | # | Title | URL | State | Depends on | Blocks | Notes |
 |---|-------|-----|-------|-----------|--------|-------|
-| **156** | `[Integration]` Paciente domain refactor — incremental decomposition | https://github.com/diego-torres/nutriconsultas/issues/156 | open | [#121](https://github.com/diego-torres/nutriconsultas/issues/121) GET/TDEE | [#46](https://github.com/diego-torres/nutriconsultas/issues/46) Liquibase, [#132](https://github.com/diego-torres/nutriconsultas/issues/132) timing | Phases A–B (projections + `@Embeddable`, no mobile JSON changes); Phase C optional satellite tables. `#98`/`#99` DTO keys stable; `patientAuthSub` immovable. |
+| **156** | `[Integration]` Paciente domain refactor — incremental decomposition | https://github.com/diego-torres/nutriconsultas/issues/156 | **NEXT** | [#121](https://github.com/diego-torres/nutriconsultas/issues/121) GET/TDEE | [#46](https://github.com/diego-torres/nutriconsultas/issues/46) Liquibase, [#132](https://github.com/diego-torres/nutriconsultas/issues/132) timing | Phases A–B (projections + `@Embeddable`, no mobile JSON changes); Phase C optional satellite tables. `#98`/`#99` DTO keys stable; `patientAuthSub` immovable. |
 | 46 | Implement Liquibase for database change management | https://github.com/diego-torres/nutriconsultas/issues/46 | open | **156** (Phases A–B min.) | — | First Liquibase baseline must capture post-#156 `Paciente` schema. Until then: `ddl-auto=update` + manual SQL if Phase C. |
 | 132 | Invitation & patient onboarding data model | https://github.com/diego-torres/nutriconsultas/issues/132 | open | #107, **156** (Phase B) | — | `Paciente.status` enum + `Invitation` entity; Liquibase via #46 after #156. |
 
@@ -167,8 +167,8 @@ Each mobile feature consumes these backend endpoints. Two-way linking with the m
 | 96, 97 | Mensajes | mobile #19, #14, #6 | Read + patient send |
 | 98, 99 | Progreso | mobile #16/#20, #15, #8 | Read-only |
 | 107, 108, 109 | Auth / linkage | mobile #5, #7, #13, #22 | Auth |
-| 116 | `senderDisplayName` (optional) | mobile #19 | Read-only (additive) | **in-progress** — branch `mobile-api/116-sender-display-name` |
-| 114 | nutritionist reply | — (web only; feeds #96) | — |
+| 116 | `senderDisplayName` (optional) | mobile #19 | Read-only (additive) | **done** on `main` |
+| 114 | nutritionist reply | — (web only; feeds #96) | Write (nutritionist) | **done** — `POST /rest/patient-messages/thread/{pacienteId}` + admin widget |
 | 156 | `Paciente` internal refactor (pre-Liquibase) | — (backend only) | — | No mobile JSON change; `#98`/`#99` regression required per PR |
 | 132–141 | Invitation onboarding | mobile (future) | Auth + profile | Replaces #109 manual linkage for new patients; gated by #156 |
 

--- a/src/test/java/com/nutriconsultas/message/PatientMessageIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/message/PatientMessageIntegrationTest.java
@@ -1,0 +1,133 @@
+package com.nutriconsultas.message;
+
+import static com.nutriconsultas.mobile.MobileIntegrationTestJwt.mobileJwt;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.profile.NutritionistProfile;
+import com.nutriconsultas.profile.NutritionistProfileRepository;
+
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class PatientMessageIntegrationTest {
+
+	private static final String NUTRITIONIST_SUB = "auth0|114-nutritionist";
+
+	private static final String OTHER_NUTRITIONIST_SUB = "auth0|114-other-nutritionist";
+
+	private static final String PATIENT_AUTH_SUB = "auth0|114-patient-linked";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@Autowired
+	private PatientMessageRepository patientMessageRepository;
+
+	@Autowired
+	private NutritionistProfileRepository nutritionistProfileRepository;
+
+	@Autowired
+	private RateLimiterRegistry rateLimiterRegistry;
+
+	private Paciente linkedPaciente;
+
+	@BeforeEach
+	void seedData() {
+		rateLimiterRegistry.remove("patientMessages:" + PATIENT_AUTH_SUB);
+		linkedPaciente = pacienteRepository.findByPatientAuthSub(PATIENT_AUTH_SUB).orElseGet(() -> {
+			final Paciente paciente = samplePaciente(PATIENT_AUTH_SUB, NUTRITIONIST_SUB);
+			return pacienteRepository.saveAndFlush(paciente);
+		});
+		patientMessageRepository.findThreadForPatient(linkedPaciente.getId(), null, PageRequest.of(0, 500))
+			.forEach(patientMessageRepository::delete);
+		final NutritionistProfile profile = nutritionistProfileRepository.findByUserId(NUTRITIONIST_SUB)
+			.orElseGet(NutritionistProfile::new);
+		profile.setUserId(NUTRITIONIST_SUB);
+		profile.setDisplayName("Lic. Ana López");
+		nutritionistProfileRepository.saveAndFlush(profile);
+	}
+
+	@Test
+	void nutritionistReplyAppearsInMobileMessageThread() throws Exception {
+		mockMvc
+			.perform(post("/rest/mobile/patient/messages").with(mobileJwt(PATIENT_AUTH_SUB))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"body\":\"Tengo una duda sobre mi plan\"}"))
+			.andExpect(status().isCreated());
+
+		mockMvc
+			.perform(post("/rest/patient-messages/thread/" + linkedPaciente.getId()).with(oidcLogin()
+				.idToken(token -> token.subject(NUTRITIONIST_SUB).claim("name", "Nutritionist")))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"body\":\"Claro, revisemos tu plan juntos\"}"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.senderRole").value("NUTRITIONIST"))
+			.andExpect(jsonPath("$.body").value("Claro, revisemos tu plan juntos"));
+
+		mockMvc.perform(get("/rest/mobile/patient/messages").with(mobileJwt(PATIENT_AUTH_SUB)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content[0].senderRole").value("NUTRITIONIST"))
+			.andExpect(jsonPath("$.data.content[0].body").value("Claro, revisemos tu plan juntos"))
+			.andExpect(jsonPath("$.data.content[0].senderDisplayName").value("Lic. Ana López"))
+			.andExpect(jsonPath("$.data.content[0].read").value(false))
+			.andExpect(jsonPath("$.data.content[1].senderRole").value("PATIENT"))
+			.andExpect(jsonPath("$.data.content[1].body").value("Tengo una duda sobre mi plan"));
+	}
+
+	@Test
+	void sendMessageForOtherNutritionistPatientReturnsNotFound() throws Exception {
+		final Paciente otherPatient = pacienteRepository.findByPatientAuthSub("auth0|114-other-patient")
+			.orElseGet(() -> pacienteRepository.saveAndFlush(samplePaciente("auth0|114-other-patient",
+					OTHER_NUTRITIONIST_SUB)));
+
+		mockMvc
+			.perform(post("/rest/patient-messages/thread/" + otherPatient.getId()).with(oidcLogin()
+				.idToken(token -> token.subject(NUTRITIONIST_SUB).claim("name", "Nutritionist")))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"body\":\"Hola\"}"))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void sendMessageWithoutAuthenticationRedirectsToLogin() throws Exception {
+		mockMvc
+			.perform(post("/rest/patient-messages/thread/" + linkedPaciente.getId())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"body\":\"Hola\"}"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrlPattern("**/oauth2/authorization/**"));
+	}
+
+	private static Paciente samplePaciente(final String patientAuthSub, final String nutritionistUserId) {
+		final Paciente paciente = new Paciente();
+		paciente.setName("Paciente integración 114");
+		paciente.setUserId(nutritionistUserId);
+		paciente.setPatientAuthSub(patientAuthSub);
+		paciente.setDob(new java.util.Date());
+		paciente.setGender("F");
+		return paciente;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/message/PatientMessageServiceTest.java
+++ b/src/test/java/com/nutriconsultas/message/PatientMessageServiceTest.java
@@ -104,6 +104,18 @@ class PatientMessageServiceTest {
 	}
 
 	@Test
+	void sendAsNutritionist_whenPatientNotOwned_throwsNotFound() {
+		when(pacienteRepository.findByIdAndUserId(1L, USER_ID)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> patientMessageService.sendAsNutritionist(1L, USER_ID, "Respuesta"))
+			.isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+			.isEqualTo(HttpStatus.NOT_FOUND);
+
+		verify(patientMessageRepository, never()).save(any(PatientMessage.class));
+	}
+
+	@Test
 	void markThreadReadByNutritionist_delegatesToRepository() {
 		final Paciente paciente = samplePaciente(1L);
 		when(pacienteRepository.findByIdAndUserId(1L, USER_ID)).thenReturn(Optional.of(paciente));


### PR DESCRIPTION
## Summary
- Adds `PatientMessageIntegrationTest` proving the admin→mobile messaging loop (patient send → nutritionist reply → patient sees reply with `senderDisplayName`)
- Adds IDOR guard test for cross-tenant nutritionist reply attempts
- Marks #114 and #116 **done** in registries; advances **NEXT** to #156

## Test plan
- [x] `PatientMessageIntegrationTest` — round-trip, IDOR 404, unauthenticated redirect
- [x] `PatientMessageServiceTest` — not-owned patient → 404
- [ ] CI green (`lint` + `build`)

Closes #114

Made with [Cursor](https://cursor.com)