### PR TITLE
fix(ci): SpotBugs artifact upload — compile before spotbugs:check (#129)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,7 +42,7 @@ jobs:
       # Note: Using custom checkstyle rules instead of Spring Java Format validation
       # Spring Java Format is available for explicit use: mvn spring-javaformat:apply
     - name: Run SpotBugs
-      run: mvn -B spotbugs:check
+      run: mvn -B compile spotbugs:check
     - name: Run PMD
       run: mvn -B pmd:check -Pci
     - name: Validate Thymeleaf templates
@@ -60,7 +60,7 @@ jobs:
         retention-days: 7
     - name: Upload SpotBugs results
       uses: actions/upload-artifact@v7
-      if: always()
+      if: always() && hashFiles('target/spotbugsXml.xml') != ''
       with:
         name: spotbugs-results
         path: target/spotbugsXml.xml


### PR DESCRIPTION
## Summary
- Run `mvn -B compile spotbugs:check` in the lint job so SpotBugs has compiled bytecode on a clean CI checkout
- Guard the `spotbugs-results` artifact upload with `hashFiles('target/spotbugsXml.xml')` to avoid Actions warnings when the report is absent

Fixes #129

## Root cause
On fresh CI checkouts, `spotbugs:check` alone skipped the report goal because no classes were compiled, so `target/spotbugsXml.xml` was never created and the upload step warned on every run.

## Test plan
- [x] Local: `mvn clean compile spotbugs:check` generates `target/spotbugsXml.xml`
- [ ] CI lint job uploads `spotbugs-results` without "No files were found" warning
- [ ] SpotBugs analysis still uses the same plugin config/thresholds


Made with [Cursor](https://cursor.com)