### PR TITLE
feat(integration): Paciente read projections (#156 Phase A)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -10,7 +10,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) | Canonical cross-repo contract — §F8 schema/enum map, per-issue corrected scope |
 | [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) | Endpoint request/response specs (#91–#99) with field mappings |
 
-**Current next issue:** [#156 — Paciente domain refactor](https://github.com/diego-torres/nutriconsultas/issues/156) — **NEXT** (integration prerequisite). ~~#114~~ nutritionist reply **done**. ~~#116~~ `senderDisplayName` **done** on `main`.
+**Current next issue:** [#156 — Paciente domain refactor](https://github.com/diego-torres/nutriconsultas/issues/156) — **in-progress** (Phase A done on `integration/a-paciente-projections`; **NEXT:** Phase B `@Embeddable`). ~~#114~~ nutritionist reply **done**. ~~#116~~ `senderDisplayName` **done** on `main`.
 
 ---
 
@@ -322,13 +322,13 @@ gh pr create ...
 
 | Field | Value |
 |-------|-------|
-| **Next issue** | [#156 — Paciente domain refactor](https://github.com/diego-torres/nutriconsultas/issues/156) |
-| **Status** | **NEXT** |
-| **Phase** | Integration prerequisite (blocks #46 Liquibase, #132 onboarding) |
+| **Next issue** | [#156 — Paciente domain refactor](https://github.com/diego-torres/nutriconsultas/issues/156) Phase B |
+| **Status** | **in-progress** (Phase A on branch `integration/a-paciente-projections`) |
+| **Phase** | Integration prerequisite — Phase A read projections **done**; Phase B `@Embeddable` **NEXT** |
 | **Depends on** | #121 |
 | **Blocks** | #46, #132 |
 | **Just completed** | [#114](https://github.com/diego-torres/nutriconsultas/issues/114) — nutritionist reply (admin REST + web widget; `PatientMessageIntegrationTest` round-trip); [#116](https://github.com/diego-torres/nutriconsultas/issues/116) — `senderDisplayName` on `main` |
-| **In scope for #156** | Incremental `Paciente` decomposition (projections + `@Embeddable`); no mobile JSON contract changes |
+| **In scope for #156** | Phase A: read projections ✓ (this branch). **NEXT:** Phase B `@Embeddable` grouping (same table). Phase C optional. No mobile JSON contract changes. |
 
 ### Upcoming gates
 
@@ -345,7 +345,9 @@ gh pr create ...
 
 **Patient mobile API on `main`:** JWT resource server (#107), DTO envelope (#110), patient linkage (#109), visits (#91/#92), diet plans (#93–#95), messages list/send (#96/#97 with HTTP 201 + rate limit), progress snapshot (#98) + measurements time series (#99, PR #153), localized API errors (#111), Resilience4j write throttling (#113), **OpenAPI spec (#112, PR #164)**, **`senderDisplayName` (#116)**, **nutritionist reply (#114)**. Dashboard IMC gauge (#106) done for web tablero.
 
-**Next:** #156 `Paciente` domain refactor (integration prerequisite — blocks Liquibase #46 and onboarding #132).
+**Next:** #156 Phase B — `@Embeddable` grouping (`PacienteEnergyPreferences`, `PacienteMedicalHistory`, `PacienteBodySnapshot`); then #46 Liquibase baseline.
+
+**In progress:** #156 Phase A read projections on branch `integration/a-paciente-projections` (`PacienteListView`, `PacienteAuthView`, `PacienteCalendarView`).
 
 **GitHub drift (close when convenient):** #97 and #111 are **done on `main`** but still **open on GitHub** (implemented in PRs #147, #151).
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-15 — #114 nutritionist reply **done** (branch `mobile-api/114-nutritionist-reply`: integration test for admin→mobile loop). #116 `senderDisplayName` **done** on `main`. **NEXT:** #156.
+**Last updated:** 2026-06-15 — #156 Phase A (read projections) **in-progress** on branch `integration/a-paciente-projections`. #114 nutritionist reply **done**. #116 `senderDisplayName` **done** on `main`. **NEXT:** #156 Phase B (`@Embeddable` grouping).
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -49,7 +49,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 (#107, #109, #110) is **done**. Patient linkage (#109) is **done**. Endpoints **#91–#99 are done** on `main` (PR #153). OpenAPI (#112, PR #164) is **done**. **#115 PHI audit done** (PR #168). **#116 `senderDisplayName` done** on `main`. **#114 nutritionist reply done** on `main` (admin REST + web widget since PR #146; integration test on branch `mobile-api/114-nutritionist-reply`). **NEXT:** #156.
+Phase 0 (#107, #109, #110) is **done**. Patient linkage (#109) is **done**. Endpoints **#91–#99 are done** on `main` (PR #153). OpenAPI (#112, PR #164) is **done**. **#115 PHI audit done** (PR #168). **#116 `senderDisplayName` done** on `main`. **#114 nutritionist reply done** on `main`. **#156 in-progress** — Phase A read projections on branch `integration/a-paciente-projections`; **NEXT within #156:** Phase B `@Embeddable`.
 
 ---
 
@@ -130,7 +130,7 @@ Schema-affecting work must respect mobile DTO contracts (§F8). These issues are
 
 | # | Title | URL | State | Depends on | Blocks | Notes |
 |---|-------|-----|-------|-----------|--------|-------|
-| **156** | `[Integration]` Paciente domain refactor — incremental decomposition | https://github.com/diego-torres/nutriconsultas/issues/156 | **NEXT** | [#121](https://github.com/diego-torres/nutriconsultas/issues/121) GET/TDEE | [#46](https://github.com/diego-torres/nutriconsultas/issues/46) Liquibase, [#132](https://github.com/diego-torres/nutriconsultas/issues/132) timing | Phases A–B (projections + `@Embeddable`, no mobile JSON changes); Phase C optional satellite tables. `#98`/`#99` DTO keys stable; `patientAuthSub` immovable. |
+| **156** | `[Integration]` Paciente domain refactor — incremental decomposition | https://github.com/diego-torres/nutriconsultas/issues/156 | **in-progress** | [#121](https://github.com/diego-torres/nutriconsultas/issues/121) GET/TDEE | [#46](https://github.com/diego-torres/nutriconsultas/issues/46) Liquibase, [#132](https://github.com/diego-torres/nutriconsultas/issues/132) timing | **Phase A done** (branch `integration/a-paciente-projections`): `PacienteListView`, `PacienteAuthView`, `PacienteCalendarView` + JPQL projections; no schema change. **NEXT:** Phase B `@Embeddable`. Mobile `#98`/`#99` DTO keys unchanged. |
 | 46 | Implement Liquibase for database change management | https://github.com/diego-torres/nutriconsultas/issues/46 | open | **156** (Phases A–B min.) | — | First Liquibase baseline must capture post-#156 `Paciente` schema. Until then: `ddl-auto=update` + manual SQL if Phase C. |
 | 132 | Invitation & patient onboarding data model | https://github.com/diego-torres/nutriconsultas/issues/132 | open | #107, **156** (Phase B) | — | `Paciente.status` enum + `Invitation` entity; Liquibase via #46 after #156. |
 
@@ -169,7 +169,7 @@ Each mobile feature consumes these backend endpoints. Two-way linking with the m
 | 107, 108, 109 | Auth / linkage | mobile #5, #7, #13, #22 | Auth |
 | 116 | `senderDisplayName` (optional) | mobile #19 | Read-only (additive) | **done** on `main` |
 | 114 | nutritionist reply | — (web only; feeds #96) | Write (nutritionist) | **done** — `POST /rest/patient-messages/thread/{pacienteId}` + admin widget |
-| 156 | `Paciente` internal refactor (pre-Liquibase) | — (backend only) | — | No mobile JSON change; `#98`/`#99` regression required per PR |
+| 156 | `Paciente` internal refactor (pre-Liquibase) | — (backend only) | — | **in-progress** — Phase A projections on branch `integration/a-paciente-projections`; Phase B `@Embeddable` **NEXT** |
 | 132–141 | Invitation onboarding | mobile (future) | Auth + profile | Replaces #109 manual linkage for new patients; gated by #156 |
 
 **Common contract for every #91–#99** (ALIGNMENT-SPEC §"CORRECTED SCOPE"):

--- a/src/main/java/com/nutriconsultas/calendar/CalendarController.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarController.java
@@ -78,7 +78,7 @@ public class CalendarController extends AbstractAuthorizedController {
 			log.debug("Preselected patient for new event: {}", LogRedaction.redactPaciente(paciente));
 		}
 		model.addAttribute("event", event);
-		model.addAttribute("pacientes", pacienteRepository.findByUserId(userId));
+		model.addAttribute("pacientes", pacienteRepository.findCalendarViewsByUserId(userId));
 		model.addAttribute("statuses", EventStatus.values());
 		model.addAttribute("pacientePreseleccionado", pacientePreseleccionado);
 		log.debug("Finished nuevo method with model {}", model);
@@ -139,7 +139,7 @@ public class CalendarController extends AbstractAuthorizedController {
 		if (hasErrors) {
 			model.addAttribute("activeMenu", "calendario");
 			model.addAttribute("event", event);
-			model.addAttribute("pacientes", pacienteRepository.findByUserId(userId));
+			model.addAttribute("pacientes", pacienteRepository.findCalendarViewsByUserId(userId));
 			model.addAttribute("statuses", EventStatus.values());
 			model.addAttribute("pacientePreseleccionado", Boolean.TRUE.equals(redirectToHistorial));
 			resultView = "sbadmin/calendar/formulario";
@@ -197,7 +197,7 @@ public class CalendarController extends AbstractAuthorizedController {
 
 		model.addAttribute("activeMenu", "calendario");
 		model.addAttribute("event", event);
-		model.addAttribute("pacientes", pacienteRepository.findByUserId(userId));
+		model.addAttribute("pacientes", pacienteRepository.findCalendarViewsByUserId(userId));
 		model.addAttribute("statuses", EventStatus.values());
 		model.addAttribute("pacientePreseleccionado", false);
 		return "sbadmin/calendar/formulario";
@@ -275,7 +275,7 @@ public class CalendarController extends AbstractAuthorizedController {
 				.forEach(error -> log.error("Error: {} - {}", error.getObjectName(), error.getDefaultMessage()));
 			model.addAttribute("activeMenu", "calendario");
 			model.addAttribute("event", event);
-			model.addAttribute("pacientes", pacienteRepository.findByUserId(userId));
+			model.addAttribute("pacientes", pacienteRepository.findCalendarViewsByUserId(userId));
 			model.addAttribute("statuses", EventStatus.values());
 			model.addAttribute("pacientePreseleccionado", false);
 			return "sbadmin/calendar/formulario";

--- a/src/main/java/com/nutriconsultas/calendar/CalendarEventRestController.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarEventRestController.java
@@ -284,7 +284,8 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 			log.error("Cannot get pacientes: user ID is null");
 			return List.of();
 		}
-		final List<Paciente> pacientes = pacienteRepository.findByUserId(userId);
+		final List<com.nutriconsultas.paciente.projection.PacienteCalendarView> pacientes = pacienteRepository
+			.findCalendarViewsByUserId(userId);
 		return pacientes.stream().map(p -> {
 			final Map<String, Object> pacienteMap = new HashMap<>();
 			pacienteMap.put("id", p.getId());

--- a/src/main/java/com/nutriconsultas/mobile/AbstractMobilePatientController.java
+++ b/src/main/java/com/nutriconsultas/mobile/AbstractMobilePatientController.java
@@ -2,11 +2,12 @@ package com.nutriconsultas.mobile;
 
 import org.springframework.security.oauth2.jwt.Jwt;
 
-import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
 
 /**
- * Base controller for patient mobile endpoints. Resolves the authenticated
- * {@link Paciente} from JWT {@code sub} → {@code Paciente.patientAuthSub}.
+ * Base controller for patient mobile endpoints. Resolves the authenticated patient from
+ * JWT {@code sub} → {@code Paciente.patientAuthSub} using a lightweight auth projection
+ * (#156 Phase A).
  */
 public abstract class AbstractMobilePatientController {
 
@@ -16,11 +17,15 @@ public abstract class AbstractMobilePatientController {
 		this.patientAuthService = patientAuthService;
 	}
 
-	protected Paciente getAuthenticatedPaciente(final Jwt jwt) {
+	protected PacienteAuthView getAuthenticatedPacienteAuthView(final Jwt jwt) {
 		if (jwt == null) {
 			throw new PatientNotLinkedException();
 		}
-		return patientAuthService.requirePacienteByJwt(jwt);
+		return patientAuthService.requireAuthViewByJwt(jwt);
+	}
+
+	protected Long getAuthenticatedPacienteId(final Jwt jwt) {
+		return getAuthenticatedPacienteAuthView(jwt).getId();
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanController.java
@@ -17,7 +17,6 @@ import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
 import com.nutriconsultas.mobile.dto.DietPlanPdfResult;
 import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
 import com.nutriconsultas.mobile.dto.PagedResponse;
-import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.util.LogRedaction;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -50,13 +49,13 @@ public class MobilePatientDietPlanController extends AbstractMobilePatientContro
 			@Parameter(description = "Page size") @RequestParam(defaultValue = "20") final int size,
 			@Parameter(description = "When true, return only active assignments") @RequestParam(
 					defaultValue = "false") final boolean activeOnly) {
-		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		final Long pacienteId = getAuthenticatedPacienteId(jwt);
 		if (log.isDebugEnabled()) {
-			log.debug("Mobile list diet plans for patient {} activeOnly={}",
-					LogRedaction.redactPaciente(paciente.getId()), activeOnly);
+			log.debug("Mobile list diet plans for patient {} activeOnly={}", LogRedaction.redactPaciente(pacienteId),
+					activeOnly);
 		}
-		final PagedResponse<DietPlanSummaryDto> plans = mobilePatientDietPlanService.listDietPlans(paciente.getId(),
-				page, size, activeOnly);
+		final PagedResponse<DietPlanSummaryDto> plans = mobilePatientDietPlanService.listDietPlans(pacienteId, page,
+				size, activeOnly);
 		return ApiResponse.ok(plans);
 	}
 
@@ -69,12 +68,12 @@ public class MobilePatientDietPlanController extends AbstractMobilePatientContro
 			description = "Diet plan detail with ingestas and platillos")
 	public ApiResponse<DietPlanDetailDto> getDietPlanDetail(@AuthenticationPrincipal final Jwt jwt,
 			@Parameter(description = "PacienteDieta assignment identifier") @PathVariable final Long assignmentId) {
-		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		final Long pacienteId = getAuthenticatedPacienteId(jwt);
 		if (log.isDebugEnabled()) {
 			log.debug("Mobile get diet plan {} for patient {}", LogRedaction.redactPacienteDieta(assignmentId),
-					LogRedaction.redactPaciente(paciente.getId()));
+					LogRedaction.redactPaciente(pacienteId));
 		}
-		final DietPlanDetailDto plan = mobilePatientDietPlanService.getDietPlanDetail(paciente.getId(), assignmentId);
+		final DietPlanDetailDto plan = mobilePatientDietPlanService.getDietPlanDetail(pacienteId, assignmentId);
 		return ApiResponse.ok(plan);
 	}
 
@@ -87,12 +86,12 @@ public class MobilePatientDietPlanController extends AbstractMobilePatientContro
 			content = @Content(mediaType = MediaType.APPLICATION_PDF_VALUE))
 	public ResponseEntity<byte[]> getDietPlanPdf(@AuthenticationPrincipal final Jwt jwt,
 			@Parameter(description = "PacienteDieta assignment identifier") @PathVariable final Long assignmentId) {
-		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		final Long pacienteId = getAuthenticatedPacienteId(jwt);
 		if (log.isDebugEnabled()) {
 			log.debug("Mobile get diet plan PDF {} for patient {}", LogRedaction.redactPacienteDieta(assignmentId),
-					LogRedaction.redactPaciente(paciente.getId()));
+					LogRedaction.redactPaciente(pacienteId));
 		}
-		final DietPlanPdfResult pdf = mobilePatientDietPlanService.generateDietPlanPdf(paciente.getId(), assignmentId);
+		final DietPlanPdfResult pdf = mobilePatientDietPlanService.generateDietPlanPdf(pacienteId, assignmentId);
 		return ResponseEntity.ok()
 			.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + pdf.filename() + "\"")
 			.contentType(MediaType.APPLICATION_PDF)

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageController.java
@@ -16,7 +16,7 @@ import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.CursorPagedResponse;
 import com.nutriconsultas.mobile.dto.PatientMessageSummaryDto;
 import com.nutriconsultas.mobile.dto.SendPatientMessageRequest;
-import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
 import com.nutriconsultas.util.LogRedaction;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,12 +49,12 @@ public class MobilePatientMessageController extends AbstractMobilePatientControl
 			@Parameter(description = "Opaque cursor from a previous page") @RequestParam(
 					required = false) final String cursor,
 			@Parameter(description = "Page size") @RequestParam(defaultValue = "20") final int size) {
-		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		final Long pacienteId = getAuthenticatedPacienteId(jwt);
 		if (log.isDebugEnabled()) {
-			log.debug("Mobile list messages request for patient {}", LogRedaction.redactPaciente(paciente.getId()));
+			log.debug("Mobile list messages request for patient {}", LogRedaction.redactPaciente(pacienteId));
 		}
 		final CursorPagedResponse<PatientMessageSummaryDto> messages = mobilePatientMessageService
-			.listMessages(paciente.getId(), cursor, size);
+			.listMessages(pacienteId, cursor, size);
 		return ApiResponse.ok(messages);
 	}
 
@@ -66,11 +66,11 @@ public class MobilePatientMessageController extends AbstractMobilePatientControl
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Created message summary")
 	public ApiResponse<PatientMessageSummaryDto> sendMessage(@AuthenticationPrincipal final Jwt jwt,
 			@Valid @RequestBody final SendPatientMessageRequest request) {
-		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		final PacienteAuthView authView = getAuthenticatedPacienteAuthView(jwt);
 		if (log.isDebugEnabled()) {
-			log.debug("Mobile send message request for patient {}", LogRedaction.redactPaciente(paciente.getId()));
+			log.debug("Mobile send message request for patient {}", LogRedaction.redactPaciente(authView.getId()));
 		}
-		final PatientMessageSummaryDto sent = mobilePatientMessageService.sendMessage(paciente, request.body());
+		final PatientMessageSummaryDto sent = mobilePatientMessageService.sendMessage(authView, request.body());
 		return ApiResponse.ok(sent);
 	}
 

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientMessageService.java
@@ -17,6 +17,8 @@ import com.nutriconsultas.message.PatientMessageRepository;
 import com.nutriconsultas.mobile.dto.CursorPagedResponse;
 import com.nutriconsultas.mobile.dto.PatientMessageSummaryDto;
 import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
 import com.nutriconsultas.profile.NutritionistBrandingHelper;
 import com.nutriconsultas.profile.NutritionistProfileRepository;
 import com.nutriconsultas.util.LogRedaction;
@@ -35,13 +37,16 @@ public class MobilePatientMessageService {
 
 	private final NutritionistProfileRepository nutritionistProfileRepository;
 
+	private final PacienteRepository pacienteRepository;
+
 	private final PatientWriteRateLimiter patientWriteRateLimiter;
 
 	public MobilePatientMessageService(final PatientMessageRepository patientMessageRepository,
 			final NutritionistProfileRepository nutritionistProfileRepository,
-			final PatientWriteRateLimiter patientWriteRateLimiter) {
+			final PacienteRepository pacienteRepository, final PatientWriteRateLimiter patientWriteRateLimiter) {
 		this.patientMessageRepository = patientMessageRepository;
 		this.nutritionistProfileRepository = nutritionistProfileRepository;
+		this.pacienteRepository = pacienteRepository;
 		this.patientWriteRateLimiter = patientWriteRateLimiter;
 	}
 
@@ -68,15 +73,16 @@ public class MobilePatientMessageService {
 	}
 
 	@Transactional
-	public PatientMessageSummaryDto sendMessage(final Paciente paciente, final String body) {
-		return patientWriteRateLimiter.execute(PatientWriteRateLimiter.PATIENT_MESSAGES, paciente.getPatientAuthSub(),
-				() -> persistPatientMessage(paciente, body));
+	public PatientMessageSummaryDto sendMessage(final PacienteAuthView authView, final String body) {
+		return patientWriteRateLimiter.execute(PatientWriteRateLimiter.PATIENT_MESSAGES, authView.getPatientAuthSub(),
+				() -> persistPatientMessage(authView, body));
 	}
 
-	private PatientMessageSummaryDto persistPatientMessage(final Paciente paciente, final String body) {
+	private PatientMessageSummaryDto persistPatientMessage(final PacienteAuthView authView, final String body) {
 		final PatientMessage message = new PatientMessage();
-		message.setPaciente(paciente);
-		message.setNutritionistUserId(paciente.getUserId());
+		final Paciente pacienteRef = pacienteRepository.getReferenceById(authView.getId());
+		message.setPaciente(pacienteRef);
+		message.setNutritionistUserId(authView.getUserId());
 		message.setSenderRole(MessageSenderRole.PATIENT);
 		message.setBody(body.trim());
 		final PatientMessage saved = patientMessageRepository.save(message);

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressController.java
@@ -13,7 +13,6 @@ import com.nutriconsultas.mobile.config.MobileOpenApiResponses;
 import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.PatientProgressSnapshotDto;
 import com.nutriconsultas.mobile.dto.ProgressMeasurementsDto;
-import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.util.LogRedaction;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -41,11 +40,11 @@ public class MobilePatientProgressController extends AbstractMobilePatientContro
 	@MobileOpenApiResponses.AuthenticatedPatient
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Progress snapshot")
 	public ApiResponse<PatientProgressSnapshotDto> getProgress(@AuthenticationPrincipal final Jwt jwt) {
-		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		final Long pacienteId = getAuthenticatedPacienteId(jwt);
 		if (log.isDebugEnabled()) {
-			log.debug("Mobile progress snapshot request for patient {}", LogRedaction.redactPaciente(paciente.getId()));
+			log.debug("Mobile progress snapshot request for patient {}", LogRedaction.redactPaciente(pacienteId));
 		}
-		final PatientProgressSnapshotDto snapshot = mobilePatientProgressService.getSnapshot(paciente.getId());
+		final PatientProgressSnapshotDto snapshot = mobilePatientProgressService.getSnapshot(pacienteId);
 		return ApiResponse.ok(snapshot);
 	}
 
@@ -64,13 +63,12 @@ public class MobilePatientProgressController extends AbstractMobilePatientContro
 					required = false) final Instant to,
 			@Parameter(description = "Maximum rows (capped at 365)") @RequestParam(
 					required = false) final Integer maxRows) {
-		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		final Long pacienteId = getAuthenticatedPacienteId(jwt);
 		if (log.isDebugEnabled()) {
-			log.debug("Mobile progress measurements request for patient {}",
-					LogRedaction.redactPaciente(paciente.getId()));
+			log.debug("Mobile progress measurements request for patient {}", LogRedaction.redactPaciente(pacienteId));
 		}
-		final ProgressMeasurementsDto measurements = mobilePatientProgressService.listMeasurements(paciente.getId(),
-				from, to, maxRows);
+		final ProgressMeasurementsDto measurements = mobilePatientProgressService.listMeasurements(pacienteId, from, to,
+				maxRows);
 		return ApiResponse.ok(measurements);
 	}
 

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitController.java
@@ -16,7 +16,6 @@ import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.PagedResponse;
 import com.nutriconsultas.mobile.dto.VisitDetailDto;
 import com.nutriconsultas.mobile.dto.VisitSummaryDto;
-import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.util.LogRedaction;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -51,11 +50,11 @@ public class MobilePatientVisitController extends AbstractMobilePatientControlle
 					required = false) final Instant from,
 			@Parameter(description = "Inclusive end instant (ISO-8601)") @RequestParam(
 					required = false) final Instant to) {
-		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		final Long pacienteId = getAuthenticatedPacienteId(jwt);
 		if (log.isDebugEnabled()) {
-			log.debug("Mobile list visits request for patient {}", LogRedaction.redactPaciente(paciente.getId()));
+			log.debug("Mobile list visits request for patient {}", LogRedaction.redactPaciente(pacienteId));
 		}
-		final PagedResponse<VisitSummaryDto> visits = mobilePatientVisitService.listVisits(paciente.getId(), page, size,
+		final PagedResponse<VisitSummaryDto> visits = mobilePatientVisitService.listVisits(pacienteId, page, size,
 				status, from, to);
 		return ApiResponse.ok(visits);
 	}
@@ -67,12 +66,12 @@ public class MobilePatientVisitController extends AbstractMobilePatientControlle
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Visit detail")
 	public ApiResponse<VisitDetailDto> getVisitDetail(@AuthenticationPrincipal final Jwt jwt,
 			@Parameter(description = "Visit identifier") @PathVariable final Long visitId) {
-		final Paciente paciente = getAuthenticatedPaciente(jwt);
+		final Long pacienteId = getAuthenticatedPacienteId(jwt);
 		if (log.isDebugEnabled()) {
 			log.debug("Mobile get visit {} for patient {}", LogRedaction.redactCalendarEvent(visitId),
-					LogRedaction.redactPaciente(paciente.getId()));
+					LogRedaction.redactPaciente(pacienteId));
 		}
-		final VisitDetailDto visit = mobilePatientVisitService.getVisitDetail(paciente.getId(), visitId);
+		final VisitDetailDto visit = mobilePatientVisitService.getVisitDetail(pacienteId, visitId);
 		return ApiResponse.ok(visit);
 	}
 

--- a/src/main/java/com/nutriconsultas/mobile/PatientAuthLinkageService.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientAuthLinkageService.java
@@ -66,7 +66,7 @@ public class PatientAuthLinkageService {
 	}
 
 	private Paciente assignSub(final Paciente paciente, final String patientAuthSub) {
-		pacienteRepository.findByPatientAuthSub(patientAuthSub).ifPresent(existing -> {
+		pacienteRepository.findAuthViewByPatientAuthSub(patientAuthSub).ifPresent(existing -> {
 			if (!existing.getId().equals(paciente.getId())) {
 				throw new PatientAuthSubAlreadyLinkedException();
 			}

--- a/src/main/java/com/nutriconsultas/mobile/PatientAuthService.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientAuthService.java
@@ -6,8 +6,8 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
 import com.nutriconsultas.util.LogRedaction;
 
 import lombok.extern.slf4j.Slf4j;
@@ -23,30 +23,25 @@ public class PatientAuthService {
 	}
 
 	@Transactional(readOnly = true)
-	public Optional<Paciente> findByJwt(final Jwt jwt) {
+	public Optional<PacienteAuthView> findAuthViewByJwt(final Jwt jwt) {
 		if (jwt == null || jwt.getSubject() == null) {
 			return Optional.empty();
 		}
-		return pacienteRepository.findByPatientAuthSub(jwt.getSubject());
+		return pacienteRepository.findAuthViewByPatientAuthSub(jwt.getSubject());
 	}
 
 	@Transactional(readOnly = true)
-	public Paciente requirePacienteByJwt(final Jwt jwt) {
-		return findByJwt(jwt).orElseThrow(PatientNotLinkedException::new);
-	}
-
-	@Transactional(readOnly = true)
-	public Paciente requirePacienteById(final Long pacienteId) {
-		return pacienteRepository.findById(pacienteId).orElseThrow(PatientNotLinkedException::new);
+	public PacienteAuthView requireAuthViewByJwt(final Jwt jwt) {
+		return findAuthViewByJwt(jwt).orElseThrow(PatientNotLinkedException::new);
 	}
 
 	@Transactional(readOnly = true)
 	public PatientPrincipal resolvePrincipal(final Jwt jwt) {
-		final Paciente paciente = requirePacienteByJwt(jwt);
+		final PacienteAuthView authView = requireAuthViewByJwt(jwt);
 		if (log.isDebugEnabled()) {
-			log.debug("Resolved mobile patient principal: {}", LogRedaction.redactPaciente(paciente.getId()));
+			log.debug("Resolved mobile patient principal: {}", LogRedaction.redactPaciente(authView.getId()));
 		}
-		return new PatientPrincipal(paciente.getId(), jwt.getSubject());
+		return new PatientPrincipal(authView.getId(), jwt.getSubject());
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/paciente/PacienteComparators.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteComparators.java
@@ -6,42 +6,44 @@ import java.util.Map;
 
 import com.nutriconsultas.dataTables.paging.ComparatorKey;
 import com.nutriconsultas.dataTables.paging.Direction;
+import com.nutriconsultas.paciente.projection.PacienteListView;
 
 public final class PacienteComparators {
 
-	private static final Map<ComparatorKey, Comparator<Paciente>> MAP = new HashMap<>();
+	private static final Map<ComparatorKey, Comparator<PacienteListView>> MAP = new HashMap<>();
 
 	static {
-		MAP.put(new ComparatorKey("nombre", Direction.asc), Comparator.comparing(Paciente::getName));
-		MAP.put(new ComparatorKey("nombre", Direction.desc), Comparator.comparing(Paciente::getName).reversed());
+		MAP.put(new ComparatorKey("nombre", Direction.asc), Comparator.comparing(PacienteListView::getName));
+		MAP.put(new ComparatorKey("nombre", Direction.desc),
+				Comparator.comparing(PacienteListView::getName).reversed());
 
 		MAP.put(new ComparatorKey("dob", Direction.asc),
-				Comparator.comparing(Paciente::getDob, Comparator.nullsLast(Comparator.naturalOrder())));
+				Comparator.comparing(PacienteListView::getDob, Comparator.nullsLast(Comparator.naturalOrder())));
 		MAP.put(new ComparatorKey("dob", Direction.desc),
-				Comparator.comparing(Paciente::getDob, Comparator.nullsLast(Comparator.reverseOrder())));
+				Comparator.comparing(PacienteListView::getDob, Comparator.nullsLast(Comparator.reverseOrder())));
 
 		MAP.put(new ComparatorKey("email", Direction.asc),
-				Comparator.comparing(Paciente::getEmail, Comparator.nullsLast(Comparator.naturalOrder())));
+				Comparator.comparing(PacienteListView::getEmail, Comparator.nullsLast(Comparator.naturalOrder())));
 		MAP.put(new ComparatorKey("email", Direction.desc),
-				Comparator.comparing(Paciente::getEmail, Comparator.nullsLast(Comparator.reverseOrder())));
+				Comparator.comparing(PacienteListView::getEmail, Comparator.nullsLast(Comparator.reverseOrder())));
 
 		MAP.put(new ComparatorKey("phone", Direction.asc),
-				Comparator.comparing(Paciente::getPhone, Comparator.nullsLast(Comparator.naturalOrder())));
+				Comparator.comparing(PacienteListView::getPhone, Comparator.nullsLast(Comparator.naturalOrder())));
 		MAP.put(new ComparatorKey("phone", Direction.desc),
-				Comparator.comparing(Paciente::getPhone, Comparator.nullsLast(Comparator.reverseOrder())));
+				Comparator.comparing(PacienteListView::getPhone, Comparator.nullsLast(Comparator.reverseOrder())));
 
 		MAP.put(new ComparatorKey("gender", Direction.asc),
-				Comparator.comparing(Paciente::getGender, Comparator.nullsLast(Comparator.naturalOrder())));
+				Comparator.comparing(PacienteListView::getGender, Comparator.nullsLast(Comparator.naturalOrder())));
 		MAP.put(new ComparatorKey("gender", Direction.desc),
-				Comparator.comparing(Paciente::getGender, Comparator.nullsLast(Comparator.reverseOrder())));
+				Comparator.comparing(PacienteListView::getGender, Comparator.nullsLast(Comparator.reverseOrder())));
 
-		MAP.put(new ComparatorKey("responsible", Direction.asc),
-				Comparator.comparing(Paciente::getResponsibleName, Comparator.nullsLast(Comparator.naturalOrder())));
-		MAP.put(new ComparatorKey("responsible", Direction.desc),
-				Comparator.comparing(Paciente::getResponsibleName, Comparator.nullsLast(Comparator.reverseOrder())));
+		MAP.put(new ComparatorKey("responsible", Direction.asc), Comparator
+			.comparing(PacienteListView::getResponsibleName, Comparator.nullsLast(Comparator.naturalOrder())));
+		MAP.put(new ComparatorKey("responsible", Direction.desc), Comparator
+			.comparing(PacienteListView::getResponsibleName, Comparator.nullsLast(Comparator.reverseOrder())));
 	}
 
-	public static Comparator<Paciente> getComparator(String name, Direction dir) {
+	public static Comparator<PacienteListView> getComparator(String name, Direction dir) {
 		return MAP.get(new ComparatorKey(name, dir));
 	}
 

--- a/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
@@ -10,8 +10,15 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
+import com.nutriconsultas.paciente.projection.PacienteCalendarView;
+import com.nutriconsultas.paciente.projection.PacienteListView;
+
 @Repository
 public interface PacienteRepository extends JpaRepository<Paciente, Long> {
+
+	String LIST_VIEW_SELECT = "SELECT p.id AS id, p.name AS name, p.email AS email, p.phone AS phone, "
+			+ "p.dob AS dob, p.gender AS gender, p.responsibleName AS responsibleName ";
 
 	List<Paciente> findByUserId(String userId);
 
@@ -20,6 +27,29 @@ public interface PacienteRepository extends JpaRepository<Paciente, Long> {
 	Optional<Paciente> findByIdAndUserId(Long id, String userId);
 
 	Optional<Paciente> findByPatientAuthSub(String patientAuthSub);
+
+	@Query(LIST_VIEW_SELECT + "FROM Paciente p WHERE p.userId = :userId")
+	Page<PacienteListView> findListViewsByUserId(@Param("userId") String userId, Pageable pageable);
+
+	@Query(LIST_VIEW_SELECT + "FROM Paciente p WHERE p.userId = :userId AND "
+			+ "(LOWER(p.name) LIKE LOWER(:searchTerm) OR LOWER(p.email) LIKE LOWER(:searchTerm) "
+			+ "OR LOWER(p.phone) LIKE LOWER(:searchTerm) OR LOWER(p.responsibleName) LIKE LOWER(:searchTerm))")
+	Page<PacienteListView> findListViewsByUserIdAndSearchTerm(@Param("userId") String userId,
+			@Param("searchTerm") String searchTerm, Pageable pageable);
+
+	@Query(LIST_VIEW_SELECT + "FROM Paciente p WHERE p.userId = :userId AND "
+			+ "(LOWER(p.name) LIKE LOWER(:searchTerm) OR LOWER(p.email) LIKE LOWER(:searchTerm) "
+			+ "OR LOWER(p.phone) LIKE LOWER(:searchTerm))")
+	List<PacienteListView> findListViewsByUserIdAndSearchTerm(@Param("userId") String userId,
+			@Param("searchTerm") String searchTerm);
+
+	@Query("SELECT p.id AS id, p.patientAuthSub AS patientAuthSub, p.userId AS userId FROM Paciente p "
+			+ "WHERE p.patientAuthSub = :patientAuthSub")
+	Optional<PacienteAuthView> findAuthViewByPatientAuthSub(@Param("patientAuthSub") String patientAuthSub);
+
+	@Query("SELECT p.id AS id, p.name AS name, p.dob AS dob, p.gender AS gender FROM Paciente p "
+			+ "WHERE p.userId = :userId ORDER BY p.name ASC")
+	List<PacienteCalendarView> findCalendarViewsByUserId(@Param("userId") String userId);
 
 	@Query("SELECT p FROM Paciente p WHERE p.userId = :userId AND "
 			+ "(LOWER(p.name) LIKE LOWER(:searchTerm) OR LOWER(p.email) LIKE LOWER(:searchTerm) "

--- a/src/main/java/com/nutriconsultas/paciente/PacienteRestController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteRestController.java
@@ -34,6 +34,7 @@ import com.nutriconsultas.dataTables.paging.Direction;
 import com.nutriconsultas.dataTables.paging.Order;
 import com.nutriconsultas.dataTables.paging.PageArray;
 import com.nutriconsultas.dataTables.paging.PagingRequest;
+import com.nutriconsultas.paciente.projection.PacienteListView;
 import com.nutriconsultas.util.LogRedaction;
 
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +42,7 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @RequestMapping("/rest/pacientes")
 @Slf4j
-public class PacienteRestController extends AbstractGridController<Paciente> {
+public class PacienteRestController extends AbstractGridController<PacienteListView> {
 
 	@Autowired
 	private PacienteService service;
@@ -119,7 +120,7 @@ public class PacienteRestController extends AbstractGridController<Paciente> {
 		}
 		pagingRequest.setColumns(getColumns());
 		final String nonNullUserId = userId;
-		final com.nutriconsultas.dataTables.paging.Page<Paciente> page = getRows(pagingRequest, nonNullUserId);
+		final com.nutriconsultas.dataTables.paging.Page<PacienteListView> page = getRows(pagingRequest, nonNullUserId);
 		log.debug("page with records: {}", page.getRecordsTotal());
 		final PageArray pageArray = new PageArray();
 		pageArray.setData(page.getData().stream().map(this::toStringList).collect(Collectors.toList()));
@@ -136,28 +137,28 @@ public class PacienteRestController extends AbstractGridController<Paciente> {
 	 * @param userId the user ID to filter by (must not be null)
 	 * @return the page of patients
 	 */
-	protected com.nutriconsultas.dataTables.paging.Page<Paciente> getRows(final PagingRequest pagingRequest,
+	protected com.nutriconsultas.dataTables.paging.Page<PacienteListView> getRows(final PagingRequest pagingRequest,
 			@org.springframework.lang.NonNull final String userId) {
 		log.debug("starting getRows with pagingRequest: {} for userId: {}", pagingRequest, userId);
 		final Pageable pageable = toPageable(pagingRequest);
 		final String searchValue = pagingRequest.getSearch() != null && pagingRequest.getSearch().getValue() != null
 				? pagingRequest.getSearch().getValue().trim() : null;
 
-		final Page<Paciente> springPage;
+		final Page<PacienteListView> springPage;
 		final long totalCount;
 		final long filteredCount;
 
 		if (searchValue != null && !searchValue.isEmpty()) {
-			springPage = service.findAllByUserIdAndSearchTerm(userId, searchValue, pageable);
+			springPage = service.findListViewsByUserIdAndSearchTerm(userId, searchValue, pageable);
 			filteredCount = service.countByUserIdAndSearchTerm(userId, searchValue);
 		}
 		else {
-			springPage = service.findAllByUserId(userId, pageable);
+			springPage = service.findListViewsByUserId(userId, pageable);
 			filteredCount = service.countByUserId(userId);
 		}
 		totalCount = service.countByUserId(userId);
 
-		final com.nutriconsultas.dataTables.paging.Page<Paciente> result = new com.nutriconsultas.dataTables.paging.Page<>(
+		final com.nutriconsultas.dataTables.paging.Page<PacienteListView> result = new com.nutriconsultas.dataTables.paging.Page<>(
 				springPage.getContent());
 		result.setRecordsFiltered((int) filteredCount);
 		result.setRecordsTotal((int) totalCount);
@@ -169,8 +170,8 @@ public class PacienteRestController extends AbstractGridController<Paciente> {
 	}
 
 	@Override
-	protected List<String> toStringList(final Paciente row) {
-		log.debug("converting Paciente row {} to string list.", LogRedaction.redactPaciente(row));
+	protected List<String> toStringList(final PacienteListView row) {
+		log.debug("converting Paciente list view row {} to string list.", LogRedaction.redactPaciente(row.getId()));
 		final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
 		return Arrays.asList("<a href='/admin/pacientes/" + row.getId() + "'>" + row.getName() + "</a>",
 				row.getDob() != null ? dateFormat.format(row.getDob()) : "", //
@@ -181,30 +182,30 @@ public class PacienteRestController extends AbstractGridController<Paciente> {
 	}
 
 	@Override
-	protected List<Paciente> getData() {
+	protected List<PacienteListView> getData() {
 		log.warn("getData() called without userId filter. This should not happen in production.");
-		return service.findAll();
+		return List.of();
 	}
 
 	/**
-	 * Gets patient data filtered by userId.
+	 * Gets patient list views filtered by userId.
 	 * @param userId the user ID to filter by (must not be null)
-	 * @return list of patients for the user
+	 * @return list of patient list views for the user
 	 */
-	protected List<Paciente> getData(@org.springframework.lang.NonNull final String userId) {
-		log.debug("getting all Paciente records for userId: {}", userId);
-		return service.findAllByUserId(userId);
+	protected List<PacienteListView> getData(@org.springframework.lang.NonNull final String userId) {
+		log.debug("getting Paciente list views for userId: {}", userId);
+		return service.findListViewsByUserId(userId, Pageable.unpaged()).getContent();
 	}
 
 	@Override
-	protected Predicate<Paciente> getPredicate(final String value) {
+	protected Predicate<PacienteListView> getPredicate(final String value) {
 		return row -> row.getName().toLowerCase().contains(value) || row.getName().toLowerCase().startsWith(value)
-				|| row.getResponsibleName().toLowerCase().contains(value)
-				|| row.getResponsibleName().toLowerCase().startsWith(value);
+				|| (row.getResponsibleName() != null && (row.getResponsibleName().toLowerCase().contains(value)
+						|| row.getResponsibleName().toLowerCase().startsWith(value)));
 	}
 
 	@Override
-	protected Comparator<Paciente> getComparator(final String column, final Direction dir) {
+	protected Comparator<PacienteListView> getComparator(final String column, final Direction dir) {
 		log.debug("getting Paciente comparator with column {} and direction {}.", column, dir);
 		return PacienteComparators.getComparator(column, dir);
 	}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteService.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteService.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.lang.NonNull;
 
+import com.nutriconsultas.paciente.projection.PacienteListView;
+
 public interface PacienteService {
 
 	Paciente findById(@NonNull Long id);
@@ -17,6 +19,13 @@ public interface PacienteService {
 	List<Paciente> findAllByUserId(@NonNull String userId);
 
 	Page<Paciente> findAllByUserId(@NonNull String userId, Pageable pageable);
+
+	Page<PacienteListView> findListViewsByUserId(@NonNull String userId, Pageable pageable);
+
+	List<PacienteListView> findListViewsByUserIdAndSearchTerm(@NonNull String userId, @NonNull String searchTerm);
+
+	Page<PacienteListView> findListViewsByUserIdAndSearchTerm(@NonNull String userId, @NonNull String searchTerm,
+			Pageable pageable);
 
 	Page<Paciente> findAllByUserIdAndSearchTerm(@NonNull String userId, @NonNull String searchTerm, Pageable pageable);
 

--- a/src/main/java/com/nutriconsultas/paciente/PacienteServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.nutriconsultas.paciente.projection.PacienteListView;
 import com.nutriconsultas.util.LogRedaction;
 
 import lombok.extern.slf4j.Slf4j;
@@ -69,6 +70,32 @@ public class PacienteServiceImpl implements PacienteService {
 	public Page<Paciente> findAllByUserId(@NonNull final String userId, final Pageable pageable) {
 		log.info("getting paginated Paciente records for userId {} with pageable {}.", userId, pageable);
 		return repo.findByUserId(userId, pageable);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Page<PacienteListView> findListViewsByUserId(@NonNull final String userId, final Pageable pageable) {
+		log.info("getting paginated Paciente list views for userId {} with pageable {}.", userId, pageable);
+		return repo.findListViewsByUserId(userId, pageable);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<PacienteListView> findListViewsByUserIdAndSearchTerm(@NonNull final String userId,
+			@NonNull final String searchTerm) {
+		log.info("searching Paciente list views for userId {} with search term '{}'.", userId, searchTerm);
+		final String searchPattern = "%" + searchTerm.toLowerCase() + "%";
+		return repo.findListViewsByUserIdAndSearchTerm(userId, searchPattern);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Page<PacienteListView> findListViewsByUserIdAndSearchTerm(@NonNull final String userId,
+			@NonNull final String searchTerm, final Pageable pageable) {
+		log.info("searching paginated Paciente list views for userId {} with search term '{}' and pageable {}.", userId,
+				searchTerm, pageable);
+		final String searchPattern = "%" + searchTerm.toLowerCase() + "%";
+		return repo.findListViewsByUserIdAndSearchTerm(userId, searchPattern, pageable);
 	}
 
 	@Override

--- a/src/main/java/com/nutriconsultas/paciente/projection/PacienteAuthView.java
+++ b/src/main/java/com/nutriconsultas/paciente/projection/PacienteAuthView.java
@@ -1,0 +1,15 @@
+package com.nutriconsultas.paciente.projection;
+
+/**
+ * Read-only projection for mobile JWT resolution ({@code sub} → {@code patientAuthSub}) —
+ * #156 Phase A.
+ */
+public interface PacienteAuthView {
+
+	Long getId();
+
+	String getPatientAuthSub();
+
+	String getUserId();
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/projection/PacienteCalendarView.java
+++ b/src/main/java/com/nutriconsultas/paciente/projection/PacienteCalendarView.java
@@ -1,0 +1,18 @@
+package com.nutriconsultas.paciente.projection;
+
+import java.util.Date;
+
+/**
+ * Read-only projection for calendar patient preselect dropdowns — #156 Phase A.
+ */
+public interface PacienteCalendarView {
+
+	Long getId();
+
+	String getName();
+
+	Date getDob();
+
+	String getGender();
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/projection/PacienteListView.java
+++ b/src/main/java/com/nutriconsultas/paciente/projection/PacienteListView.java
@@ -1,0 +1,25 @@
+package com.nutriconsultas.paciente.projection;
+
+import java.util.Date;
+
+/**
+ * Read-only projection for patient grid and search — excludes heavy TEXT and
+ * energy-preference columns (#156 Phase A).
+ */
+public interface PacienteListView {
+
+	Long getId();
+
+	String getName();
+
+	String getEmail();
+
+	String getPhone();
+
+	Date getDob();
+
+	String getGender();
+
+	String getResponsibleName();
+
+}

--- a/src/main/java/com/nutriconsultas/search/SearchServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/search/SearchServiceImpl.java
@@ -15,8 +15,8 @@ import com.nutriconsultas.calendar.CalendarEvent;
 import com.nutriconsultas.calendar.CalendarEventRepository;
 import com.nutriconsultas.clinical.exam.ClinicalExam;
 import com.nutriconsultas.clinical.exam.ClinicalExamRepository;
-import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.projection.PacienteListView;
 import com.nutriconsultas.platillos.Platillo;
 import com.nutriconsultas.platillos.PlatilloRepository;
 
@@ -52,7 +52,8 @@ public class SearchServiceImpl implements SearchService {
 		final int pageNumber = Math.max(1, page);
 
 		// Search Pacientes (filtered by userId)
-		final List<Paciente> allPacientes = pacienteRepository.findByUserIdAndSearchTerm(userId, searchTerm);
+		final List<PacienteListView> allPacientes = pacienteRepository.findListViewsByUserIdAndSearchTerm(userId,
+				searchTerm);
 		final List<SearchResult> allPacienteResults = allPacientes.stream()
 			.map(p -> new SearchResult(SearchResultType.PACIENTE, p.getId(), p.getName(), buildPacienteDescription(p),
 					"/admin/pacientes/" + p.getId()))
@@ -119,7 +120,7 @@ public class SearchServiceImpl implements SearchService {
 		return new PaginatedSearchResults(paginatedResults, totalCount, pageNumber, PAGE_SIZE, totalPages);
 	}
 
-	private String buildPacienteDescription(final Paciente paciente) {
+	private String buildPacienteDescription(final PacienteListView paciente) {
 		final List<String> parts = new ArrayList<>();
 		if (paciente.getEmail() != null && !paciente.getEmail().isEmpty()) {
 			parts.add("Email: " + paciente.getEmail());

--- a/src/test/java/com/nutriconsultas/calendar/CalendarControllerTest.java
+++ b/src/test/java/com/nutriconsultas/calendar/CalendarControllerTest.java
@@ -33,6 +33,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.projection.PacienteCalendarView;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -81,9 +82,9 @@ public class CalendarControllerTest {
 		when(calendarEventService.findById(1L)).thenReturn(event);
 		when(calendarEventService.findById(999L)).thenReturn(null);
 
-		List<Paciente> pacientes = new ArrayList<>();
-		pacientes.add(paciente);
-		when(pacienteRepository.findByUserId(TEST_USER_ID)).thenReturn(pacientes);
+		final List<PacienteCalendarView> pacientes = new ArrayList<>();
+		pacientes.add(calendarViewFrom(paciente));
+		when(pacienteRepository.findCalendarViewsByUserId(TEST_USER_ID)).thenReturn(pacientes);
 		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
 		when(pacienteRepository.findByIdAndUserId(999L, TEST_USER_ID)).thenReturn(java.util.Optional.empty());
 	}
@@ -842,6 +843,30 @@ public class CalendarControllerTest {
 		assertEquals(1L, persistedEvent.getId(), "ID should be preserved");
 
 		log.info("Finishing testGuardarButtonPersistsAllChanges");
+	}
+
+	private static PacienteCalendarView calendarViewFrom(final Paciente entity) {
+		return new PacienteCalendarView() {
+			@Override
+			public Long getId() {
+				return entity.getId();
+			}
+
+			@Override
+			public String getName() {
+				return entity.getName();
+			}
+
+			@Override
+			public Date getDob() {
+				return entity.getDob();
+			}
+
+			@Override
+			public String getGender() {
+				return entity.getGender();
+			}
+		};
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/calendar/CalendarEventRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/calendar/CalendarEventRestControllerTest.java
@@ -39,6 +39,7 @@ import com.nutriconsultas.paciente.BodyFatCalculatorService;
 import com.nutriconsultas.paciente.NivelPeso;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.projection.PacienteCalendarView;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -64,7 +65,7 @@ public class CalendarEventRestControllerTest {
 
 	private Paciente paciente;
 
-	private List<Paciente> pacientes;
+	private List<PacienteCalendarView> pacientes;
 
 	private OidcUser principal;
 
@@ -137,13 +138,13 @@ public class CalendarEventRestControllerTest {
 
 		// Create test pacientes list
 		pacientes = new ArrayList<>();
-		pacientes.add(paciente);
+		pacientes.add(calendarViewFrom(paciente));
 		final Paciente paciente2 = new Paciente();
 		paciente2.setId(2L);
 		paciente2.setName("Maria Garcia");
 		paciente2.setUserId(TEST_USER_ID);
-		pacientes.add(paciente2);
-		lenient().when(pacienteRepository.findByUserId(TEST_USER_ID)).thenReturn(pacientes);
+		pacientes.add(calendarViewFrom(paciente2));
+		lenient().when(pacienteRepository.findCalendarViewsByUserId(TEST_USER_ID)).thenReturn(pacientes);
 
 		log.info("finished setting up calendar event service with {} events", events.size());
 	}
@@ -918,7 +919,7 @@ public class CalendarEventRestControllerTest {
 		// Assert
 		assertThat(result).isNotNull();
 		assertThat(result.size()).isEqualTo(2);
-		verify(pacienteRepository).findByUserId(TEST_USER_ID);
+		verify(pacienteRepository).findCalendarViewsByUserId(TEST_USER_ID);
 
 		// Verify first paciente
 		final Map<String, Object> paciente1 = result.get(0);
@@ -939,7 +940,7 @@ public class CalendarEventRestControllerTest {
 	public void testGetPacientesEmptyList() {
 		log.info("starting testGetPacientesEmptyList");
 		// Arrange
-		when(pacienteRepository.findByUserId(TEST_USER_ID)).thenReturn(new ArrayList<>());
+		when(pacienteRepository.findCalendarViewsByUserId(TEST_USER_ID)).thenReturn(new ArrayList<>());
 
 		// Act
 		final List<Map<String, Object>> result = calendarEventRestController.getPacientes(principal);
@@ -947,7 +948,7 @@ public class CalendarEventRestControllerTest {
 		// Assert
 		assertThat(result).isNotNull();
 		assertThat(result).isEmpty();
-		verify(pacienteRepository).findByUserId(TEST_USER_ID);
+		verify(pacienteRepository).findCalendarViewsByUserId(TEST_USER_ID);
 		log.info("finished testGetPacientesEmptyList");
 	}
 
@@ -2019,6 +2020,30 @@ public class CalendarEventRestControllerTest {
 		verify(pacienteRepository)
 			.save(org.mockito.ArgumentMatchers.argThat(p -> p.getImc() != null && p.getBmr() == null));
 		log.info("finished updateEvent_withExplicitImcOnly_updatesImcWithoutBmr");
+	}
+
+	private static PacienteCalendarView calendarViewFrom(final Paciente entity) {
+		return new PacienteCalendarView() {
+			@Override
+			public Long getId() {
+				return entity.getId();
+			}
+
+			@Override
+			public String getName() {
+				return entity.getName();
+			}
+
+			@Override
+			public Date getDob() {
+				return entity.getDob();
+			}
+
+			@Override
+			public String getGender() {
+				return entity.getGender();
+			}
+		};
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanControllerTest.java
@@ -1,7 +1,6 @@
 package com.nutriconsultas.mobile;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -23,8 +22,8 @@ import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.DietPlanPdfResult;
 import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
 import com.nutriconsultas.mobile.dto.PagedResponse;
-import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteDietaStatus;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
 
 @ExtendWith(MockitoExtension.class)
 class MobilePatientDietPlanControllerTest {
@@ -42,15 +41,13 @@ class MobilePatientDietPlanControllerTest {
 
 	@Test
 	void listDietPlans_returnsApiResponseEnvelope() {
-		final Paciente paciente = new Paciente();
-		paciente.setId(3L);
 		final DietPlanSummaryDto summary = new DietPlanSummaryDto(7L, PacienteDietaStatus.ACTIVE, null, null, null,
 				"Plan A", 2000, 100.0, 70.0, 250.0);
 		final PagedResponse<DietPlanSummaryDto> page = PagedResponse
 			.of(new PageImpl<>(List.of(summary), PageRequest.of(0, 20), 1));
 		final Jwt jwt = jwtWithSub(PATIENT_SUB);
 
-		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);
+		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(authView(3L));
 		when(mobilePatientDietPlanService.listDietPlans(3L, 0, 20, true)).thenReturn(page);
 
 		final ApiResponse<PagedResponse<DietPlanSummaryDto>> response = controller.listDietPlans(jwt, 0, 20, true);
@@ -63,13 +60,11 @@ class MobilePatientDietPlanControllerTest {
 
 	@Test
 	void getDietPlanPdf_returnsPdfResponseWithContentDisposition() {
-		final Paciente paciente = new Paciente();
-		paciente.setId(3L);
 		final Jwt jwt = jwtWithSub(PATIENT_SUB);
 		final byte[] pdfBytes = new byte[] { 37, 80, 68, 70 };
 		final DietPlanPdfResult pdf = new DietPlanPdfResult(pdfBytes, "Plan A.pdf");
 
-		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);
+		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(authView(3L));
 		when(mobilePatientDietPlanService.generateDietPlanPdf(3L, 7L)).thenReturn(pdf);
 
 		final ResponseEntity<byte[]> response = controller.getDietPlanPdf(jwt, 7L);
@@ -84,6 +79,25 @@ class MobilePatientDietPlanControllerTest {
 
 	private static Jwt jwtWithSub(final String subject) {
 		return Jwt.withTokenValue("token").header("alg", "none").subject(subject).build();
+	}
+
+	private static PacienteAuthView authView(final Long id) {
+		return new PacienteAuthView() {
+			@Override
+			public Long getId() {
+				return id;
+			}
+
+			@Override
+			public String getPatientAuthSub() {
+				return PATIENT_SUB;
+			}
+
+			@Override
+			public String getUserId() {
+				return "auth0|nutritionist";
+			}
+		};
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageControllerTest.java
@@ -20,7 +20,7 @@ import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.CursorPagedResponse;
 import com.nutriconsultas.mobile.dto.PatientMessageSummaryDto;
 import com.nutriconsultas.mobile.dto.SendPatientMessageRequest;
-import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
 
 @ExtendWith(MockitoExtension.class)
 class MobilePatientMessageControllerTest {
@@ -38,14 +38,12 @@ class MobilePatientMessageControllerTest {
 
 	@Test
 	void listMessages_returnsApiResponseEnvelope() {
-		final Paciente paciente = new Paciente();
-		paciente.setId(5L);
 		final PatientMessageSummaryDto summary = new PatientMessageSummaryDto(1L, Instant.parse("2026-06-01T12:00:00Z"),
 				MessageSenderRole.PATIENT, "Hola", true, null);
 		final CursorPagedResponse<PatientMessageSummaryDto> page = CursorPagedResponse.of(List.of(summary), null);
 		final Jwt jwt = jwtWithSub(PATIENT_SUB);
 
-		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);
+		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(authView(5L));
 		when(mobilePatientMessageService.listMessages(eq(5L), eq(null), eq(20))).thenReturn(page);
 
 		final ApiResponse<CursorPagedResponse<PatientMessageSummaryDto>> response = controller.listMessages(jwt, null,
@@ -59,14 +57,13 @@ class MobilePatientMessageControllerTest {
 
 	@Test
 	void sendMessage_returnsCreatedMessageInApiResponseEnvelope() {
-		final Paciente paciente = new Paciente();
-		paciente.setId(5L);
+		final PacienteAuthView authView = authView(5L);
 		final PatientMessageSummaryDto sent = new PatientMessageSummaryDto(9L, Instant.parse("2026-06-01T12:00:00Z"),
 				MessageSenderRole.PATIENT, "Hola doctor", true, null);
 		final Jwt jwt = jwtWithSub(PATIENT_SUB);
 
-		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);
-		when(mobilePatientMessageService.sendMessage(paciente, "Hola doctor")).thenReturn(sent);
+		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(authView);
+		when(mobilePatientMessageService.sendMessage(authView, "Hola doctor")).thenReturn(sent);
 
 		final ApiResponse<PatientMessageSummaryDto> response = controller.sendMessage(jwt,
 				new SendPatientMessageRequest("Hola doctor"));
@@ -74,11 +71,30 @@ class MobilePatientMessageControllerTest {
 		assertThat(response.data().id()).isEqualTo(9L);
 		assertThat(response.data().senderRole()).isEqualTo(MessageSenderRole.PATIENT);
 		assertThat(response.data().body()).isEqualTo("Hola doctor");
-		verify(mobilePatientMessageService).sendMessage(paciente, "Hola doctor");
+		verify(mobilePatientMessageService).sendMessage(authView, "Hola doctor");
 	}
 
 	private static Jwt jwtWithSub(final String subject) {
 		return Jwt.withTokenValue("token").header("alg", "none").subject(subject).build();
+	}
+
+	private static PacienteAuthView authView(final Long id) {
+		return new PacienteAuthView() {
+			@Override
+			public Long getId() {
+				return id;
+			}
+
+			@Override
+			public String getPatientAuthSub() {
+				return PATIENT_SUB;
+			}
+
+			@Override
+			public String getUserId() {
+				return "auth0|nutritionist-owner";
+			}
+		};
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageServiceTest.java
@@ -25,6 +25,8 @@ import com.nutriconsultas.message.PatientMessageRepository;
 import com.nutriconsultas.mobile.dto.CursorPagedResponse;
 import com.nutriconsultas.mobile.dto.PatientMessageSummaryDto;
 import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
 import com.nutriconsultas.profile.NutritionistProfile;
 import com.nutriconsultas.profile.NutritionistProfileRepository;
 
@@ -41,6 +43,9 @@ class MobilePatientMessageServiceTest {
 
 	@Mock
 	private NutritionistProfileRepository nutritionistProfileRepository;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
 
 	@Mock
 	private PatientWriteRateLimiter patientWriteRateLimiter;
@@ -111,10 +116,10 @@ class MobilePatientMessageServiceTest {
 
 	@Test
 	void sendMessage_doesNotIncludeSenderDisplayNameForPatientMessages() throws Exception {
-		final Paciente paciente = new Paciente();
-		paciente.setId(5L);
-		paciente.setUserId("auth0|nutritionist-owner");
-		paciente.setPatientAuthSub("auth0|mobile-message-patient");
+		final PacienteAuthView authView = authView(5L, "auth0|nutritionist-owner", "auth0|mobile-message-patient");
+		final Paciente pacienteRef = new Paciente();
+		pacienteRef.setId(5L);
+		when(pacienteRepository.getReferenceById(5L)).thenReturn(pacienteRef);
 		when(patientWriteRateLimiter.execute(eq(PatientWriteRateLimiter.PATIENT_MESSAGES),
 				eq("auth0|mobile-message-patient"), any(Callable.class)))
 			.thenAnswer(invocation -> {
@@ -130,7 +135,7 @@ class MobilePatientMessageServiceTest {
 			return saved;
 		});
 
-		final PatientMessageSummaryDto sent = service.sendMessage(paciente, "  Hola doctor  ");
+		final PatientMessageSummaryDto sent = service.sendMessage(authView, "  Hola doctor  ");
 
 		assertThat(sent.id()).isEqualTo(77L);
 		assertThat(sent.senderRole()).isEqualTo(MessageSenderRole.PATIENT);
@@ -141,7 +146,26 @@ class MobilePatientMessageServiceTest {
 		verify(patientMessageRepository).save(captor.capture());
 		assertThat(captor.getValue().getSenderRole()).isEqualTo(MessageSenderRole.PATIENT);
 		assertThat(captor.getValue().getNutritionistUserId()).isEqualTo("auth0|nutritionist-owner");
-		assertThat(captor.getValue().getPaciente()).isSameAs(paciente);
+		assertThat(captor.getValue().getPaciente()).isSameAs(pacienteRef);
+	}
+
+	private static PacienteAuthView authView(final Long id, final String userId, final String patientAuthSub) {
+		return new PacienteAuthView() {
+			@Override
+			public Long getId() {
+				return id;
+			}
+
+			@Override
+			public String getPatientAuthSub() {
+				return patientAuthSub;
+			}
+
+			@Override
+			public String getUserId() {
+				return userId;
+			}
+		};
 	}
 
 	private static PatientMessage sampleMessage(final Long id, final String body) {

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientProgressControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientProgressControllerTest.java
@@ -19,7 +19,7 @@ import com.nutriconsultas.mobile.dto.PatientProgressSnapshotDto;
 import com.nutriconsultas.mobile.dto.ProgressMeasurementPointDto;
 import com.nutriconsultas.mobile.dto.ProgressMeasurementsDto;
 import com.nutriconsultas.paciente.NivelPeso;
-import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
 
 @ExtendWith(MockitoExtension.class)
 class MobilePatientProgressControllerTest {
@@ -37,14 +37,12 @@ class MobilePatientProgressControllerTest {
 
 	@Test
 	void getProgress_returnsApiResponseEnvelope() {
-		final Paciente paciente = new Paciente();
-		paciente.setId(5L);
 		final PatientProgressSnapshotDto snapshot = new PatientProgressSnapshotDto(
 				Instant.parse("2026-06-01T10:00:00Z"), null, 70.0, 1.70, 24.2, NivelPeso.NORMAL, "Normal", 1500.0, 22.0,
 				null, null, null);
 		final Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject(PATIENT_SUB).build();
 
-		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);
+		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(authView(5L));
 		when(mobilePatientProgressService.getSnapshot(5L)).thenReturn(snapshot);
 
 		final ApiResponse<PatientProgressSnapshotDto> response = controller.getProgress(jwt);
@@ -57,14 +55,12 @@ class MobilePatientProgressControllerTest {
 
 	@Test
 	void listMeasurements_returnsApiResponseEnvelope() {
-		final Paciente paciente = new Paciente();
-		paciente.setId(5L);
 		final ProgressMeasurementsDto series = new ProgressMeasurementsDto(List
 			.of(new ProgressMeasurementPointDto(Instant.parse("2026-06-01T10:00:00Z"), 70.0, 1.70, 24.2, 22.0, null)),
 				1, false);
 		final Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject(PATIENT_SUB).build();
 
-		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);
+		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(authView(5L));
 		when(mobilePatientProgressService.listMeasurements(5L, null, null, null)).thenReturn(series);
 
 		final ApiResponse<ProgressMeasurementsDto> response = controller.listMeasurements(jwt, null, null, null);
@@ -74,6 +70,25 @@ class MobilePatientProgressControllerTest {
 		assertThat(response.data().measurements().get(0).weightKg()).isEqualTo(70.0);
 		assertThat(response.timestamp()).isNotNull();
 		verify(mobilePatientProgressService).listMeasurements(5L, null, null, null);
+	}
+
+	private static PacienteAuthView authView(final Long id) {
+		return new PacienteAuthView() {
+			@Override
+			public Long getId() {
+				return id;
+			}
+
+			@Override
+			public String getPatientAuthSub() {
+				return PATIENT_SUB;
+			}
+
+			@Override
+			public String getUserId() {
+				return "auth0|nutritionist";
+			}
+		};
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitControllerTest.java
@@ -21,7 +21,7 @@ import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.PagedResponse;
 import com.nutriconsultas.mobile.dto.VisitDetailDto;
 import com.nutriconsultas.mobile.dto.VisitSummaryDto;
-import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
 
 @ExtendWith(MockitoExtension.class)
 class MobilePatientVisitControllerTest {
@@ -39,14 +39,12 @@ class MobilePatientVisitControllerTest {
 
 	@Test
 	void listVisits_returnsApiResponseEnvelope() {
-		final Paciente paciente = new Paciente();
-		paciente.setId(5L);
 		final VisitSummaryDto summary = new VisitSummaryDto(1L, null, "Consulta", EventStatus.SCHEDULED, 45, null);
 		final PagedResponse<VisitSummaryDto> page = PagedResponse
 			.of(new PageImpl<>(List.of(summary), PageRequest.of(0, 20), 1));
 		final Jwt jwt = jwtWithSub(PATIENT_SUB);
 
-		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);
+		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(authView(5L, PATIENT_SUB));
 		when(mobilePatientVisitService.listVisits(eq(5L), eq(0), eq(20), eq(null), eq(null), eq(null)))
 			.thenReturn(page);
 
@@ -61,13 +59,11 @@ class MobilePatientVisitControllerTest {
 
 	@Test
 	void getVisitDetail_returnsApiResponseEnvelope() {
-		final Paciente paciente = new Paciente();
-		paciente.setId(5L);
 		final VisitDetailDto detail = new VisitDetailDto(8L, null, "Consulta", EventStatus.SCHEDULED, 45, null,
 				"Descripción", null, null, null, null, null, null, null, null, null, null, null);
 		final Jwt jwt = jwtWithSub(PATIENT_SUB);
 
-		when(patientAuthService.requirePacienteByJwt(jwt)).thenReturn(paciente);
+		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(authView(5L, PATIENT_SUB));
 		when(mobilePatientVisitService.getVisitDetail(5L, 8L)).thenReturn(detail);
 
 		final ApiResponse<VisitDetailDto> response = controller.getVisitDetail(jwt, 8L);
@@ -80,6 +76,25 @@ class MobilePatientVisitControllerTest {
 
 	private static Jwt jwtWithSub(final String subject) {
 		return Jwt.withTokenValue("token").header("alg", "none").subject(subject).build();
+	}
+
+	private static PacienteAuthView authView(final Long id, final String patientAuthSub) {
+		return new PacienteAuthView() {
+			@Override
+			public Long getId() {
+				return id;
+			}
+
+			@Override
+			public String getPatientAuthSub() {
+				return patientAuthSub;
+			}
+
+			@Override
+			public String getUserId() {
+				return "auth0|nutritionist";
+			}
+		};
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/mobile/MobilePhiLoggingIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePhiLoggingIntegrationTest.java
@@ -19,6 +19,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.nutriconsultas.message.PatientMessage;
 import com.nutriconsultas.message.PatientMessageRepository;
 import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
+import com.nutriconsultas.profile.NutritionistProfileRepository;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -38,6 +41,12 @@ class MobilePhiLoggingIntegrationTest {
 
 	@Mock
 	private PatientMessageRepository patientMessageRepository;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Mock
+	private NutritionistProfileRepository nutritionistProfileRepository;
 
 	@Mock
 	private PatientWriteRateLimiter patientWriteRateLimiter;
@@ -64,10 +73,25 @@ class MobilePhiLoggingIntegrationTest {
 
 	@Test
 	void sendMessage_doesNotLogMessageBodyOrRawAuthSub() throws Exception {
-		final Paciente paciente = new Paciente();
-		paciente.setId(12L);
-		paciente.setUserId("auth0|nutritionist-owner");
-		paciente.setPatientAuthSub(PATIENT_SUB);
+		final PacienteAuthView authView = new PacienteAuthView() {
+			@Override
+			public Long getId() {
+				return 12L;
+			}
+
+			@Override
+			public String getPatientAuthSub() {
+				return PATIENT_SUB;
+			}
+
+			@Override
+			public String getUserId() {
+				return "auth0|nutritionist-owner";
+			}
+		};
+		final Paciente pacienteRef = new Paciente();
+		pacienteRef.setId(12L);
+		when(pacienteRepository.getReferenceById(12L)).thenReturn(pacienteRef);
 		when(patientWriteRateLimiter.execute(eq(PatientWriteRateLimiter.PATIENT_MESSAGES), eq(PATIENT_SUB),
 				any(Callable.class)))
 			.thenAnswer(invocation -> {
@@ -83,7 +107,7 @@ class MobilePhiLoggingIntegrationTest {
 			return saved;
 		});
 
-		service.sendMessage(paciente, PHI_MESSAGE_BODY);
+		service.sendMessage(authView, PHI_MESSAGE_BODY);
 
 		assertThat(logAppender.list).isNotEmpty();
 		for (final ILoggingEvent event : logAppender.list) {

--- a/src/test/java/com/nutriconsultas/mobile/PatientAuthLinkageServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/PatientAuthLinkageServiceTest.java
@@ -24,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.nutriconsultas.auth0.Auth0UserLookup;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
 
 @ExtendWith(MockitoExtension.class)
 class PatientAuthLinkageServiceTest {
@@ -63,7 +64,7 @@ class PatientAuthLinkageServiceTest {
 
 	@Test
 	void linkBySub_setsPatientAuthSub() {
-		when(pacienteRepository.findByPatientAuthSub(PATIENT_SUB)).thenReturn(Optional.empty());
+		when(pacienteRepository.findAuthViewByPatientAuthSub(PATIENT_SUB)).thenReturn(Optional.empty());
 		when(pacienteRepository.save(any(Paciente.class))).thenAnswer(inv -> inv.getArgument(0));
 
 		final Paciente linked = service.linkBySub(1L, NUTRITIONIST_SUB, PATIENT_SUB);
@@ -76,7 +77,7 @@ class PatientAuthLinkageServiceTest {
 	void linkBySub_whenSubAlreadyUsedByOtherPatient_throws() {
 		final Paciente other = samplePaciente(99L, "other@example.com");
 		other.setPatientAuthSub(PATIENT_SUB);
-		when(pacienteRepository.findByPatientAuthSub(PATIENT_SUB)).thenReturn(Optional.of(other));
+		when(pacienteRepository.findAuthViewByPatientAuthSub(PATIENT_SUB)).thenReturn(Optional.of(authView(other)));
 
 		assertThatThrownBy(() -> service.linkBySub(1L, NUTRITIONIST_SUB, PATIENT_SUB))
 			.isInstanceOf(PatientAuthSubAlreadyLinkedException.class);
@@ -87,7 +88,7 @@ class PatientAuthLinkageServiceTest {
 	void linkByEmail_usesAuth0Lookup() {
 		when(auth0UserLookup.isConfigured()).thenReturn(true);
 		when(auth0UserLookup.findUserIdByEmail("patient@example.com")).thenReturn(Optional.of(PATIENT_SUB));
-		when(pacienteRepository.findByPatientAuthSub(PATIENT_SUB)).thenReturn(Optional.empty());
+		when(pacienteRepository.findAuthViewByPatientAuthSub(PATIENT_SUB)).thenReturn(Optional.empty());
 		when(pacienteRepository.save(any(Paciente.class))).thenAnswer(inv -> inv.getArgument(0));
 
 		final Paciente linked = service.linkByEmail(1L, NUTRITIONIST_SUB);
@@ -143,6 +144,25 @@ class PatientAuthLinkageServiceTest {
 		assertThat(status.isLinked()).isTrue();
 		assertThat(status.getPatientAuthSubRedacted()).contains("…");
 		assertThat(status.getPatientAuthSubRedacted()).doesNotContain(PATIENT_SUB);
+	}
+
+	private static PacienteAuthView authView(final Paciente entity) {
+		return new PacienteAuthView() {
+			@Override
+			public Long getId() {
+				return entity.getId();
+			}
+
+			@Override
+			public String getPatientAuthSub() {
+				return entity.getPatientAuthSub();
+			}
+
+			@Override
+			public String getUserId() {
+				return entity.getUserId();
+			}
+		};
 	}
 
 	private static Paciente samplePaciente(final Long id, final String email) {

--- a/src/test/java/com/nutriconsultas/mobile/PatientAuthServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/PatientAuthServiceTest.java
@@ -4,9 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.Date;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -16,13 +13,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.jwt.Jwt;
 
-import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
 
 @ExtendWith(MockitoExtension.class)
 class PatientAuthServiceTest {
 
 	private static final String LINKED_SUB = "auth0|linked-patient";
+
+	private static final String NUTRITIONIST_SUB = "nutritionist-sub";
 
 	@Mock
 	private PacienteRepository pacienteRepository;
@@ -31,28 +30,27 @@ class PatientAuthServiceTest {
 	private PatientAuthService patientAuthService;
 
 	@Test
-	void findByJwt_returnsPacienteWhenPatientAuthSubMatches() {
-		final Paciente paciente = samplePaciente(LINKED_SUB);
-		when(pacienteRepository.findByPatientAuthSub(LINKED_SUB)).thenReturn(Optional.of(paciente));
+	void findAuthViewByJwt_returnsViewWhenPatientAuthSubMatches() {
+		final PacienteAuthView authView = sampleAuthView(LINKED_SUB, 7L);
+		when(pacienteRepository.findAuthViewByPatientAuthSub(LINKED_SUB)).thenReturn(Optional.of(authView));
 
-		final Optional<Paciente> result = patientAuthService.findByJwt(jwtWithSub(LINKED_SUB));
+		final Optional<PacienteAuthView> result = patientAuthService.findAuthViewByJwt(jwtWithSub(LINKED_SUB));
 
-		assertThat(result).contains(paciente);
+		assertThat(result).contains(authView);
 	}
 
 	@Test
-	void requirePacienteByJwt_throwsWhenSubIsUnlinked() {
-		when(pacienteRepository.findByPatientAuthSub("auth0|unknown")).thenReturn(Optional.empty());
+	void requireAuthViewByJwt_throwsWhenSubIsUnlinked() {
+		when(pacienteRepository.findAuthViewByPatientAuthSub("auth0|unknown")).thenReturn(Optional.empty());
 
-		assertThatThrownBy(() -> patientAuthService.requirePacienteByJwt(jwtWithSub("auth0|unknown")))
+		assertThatThrownBy(() -> patientAuthService.requireAuthViewByJwt(jwtWithSub("auth0|unknown")))
 			.isInstanceOf(PatientNotLinkedException.class);
 	}
 
 	@Test
 	void resolvePrincipal_returnsNonPhiIdentifiers() {
-		final Paciente paciente = samplePaciente(LINKED_SUB);
-		paciente.setId(42L);
-		when(pacienteRepository.findByPatientAuthSub(LINKED_SUB)).thenReturn(Optional.of(paciente));
+		final PacienteAuthView authView = sampleAuthView(LINKED_SUB, 42L);
+		when(pacienteRepository.findAuthViewByPatientAuthSub(LINKED_SUB)).thenReturn(Optional.of(authView));
 
 		final PatientPrincipal principal = patientAuthService.resolvePrincipal(jwtWithSub(LINKED_SUB));
 
@@ -68,15 +66,23 @@ class PatientAuthServiceTest {
 			.build();
 	}
 
-	private static Paciente samplePaciente(final String patientAuthSub) {
-		final Paciente paciente = new Paciente();
-		paciente.setName("Test Patient");
-		paciente.setUserId("nutritionist-sub");
-		paciente.setPatientAuthSub(patientAuthSub);
-		final LocalDate dob = LocalDate.now().minusYears(30);
-		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
-		paciente.setGender("M");
-		return paciente;
+	private static PacienteAuthView sampleAuthView(final String patientAuthSub, final Long id) {
+		return new PacienteAuthView() {
+			@Override
+			public Long getId() {
+				return id;
+			}
+
+			@Override
+			public String getPatientAuthSub() {
+				return patientAuthSub;
+			}
+
+			@Override
+			public String getUserId() {
+				return NUTRITIONIST_SUB;
+			}
+		};
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/paciente/PacienteProjectionRepositoryTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteProjectionRepositoryTest.java
@@ -1,0 +1,98 @@
+package com.nutriconsultas.paciente;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
+import com.nutriconsultas.paciente.projection.PacienteCalendarView;
+import com.nutriconsultas.paciente.projection.PacienteListView;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class PacienteProjectionRepositoryTest {
+
+	private static final String USER_ID = "nutritionist-projection-test";
+
+	private static final String PATIENT_SUB = "auth0|projection-patient";
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@BeforeEach
+	void seedPaciente() {
+		pacienteRepository.deleteAll();
+		pacienteRepository.save(samplePaciente());
+	}
+
+	@Test
+	void findListViewsByUserId_returnsGridFieldsWithoutLoadingFullEntity() {
+		final Page<PacienteListView> page = pacienteRepository.findListViewsByUserId(USER_ID, PageRequest.of(0, 10));
+
+		assertThat(page.getContent()).hasSize(1);
+		final PacienteListView view = page.getContent().get(0);
+		assertThat(view.getName()).isEqualTo("Projection Grid Patient");
+		assertThat(view.getEmail()).isEqualTo("grid@example.com");
+		assertThat(view.getPhone()).isEqualTo("5551234");
+		assertThat(view.getGender()).isEqualTo("F");
+		assertThat(view.getResponsibleName()).isEqualTo("Tutor Test");
+	}
+
+	@Test
+	void findListViewsByUserIdAndSearchTerm_matchesNameEmailOrPhone() {
+		final Page<PacienteListView> byEmail = pacienteRepository.findListViewsByUserIdAndSearchTerm(USER_ID,
+				"%grid@example%", PageRequest.of(0, 10));
+		final List<PacienteListView> byPhone = pacienteRepository.findListViewsByUserIdAndSearchTerm(USER_ID,
+				"%5551234");
+
+		assertThat(byEmail.getContent()).hasSize(1);
+		assertThat(byPhone).hasSize(1);
+	}
+
+	@Test
+	void findAuthViewByPatientAuthSub_returnsIdentityFields() {
+		final Optional<PacienteAuthView> authView = pacienteRepository.findAuthViewByPatientAuthSub(PATIENT_SUB);
+
+		assertThat(authView).isPresent();
+		assertThat(authView.orElseThrow().getUserId()).isEqualTo(USER_ID);
+		assertThat(authView.orElseThrow().getPatientAuthSub()).isEqualTo(PATIENT_SUB);
+	}
+
+	@Test
+	void findCalendarViewsByUserId_returnsCalendarDropdownFields() {
+		final List<PacienteCalendarView> views = pacienteRepository.findCalendarViewsByUserId(USER_ID);
+
+		assertThat(views).hasSize(1);
+		assertThat(views.get(0).getName()).isEqualTo("Projection Grid Patient");
+		assertThat(views.get(0).getGender()).isEqualTo("F");
+		assertThat(views.get(0).getDob()).isNotNull();
+	}
+
+	private static Paciente samplePaciente() {
+		final Paciente paciente = new Paciente();
+		paciente.setName("Projection Grid Patient");
+		paciente.setUserId(USER_ID);
+		paciente.setPatientAuthSub(PATIENT_SUB);
+		paciente.setEmail("grid@example.com");
+		paciente.setPhone("5551234");
+		paciente.setGender("F");
+		paciente.setResponsibleName("Tutor Test");
+		paciente.setAntecedentesPatologicosPersonales("Heavy TEXT antecedentes should not be required for list views");
+		final LocalDate dob = LocalDate.now().minusYears(28);
+		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		return paciente;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/PacienteRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteRestControllerTest.java
@@ -39,6 +39,7 @@ import com.nutriconsultas.dataTables.paging.Order;
 import com.nutriconsultas.dataTables.paging.PageArray;
 import com.nutriconsultas.dataTables.paging.PagingRequest;
 import com.nutriconsultas.dataTables.paging.Search;
+import com.nutriconsultas.paciente.projection.PacienteListView;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -109,7 +110,8 @@ public class PacienteRestControllerTest {
 		// Arrange
 		final Pageable pageable = PageRequest.of(0, 10);
 		final Page<Paciente> springPage = new PageImpl<>(Arrays.asList(paciente1, paciente2), pageable, 2);
-		when(service.findAllByUserId(eq(TEST_USER_ID), any(Pageable.class))).thenReturn(springPage);
+		when(service.findListViewsByUserId(eq(TEST_USER_ID), any(Pageable.class)))
+			.thenReturn(toListViewPage(springPage));
 		when(service.countByUserId(eq(TEST_USER_ID))).thenReturn(2L);
 
 		final PagingRequest pagingRequest = new PagingRequest();
@@ -129,7 +131,7 @@ public class PacienteRestControllerTest {
 		assertThat(result.getDraw()).isEqualTo(1);
 		assertThat(result.getData()).isNotEmpty();
 		assertThat(result.getData().size()).isEqualTo(2);
-		verify(service).findAllByUserId(eq(TEST_USER_ID), any(Pageable.class));
+		verify(service).findListViewsByUserId(eq(TEST_USER_ID), any(Pageable.class));
 		verify(service, times(2)).countByUserId(eq(TEST_USER_ID));
 		log.info("finished testGetPageArray");
 	}
@@ -140,8 +142,8 @@ public class PacienteRestControllerTest {
 		// Arrange
 		final Pageable pageable = PageRequest.of(0, 10);
 		final Page<Paciente> springPage = new PageImpl<>(Arrays.asList(paciente1), pageable, 1);
-		when(service.findAllByUserIdAndSearchTerm(eq(TEST_USER_ID), eq("juan"), any(Pageable.class)))
-			.thenReturn(springPage);
+		when(service.findListViewsByUserIdAndSearchTerm(eq(TEST_USER_ID), eq("juan"), any(Pageable.class)))
+			.thenReturn(toListViewPage(springPage));
 		when(service.countByUserIdAndSearchTerm(eq(TEST_USER_ID), eq("juan"))).thenReturn(1L);
 		when(service.countByUserId(eq(TEST_USER_ID))).thenReturn(2L);
 
@@ -162,7 +164,7 @@ public class PacienteRestControllerTest {
 		assertThat(result.getDraw()).isEqualTo(1);
 		assertThat(result.getData()).isNotEmpty();
 		assertThat(result.getData().size()).isEqualTo(1);
-		verify(service).findAllByUserIdAndSearchTerm(eq(TEST_USER_ID), eq("juan"), any(Pageable.class));
+		verify(service).findListViewsByUserIdAndSearchTerm(eq(TEST_USER_ID), eq("juan"), any(Pageable.class));
 		verify(service).countByUserIdAndSearchTerm(eq(TEST_USER_ID), eq("juan"));
 		verify(service).countByUserId(eq(TEST_USER_ID));
 		log.info("finished testGetPageArrayWithSearch");
@@ -196,7 +198,8 @@ public class PacienteRestControllerTest {
 		// Arrange - Request second page with 1 item per page
 		final Pageable pageable = PageRequest.of(1, 1);
 		final Page<Paciente> springPage = new PageImpl<>(Arrays.asList(paciente2), pageable, 2);
-		when(service.findAllByUserId(eq(TEST_USER_ID), any(Pageable.class))).thenReturn(springPage);
+		when(service.findListViewsByUserId(eq(TEST_USER_ID), any(Pageable.class)))
+			.thenReturn(toListViewPage(springPage));
 		when(service.countByUserId(eq(TEST_USER_ID))).thenReturn(2L);
 
 		final PagingRequest pagingRequest = new PagingRequest();
@@ -214,7 +217,7 @@ public class PacienteRestControllerTest {
 		assertThat(result.getRecordsTotal()).isEqualTo(2);
 		assertThat(result.getRecordsFiltered()).isEqualTo(2);
 		assertThat(result.getData()).hasSize(1);
-		verify(service).findAllByUserId(eq(TEST_USER_ID), any(Pageable.class));
+		verify(service).findListViewsByUserId(eq(TEST_USER_ID), any(Pageable.class));
 		log.info("finished testGetPageArrayWithPagination");
 	}
 
@@ -225,7 +228,8 @@ public class PacienteRestControllerTest {
 		final Pageable pageable = PageRequest.of(0, 10,
 				org.springframework.data.domain.Sort.by(org.springframework.data.domain.Sort.Direction.ASC, "name"));
 		final Page<Paciente> springPage = new PageImpl<>(Arrays.asList(paciente1, paciente2), pageable, 2);
-		when(service.findAllByUserId(eq(TEST_USER_ID), any(Pageable.class))).thenReturn(springPage);
+		when(service.findListViewsByUserId(eq(TEST_USER_ID), any(Pageable.class)))
+			.thenReturn(toListViewPage(springPage));
 		when(service.countByUserId(eq(TEST_USER_ID))).thenReturn(2L);
 
 		final PagingRequest pagingRequest = new PagingRequest();
@@ -242,7 +246,7 @@ public class PacienteRestControllerTest {
 		// Assert
 		assertThat(result).isNotNull();
 		assertThat(result.getRecordsTotal()).isEqualTo(2);
-		verify(service).findAllByUserId(eq(TEST_USER_ID), any(Pageable.class));
+		verify(service).findListViewsByUserId(eq(TEST_USER_ID), any(Pageable.class));
 		log.info("finished testGetPageArrayWithSorting");
 	}
 
@@ -250,7 +254,7 @@ public class PacienteRestControllerTest {
 	public void testToStringList() {
 		log.info("starting testToStringList");
 		// Act
-		final List<String> result = controller.toStringList(paciente1);
+		final List<String> result = controller.toStringList(toListView(paciente1));
 
 		// Assert
 		assertThat(result).isNotNull();
@@ -279,7 +283,7 @@ public class PacienteRestControllerTest {
 		paciente.setResponsibleName(null);
 
 		// Act
-		final List<String> result = controller.toStringList(paciente);
+		final List<String> result = controller.toStringList(toListView(paciente));
 
 		// Assert
 		assertThat(result).isNotNull();
@@ -316,7 +320,8 @@ public class PacienteRestControllerTest {
 		// Arrange
 		final Pageable pageable = PageRequest.of(0, 10);
 		final Page<Paciente> springPage = new PageImpl<>(Arrays.asList(paciente1, paciente2), pageable, 2);
-		when(service.findAllByUserId(eq(TEST_USER_ID), any(Pageable.class))).thenReturn(springPage);
+		when(service.findListViewsByUserId(eq(TEST_USER_ID), any(Pageable.class)))
+			.thenReturn(toListViewPage(springPage));
 		when(service.countByUserId(eq(TEST_USER_ID))).thenReturn(2L);
 
 		final PagingRequest pagingRequest = new PagingRequest();
@@ -328,7 +333,7 @@ public class PacienteRestControllerTest {
 		pagingRequest.setColumns(controller.getColumns());
 
 		// Act
-		final com.nutriconsultas.dataTables.paging.Page<Paciente> result = controller.getRows(pagingRequest,
+		final com.nutriconsultas.dataTables.paging.Page<PacienteListView> result = controller.getRows(pagingRequest,
 				TEST_USER_ID);
 
 		// Assert
@@ -336,7 +341,7 @@ public class PacienteRestControllerTest {
 		assertThat(result.getRecordsTotal()).isEqualTo(2);
 		assertThat(result.getRecordsFiltered()).isEqualTo(2);
 		assertThat(result.getData()).hasSize(2);
-		verify(service).findAllByUserId(eq(TEST_USER_ID), any(Pageable.class));
+		verify(service).findListViewsByUserId(eq(TEST_USER_ID), any(Pageable.class));
 		log.info("finished testGetRows");
 	}
 
@@ -346,8 +351,8 @@ public class PacienteRestControllerTest {
 		// Arrange
 		final Pageable pageable = PageRequest.of(0, 10);
 		final Page<Paciente> springPage = new PageImpl<>(Arrays.asList(paciente1), pageable, 1);
-		when(service.findAllByUserIdAndSearchTerm(eq(TEST_USER_ID), eq("juan"), any(Pageable.class)))
-			.thenReturn(springPage);
+		when(service.findListViewsByUserIdAndSearchTerm(eq(TEST_USER_ID), eq("juan"), any(Pageable.class)))
+			.thenReturn(toListViewPage(springPage));
 		when(service.countByUserIdAndSearchTerm(eq(TEST_USER_ID), eq("juan"))).thenReturn(1L);
 		when(service.countByUserId(eq(TEST_USER_ID))).thenReturn(2L);
 
@@ -360,7 +365,7 @@ public class PacienteRestControllerTest {
 		pagingRequest.setColumns(controller.getColumns());
 
 		// Act
-		final com.nutriconsultas.dataTables.paging.Page<Paciente> result = controller.getRows(pagingRequest,
+		final com.nutriconsultas.dataTables.paging.Page<PacienteListView> result = controller.getRows(pagingRequest,
 				TEST_USER_ID);
 
 		// Assert
@@ -368,7 +373,7 @@ public class PacienteRestControllerTest {
 		assertThat(result.getRecordsTotal()).isEqualTo(2);
 		assertThat(result.getRecordsFiltered()).isEqualTo(1);
 		assertThat(result.getData()).hasSize(1);
-		verify(service).findAllByUserIdAndSearchTerm(eq(TEST_USER_ID), eq("juan"), any(Pageable.class));
+		verify(service).findListViewsByUserIdAndSearchTerm(eq(TEST_USER_ID), eq("juan"), any(Pageable.class));
 		verify(service).countByUserIdAndSearchTerm(eq(TEST_USER_ID), eq("juan"));
 		log.info("finished testGetRowsWithSearch");
 	}
@@ -447,6 +452,49 @@ public class PacienteRestControllerTest {
 				new HashMap<>(java.util.Map.of("bmr", "1650.0")), null);
 
 		assertThat(response.getStatusCode().value()).isEqualTo(401);
+	}
+
+	private static PacienteListView toListView(final Paciente paciente) {
+		return new PacienteListView() {
+			@Override
+			public Long getId() {
+				return paciente.getId();
+			}
+
+			@Override
+			public String getName() {
+				return paciente.getName();
+			}
+
+			@Override
+			public String getEmail() {
+				return paciente.getEmail();
+			}
+
+			@Override
+			public String getPhone() {
+				return paciente.getPhone();
+			}
+
+			@Override
+			public Date getDob() {
+				return paciente.getDob();
+			}
+
+			@Override
+			public String getGender() {
+				return paciente.getGender();
+			}
+
+			@Override
+			public String getResponsibleName() {
+				return paciente.getResponsibleName();
+			}
+		};
+	}
+
+	private static Page<PacienteListView> toListViewPage(final Page<Paciente> springPage) {
+		return springPage.map(PacienteRestControllerTest::toListView);
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/search/SearchServiceTest.java
+++ b/src/test/java/com/nutriconsultas/search/SearchServiceTest.java
@@ -26,6 +26,7 @@ import com.nutriconsultas.clinical.exam.ClinicalExam;
 import com.nutriconsultas.clinical.exam.ClinicalExamRepository;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.projection.PacienteListView;
 import com.nutriconsultas.platillos.Platillo;
 import com.nutriconsultas.platillos.PlatilloRepository;
 
@@ -58,6 +59,8 @@ public class SearchServiceTest {
 
 	private Paciente paciente;
 
+	private PacienteListView pacienteListView;
+
 	private Alimento alimento;
 
 	private Platillo platillo;
@@ -77,6 +80,7 @@ public class SearchServiceTest {
 		paciente.setEmail("juan@example.com");
 		paciente.setPhone("1234567890");
 		paciente.setUserId(TEST_USER_ID);
+		pacienteListView = listViewFrom(paciente);
 
 		// Create test alimento
 		alimento = new Alimento();
@@ -115,8 +119,8 @@ public class SearchServiceTest {
 		log.info("starting testSearchWithResults");
 		// Arrange
 		final String query = "Juan";
-		when(pacienteRepository.findByUserIdAndSearchTerm(eq(TEST_USER_ID), any(String.class)))
-			.thenReturn(Arrays.asList(paciente));
+		when(pacienteRepository.findListViewsByUserIdAndSearchTerm(eq(TEST_USER_ID), any(String.class)))
+			.thenReturn(Arrays.asList(pacienteListView));
 		when(alimentosRepository.findByNombreAlimentoContainingIgnoreCase(query)).thenReturn(new ArrayList<>());
 		when(platilloRepository.findByNameContainingIgnoreCase(query)).thenReturn(new ArrayList<>());
 		when(calendarEventRepository.findByUserIdAndSearchTerm(eq(TEST_USER_ID), any(String.class)))
@@ -139,7 +143,7 @@ public class SearchServiceTest {
 		assertThat(result.getClinicalExams().getTotalCount()).isEqualTo(1);
 		assertThat(result.getTotalResults()).isEqualTo(3);
 
-		verify(pacienteRepository).findByUserIdAndSearchTerm(eq(TEST_USER_ID), any(String.class));
+		verify(pacienteRepository).findListViewsByUserIdAndSearchTerm(eq(TEST_USER_ID), any(String.class));
 		verify(alimentosRepository).findByNombreAlimentoContainingIgnoreCase(query);
 		verify(platilloRepository).findByNameContainingIgnoreCase(query);
 		verify(calendarEventRepository).findByUserIdAndSearchTerm(eq(TEST_USER_ID), any(String.class));
@@ -152,7 +156,7 @@ public class SearchServiceTest {
 		log.info("starting testSearchWithNoResults");
 		// Arrange
 		final String query = "Nonexistent";
-		when(pacienteRepository.findByUserIdAndSearchTerm(eq(TEST_USER_ID), any(String.class)))
+		when(pacienteRepository.findListViewsByUserIdAndSearchTerm(eq(TEST_USER_ID), any(String.class)))
 			.thenReturn(new ArrayList<>());
 		when(alimentosRepository.findByNombreAlimentoContainingIgnoreCase(query)).thenReturn(new ArrayList<>());
 		when(platilloRepository.findByNameContainingIgnoreCase(query)).thenReturn(new ArrayList<>());
@@ -181,7 +185,7 @@ public class SearchServiceTest {
 		log.info("starting testSearchAlimentos");
 		// Arrange
 		final String query = "Manzana";
-		when(pacienteRepository.findByUserIdAndSearchTerm(eq(TEST_USER_ID), any(String.class)))
+		when(pacienteRepository.findListViewsByUserIdAndSearchTerm(eq(TEST_USER_ID), any(String.class)))
 			.thenReturn(new ArrayList<>());
 		when(alimentosRepository.findByNombreAlimentoContainingIgnoreCase(query)).thenReturn(Arrays.asList(alimento));
 		when(platilloRepository.findByNameContainingIgnoreCase(query)).thenReturn(new ArrayList<>());
@@ -208,7 +212,7 @@ public class SearchServiceTest {
 		log.info("starting testSearchPlatillos");
 		// Arrange
 		final String query = "Ensalada";
-		when(pacienteRepository.findByUserIdAndSearchTerm(eq(TEST_USER_ID), any(String.class)))
+		when(pacienteRepository.findListViewsByUserIdAndSearchTerm(eq(TEST_USER_ID), any(String.class)))
 			.thenReturn(new ArrayList<>());
 		when(alimentosRepository.findByNombreAlimentoContainingIgnoreCase(query)).thenReturn(new ArrayList<>());
 		when(platilloRepository.findByNameContainingIgnoreCase(query)).thenReturn(Arrays.asList(platillo));
@@ -228,6 +232,45 @@ public class SearchServiceTest {
 		assertThat(result.getPlatillos().getTotalCount()).isEqualTo(1);
 		assertThat(result.getTotalResults()).isEqualTo(1);
 		log.info("finished testSearchPlatillos");
+	}
+
+	private static PacienteListView listViewFrom(final Paciente entity) {
+		return new PacienteListView() {
+			@Override
+			public Long getId() {
+				return entity.getId();
+			}
+
+			@Override
+			public String getName() {
+				return entity.getName();
+			}
+
+			@Override
+			public String getEmail() {
+				return entity.getEmail();
+			}
+
+			@Override
+			public String getPhone() {
+				return entity.getPhone();
+			}
+
+			@Override
+			public Date getDob() {
+				return entity.getDob();
+			}
+
+			@Override
+			public String getGender() {
+				return entity.getGender();
+			}
+
+			@Override
+			public String getResponsibleName() {
+				return entity.getResponsibleName();
+			}
+		};
 	}
 
 }


### PR DESCRIPTION
## Summary
- Add `PacienteListView`, `PacienteAuthView`, and `PacienteCalendarView` JPQL projections
- Route grid, mobile auth, calendar, and search reads through projections instead of full entity loads
- No schema change; mobile `#98`/`#99` DTO contracts unchanged

## Test plan
- [x] `PacienteProjectionRepositoryTest`
- [x] `PacienteRestControllerTest`, `PacienteControllerTest`
- [x] `mvn verify`

Closes part of #156 (Phase A). Phase B follows in `integration/b-paciente-embeddables`.

Made with [Cursor](https://cursor.com)