### PR TITLE
feat(integration): Paciente satellite tables (#156 Phase C)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -10,7 +10,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) | Canonical cross-repo contract — §F8 schema/enum map, per-issue corrected scope |
 | [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) | Endpoint request/response specs (#91–#99) with field mappings |
 
-**Current next issue:** [#46 — Liquibase baseline](https://github.com/diego-torres/nutriconsultas/issues/46). ~~#156~~ Paciente decomposition **done** on `main` (PRs #175/#176). ~~#114~~ nutritionist reply **done**. ~~#116~~ `senderDisplayName` **done** on `main`.
+**Current next issue:** [#156 Phase C](https://github.com/diego-torres/nutriconsultas/issues/156) satellite tables on `integration/c-paciente-satellites`, then [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46).
 
 ---
 
@@ -322,13 +322,11 @@ gh pr create ...
 
 | Field | Value |
 |-------|-------|
-| **Next issue** | [#46 — Liquibase baseline](https://github.com/diego-torres/nutriconsultas/issues/46) |
-| **Status** | **NEXT** (#156 merged to `main`) |
-| **Phase** | Integration prerequisite — #156 Phases A–B **done** (PRs #175/#176) |
-| **Depends on** | #121 |
-| **Blocks** | #46, #132 |
-| **Just completed** | [#156](https://github.com/diego-torres/nutriconsultas/issues/156) — Paciente projections (PR #175) + `@Embeddable` grouping (PR #176) on `main` |
-| **In scope for #156** | Phase A: read projections ✓ (`integration/a-paciente-projections`). Phase B: `@Embeddable` grouping ✓ (`integration/b-paciente-embeddables`, same table, `@Delegate` flat accessors). Phase C optional. No mobile JSON contract changes. |
+| **Next issue** | [#156 Phase C](https://github.com/diego-torres/nutriconsultas/issues/156) merge, then [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) |
+| **Status** | **in-progress** (Phase C on `integration/c-paciente-satellites`) |
+| **Phase** | #156 Phase C — vertical split to `paciente_medical_history` + `paciente_energy_preferences` |
+| **Just completed** | Phases A–B on `main` (PRs #175/#176) |
+| **In scope for #156** | Phase A ✓ projections. Phase B ✓ `@Embeddable` body snapshot. **Phase C:** LAZY `@OneToOne` satellites + `db/manual/postgresql-paciente-phase-c-*.sql` + ER doc. No mobile JSON changes. |
 
 ### Upcoming gates
 
@@ -345,9 +343,9 @@ gh pr create ...
 
 **Patient mobile API on `main`:** JWT resource server (#107), DTO envelope (#110), patient linkage (#109), visits (#91/#92), diet plans (#93–#95), messages list/send (#96/#97 with HTTP 201 + rate limit), progress snapshot (#98) + measurements time series (#99, PR #153), localized API errors (#111), Resilience4j write throttling (#113), **OpenAPI spec (#112, PR #164)**, **`senderDisplayName` (#116)**, **nutritionist reply (#114)**. Dashboard IMC gauge (#106) done for web tablero.
 
-**Next:** #46 Liquibase baseline (post-#156 `Paciente` schema).
+**Next:** Merge #156 Phase C (`integration/c-paciente-satellites`), then #46 Liquibase baseline.
 
-**Just merged:** #156 Phases A–B on `main` — PR [#175](https://github.com/diego-torres/nutriconsultas/pull/175) (projections) + PR [#176](https://github.com/diego-torres/nutriconsultas/pull/176) (`PacienteBodySnapshot`, `PacienteEnergyPreferences`, `PacienteMedicalHistory`).
+**In progress:** Phase C — `paciente_medical_history` + `paciente_energy_preferences` satellite tables; `mvn verify` green on branch.
 
 **GitHub drift (close when convenient):** #97 and #111 are **done on `main`** but still **open on GitHub** (implemented in PRs #147, #151).
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-16 — #156 Phases A–B **done** on `main` (PRs [#175](https://github.com/diego-torres/nutriconsultas/pull/175), [#176](https://github.com/diego-torres/nutriconsultas/pull/176)). **NEXT:** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline.
+**Last updated:** 2026-06-16 — #156 Phase C (satellite tables) **in-progress** on `integration/c-paciente-satellites`. Phases A–B **done** on `main` (PRs #175/#176). **NEXT:** merge Phase C → [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -35,7 +35,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | **Greenfield** | Message entity/repo/service/controllers **implemented** (#96/#97, PRs #146–#147, #151). Contact form uses `ContactInquiry` (not patient thread). |
 | **Branding** | `NutritionistProfile` (entity @ `228bbc3`: `userId`, `displayName`, `cedulaProfesional`, `logoExtension`, `registro`) already brands diet PDFs (#95) transparently; supplies optional `senderDisplayName` for #96 (#116). |
 | **Package note** | Actual entity package is `com.nutriconsultas.paciente` (singular) — issue #107 text says `pacientes`; follow the code. |
-| **`Paciente` entity** | Decomposed on `main` via [#156](https://github.com/diego-torres/nutriconsultas/issues/156) (PRs #175/#176): read projections (Phase A) + `@Embeddable` groups `PacienteBodySnapshot`, `PacienteEnergyPreferences`, `PacienteMedicalHistory` (Phase B, same table, flat accessors via `@Delegate`). Mobile `#98`/`#99` consume **DTOs** — not the entity shape. **NEXT:** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline. |
+| **`Paciente` entity** | Decomposed via [#156](https://github.com/diego-torres/nutriconsultas/issues/156): projections (Phase A) + body snapshot `@Embeddable` (Phase B) + LAZY `@OneToOne` satellites `paciente_medical_history` / `paciente_energy_preferences` (Phase C, branch `integration/c-paciente-satellites`). Flat accessors via `@Delegate`. Mobile `#98`/`#99` DTOs unchanged. ER: [`docs/integration/paciente-er-phase-c.md`](docs/integration/paciente-er-phase-c.md). |
 
 ---
 
@@ -49,7 +49,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 (#107, #109, #110) is **done**. Patient linkage (#109) is **done**. Endpoints **#91–#99 are done** on `main` (PR #153). OpenAPI (#112, PR #164) is **done**. **#115 PHI audit done** (PR #168). **#116 `senderDisplayName` done** on `main`. **#114 nutritionist reply done** on `main`. **#156 done** on `main` (PRs #175 Phase A projections, #176 Phase B `@Embeddable`). **NEXT:** #46 Liquibase baseline.
+Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. **#156 Phases A–B done** (PRs #175/#176); **Phase C in-progress** (`integration/c-paciente-satellites`). **NEXT:** merge Phase C, then #46 Liquibase baseline.
 
 ---
 
@@ -130,8 +130,8 @@ Schema-affecting work must respect mobile DTO contracts (§F8). These issues are
 
 | # | Title | URL | State | Depends on | Blocks | Notes |
 |---|-------|-----|-------|-----------|--------|-------|
-| **156** | `[Integration]` Paciente domain refactor — incremental decomposition | https://github.com/diego-torres/nutriconsultas/issues/156 | **done** | [#121](https://github.com/diego-torres/nutriconsultas/issues/121) GET/TDEE | — (unblocked #46) | Merged PRs [#175](https://github.com/diego-torres/nutriconsultas/pull/175) (projections) + [#176](https://github.com/diego-torres/nutriconsultas/pull/176) (`@Embeddable`); no schema change. Phase C (satellite tables) optional. Mobile `#98`/`#99` DTO keys unchanged. |
-| 46 | Implement Liquibase for database change management | https://github.com/diego-torres/nutriconsultas/issues/46 | **NEXT** | ~~156~~ ✓ | — | First Liquibase baseline must capture post-#156 `Paciente` schema. Until then: `ddl-auto=update` + manual SQL if Phase C. |
+| **156** | `[Integration]` Paciente domain refactor — incremental decomposition | https://github.com/diego-torres/nutriconsultas/issues/156 | **in-progress** | [#121](https://github.com/diego-torres/nutriconsultas/issues/121) GET/TDEE | [#46](https://github.com/diego-torres/nutriconsultas/issues/46) Liquibase | PRs #175/#176 merged (Phases A–B). **Phase C** on `integration/c-paciente-satellites`: `paciente_medical_history` + `paciente_energy_preferences` LAZY `@OneToOne`, manual SQL in `db/manual/`, `PacienteSatelliteLazyLoadTest`. Mobile DTOs unchanged. |
+| 46 | Implement Liquibase for database change management | https://github.com/diego-torres/nutriconsultas/issues/46 | **NEXT** | **156** (Phase C merge) | — | First Liquibase baseline must capture post-Phase C schema ([`paciente-er-phase-c.md`](docs/integration/paciente-er-phase-c.md)). |
 | 132 | Invitation & patient onboarding data model | https://github.com/diego-torres/nutriconsultas/issues/132 | open | #107, **156** (Phase B) | — | `Paciente.status` enum + `Invitation` entity; Liquibase via #46 after #156. |
 
 ---
@@ -169,7 +169,7 @@ Each mobile feature consumes these backend endpoints. Two-way linking with the m
 | 107, 108, 109 | Auth / linkage | mobile #5, #7, #13, #22 | Auth |
 | 116 | `senderDisplayName` (optional) | mobile #19 | Read-only (additive) | **done** on `main` |
 | 114 | nutritionist reply | — (web only; feeds #96) | Write (nutritionist) | **done** — `POST /rest/patient-messages/thread/{pacienteId}` + admin widget |
-| 156 | `Paciente` internal refactor (pre-Liquibase) | — (backend only) | — | **done** — PRs #175/#176 on `main` |
+| 156 | `Paciente` internal refactor (pre-Liquibase) | — (backend only) | — | **in-progress** — Phase C satellites on `integration/c-paciente-satellites`; Phases A–B on `main` |
 | 132–141 | Invitation onboarding | mobile (future) | Auth + profile | Replaces #109 manual linkage for new patients; gated by #156 |
 
 **Common contract for every #91–#99** (ALIGNMENT-SPEC §"CORRECTED SCOPE"):

--- a/docs/integration/paciente-er-phase-c.md
+++ b/docs/integration/paciente-er-phase-c.md
@@ -1,0 +1,29 @@
+# Paciente schema after #156 Phase C
+
+Handoff reference for [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline.
+
+## Entity-relationship (post Phase C)
+
+```
+paciente (core + body snapshot embeddable columns)
+├── 1:1 paciente_medical_history   (LAZY, FK paciente_id)
+├── 1:1 paciente_energy_preferences (LAZY, FK paciente_id)
+└── 1:N body_metric_record, calendar_event, … (unchanged)
+
+paciente_medical_history
+└── TEXT antecedentes*, alergias, historial, desarrollo, tipo_sanguineo, 8 pathology flags
+
+paciente_energy_preferences
+└── GET/TDEE prefs: activity factors, BMR formula, TEF, physiological stress
+```
+
+Body snapshot (`peso`, `estatura`, `imc`, `bmr`, `get_kcal`, `nivel_peso`, cached TDEE fields) remains **embedded** on `paciente` (Phase B). Phase D may later move snapshot to `BodyMetricRecord` only.
+
+## Manual migration (pre-Liquibase)
+
+| Script | Purpose |
+|--------|---------|
+| `postgresql-paciente-phase-c-split.sql` | Create satellites, copy data, drop wide columns from `paciente` |
+| `postgresql-paciente-phase-c-rollback.sql` | Restore wide `paciente` columns from satellites |
+
+Dev/test: Hibernate `ddl-auto=update` creates satellite tables; production applies forward script before deploying Phase C code.

--- a/src/main/java/com/nutriconsultas/paciente/Paciente.java
+++ b/src/main/java/com/nutriconsultas/paciente/Paciente.java
@@ -4,12 +4,17 @@ import java.util.Date;
 
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 import jakarta.validation.constraints.NotBlank;
@@ -19,9 +24,12 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 
 import com.nutriconsultas.paciente.embeddable.PacienteBodySnapshot;
-import com.nutriconsultas.paciente.embeddable.PacienteEnergyPreferences;
-import com.nutriconsultas.paciente.embeddable.PacienteMedicalHistory;
+import com.nutriconsultas.paciente.satellite.PacienteEnergyPreferences;
+import com.nutriconsultas.paciente.satellite.PacienteMedicalHistory;
 import com.nutriconsultas.paciente.validation.ValidPregnancy;
+
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -92,61 +100,55 @@ public class Paciente {
 	@Delegate
 	private PacienteBodySnapshot bodySnapshot = new PacienteBodySnapshot();
 
-	@Embedded
-	@AttributeOverrides({
-			@AttributeOverride(name = "activityFactorScale", column = @Column(name = "activity_factor_scale")),
-			@AttributeOverride(name = "preferredBmrFormula", column = @Column(name = "preferred_bmr_formula")),
-			@AttributeOverride(name = "physicalActivityLevel", column = @Column(name = "physical_activity_level")),
-			@AttributeOverride(name = "activityFactor", column = @Column(name = "activity_factor")),
-			@AttributeOverride(name = "customFactorSedentary", column = @Column(name = "custom_factor_sedentary")),
-			@AttributeOverride(name = "customFactorLight", column = @Column(name = "custom_factor_light")),
-			@AttributeOverride(name = "customFactorModerate", column = @Column(name = "custom_factor_moderate")),
-			@AttributeOverride(name = "customFactorIntense", column = @Column(name = "custom_factor_intense")),
-			@AttributeOverride(name = "customFactorVeryIntense", column = @Column(name = "custom_factor_very_intense")),
-			@AttributeOverride(name = "physiologicalStressActive",
-					column = @Column(name = "physiological_stress_active")),
-			@AttributeOverride(name = "physiologicalStressType", column = @Column(name = "physiological_stress_type")),
-			@AttributeOverride(name = "stressFormulaTable", column = @Column(name = "stress_formula_table")),
-			@AttributeOverride(name = "stressIncrementMode", column = @Column(name = "stress_increment_mode")),
-			@AttributeOverride(name = "stressFactorValue", column = @Column(name = "stress_factor_value")),
-			@AttributeOverride(name = "stressValidFrom", column = @Column(name = "stress_valid_from")),
-			@AttributeOverride(name = "stressValidUntil", column = @Column(name = "stress_valid_until")),
-			@AttributeOverride(name = "stressFeverTemperature", column = @Column(name = "stress_fever_temperature")),
-			@AttributeOverride(name = "tefMethod", column = @Column(name = "tef_method")),
-			@AttributeOverride(name = "tefBase", column = @Column(name = "tef_base")),
-			@AttributeOverride(name = "tefFixedPercent", column = @Column(name = "tef_fixed_percent")),
-			@AttributeOverride(name = "tefMacroProteinPercent", column = @Column(name = "tef_macro_protein_percent")),
-			@AttributeOverride(name = "tefMacroCarbsPercent", column = @Column(name = "tef_macro_carbs_percent")),
-			@AttributeOverride(name = "tefMacroFatPercent", column = @Column(name = "tef_macro_fat_percent")) })
-	@Delegate
+	@LazyToOne(LazyToOneOption.NO_PROXY)
+	@OneToOne(mappedBy = "paciente", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+	@Delegate(excludes = PacienteEnergyPreferencesDelegateExcludes.class)
 	private PacienteEnergyPreferences energyPreferences = new PacienteEnergyPreferences();
 
-	@Embedded
-	@AttributeOverrides({
-			@AttributeOverride(name = "antecedentesPrenatales", column = @Column(name = "antecedentes_prenatales")),
-			@AttributeOverride(name = "antecedentesNatales", column = @Column(name = "antecedentes_natales")),
-			@AttributeOverride(name = "antecedentesPatologicosPersonales",
-					column = @Column(name = "antecedentes_patologicos_personales")),
-			@AttributeOverride(name = "antecedentesPatologicosFamiliares",
-					column = @Column(name = "antecedentes_patologicos_familiares")),
-			@AttributeOverride(name = "complicaciones", column = @Column(name = "complicaciones")),
-			@AttributeOverride(name = "tipoSanguineo", column = @Column(name = "tipo_sanguineo")),
-			@AttributeOverride(name = "historialAlimenticio", column = @Column(name = "historial_alimenticio")),
-			@AttributeOverride(name = "desarrolloPsicomotor", column = @Column(name = "desarrollo_psicomotor")),
-			@AttributeOverride(name = "alergias", column = @Column(name = "alergias")),
-			@AttributeOverride(name = "hipertension", column = @Column(name = "hipertension")),
-			@AttributeOverride(name = "diabetes", column = @Column(name = "diabetes")),
-			@AttributeOverride(name = "hipotiroidismo", column = @Column(name = "hipotiroidismo")),
-			@AttributeOverride(name = "obesidad", column = @Column(name = "obesidad")),
-			@AttributeOverride(name = "anemia", column = @Column(name = "anemia")),
-			@AttributeOverride(name = "bulimia", column = @Column(name = "bulimia")),
-			@AttributeOverride(name = "anorexia", column = @Column(name = "anorexia")),
-			@AttributeOverride(name = "enfermedadesHepaticas", column = @Column(name = "enfermedades_hepaticas")) })
-	@Delegate
+	@LazyToOne(LazyToOneOption.NO_PROXY)
+	@OneToOne(mappedBy = "paciente", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+	@Delegate(excludes = PacienteMedicalHistoryDelegateExcludes.class)
 	private PacienteMedicalHistory medicalHistory = new PacienteMedicalHistory();
 
 	// ESTADO DE EMBARAZO (solo para mujeres entre 12-50 años)
 	@ValidPregnancy
 	private Boolean pregnancy = false;
+
+	@PrePersist
+	@PreUpdate
+	private void linkSatelliteRows() {
+		if (energyPreferences == null) {
+			energyPreferences = new PacienteEnergyPreferences();
+		}
+		if (medicalHistory == null) {
+			medicalHistory = new PacienteMedicalHistory();
+		}
+		energyPreferences.setPaciente(this);
+		medicalHistory.setPaciente(this);
+	}
+
+	private interface PacienteEnergyPreferencesDelegateExcludes {
+
+		Long getId();
+
+		void setId(Long id);
+
+		Paciente getPaciente();
+
+		void setPaciente(Paciente paciente);
+
+	}
+
+	private interface PacienteMedicalHistoryDelegateExcludes {
+
+		Long getId();
+
+		void setId(Long id);
+
+		Paciente getPaciente();
+
+		void setPaciente(Paciente paciente);
+
+	}
 
 }

--- a/src/main/java/com/nutriconsultas/paciente/Paciente.java
+++ b/src/main/java/com/nutriconsultas/paciente/Paciente.java
@@ -116,7 +116,7 @@ public class Paciente {
 
 	@PrePersist
 	@PreUpdate
-	private void linkSatelliteRows() {
+	void linkSatelliteRows() {
 		if (energyPreferences == null) {
 			energyPreferences = new PacienteEnergyPreferences();
 		}

--- a/src/main/java/com/nutriconsultas/paciente/satellite/PacienteEnergyPreferences.java
+++ b/src/main/java/com/nutriconsultas/paciente/satellite/PacienteEnergyPreferences.java
@@ -1,16 +1,8 @@
-package com.nutriconsultas.paciente.embeddable;
+package com.nutriconsultas.paciente.satellite;
 
 import java.util.Date;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
-
-import org.springframework.format.annotation.DateTimeFormat;
-
+import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.calculation.ActivityFactorScale;
 import com.nutriconsultas.paciente.calculation.BmrFormulaType;
 import com.nutriconsultas.paciente.calculation.PhysicalActivityLevel;
@@ -21,21 +13,41 @@ import com.nutriconsultas.paciente.calculation.TefBase;
 import com.nutriconsultas.paciente.calculation.TefCalculationService;
 import com.nutriconsultas.paciente.calculation.TefMethod;
 
-import lombok.AllArgsConstructor;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
 
 /**
- * Patient energy-expenditure preferences (GET/TDEE, TEF, activity factors, stress) — #156
- * Phase B.
+ * Energy-expenditure preferences (GET/TDEE, TEF, activity, stress) — #156 Phase C
+ * satellite table.
  */
-@Embeddable
+@Entity
+@Table(name = "paciente_energy_preferences")
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 public class PacienteEnergyPreferences {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne(optional = false)
+	@JoinColumn(name = "paciente_id", nullable = false, unique = true)
+	private Paciente paciente;
 
 	@Enumerated(EnumType.STRING)
 	@Column(length = 30)

--- a/src/main/java/com/nutriconsultas/paciente/satellite/PacienteMedicalHistory.java
+++ b/src/main/java/com/nutriconsultas/paciente/satellite/PacienteMedicalHistory.java
@@ -1,22 +1,36 @@
-package com.nutriconsultas.paciente.embeddable;
+package com.nutriconsultas.paciente.satellite;
+
+import com.nutriconsultas.paciente.Paciente;
 
 import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-
-import lombok.AllArgsConstructor;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
- * Medical history text fields and common pathology flags — #156 Phase B.
+ * Medical history and pathology flags for a patient — #156 Phase C satellite table.
  */
-@Embeddable
+@Entity
+@Table(name = "paciente_medical_history")
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 public class PacienteMedicalHistory {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne(optional = false)
+	@JoinColumn(name = "paciente_id", nullable = false, unique = true)
+	private Paciente paciente;
 
 	@Column(columnDefinition = "TEXT")
 	private String antecedentesPrenatales;

--- a/src/main/resources/db/manual/postgresql-paciente-phase-c-rollback.sql
+++ b/src/main/resources/db/manual/postgresql-paciente-phase-c-rollback.sql
@@ -1,0 +1,102 @@
+-- Rollback for postgresql-paciente-phase-c-split.sql (Issue #156 Phase C).
+-- Restores wide paciente columns from satellite tables. Satellite rows must exist.
+-- WARNING: run only if forward migration was applied and rollback is required.
+
+BEGIN;
+
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS antecedentes_prenatales TEXT;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS antecedentes_natales TEXT;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS antecedentes_patologicos_personales TEXT;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS antecedentes_patologicos_familiares TEXT;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS complicaciones TEXT;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS tipo_sanguineo VARCHAR(4);
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS historial_alimenticio TEXT;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS desarrollo_psicomotor TEXT;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS alergias TEXT;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS hipertension BOOLEAN DEFAULT FALSE;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS diabetes BOOLEAN DEFAULT FALSE;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS hipotiroidismo BOOLEAN DEFAULT FALSE;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS obesidad BOOLEAN DEFAULT FALSE;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS anemia BOOLEAN DEFAULT FALSE;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS bulimia BOOLEAN DEFAULT FALSE;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS anorexia BOOLEAN DEFAULT FALSE;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS enfermedades_hepaticas BOOLEAN DEFAULT FALSE;
+
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS activity_factor_scale VARCHAR(30);
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS preferred_bmr_formula VARCHAR(30);
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS physical_activity_level VARCHAR(30);
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS activity_factor DOUBLE PRECISION;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS custom_factor_sedentary DOUBLE PRECISION;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS custom_factor_light DOUBLE PRECISION;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS custom_factor_moderate DOUBLE PRECISION;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS custom_factor_intense DOUBLE PRECISION;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS custom_factor_very_intense DOUBLE PRECISION;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS physiological_stress_active BOOLEAN DEFAULT FALSE;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS physiological_stress_type VARCHAR(40);
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS stress_formula_table VARCHAR(30);
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS stress_increment_mode VARCHAR(30);
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS stress_factor_value DOUBLE PRECISION;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS stress_valid_from DATE;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS stress_valid_until DATE;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS stress_fever_temperature DOUBLE PRECISION;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS tef_method VARCHAR(30);
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS tef_base VARCHAR(30);
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS tef_fixed_percent DOUBLE PRECISION;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS tef_macro_protein_percent DOUBLE PRECISION;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS tef_macro_carbs_percent DOUBLE PRECISION;
+ALTER TABLE paciente ADD COLUMN IF NOT EXISTS tef_macro_fat_percent DOUBLE PRECISION;
+
+UPDATE paciente p
+SET
+    antecedentes_prenatales = pmh.antecedentes_prenatales,
+    antecedentes_natales = pmh.antecedentes_natales,
+    antecedentes_patologicos_personales = pmh.antecedentes_patologicos_personales,
+    antecedentes_patologicos_familiares = pmh.antecedentes_patologicos_familiares,
+    complicaciones = pmh.complicaciones,
+    tipo_sanguineo = pmh.tipo_sanguineo,
+    historial_alimenticio = pmh.historial_alimenticio,
+    desarrollo_psicomotor = pmh.desarrollo_psicomotor,
+    alergias = pmh.alergias,
+    hipertension = pmh.hipertension,
+    diabetes = pmh.diabetes,
+    hipotiroidismo = pmh.hipotiroidismo,
+    obesidad = pmh.obesidad,
+    anemia = pmh.anemia,
+    bulimia = pmh.bulimia,
+    anorexia = pmh.anorexia,
+    enfermedades_hepaticas = pmh.enfermedades_hepaticas
+FROM paciente_medical_history pmh
+WHERE pmh.paciente_id = p.id;
+
+UPDATE paciente p
+SET
+    activity_factor_scale = pep.activity_factor_scale,
+    preferred_bmr_formula = pep.preferred_bmr_formula,
+    physical_activity_level = pep.physical_activity_level,
+    activity_factor = pep.activity_factor,
+    custom_factor_sedentary = pep.custom_factor_sedentary,
+    custom_factor_light = pep.custom_factor_light,
+    custom_factor_moderate = pep.custom_factor_moderate,
+    custom_factor_intense = pep.custom_factor_intense,
+    custom_factor_very_intense = pep.custom_factor_very_intense,
+    physiological_stress_active = pep.physiological_stress_active,
+    physiological_stress_type = pep.physiological_stress_type,
+    stress_formula_table = pep.stress_formula_table,
+    stress_increment_mode = pep.stress_increment_mode,
+    stress_factor_value = pep.stress_factor_value,
+    stress_valid_from = pep.stress_valid_from,
+    stress_valid_until = pep.stress_valid_until,
+    stress_fever_temperature = pep.stress_fever_temperature,
+    tef_method = pep.tef_method,
+    tef_base = pep.tef_base,
+    tef_fixed_percent = pep.tef_fixed_percent,
+    tef_macro_protein_percent = pep.tef_macro_protein_percent,
+    tef_macro_carbs_percent = pep.tef_macro_carbs_percent,
+    tef_macro_fat_percent = pep.tef_macro_fat_percent
+FROM paciente_energy_preferences pep
+WHERE pep.paciente_id = p.id;
+
+DROP TABLE IF EXISTS paciente_energy_preferences;
+DROP TABLE IF EXISTS paciente_medical_history;
+
+COMMIT;

--- a/src/main/resources/db/manual/postgresql-paciente-phase-c-split.sql
+++ b/src/main/resources/db/manual/postgresql-paciente-phase-c-split.sql
@@ -1,0 +1,200 @@
+-- Issue #156 Phase C: split medical history and energy preferences into satellite tables.
+-- Apply on PostgreSQL when Hibernate ddl-auto is not used (production / external schema management).
+-- Prerequisites: backup database; run during maintenance window.
+-- Dev: Hibernate ddl-auto=update creates satellite tables automatically; run data migration only.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS paciente_medical_history (
+    id BIGSERIAL PRIMARY KEY,
+    paciente_id BIGINT NOT NULL UNIQUE REFERENCES paciente (id) ON DELETE CASCADE,
+    antecedentes_prenatales TEXT,
+    antecedentes_natales TEXT,
+    antecedentes_patologicos_personales TEXT,
+    antecedentes_patologicos_familiares TEXT,
+    complicaciones TEXT,
+    tipo_sanguineo VARCHAR(4),
+    historial_alimenticio TEXT,
+    desarrollo_psicomotor TEXT,
+    alergias TEXT,
+    hipertension BOOLEAN DEFAULT FALSE,
+    diabetes BOOLEAN DEFAULT FALSE,
+    hipotiroidismo BOOLEAN DEFAULT FALSE,
+    obesidad BOOLEAN DEFAULT FALSE,
+    anemia BOOLEAN DEFAULT FALSE,
+    bulimia BOOLEAN DEFAULT FALSE,
+    anorexia BOOLEAN DEFAULT FALSE,
+    enfermedades_hepaticas BOOLEAN DEFAULT FALSE
+);
+
+CREATE TABLE IF NOT EXISTS paciente_energy_preferences (
+    id BIGSERIAL PRIMARY KEY,
+    paciente_id BIGINT NOT NULL UNIQUE REFERENCES paciente (id) ON DELETE CASCADE,
+    activity_factor_scale VARCHAR(30),
+    preferred_bmr_formula VARCHAR(30),
+    physical_activity_level VARCHAR(30),
+    activity_factor DOUBLE PRECISION,
+    custom_factor_sedentary DOUBLE PRECISION,
+    custom_factor_light DOUBLE PRECISION,
+    custom_factor_moderate DOUBLE PRECISION,
+    custom_factor_intense DOUBLE PRECISION,
+    custom_factor_very_intense DOUBLE PRECISION,
+    physiological_stress_active BOOLEAN DEFAULT FALSE,
+    physiological_stress_type VARCHAR(40),
+    stress_formula_table VARCHAR(30),
+    stress_increment_mode VARCHAR(30),
+    stress_factor_value DOUBLE PRECISION,
+    stress_valid_from DATE,
+    stress_valid_until DATE,
+    stress_fever_temperature DOUBLE PRECISION,
+    tef_method VARCHAR(30),
+    tef_base VARCHAR(30),
+    tef_fixed_percent DOUBLE PRECISION,
+    tef_macro_protein_percent DOUBLE PRECISION,
+    tef_macro_carbs_percent DOUBLE PRECISION,
+    tef_macro_fat_percent DOUBLE PRECISION
+);
+
+INSERT INTO paciente_medical_history (
+    paciente_id,
+    antecedentes_prenatales,
+    antecedentes_natales,
+    antecedentes_patologicos_personales,
+    antecedentes_patologicos_familiares,
+    complicaciones,
+    tipo_sanguineo,
+    historial_alimenticio,
+    desarrollo_psicomotor,
+    alergias,
+    hipertension,
+    diabetes,
+    hipotiroidismo,
+    obesidad,
+    anemia,
+    bulimia,
+    anorexia,
+    enfermedades_hepaticas
+)
+SELECT
+    id,
+    antecedentes_prenatales,
+    antecedentes_natales,
+    antecedentes_patologicos_personales,
+    antecedentes_patologicos_familiares,
+    complicaciones,
+    tipo_sanguineo,
+    historial_alimenticio,
+    desarrollo_psicomotor,
+    alergias,
+    COALESCE(hipertension, FALSE),
+    COALESCE(diabetes, FALSE),
+    COALESCE(hipotiroidismo, FALSE),
+    COALESCE(obesidad, FALSE),
+    COALESCE(anemia, FALSE),
+    COALESCE(bulimia, FALSE),
+    COALESCE(anorexia, FALSE),
+    COALESCE(enfermedades_hepaticas, FALSE)
+FROM paciente
+WHERE NOT EXISTS (
+    SELECT 1 FROM paciente_medical_history pmh WHERE pmh.paciente_id = paciente.id
+);
+
+INSERT INTO paciente_energy_preferences (
+    paciente_id,
+    activity_factor_scale,
+    preferred_bmr_formula,
+    physical_activity_level,
+    activity_factor,
+    custom_factor_sedentary,
+    custom_factor_light,
+    custom_factor_moderate,
+    custom_factor_intense,
+    custom_factor_very_intense,
+    physiological_stress_active,
+    physiological_stress_type,
+    stress_formula_table,
+    stress_increment_mode,
+    stress_factor_value,
+    stress_valid_from,
+    stress_valid_until,
+    stress_fever_temperature,
+    tef_method,
+    tef_base,
+    tef_fixed_percent,
+    tef_macro_protein_percent,
+    tef_macro_carbs_percent,
+    tef_macro_fat_percent
+)
+SELECT
+    id,
+    activity_factor_scale,
+    preferred_bmr_formula,
+    physical_activity_level,
+    activity_factor,
+    custom_factor_sedentary,
+    custom_factor_light,
+    custom_factor_moderate,
+    custom_factor_intense,
+    custom_factor_very_intense,
+    COALESCE(physiological_stress_active, FALSE),
+    physiological_stress_type,
+    stress_formula_table,
+    stress_increment_mode,
+    stress_factor_value,
+    stress_valid_from,
+    stress_valid_until,
+    stress_fever_temperature,
+    tef_method,
+    tef_base,
+    tef_fixed_percent,
+    tef_macro_protein_percent,
+    tef_macro_carbs_percent,
+    tef_macro_fat_percent
+FROM paciente
+WHERE NOT EXISTS (
+    SELECT 1 FROM paciente_energy_preferences pep WHERE pep.paciente_id = paciente.id
+);
+
+ALTER TABLE paciente DROP COLUMN IF EXISTS antecedentes_prenatales;
+ALTER TABLE paciente DROP COLUMN IF EXISTS antecedentes_natales;
+ALTER TABLE paciente DROP COLUMN IF EXISTS antecedentes_patologicos_personales;
+ALTER TABLE paciente DROP COLUMN IF EXISTS antecedentes_patologicos_familiares;
+ALTER TABLE paciente DROP COLUMN IF EXISTS complicaciones;
+ALTER TABLE paciente DROP COLUMN IF EXISTS tipo_sanguineo;
+ALTER TABLE paciente DROP COLUMN IF EXISTS historial_alimenticio;
+ALTER TABLE paciente DROP COLUMN IF EXISTS desarrollo_psicomotor;
+ALTER TABLE paciente DROP COLUMN IF EXISTS alergias;
+ALTER TABLE paciente DROP COLUMN IF EXISTS hipertension;
+ALTER TABLE paciente DROP COLUMN IF EXISTS diabetes;
+ALTER TABLE paciente DROP COLUMN IF EXISTS hipotiroidismo;
+ALTER TABLE paciente DROP COLUMN IF EXISTS obesidad;
+ALTER TABLE paciente DROP COLUMN IF EXISTS anemia;
+ALTER TABLE paciente DROP COLUMN IF EXISTS bulimia;
+ALTER TABLE paciente DROP COLUMN IF EXISTS anorexia;
+ALTER TABLE paciente DROP COLUMN IF EXISTS enfermedades_hepaticas;
+
+ALTER TABLE paciente DROP COLUMN IF EXISTS activity_factor_scale;
+ALTER TABLE paciente DROP COLUMN IF EXISTS preferred_bmr_formula;
+ALTER TABLE paciente DROP COLUMN IF EXISTS physical_activity_level;
+ALTER TABLE paciente DROP COLUMN IF EXISTS activity_factor;
+ALTER TABLE paciente DROP COLUMN IF EXISTS custom_factor_sedentary;
+ALTER TABLE paciente DROP COLUMN IF EXISTS custom_factor_light;
+ALTER TABLE paciente DROP COLUMN IF EXISTS custom_factor_moderate;
+ALTER TABLE paciente DROP COLUMN IF EXISTS custom_factor_intense;
+ALTER TABLE paciente DROP COLUMN IF EXISTS custom_factor_very_intense;
+ALTER TABLE paciente DROP COLUMN IF EXISTS physiological_stress_active;
+ALTER TABLE paciente DROP COLUMN IF EXISTS physiological_stress_type;
+ALTER TABLE paciente DROP COLUMN IF EXISTS stress_formula_table;
+ALTER TABLE paciente DROP COLUMN IF EXISTS stress_increment_mode;
+ALTER TABLE paciente DROP COLUMN IF EXISTS stress_factor_value;
+ALTER TABLE paciente DROP COLUMN IF EXISTS stress_valid_from;
+ALTER TABLE paciente DROP COLUMN IF EXISTS stress_valid_until;
+ALTER TABLE paciente DROP COLUMN IF EXISTS stress_fever_temperature;
+ALTER TABLE paciente DROP COLUMN IF EXISTS tef_method;
+ALTER TABLE paciente DROP COLUMN IF EXISTS tef_base;
+ALTER TABLE paciente DROP COLUMN IF EXISTS tef_fixed_percent;
+ALTER TABLE paciente DROP COLUMN IF EXISTS tef_macro_protein_percent;
+ALTER TABLE paciente DROP COLUMN IF EXISTS tef_macro_carbs_percent;
+ALTER TABLE paciente DROP COLUMN IF EXISTS tef_macro_fat_percent;
+
+COMMIT;

--- a/src/test/java/com/nutriconsultas/paciente/PacienteEmbeddablePersistenceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteEmbeddablePersistenceTest.java
@@ -17,6 +17,10 @@ import com.nutriconsultas.paciente.calculation.ActivityFactorScale;
 import com.nutriconsultas.paciente.calculation.BmrFormulaType;
 import com.nutriconsultas.paciente.calculation.PhysicalActivityLevel;
 
+/**
+ * Ensures body snapshot embeddable and Phase C satellite rows round-trip through JPA —
+ * #156.
+ */
 @DataJpaTest
 @ActiveProfiles("test")
 class PacienteEmbeddablePersistenceTest {

--- a/src/test/java/com/nutriconsultas/paciente/PacienteSatelliteLazyLoadTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteSatelliteLazyLoadTest.java
@@ -1,0 +1,92 @@
+package com.nutriconsultas.paciente;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.nutriconsultas.paciente.projection.PacienteListView;
+
+/**
+ * Verifies #156 Phase C: patient grid projections do not join satellite tables (no N+1 on
+ * list paths).
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+class PacienteSatelliteLazyLoadTest {
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Autowired
+	private SessionFactory sessionFactory;
+
+	private Statistics statistics;
+
+	@BeforeEach
+	void enableStatistics() {
+		statistics = sessionFactory.getStatistics();
+		statistics.setStatisticsEnabled(true);
+		statistics.clear();
+	}
+
+	@Test
+	void listProjection_usesSingleQueryWithoutSatelliteJoins() {
+		final Paciente paciente = samplePaciente();
+		paciente.setAntecedentesPrenatales("Projection isolation");
+		paciente.setHipertension(true);
+		pacienteRepository.saveAndFlush(paciente);
+		entityManager.clear();
+		statistics.clear();
+
+		final List<PacienteListView> views = pacienteRepository
+			.findListViewsByUserId("nutritionist-satellite", PageRequest.of(0, 10))
+			.getContent();
+
+		assertThat(views).hasSize(1);
+		assertThat(views.get(0).getName()).isEqualTo("Satellite Lazy Test");
+		assertThat(statistics.getPrepareStatementCount()).isEqualTo(1);
+	}
+
+	@Test
+	void findById_loadsSatelliteDataViaDelegatedAccessors() {
+		final Paciente paciente = samplePaciente();
+		paciente.setAntecedentesPrenatales("Sin antecedentes");
+		paciente.setHipertension(true);
+
+		final Paciente saved = pacienteRepository.saveAndFlush(paciente);
+		entityManager.clear();
+
+		final Paciente loaded = pacienteRepository.findById(saved.getId()).orElseThrow();
+
+		assertThat(loaded.getAntecedentesPrenatales()).isEqualTo("Sin antecedentes");
+		assertThat(loaded.getHipertension()).isTrue();
+	}
+
+	private static Paciente samplePaciente() {
+		final Paciente paciente = new Paciente();
+		paciente.setName("Satellite Lazy Test");
+		paciente.setUserId("nutritionist-satellite");
+		final LocalDate dob = LocalDate.now().minusYears(30);
+		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		paciente.setGender("M");
+		return paciente;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Extract `PacienteMedicalHistory` and `PacienteEnergyPreferences` into LAZY `@OneToOne` satellite tables (`paciente_medical_history`, `paciente_energy_preferences`)
- Keep `PacienteBodySnapshot` embedded on `paciente`; flat Thymeleaf/service accessors via `@Delegate`
- Add PostgreSQL forward/rollback scripts under `db/manual/` and ER handoff doc for #46 Liquibase

## Test plan
- [x] `PacienteSatelliteLazyLoadTest` — grid projection uses single query (no satellite joins)
- [x] `PacienteEmbeddablePersistenceTest` — body snapshot + satellite round-trip
- [x] `PacienteControllerTest`, `PacienteProjectionRepositoryTest`, mobile progress tests
- [x] `mvn verify`

## Production note
Run `postgresql-paciente-phase-c-split.sql` on existing PostgreSQL before deploy (dev uses `ddl-auto=update`).

Closes #156 Phase C. Unblocks #46 Liquibase baseline with final `Paciente` schema.

Made with [Cursor](https://cursor.com)