### PR TITLE
fix(paciente): guard null bodySnapshot after JPA load (#193)

### DIFF
--- a/src/main/java/com/nutriconsultas/paciente/Paciente.java
+++ b/src/main/java/com/nutriconsultas/paciente/Paciente.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.PostLoad;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Temporal;
@@ -114,9 +115,13 @@ public class Paciente {
 	@ValidPregnancy
 	private Boolean pregnancy = false;
 
+	@PostLoad
 	@PrePersist
 	@PreUpdate
-	void linkSatelliteRows() {
+	void ensureEmbeddedRows() {
+		if (bodySnapshot == null) {
+			bodySnapshot = new PacienteBodySnapshot();
+		}
 		if (energyPreferences == null) {
 			energyPreferences = new PacienteEnergyPreferences();
 		}

--- a/src/test/java/com/nutriconsultas/paciente/PacienteEmbeddablePersistenceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteEmbeddablePersistenceTest.java
@@ -32,6 +32,19 @@ class PacienteEmbeddablePersistenceTest {
 	private EntityManager entityManager;
 
 	@Test
+	void saveAndLoad_nullBodyMetrics_allowsDelegatedGettersWithoutNpe() {
+		final Paciente saved = pacienteRepository.saveAndFlush(samplePaciente());
+		entityManager.clear();
+
+		final Paciente loaded = pacienteRepository.findById(saved.getId()).orElseThrow();
+
+		assertThat(loaded.getBodySnapshot()).isNotNull();
+		assertThat(loaded.getGetKcal()).isNull();
+		assertThat(loaded.getBmr()).isNull();
+		assertThat(loaded.getPeso()).isNull();
+	}
+
+	@Test
 	void saveAndLoad_preservesEmbeddableFieldsViaDelegatedAccessors() {
 		final Paciente paciente = samplePaciente();
 		paciente.setPeso(72.5);


### PR DESCRIPTION
## Summary
- Initialize `PacienteBodySnapshot` in `@PostLoad` when Hibernate leaves the embeddable null (all body-metric columns NULL in DB).
- Prevents NPE on delegated getters (`getGetKcal`, `getBmr`, etc.) when rendering patient profile and other Thymeleaf views.
- Adds JPA regression test for patients saved/loaded without body metrics.

Fixes #193

## Test plan
- [x] `mvn test -Dtest=PacienteEmbeddablePersistenceTest`
- [x] `mvn checkstyle:check`
- [ ] CI green
- [ ] After deploy: open `/admin/pacientes/2/perfil` in production and confirm "GET: sin dato" instead of 500


Made with [Cursor](https://cursor.com)