### PR TITLE
docs(subscription): add enforcement plan, workflow, and issue registry

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -351,4 +351,6 @@ gh pr create ...
 
 **Schema gate (parallel track):** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline **NEXT** (post-#156); then [#132–#141](https://github.com/diego-torres/nutriconsultas/issues/132) invitation onboarding (see [`ISSUE.md`](ISSUE.md) Phase 2).
 
+**Subscription track (parallel):** [#180–#190](https://github.com/diego-torres/nutriconsultas/issues/180) subscription enforcement — see [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) and [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md). Schema gated by #46; platform admin RBAC (#183) can start earlier.
+
 See [`ISSUE.md`](ISSUE.md) Data contracts and [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) §F8 for per-endpoint field requirements.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -559,6 +559,12 @@ public class ExampleRestController {
 
 Issue registry: [`ISSUE.md`](ISSUE.md). Agent workflow: [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md).
 
+## Subscription & access enforcement (tracking)
+
+Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow: [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md). Design: [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md).
+
+**Epic #180–#190** (2026-06-16): platform admin RBAC, Auth0 role groups (`nutriologo-basico` … `director-consultorio`), paid admin invitations + payment provider, subscription lifecycle (grace, payment override), director clinic invites, patient/nutritionist limits, report/PDF gating. **Gated by #46 Liquibase** for schema work; #183 can start earlier.
+
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 
 **Next:** [#156](https://github.com/diego-torres/nutriconsultas/issues/156) `Paciente` domain refactor. ~~#114~~ nutritionist reply **done**. ~~#116~~ `senderDisplayName` **done** on `main`. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164).

--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -1,0 +1,108 @@
+# Issue Registry — `[Subscription]` track
+
+Living index of GitHub issues that implement **subscription enforcement**, platform admin RBAC, clinic hierarchy, and plan-gated features on the nutritionist web app. Update when status changes (commit on the PR that closes work).
+
+**Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
+**Workflow:** [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md)  
+**Design doc:** [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md)  
+**Last updated:** 2026-06-16 — epic created; issues #180–#190 (+ #191 closed duplicate).
+
+> **Scope.** This registry tracks `[Subscription]` issues only. The patient mobile API lives in [`ISSUE.md`](ISSUE.md). Patient invitation onboarding (#132–#141) is orthogonal — do not merge nutritionist and patient invitation entities.
+
+---
+
+## Legend
+
+| State | Meaning |
+|-------|---------|
+| `NEXT` | Active — pick this up now (if unblocked) |
+| `open` | Not started |
+| `in-progress` | Branch / PR open |
+| `done` | Merged to `main` |
+| `deferred` | Paused |
+
+---
+
+## Integration prerequisite
+
+| # | Title | URL | State | Blocks |
+|---|-------|-----|-------|--------|
+| 46 | Implement Liquibase for database change management | https://github.com/diego-torres/nutriconsultas/issues/46 | **NEXT** (mobile track) | #180 subscription schema |
+
+Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platform admin RBAC) can start before #46.
+
+---
+
+## Phase 0 — Schema & entitlements
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| **180** | Plan catalog, subscription schema & Liquibase | https://github.com/diego-torres/nutriconsultas/issues/180 | open | **46** | `PlanTier`, `Subscription`, `Clinic`, invitations — **NEXT** after #46 |
+| 181 | SubscriptionEntitlementService — plan tier resolution | https://github.com/diego-torres/nutriconsultas/issues/181 | open | 180 | Central `hasEntitlement()` |
+| 182 | Auth0 role sync — nutriologo-* and director-consultorio | https://github.com/diego-torres/nutriconsultas/issues/182 | open | 181, 108 | Management API group assign |
+| 183 | Platform admin RBAC — enforce admin allowlist | https://github.com/diego-torres/nutriconsultas/issues/183 | open | — | Extends `PlatformAdminService`; can start early |
+
+**Suggested order:** #46 → **#180** → #181 → #182; **#183** in parallel when touching admin UI.
+
+---
+
+## Phase 1 — Billing & lifecycle
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| 189 | Payment provider integration (Mercado Pago / abstraction) | https://github.com/diego-torres/nutriconsultas/issues/189 | open | 180 | Webhooks, idempotency |
+| 184 | Admin invitations + payment checkout | https://github.com/diego-torres/nutriconsultas/issues/184 | open | 180, 182, 183, 189 | Paid onboarding flow |
+| 185 | Subscription lifecycle — grace, payment override, notifications | https://github.com/diego-torres/nutriconsultas/issues/185 | open | 180, 184 | ACTIVE→GRACE→SUSPENDED |
+
+---
+
+## Phase 2 — Clinic hierarchy
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| 186 | Clinic model + director-consultorio administration | https://github.com/diego-torres/nutriconsultas/issues/186 | open | 180, 181 | Seats, suspend members |
+| 188 | Director invitations for nutritionists (no payment) | https://github.com/diego-torres/nutriconsultas/issues/188 | open | 186, 185 | Inherits clinic subscription |
+
+---
+
+## Phase 3 — Enforcement
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| 190 | Enforce patient and nutritionist limits per plan | https://github.com/diego-torres/nutriconsultas/issues/190 | open | 181, 185 | 10 / 50 / unlimited; 20 nutritionists |
+| 187 | Gate report tiers and PDF export by plan | https://github.com/diego-torres/nutriconsultas/issues/187 | open | 181, 185 | Branded PDFs via `NutritionistProfile` |
+
+**Suggested order:** #190 and #187 can run in parallel after #181 + #185.
+
+---
+
+## Epic mapping (user requirements → issues)
+
+| Requirement | Issues |
+|-------------|--------|
+| 1. Platform admin allowlist only | #183 (+ existing `PlatformAdminService`) |
+| 2. Admin assigns nutriologo-* / director-consultorio | #182 |
+| 3. Admin paid invitations, payment, grace, payment override | #184, #189, #185 |
+| 4. Director invites nutritionists; enable/disable access | #186, #188 |
+| 5. Patient & nutritionist limits | #190 |
+| 6. Branded / tiered reports | #187 |
+| 7. PDF export by plan | #187 |
+
+---
+
+## Plan tier quick reference
+
+| Slug | Patients | Nutritionists | PDF | Branded reports | User admin |
+|------|----------|---------------|-----|-----------------|------------|
+| `nutriologo-basico` | 10 | 1 | ✗ | ✗ | ✗ |
+| `nutriologo-profesional` | 50 | 1 | ✓ | ✓ | ✗ |
+| `nutriologo-plus` | ∞ | 1 | ✓ | ✓ | ✗ |
+| `director-consultorio` | ∞ | 20 | ✓ | ✓ | ✓ |
+
+Full matrix: [`SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md).
+
+---
+
+## How to update
+
+Same convention as [`ISSUE.md`](ISSUE.md): mark `in-progress` when PR opens, `done` when merged, advance `NEXT` in [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md).

--- a/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
+++ b/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
@@ -1,0 +1,206 @@
+# Subscription Enforcement — Agent Workflow
+
+How AI agents (and humans) ship the **`[Subscription]`** track on **`diego-torres/nutriconsultas`**. This is a **separate parallel track** from the patient mobile API — do not mix mobile endpoint work into subscription PRs.
+
+**Why a separate workflow?** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) is scoped to `/rest/mobile/patient/**` (JWT resource server, patient DTOs, IDOR by `patientAuthSub`). Subscription enforcement touches OAuth2 web sessions, platform admin config, payment webhooks, clinic hierarchy, and Thymeleaf admin UI — different security surface, dependencies, and reviewers.
+
+**Registries**
+
+| File | Purpose |
+|------|---------|
+| [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) | `[Subscription]` issues, states, dependencies |
+| [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md) | Canonical plan tiers, entitlements, lifecycle, data model |
+| [`ISSUE.md`](ISSUE.md) | Mobile API track (orthogonal) |
+| [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
+
+**Current next issue:** See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) row marked `NEXT`.
+
+---
+
+## Product context (read before every session)
+
+| Topic | Guidance |
+|-------|----------|
+| **Audience** | **Nutritionist web app** (`/admin/**`) and platform admin surfaces — not patient mobile API. |
+| **Platform admin** | Only users in `nutriconsultas.platform.admin-user-ids` or `admin-emails` (`PlatformAdminService`). Never infer admin from Auth0 groups alone. |
+| **Roles** | `nutriologo-basico`, `nutriologo-profesional`, `nutriologo-plus`, `director-consultorio` — assigned by admins (or inherited via clinic invite). |
+| **Billing** | Monthly subscription; admin `paymentExempt` for trials/extensions; grace period after expiry. |
+| **Clinic model** | `director-consultorio` owns a `Clinic`; invites nutritionists without separate payment; can suspend members. |
+| **Enforcement** | Central `SubscriptionEntitlementService` — patient/nutritionist limits, report tiers, PDF export. |
+| **Schema gate** | **#46 Liquibase baseline first**, then subscription entities. Do not rely on `ddl-auto=update` for production. |
+| **PHI** | Never log patient names in subscription/billing logs; audit events use user IDs only. |
+
+---
+
+## Overview
+
+```mermaid
+flowchart LR
+  A[1. Triage registry] --> B[2. Branch & plan]
+  B --> C[3. Implement]
+  C --> D[4. Review]
+  D --> E[5. Tests]
+  E --> F[6. CI validation]
+  F --> G[7. Fresh baseline]
+  G --> H[8. Summaries]
+  H --> I[9. PR & registry]
+```
+
+Phases mirror [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) but context sources differ (see Phase 2).
+
+---
+
+## Phase 1 — Triage & registry sync
+
+1. **Pull latest** on `main`.
+2. **Open** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) — find `NEXT`; confirm dependencies `done`.
+3. **Sync GitHub:**
+   ```bash
+   gh issue view <number>
+   gh issue list --search "[Subscription] in:title" --state open
+   ```
+4. **Gates:**
+   - **#46 Liquibase** must be `done` before schema issues (#163+).
+   - **#163** (plan catalog + schema) blocks all enforcement issues.
+   - **#164** (entitlement service) blocks limit and report gating.
+   - Payment provider choice blocks #166 webhook work — document in plan if TBD.
+5. Update local registry when GitHub drifts.
+
+**Exit criteria:** One `NEXT` issue, dependencies satisfied, registries aligned.
+
+---
+
+## Phase 2 — Branch, context, and plan
+
+1. **Branch naming:** `subscription/<number>-<short-slug>` (e.g. `subscription/163-plan-catalog-schema`).
+2. **Context sources:**
+
+   | Source | What to extract |
+   |--------|-----------------|
+   | Issue body | Acceptance criteria |
+   | [`SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md) | Entitlements table, state machine, invitation flows |
+   | `PlatformAdminService` | Existing admin detection |
+   | `eterna/index.html` pricing table | Marketing ↔ `PlanTier` mapping |
+   | `PatientReportRestController` | PDF endpoints to gate |
+   | `SecurityConfig.java` | Web OAuth2 chain (not mobile chain) |
+
+3. **Plan must include:** entities/migrations, services, admin UI routes, Auth0 sync touchpoints, webhook security, test matrix, explicit out-of-scope.
+
+**Do not implement until the plan is acknowledged.**
+
+---
+
+## Phase 3 — Implement
+
+**Rules**
+
+- One issue per PR; no mobile API drive-by changes.
+- Liquibase changesets for all schema (#46+).
+- Enforce entitlements in **service layer** (controllers thin).
+- Director flows never expose platform admin capabilities.
+- Payment webhooks: idempotent, signature-verified, no PHI in payload logs.
+- Reuse invitation token patterns from mobile onboarding research (#133) — separate entities for nutritionist vs patient invites.
+
+**Exit criteria:** Acceptance criteria met; entitlement checks wired for in-scope surfaces.
+
+---
+
+## Phase 4 — Review
+
+- Platform admin routes guarded by `PlatformAdminService`.
+- Director routes scoped to owned `Clinic`.
+- Grace / suspended states behave per plan doc.
+- No cross-clinic data leakage (multi-tenant by `userId` / `clinicId`).
+- Adversarial: non-admin cannot assign `nutriologo-plus`; director cannot exceed `maxNutritionists`.
+
+---
+
+## Phase 5 — Testing
+
+| Layer | Tool | Focus |
+|-------|------|-------|
+| Entitlement service | JUnit + Mockito | All `PlanTier` × `Entitlement` matrix |
+| State machine | Unit | ACTIVE→GRACE→SUSPENDED transitions |
+| Admin controller | `@WebMvcTest` + `@WithMockUser` | 403 for non-admin |
+| Webhook | `@SpringBootTest` | Idempotency, invalid signature → 400 |
+| Limits | Integration | Create patient blocked at cap |
+
+```bash
+./lint.sh && bash scripts/audit-logging.sh && mvn -B verify
+```
+
+---
+
+## Phase 6 — CI validation
+
+Same as [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) Phase 6 — full `mvn verify` with `-Pci` parity.
+
+---
+
+## Phase 7 — Fresh baseline
+
+Before commit:
+
+1. `git fetch origin && git rebase origin/main`
+2. Re-run verify.
+3. Update [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) in the PR.
+4. If cross-track dependency changes (e.g. #46 merged), update mobile [`ISSUE.md`](ISSUE.md) only if explicitly coupled.
+
+---
+
+## Phase 8 — Summaries
+
+Same ELI5 + technical format as mobile workflow. Example:
+
+> **ELI5 (#170):** The app now counts how many patients you have and stops you from adding more if your plan is full — like a parking lot with a maximum number of spaces.
+>
+> **Technical:** `SubscriptionEntitlementService.assertCanCreatePatient(userId)` called from `PacienteService.save`; `PlanTier.BASICO` cap 10; returns 403 `error.subscription.patient_limit`.
+
+---
+
+## Phase 9 — Commit, PR, registry
+
+```bash
+git checkout -b subscription/163-plan-catalog-schema
+# ... work ...
+git commit -m "feat(subscription): plan catalog and subscription schema (#163)"
+gh pr create --title "feat(subscription): plan catalog and subscription schema (#163)" ...
+```
+
+Update [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) in the same PR.
+
+---
+
+## Cross-track coordination
+
+| Track | Interaction |
+|-------|-------------|
+| `[Mobile API]` #132–#141 | Patient invitations — **different** entities; share token-hashing utilities only |
+| #46 Liquibase | Subscription migrations are changesets **after** baseline |
+| #108 Auth0 tenant | Extend for nutritionist role groups / Management API |
+| `Paciente.userId` | Unchanged — still nutritionist tenant key |
+
+When both tracks touch `SecurityConfig`, coordinate in separate PRs or a thin integration PR with both leads reviewing.
+
+---
+
+## Quick reference
+
+```bash
+git fetch origin && git checkout main && git pull origin main
+gh issue list --search "[Subscription] in:title" --state open
+cat ISSUE-SUBSCRIPTION.md
+cat docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md
+```
+
+---
+
+## Current sprint pointer
+
+| Field | Value |
+|-------|-------|
+| **Next issue** | [#180 — Plan catalog & subscription schema](https://github.com/diego-torres/nutriconsultas/issues/180) |
+| **Status** | **Blocked** by [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) |
+| **Early start** | [#183 — Platform admin RBAC](https://github.com/diego-torres/nutriconsultas/issues/183) (no schema) |
+
+See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) for full registry.

--- a/docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md
+++ b/docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md
@@ -1,0 +1,305 @@
+# Subscription & Access Enforcement Plan
+
+**Product:** Minutriporcion / nutriconsultas  
+**Status:** Planning (2026-06-16)  
+**Track:** `[Subscription]` — parallel to `[Mobile API]` (see [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](../../SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md))  
+**Issue registry:** [`ISSUE-SUBSCRIPTION.md`](../../ISSUE-SUBSCRIPTION.md)
+
+---
+
+## Goals
+
+1. **Platform admins only** — users in `nutriconsultas.platform.admin-user-ids` or `nutriconsultas.platform.admin-emails` are platform administrators (already partially implemented via `PlatformAdminService`).
+2. **Role assignment** — admins assign Auth0 groups / application roles: `nutriologo-basico`, `nutriologo-profesional`, `nutriologo-plus`, `director-consultorio`.
+3. **Paid onboarding** — admins invite nutritionists and clinic directors; invitation → registration → online payment → monthly subscription with grace period and admin payment overrides.
+4. **Clinic hierarchy** — directors invite nutritionists **without** a separate payment flow; directors enable/disable nutritionist access within their clinic.
+5. **Plan limits** — enforce patient and nutritionist caps per subscription tier (landing page is source of truth until a dedicated pricing service exists).
+6. **Report entitlements** — gate basic / advanced / full reports and PDF export by plan; branded reports use `NutritionistProfile` (logo, display name, cédula).
+
+---
+
+## Non-goals (this epic)
+
+- Patient mobile API changes (`/rest/mobile/patient/**`) — subscription gates the **nutritionist web app** and admin surfaces.
+- Replacing Auth0 as identity provider.
+- Multi-currency billing beyond MXN (initial target: Mexico).
+
+---
+
+## Existing foundation
+
+| Component | Location | Notes |
+|-----------|----------|-------|
+| Platform admin allowlist | `PlatformAdminProperties`, `PlatformAdminService` | `admin-user-ids` + `admin-emails`; used today for contact-inquiry admin inbox |
+| Multi-tenant patients | `Paciente.userId` | Nutritionist OAuth `sub`; unchanged |
+| Nutritionist branding | `NutritionistProfile` | Logo + display name on diet PDFs (#95) and message `senderDisplayName` (#116) |
+| Report PDFs | `PatientReportRestController`, `PatientReportService` | Progress, nutrition analysis, clinic statistics — **no plan gating today** |
+| Pricing marketing | `templates/eterna/index.html` | Básico $5, Profesional $10, Plus $30, Consultorio $45 / mes |
+| Liquibase gate | #46 | Subscription schema lands **after** Liquibase baseline |
+
+---
+
+## Roles & identity model
+
+### Platform administrator
+
+- **Source of truth:** configuration only (`PLATFORM_ADMIN_USER_IDS`, `PLATFORM_ADMIN_EMAILS`).
+- **Not** an Auth0 group — avoids privilege escalation via group self-assignment.
+- **Capabilities:** assign roles, send paid invitations, set payment-exempt / trial flags, view subscription health, manage grace overrides.
+
+### Application roles (Auth0 groups or app_metadata)
+
+| Role slug | Marketing name | Typical assignee |
+|-----------|----------------|------------------|
+| `nutriologo-basico` | Básico | Solo nutritionist |
+| `nutriologo-profesional` | Profesional | Solo nutritionist |
+| `nutriologo-plus` | Plus | Solo nutritionist |
+| `director-consultorio` | Consultorio | Clinic director (may also practice as nutritionist) |
+
+**Recommendation:** store canonical plan on `Subscription.planTier` in DB; sync Auth0 group on assign/revoke via Management API (#108 extension). JWT / session carries groups for coarse authorization; DB is authoritative for limits and billing state.
+
+### Clinic hierarchy (`director-consultorio`)
+
+```
+Platform
+ └── Clinic (subscription owner)
+      ├── Director (director-consultorio, billing contact)
+      └── Nutritionist seats (0..maxNutritionists-1, invited by director, no separate payment)
+```
+
+- One **active subscription** per `Clinic`.
+- Solo plans (Básico–Plus): implicit clinic of one user (`maxNutritionists = 1`).
+- Consultorio: director manages roster; disabling a nutritionist revokes app access without deleting patient data (soft `membershipStatus`).
+
+---
+
+## Plan entitlements (canonical)
+
+Aligned with [`eterna/index.html`](../../src/main/resources/templates/eterna/index.html) pricing table.
+
+| Entitlement | Básico | Profesional | Plus | Consultorio |
+|-------------|--------|-------------|------|-------------|
+| `maxPatients` | 10 | 50 | unlimited (`null`) | unlimited |
+| `maxNutritionists` | 1 | 1 | 1 | 20 |
+| `patientManagement` | ✓ | ✓ | ✓ | ✓ |
+| `dietPlans` | ✓ | ✓ | ✓ | ✓ |
+| `calendar` | ✓ | ✓ | ✓ | ✓ |
+| `reportsBasic` | ✓ | ✓ | ✓ | ✓ |
+| `reportsAdvanced` | ✗ | ✓ | ✓ | ✓ |
+| `reportsFull` | ✗ | ✓ | ✓ | ✓ |
+| `pdfExport` | ✗ | ✓ | ✓ | ✓ |
+| `reportsBranded` | ✗ | ✓ | ✓ | ✓ |
+| `prioritySupport` | ✗ | ✗ | ✓ | ✓ |
+| `userAdministration` | ✗ | ✗ | ✗ | ✓ |
+
+### Report mapping (implementation)
+
+| Marketing | Code flag | Endpoints / UI |
+|-----------|-----------|----------------|
+| Reportes básicos | `reportsBasic` | In-app progress views, tablero summaries (no PDF) |
+| Reportes avanzados | `reportsAdvanced` | Extended analytics sections in `ReportController` views |
+| Reportes completos | `reportsFull` | Full patient report HTML views |
+| Exportación PDF | `pdfExport` | `GET /rest/reports/patient/{id}`, nutrition PDF, clinic statistics PDF |
+| Personalizados (logo + datos) | `reportsBranded` | `NutritionistProfile` header block on PDF templates (already partial) |
+
+Enforcement: central `SubscriptionEntitlementService.hasEntitlement(userId, Entitlement)` called from controllers/services **before** business logic; return **403** with localized message for web, JSON for REST.
+
+---
+
+## Subscription lifecycle
+
+### States
+
+| State | App access | Notes |
+|-------|------------|-------|
+| `PENDING_PAYMENT` | None (invite + checkout only) | After admin invitation, before first payment |
+| `TRIAL` | Full plan entitlements | Admin `paymentExempt=true` or explicit trial end date |
+| `ACTIVE` | Full | Paid period current |
+| `GRACE` | Read + messaging; **no** new patients / PDF | Configurable `gracePeriodDays` (default 7) after `periodEnd` |
+| `SUSPENDED` | Login blocked or redirect to billing | After grace without payment |
+| `CANCELLED` | None | Terminal; data retained per retention policy |
+
+### Payment override flag
+
+- `paymentExempt` (admin-set): skips payment provider checks; still respects plan tier limits.
+- Use cases: prueba gratuita, prórroga comercial, cuenta interna.
+- Audit: `SubscriptionAuditEvent` (who set, when, reason code).
+
+### Billing period
+
+- Monthly vigencia from successful payment webhook (or admin trial start).
+- Annual prepay (10 months price): extend `periodEnd` by 12 months — marketing only until checkout supports annual SKUs.
+
+### Grace & notifications
+
+Scheduled job (daily):
+
+1. `ACTIVE` → `GRACE` when `now > periodEnd`.
+2. Email / in-app banner to nutritionist and director (Consultorio).
+3. `GRACE` → `SUSPENDED` when `now > periodEnd + gracePeriodDays`.
+4. Reminder at T-7, T-3, T-1 days before `periodEnd` for `ACTIVE`.
+
+**PHI rule:** notifications contain subscription status and billing links only — no patient names.
+
+---
+
+## Invitation flows
+
+### A — Platform admin → nutritionist / director (with payment)
+
+```mermaid
+sequenceDiagram
+  participant Admin as Platform admin
+  participant App as nutriconsultas
+  participant Pay as Payment provider
+  participant Auth as Auth0
+  participant User as Nutritionist/Director
+
+  Admin->>App: Create invitation (email, planTier)
+  App->>User: Email with signed invite link
+  User->>Auth: Register / login
+  User->>App: Redeem invite token
+  App->>Pay: Create checkout session
+  User->>Pay: Pay subscription
+  Pay->>App: Webhook payment.succeeded
+  App->>App: Activate subscription, assign Auth0 group
+  App->>User: Redirect to /admin dashboard
+```
+
+### B — Director → nutritionist (no payment)
+
+```mermaid
+sequenceDiagram
+  participant Dir as Director
+  participant App as nutriconsultas
+  participant Auth as Auth0
+  participant Nut as Nutritionist
+
+  Dir->>App: Invite nutritionist (email) if seats available
+  App->>Nut: Email invite link
+  Nut->>Auth: Register / login
+  Nut->>App: Redeem clinic invite
+  App->>App: Link ClinicMember, inherit clinic subscription
+  App->>Nut: Access per clinic ACTIVE state
+```
+
+Director can `suspend` / `reactivate` members without Auth0 deletion (revoke group or app membership flag).
+
+---
+
+## Payment provider integration
+
+**Decision pending** — evaluate Mercado Pago (MX primary) vs Stripe (international). Abstract behind `PaymentProvider` interface:
+
+- `createCheckoutSession(invitationId, planTier, billingInterval)`
+- `handleWebhook(payload, signature)`
+- `cancelSubscription(externalId)`
+
+Store `externalSubscriptionId`, `externalCustomerId` on `Subscription`. Webhook idempotency table required.
+
+---
+
+## Data model (proposed)
+
+Liquibase changesets after #46 baseline.
+
+| Entity | Purpose |
+|--------|---------|
+| `PlanTier` | Enum: `BASICO`, `PROFESIONAL`, `PLUS`, `CONSULTORIO` |
+| `Subscription` | `clinicId`, `planTier`, `status`, `periodStart`, `periodEnd`, `paymentExempt`, `gracePeriodDays`, payment provider refs |
+| `Clinic` | `name`, `directorUserId`, `subscriptionId` |
+| `ClinicMember` | `clinicId`, `userId`, `role`, `membershipStatus` (`ACTIVE`/`SUSPENDED`), `invitedBy` |
+| `NutritionistInvitation` | Admin-paid flow: token hash, email, `planTier`, `status`, expiry |
+| `ClinicInvitation` | Director flow: token hash, email, `clinicId`, expiry |
+| `SubscriptionAuditEvent` | Admin actions, webhooks, state transitions |
+
+**Patient count:** `COUNT(paciente WHERE userId IN clinic active members)` vs `maxPatients` on director's plan (Consultorio: aggregate clinic-wide or per-seat — **default: clinic-wide**).
+
+---
+
+## Security requirements
+
+1. Platform admin endpoints: `PlatformAdminService.requirePlatformAdmin(principal)` — never trust client-sent role.
+2. Director endpoints: verify `ClinicMember.role=DIRECTOR` and `membershipStatus=ACTIVE`.
+3. Invitation tokens: CSPRNG, store SHA-256 hash only (same pattern as patient onboarding #133).
+4. Webhook endpoints: signature verification, no CSRF, rate limited.
+5. Subscription state checked on **every** authenticated `/admin/**` request (filter or `@PreAuthorize` + service).
+6. Grace mode: allow `GET` + patient messages; block `POST` paciente create, PDF generation, new invitations.
+
+---
+
+## Dependencies & build order
+
+```mermaid
+flowchart TD
+  L46[#46 Liquibase baseline]
+  S180[#180 Plan catalog + schema]
+  S181[#181 Entitlement service]
+  S182[#182 Auth0 role sync]
+  S184[#184 Admin invitations + payment]
+  S185[#185 Subscription lifecycle + grace]
+  S186[#186 Clinic + director model]
+  S188[#188 Director invitations]
+  S190[#190 Limit enforcement]
+  S187[#187 Report + PDF gating]
+
+  L46 --> S180
+  S180 --> S181
+  S181 --> S182
+  S182 --> S184
+  S184 --> S185
+  S180 --> S186
+  S186 --> S188
+  S181 --> S190
+  S181 --> S187
+  S185 --> S190
+```
+
+**Parallel track note:** `[Mobile API]` #132–#141 patient invitation onboarding is **orthogonal** — do not conflate `NutritionistInvitation` with patient `Invitation`.
+
+---
+
+## Configuration (new properties)
+
+```properties
+# Existing
+nutriconsultas.platform.admin-user-ids=${PLATFORM_ADMIN_USER_IDS:}
+nutriconsultas.platform.admin-emails=${PLATFORM_ADMIN_EMAILS:}
+
+# New (illustrative)
+nutriconsultas.subscription.grace-period-days=${SUBSCRIPTION_GRACE_PERIOD_DAYS:7}
+nutriconsultas.subscription.payment.provider=${PAYMENT_PROVIDER:mercadopago}
+nutriconsultas.subscription.payment.webhook-secret=${PAYMENT_WEBHOOK_SECRET:}
+```
+
+---
+
+## Testing strategy
+
+| Layer | Focus |
+|-------|-------|
+| Unit | `PlanEntitlements`, state machine transitions, limit counters |
+| Integration | Webhook handling, invitation redeem, Auth0 group sync (mocked) |
+| Security | Non-admin cannot assign roles; director cannot exceed seats; grace blocks PDF |
+| E2E | Admin invite → mock payment → login → create patient up to limit |
+
+---
+
+## Open decisions
+
+| # | Question | Default proposal |
+|---|----------|------------------|
+| 1 | Payment provider | Mercado Pago for MX launch |
+| 2 | Consultorio patient limit | Clinic-wide unlimited (per landing page) |
+| 3 | Grace write policy | Block new patients + PDF; allow messages |
+| 4 | Auth0 groups vs Roles | Auth0 Roles with RBAC enabled |
+| 5 | Annual billing in v1 | Monthly only; annual SKU in v2 |
+
+---
+
+## Related documents
+
+- [`ISSUE-SUBSCRIPTION.md`](../../ISSUE-SUBSCRIPTION.md) — issue registry
+- [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](../../SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md) — agent workflow
+- [`ISSUE.md`](../ISSUE.md) — mobile API track (orthogonal)
+- [`AGENT-WORKFLOW.md`](../AGENT-WORKFLOW.md) — mobile API agent workflow


### PR DESCRIPTION
## Summary
- Add `docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md` with plan tiers, RBAC, billing lifecycle, clinic hierarchy, and entitlements
- Add `ISSUE-SUBSCRIPTION.md` and `SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md` as the parallel agent track to the mobile API workflow
- Link the new track from `AGENTS.md` and `AGENT-WORKFLOW.md` (issues #180–#190 on GitHub)

## Test plan
- [x] Markdown-only change; no build impact
- [ ] Review plan tier matrix matches `eterna/index.html` pricing table
- [ ] Confirm issue links (#180–#190) resolve on GitHub

Made with [Cursor](https://cursor.com)