### PR TITLE
feat(subscription): plan catalog and subscription schema (#180)

### DIFF
--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -27,7 +27,7 @@ Living index of GitHub issues that implement **subscription enforcement**, platf
 
 | # | Title | URL | State | Blocks |
 |---|-------|-----|-------|--------|
-| 46 | Implement Liquibase for database change management | https://github.com/diego-torres/nutriconsultas/issues/46 | **NEXT** (mobile track) | #180 subscription schema |
+| 46 | Implement Liquibase for database change management | https://github.com/diego-torres/nutriconsultas/issues/46 | **done** | — |
 
 Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platform admin RBAC) can start before #46.
 
@@ -37,8 +37,8 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| **180** | Plan catalog, subscription schema & Liquibase | https://github.com/diego-torres/nutriconsultas/issues/180 | open | **46** | `PlanTier`, `Subscription`, `Clinic`, invitations — **NEXT** after #46 |
-| 181 | SubscriptionEntitlementService — plan tier resolution | https://github.com/diego-torres/nutriconsultas/issues/181 | open | 180 | Central `hasEntitlement()` |
+| **180** | Plan catalog, subscription schema & Liquibase | https://github.com/diego-torres/nutriconsultas/issues/180 | **in-progress** | **46** | `PlanTier`, `Subscription`, `Clinic`, invitations — branch `subscription/180-plan-catalog-schema` |
+| 181 | SubscriptionEntitlementService — plan tier resolution | https://github.com/diego-torres/nutriconsultas/issues/181 | **NEXT** | 180 | Central `hasEntitlement()` |
 | 182 | Auth0 role sync — nutriologo-* and director-consultorio | https://github.com/diego-torres/nutriconsultas/issues/182 | open | 181, 108 | Management API group assign |
 | 183 | Platform admin RBAC — enforce admin allowlist | https://github.com/diego-torres/nutriconsultas/issues/183 | open | — | Extends `PlatformAdminService`; can start early |
 

--- a/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
+++ b/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
@@ -199,8 +199,8 @@ cat docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md
 
 | Field | Value |
 |-------|-------|
-| **Next issue** | [#180 — Plan catalog & subscription schema](https://github.com/diego-torres/nutriconsultas/issues/180) |
-| **Status** | **Blocked** by [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) |
+| **Next issue** | [#181 — SubscriptionEntitlementService](https://github.com/diego-torres/nutriconsultas/issues/181) |
+| **Status** | **Blocked** by #180 (in progress on `subscription/180-plan-catalog-schema`) |
 | **Early start** | [#183 — Platform admin RBAC](https://github.com/diego-torres/nutriconsultas/issues/183) (no schema) |
 
 See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) for full registry.

--- a/src/main/java/com/nutriconsultas/subscription/Clinic.java
+++ b/src/main/java/com/nutriconsultas/subscription/Clinic.java
@@ -1,0 +1,49 @@
+package com.nutriconsultas.subscription;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "clinic")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Clinic {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, length = 200)
+	private String name;
+
+	@Column(name = "director_user_id", nullable = false, length = 255)
+	private String directorUserId;
+
+	@OneToOne(optional = false)
+	@JoinColumn(name = "subscription_id", nullable = false, unique = true)
+	private Subscription subscription;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private Instant createdAt;
+
+	@PrePersist
+	void onCreate() {
+		if (createdAt == null) {
+			createdAt = Instant.now();
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/ClinicInvitation.java
+++ b/src/main/java/com/nutriconsultas/subscription/ClinicInvitation.java
@@ -1,0 +1,71 @@
+package com.nutriconsultas.subscription;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Director-issued clinic invitation (no separate payment). Stores SHA-256 token hash
+ * only.
+ */
+@Entity
+@Table(name = "clinic_invitation")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClinicInvitation {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "clinic_id", nullable = false)
+	private Clinic clinic;
+
+	@Column(nullable = false, length = 255)
+	private String email;
+
+	@Column(name = "token_hash", nullable = false, length = 64, unique = true)
+	private String tokenHash;
+
+	@Column(name = "invited_by_user_id", nullable = false, length = 255)
+	private String invitedByUserId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private InvitationStatus status = InvitationStatus.PENDING;
+
+	@Column(name = "expires_at", nullable = false)
+	private Instant expiresAt;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private Instant createdAt;
+
+	@Column(name = "redeemed_at")
+	private Instant redeemedAt;
+
+	@Column(name = "redeemed_by_user_id", length = 255)
+	private String redeemedByUserId;
+
+	@PrePersist
+	void onCreate() {
+		if (createdAt == null) {
+			createdAt = Instant.now();
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/ClinicInvitationRepository.java
+++ b/src/main/java/com/nutriconsultas/subscription/ClinicInvitationRepository.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.subscription;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClinicInvitationRepository extends JpaRepository<ClinicInvitation, Long> {
+
+	Optional<ClinicInvitation> findByTokenHash(String tokenHash);
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/ClinicMember.java
+++ b/src/main/java/com/nutriconsultas/subscription/ClinicMember.java
@@ -1,0 +1,62 @@
+package com.nutriconsultas.subscription;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "clinic_member",
+		uniqueConstraints = {
+				@UniqueConstraint(name = "uk_clinic_member_clinic_user", columnNames = { "clinic_id", "user_id" }) })
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClinicMember {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "clinic_id", nullable = false)
+	private Clinic clinic;
+
+	@Column(name = "user_id", nullable = false, length = 255)
+	private String userId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private ClinicMemberRole role;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "membership_status", nullable = false, length = 20)
+	private MembershipStatus membershipStatus = MembershipStatus.ACTIVE;
+
+	@Column(name = "invited_by", length = 255)
+	private String invitedBy;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private Instant createdAt;
+
+	@PrePersist
+	void onCreate() {
+		if (createdAt == null) {
+			createdAt = Instant.now();
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/ClinicMemberRepository.java
+++ b/src/main/java/com/nutriconsultas/subscription/ClinicMemberRepository.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.subscription;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClinicMemberRepository extends JpaRepository<ClinicMember, Long> {
+
+	List<ClinicMember> findByClinicIdAndMembershipStatus(Long clinicId, MembershipStatus membershipStatus);
+
+	Optional<ClinicMember> findByClinicIdAndUserId(Long clinicId, String userId);
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/ClinicMemberRole.java
+++ b/src/main/java/com/nutriconsultas/subscription/ClinicMemberRole.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.subscription;
+
+public enum ClinicMemberRole {
+
+	DIRECTOR, NUTRITIONIST
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/ClinicRepository.java
+++ b/src/main/java/com/nutriconsultas/subscription/ClinicRepository.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.subscription;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClinicRepository extends JpaRepository<Clinic, Long> {
+
+	Optional<Clinic> findByDirectorUserId(String directorUserId);
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/Entitlement.java
+++ b/src/main/java/com/nutriconsultas/subscription/Entitlement.java
@@ -1,0 +1,12 @@
+package com.nutriconsultas.subscription;
+
+/**
+ * Feature flags gated by {@link PlanTier}. Canonical matrix:
+ * {@code docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md}.
+ */
+public enum Entitlement {
+
+	PATIENT_MANAGEMENT, DIET_PLANS, CALENDAR, REPORTS_BASIC, REPORTS_ADVANCED, REPORTS_FULL, PDF_EXPORT,
+	REPORTS_BRANDED, PRIORITY_SUPPORT, USER_ADMINISTRATION
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/InvitationStatus.java
+++ b/src/main/java/com/nutriconsultas/subscription/InvitationStatus.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.subscription;
+
+public enum InvitationStatus {
+
+	PENDING, REDEEMED, EXPIRED, CANCELLED
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/MembershipStatus.java
+++ b/src/main/java/com/nutriconsultas/subscription/MembershipStatus.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.subscription;
+
+public enum MembershipStatus {
+
+	ACTIVE, SUSPENDED
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/NutritionistInvitation.java
+++ b/src/main/java/com/nutriconsultas/subscription/NutritionistInvitation.java
@@ -1,0 +1,68 @@
+package com.nutriconsultas.subscription;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Platform-admin paid onboarding invitation. Stores SHA-256 token hash only.
+ */
+@Entity
+@Table(name = "nutritionist_invitation")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NutritionistInvitation {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, length = 255)
+	private String email;
+
+	@Column(name = "token_hash", nullable = false, length = 64, unique = true)
+	private String tokenHash;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "plan_tier", nullable = false, length = 30)
+	private PlanTier planTier;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private InvitationStatus status = InvitationStatus.PENDING;
+
+	@Column(name = "expires_at", nullable = false)
+	private Instant expiresAt;
+
+	@Column(name = "created_by_user_id", nullable = false, length = 255)
+	private String createdByUserId;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private Instant createdAt;
+
+	@Column(name = "redeemed_at")
+	private Instant redeemedAt;
+
+	@Column(name = "redeemed_by_user_id", length = 255)
+	private String redeemedByUserId;
+
+	@PrePersist
+	void onCreate() {
+		if (createdAt == null) {
+			createdAt = Instant.now();
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/NutritionistInvitationRepository.java
+++ b/src/main/java/com/nutriconsultas/subscription/NutritionistInvitationRepository.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.subscription;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NutritionistInvitationRepository extends JpaRepository<NutritionistInvitation, Long> {
+
+	Optional<NutritionistInvitation> findByTokenHash(String tokenHash);
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/PlanTier.java
+++ b/src/main/java/com/nutriconsultas/subscription/PlanTier.java
@@ -1,0 +1,81 @@
+package com.nutriconsultas.subscription;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Canonical subscription plan tiers aligned with marketing pricing on
+ * {@code eterna/index.html}.
+ */
+public enum PlanTier {
+
+	BASICO("nutriologo-basico", 10, 1,
+			EnumSet.of(Entitlement.PATIENT_MANAGEMENT, Entitlement.DIET_PLANS, Entitlement.CALENDAR,
+					Entitlement.REPORTS_BASIC)),
+
+	PROFESIONAL("nutriologo-profesional", 50, 1,
+			EnumSet.of(Entitlement.PATIENT_MANAGEMENT, Entitlement.DIET_PLANS, Entitlement.CALENDAR,
+					Entitlement.REPORTS_BASIC, Entitlement.REPORTS_ADVANCED, Entitlement.REPORTS_FULL,
+					Entitlement.PDF_EXPORT, Entitlement.REPORTS_BRANDED)),
+
+	PLUS("nutriologo-plus", null, 1,
+			EnumSet.of(Entitlement.PATIENT_MANAGEMENT, Entitlement.DIET_PLANS, Entitlement.CALENDAR,
+					Entitlement.REPORTS_BASIC, Entitlement.REPORTS_ADVANCED, Entitlement.REPORTS_FULL,
+					Entitlement.PDF_EXPORT, Entitlement.REPORTS_BRANDED, Entitlement.PRIORITY_SUPPORT)),
+
+	CONSULTORIO("director-consultorio", null, 20,
+			EnumSet.of(Entitlement.PATIENT_MANAGEMENT, Entitlement.DIET_PLANS, Entitlement.CALENDAR,
+					Entitlement.REPORTS_BASIC, Entitlement.REPORTS_ADVANCED, Entitlement.REPORTS_FULL,
+					Entitlement.PDF_EXPORT, Entitlement.REPORTS_BRANDED, Entitlement.PRIORITY_SUPPORT,
+					Entitlement.USER_ADMINISTRATION));
+
+	private final String roleSlug;
+
+	private final Integer maxPatients;
+
+	private final int maxNutritionists;
+
+	private final Set<Entitlement> entitlements;
+
+	PlanTier(final String roleSlug, final Integer maxPatients, final int maxNutritionists,
+			final Set<Entitlement> entitlements) {
+		this.roleSlug = roleSlug;
+		this.maxPatients = maxPatients;
+		this.maxNutritionists = maxNutritionists;
+		this.entitlements = Collections.unmodifiableSet(entitlements);
+	}
+
+	public String getRoleSlug() {
+		return roleSlug;
+	}
+
+	/**
+	 * Maximum patients allowed for the plan, or {@code null} for unlimited.
+	 */
+	public Integer getMaxPatients() {
+		return maxPatients;
+	}
+
+	public int getMaxNutritionists() {
+		return maxNutritionists;
+	}
+
+	public Set<Entitlement> getEntitlements() {
+		return entitlements;
+	}
+
+	public boolean hasEntitlement(final Entitlement entitlement) {
+		return entitlements.contains(entitlement);
+	}
+
+	public static PlanTier fromRoleSlug(final String roleSlug) {
+		for (final PlanTier tier : values()) {
+			if (tier.roleSlug.equals(roleSlug)) {
+				return tier;
+			}
+		}
+		throw new IllegalArgumentException("Unknown plan role slug: " + roleSlug);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/Subscription.java
+++ b/src/main/java/com/nutriconsultas/subscription/Subscription.java
@@ -1,0 +1,78 @@
+package com.nutriconsultas.subscription;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "subscription")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Subscription {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 30)
+	private PlanTier planTier;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 30)
+	private SubscriptionStatus status = SubscriptionStatus.PENDING_PAYMENT;
+
+	@Column(name = "period_start")
+	private Instant periodStart;
+
+	@Column(name = "period_end")
+	private Instant periodEnd;
+
+	@Column(name = "payment_exempt", nullable = false)
+	private boolean paymentExempt;
+
+	@Column(name = "grace_period_days", nullable = false)
+	private int gracePeriodDays = 7;
+
+	@Column(name = "external_subscription_id", length = 255)
+	private String externalSubscriptionId;
+
+	@Column(name = "external_customer_id", length = 255)
+	private String externalCustomerId;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private Instant createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private Instant updatedAt;
+
+	@PrePersist
+	void onCreate() {
+		final Instant now = Instant.now();
+		if (createdAt == null) {
+			createdAt = now;
+		}
+		if (updatedAt == null) {
+			updatedAt = now;
+		}
+	}
+
+	@PreUpdate
+	void onUpdate() {
+		updatedAt = Instant.now();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionAuditEvent.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionAuditEvent.java
@@ -1,0 +1,69 @@
+package com.nutriconsultas.subscription;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Audit trail for subscription admin actions and payment webhooks. Never store PHI.
+ */
+@Entity
+@Table(name = "subscription_audit_event")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubscriptionAuditEvent {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "subscription_id")
+	private Subscription subscription;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "event_type", nullable = false, length = 40)
+	private SubscriptionAuditEventType eventType;
+
+	@Column(name = "actor_user_id", length = 255)
+	private String actorUserId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "previous_status", length = 30)
+	private SubscriptionStatus previousStatus;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "new_status", length = 30)
+	private SubscriptionStatus newStatus;
+
+	@Column(name = "reason_code", length = 50)
+	private String reasonCode;
+
+	@Column(length = 500)
+	private String details;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private Instant createdAt;
+
+	@PrePersist
+	void onCreate() {
+		if (createdAt == null) {
+			createdAt = Instant.now();
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionAuditEventRepository.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionAuditEventRepository.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.subscription;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscriptionAuditEventRepository extends JpaRepository<SubscriptionAuditEvent, Long> {
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionAuditEventType.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionAuditEventType.java
@@ -1,0 +1,8 @@
+package com.nutriconsultas.subscription;
+
+public enum SubscriptionAuditEventType {
+
+	ADMIN_PAYMENT_OVERRIDE, ADMIN_STATE_CHANGE, WEBHOOK_PAYMENT_SUCCEEDED, WEBHOOK_PAYMENT_FAILED, STATE_TRANSITION,
+	INVITATION_REDEEMED
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionRepository.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionRepository.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.subscription;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionStatus.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionStatus.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.subscription;
+
+/**
+ * Subscription lifecycle states. See
+ * {@code docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md}.
+ */
+public enum SubscriptionStatus {
+
+	PENDING_PAYMENT, TRIAL, ACTIVE, GRACE, SUSPENDED, CANCELLED
+
+}

--- a/src/main/resources/db/changelog/changes/003-subscription-schema.yaml
+++ b/src/main/resources/db/changelog/changes/003-subscription-schema.yaml
@@ -1,0 +1,327 @@
+databaseChangeLog:
+  - changeSet:
+      id: 003-subscription-schema
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            tableExists:
+              tableName: subscription
+      changes:
+        - createTable:
+            tableName: subscription
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: plan_tier
+                  type: VARCHAR(30)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(30)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: period_start
+                  type: TIMESTAMP
+              - column:
+                  name: period_end
+                  type: TIMESTAMP
+              - column:
+                  name: payment_exempt
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: grace_period_days
+                  type: INT
+                  defaultValueNumeric: 7
+                  constraints:
+                    nullable: false
+              - column:
+                  name: external_subscription_id
+                  type: VARCHAR(255)
+              - column:
+                  name: external_customer_id
+                  type: VARCHAR(255)
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+        - createTable:
+            tableName: clinic
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: VARCHAR(200)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: director_user_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: subscription_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: clinic
+            baseColumnNames: subscription_id
+            referencedTableName: subscription
+            referencedColumnNames: id
+            constraintName: fk_clinic_subscription
+        - createIndex:
+            indexName: idx_clinic_director_user_id
+            tableName: clinic
+            columns:
+              - column:
+                  name: director_user_id
+        - createTable:
+            tableName: clinic_member
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: clinic_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: role
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: membership_status
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: invited_by
+                  type: VARCHAR(255)
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: clinic_member
+            baseColumnNames: clinic_id
+            referencedTableName: clinic
+            referencedColumnNames: id
+            constraintName: fk_clinic_member_clinic
+        - addUniqueConstraint:
+            tableName: clinic_member
+            columnNames: clinic_id, user_id
+            constraintName: uk_clinic_member_clinic_user
+        - createIndex:
+            indexName: idx_clinic_member_user_id
+            tableName: clinic_member
+            columns:
+              - column:
+                  name: user_id
+        - createTable:
+            tableName: nutritionist_invitation
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: email
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: token_hash
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
+                  name: plan_tier
+                  type: VARCHAR(30)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: expires_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_by_user_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: redeemed_at
+                  type: TIMESTAMP
+              - column:
+                  name: redeemed_by_user_id
+                  type: VARCHAR(255)
+        - createIndex:
+            indexName: idx_nutritionist_invitation_email
+            tableName: nutritionist_invitation
+            columns:
+              - column:
+                  name: email
+        - createTable:
+            tableName: clinic_invitation
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: clinic_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: email
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: token_hash
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
+                  name: invited_by_user_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: expires_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: redeemed_at
+                  type: TIMESTAMP
+              - column:
+                  name: redeemed_by_user_id
+                  type: VARCHAR(255)
+        - addForeignKeyConstraint:
+            baseTableName: clinic_invitation
+            baseColumnNames: clinic_id
+            referencedTableName: clinic
+            referencedColumnNames: id
+            constraintName: fk_clinic_invitation_clinic
+        - createTable:
+            tableName: subscription_audit_event
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: subscription_id
+                  type: BIGINT
+              - column:
+                  name: event_type
+                  type: VARCHAR(40)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: actor_user_id
+                  type: VARCHAR(255)
+              - column:
+                  name: previous_status
+                  type: VARCHAR(30)
+              - column:
+                  name: new_status
+                  type: VARCHAR(30)
+              - column:
+                  name: reason_code
+                  type: VARCHAR(50)
+              - column:
+                  name: details
+                  type: VARCHAR(500)
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: subscription_audit_event
+            baseColumnNames: subscription_id
+            referencedTableName: subscription
+            referencedColumnNames: id
+            constraintName: fk_subscription_audit_subscription
+        - createIndex:
+            indexName: idx_subscription_audit_subscription_id
+            tableName: subscription_audit_event
+            columns:
+              - column:
+                  name: subscription_id

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5,3 +5,6 @@ databaseChangeLog:
   - include:
       file: changes/002-seed-data.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/003-subscription-schema.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -2,3 +2,6 @@ databaseChangeLog:
   - include:
       file: changes/001-baseline-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/003-subscription-schema.yaml
+      relativeToChangelogFile: true

--- a/src/test/java/com/nutriconsultas/db/LiquibaseMigrationTest.java
+++ b/src/test/java/com/nutriconsultas/db/LiquibaseMigrationTest.java
@@ -14,8 +14,7 @@ import org.springframework.test.context.TestPropertySource;
  */
 @SpringBootTest
 @ActiveProfiles("test")
-@TestPropertySource(properties = {
-		"spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml" })
+@TestPropertySource(properties = { "spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml" })
 public class LiquibaseMigrationTest {
 
 	@Autowired
@@ -41,9 +40,19 @@ public class LiquibaseMigrationTest {
 
 	@Test
 	public void testDietaTemplatesSeedLoaded() {
-		final Long count = jdbc.queryForObject(
-				"SELECT COUNT(*) FROM dieta WHERE user_id = 'system:template-dietas'", Long.class);
+		final Long count = jdbc.queryForObject("SELECT COUNT(*) FROM dieta WHERE user_id = 'system:template-dietas'",
+				Long.class);
 		assertThat(count).isNotNull().isEqualTo(20L);
+	}
+
+	@Test
+	public void testSubscriptionSchemaTablesExist() {
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM subscription", Long.class)).isEqualTo(0L);
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM clinic", Long.class)).isEqualTo(0L);
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM clinic_member", Long.class)).isEqualTo(0L);
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM nutritionist_invitation", Long.class)).isEqualTo(0L);
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM clinic_invitation", Long.class)).isEqualTo(0L);
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM subscription_audit_event", Long.class)).isEqualTo(0L);
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/subscription/PlanTierTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/PlanTierTest.java
@@ -1,0 +1,58 @@
+package com.nutriconsultas.subscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class PlanTierTest {
+
+	@Test
+	void basicoLimitsAndEntitlements() {
+		assertThat(PlanTier.BASICO.getMaxPatients()).isEqualTo(10);
+		assertThat(PlanTier.BASICO.getMaxNutritionists()).isEqualTo(1);
+		assertThat(PlanTier.BASICO.getRoleSlug()).isEqualTo("nutriologo-basico");
+		assertThat(PlanTier.BASICO.hasEntitlement(Entitlement.PATIENT_MANAGEMENT)).isTrue();
+		assertThat(PlanTier.BASICO.hasEntitlement(Entitlement.REPORTS_BASIC)).isTrue();
+		assertThat(PlanTier.BASICO.hasEntitlement(Entitlement.PDF_EXPORT)).isFalse();
+		assertThat(PlanTier.BASICO.hasEntitlement(Entitlement.USER_ADMINISTRATION)).isFalse();
+	}
+
+	@Test
+	void profesionalIncludesBrandedReportsAndPdf() {
+		assertThat(PlanTier.PROFESIONAL.getMaxPatients()).isEqualTo(50);
+		assertThat(PlanTier.PROFESIONAL.hasEntitlement(Entitlement.REPORTS_ADVANCED)).isTrue();
+		assertThat(PlanTier.PROFESIONAL.hasEntitlement(Entitlement.REPORTS_FULL)).isTrue();
+		assertThat(PlanTier.PROFESIONAL.hasEntitlement(Entitlement.PDF_EXPORT)).isTrue();
+		assertThat(PlanTier.PROFESIONAL.hasEntitlement(Entitlement.REPORTS_BRANDED)).isTrue();
+		assertThat(PlanTier.PROFESIONAL.hasEntitlement(Entitlement.PRIORITY_SUPPORT)).isFalse();
+	}
+
+	@Test
+	void plusHasUnlimitedPatientsAndPrioritySupport() {
+		assertThat(PlanTier.PLUS.getMaxPatients()).isNull();
+		assertThat(PlanTier.PLUS.hasEntitlement(Entitlement.PRIORITY_SUPPORT)).isTrue();
+		assertThat(PlanTier.PLUS.hasEntitlement(Entitlement.USER_ADMINISTRATION)).isFalse();
+	}
+
+	@Test
+	void consultorioHasClinicAdministrationAndTwentySeats() {
+		assertThat(PlanTier.CONSULTORIO.getMaxPatients()).isNull();
+		assertThat(PlanTier.CONSULTORIO.getMaxNutritionists()).isEqualTo(20);
+		assertThat(PlanTier.CONSULTORIO.getRoleSlug()).isEqualTo("director-consultorio");
+		assertThat(PlanTier.CONSULTORIO.hasEntitlement(Entitlement.USER_ADMINISTRATION)).isTrue();
+	}
+
+	@Test
+	void fromRoleSlugResolvesKnownTiers() {
+		assertThat(PlanTier.fromRoleSlug("nutriologo-profesional")).isEqualTo(PlanTier.PROFESIONAL);
+		assertThat(PlanTier.fromRoleSlug("director-consultorio")).isEqualTo(PlanTier.CONSULTORIO);
+	}
+
+	@Test
+	void fromRoleSlugRejectsUnknownSlug() {
+		assertThatThrownBy(() -> PlanTier.fromRoleSlug("unknown-role")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("unknown-role");
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/subscription/SubscriptionEntityPersistenceTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/SubscriptionEntityPersistenceTest.java
@@ -1,0 +1,159 @@
+package com.nutriconsultas.subscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class SubscriptionEntityPersistenceTest {
+
+	private static final String TOKEN_HASH = "a".repeat(64);
+
+	@Autowired
+	private SubscriptionRepository subscriptionRepository;
+
+	@Autowired
+	private ClinicRepository clinicRepository;
+
+	@Autowired
+	private ClinicMemberRepository clinicMemberRepository;
+
+	@Autowired
+	private NutritionistInvitationRepository nutritionistInvitationRepository;
+
+	@Autowired
+	private ClinicInvitationRepository clinicInvitationRepository;
+
+	@Autowired
+	private SubscriptionAuditEventRepository subscriptionAuditEventRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	void subscriptionRoundTripsWithDefaults() {
+		final Subscription subscription = new Subscription();
+		subscription.setPlanTier(PlanTier.PROFESIONAL);
+		subscription.setStatus(SubscriptionStatus.ACTIVE);
+		subscription.setPeriodStart(Instant.now());
+		subscription.setPeriodEnd(Instant.now().plus(30, ChronoUnit.DAYS));
+		subscription.setPaymentExempt(false);
+		subscription.setGracePeriodDays(7);
+		subscription.setExternalSubscriptionId("ext-sub-1");
+		subscription.setExternalCustomerId("ext-cust-1");
+
+		final Subscription saved = subscriptionRepository.saveAndFlush(subscription);
+		entityManager.clear();
+
+		final Subscription loaded = subscriptionRepository.findById(saved.getId()).orElseThrow();
+		assertThat(loaded.getPlanTier()).isEqualTo(PlanTier.PROFESIONAL);
+		assertThat(loaded.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+		assertThat(loaded.getGracePeriodDays()).isEqualTo(7);
+		assertThat(loaded.getExternalSubscriptionId()).isEqualTo("ext-sub-1");
+		assertThat(loaded.getCreatedAt()).isNotNull();
+		assertThat(loaded.getUpdatedAt()).isNotNull();
+	}
+
+	@Test
+	void clinicAndMemberPersistWithSubscriptionLink() {
+		final Subscription subscription = subscriptionRepository.saveAndFlush(activeSubscription(PlanTier.CONSULTORIO));
+
+		final Clinic clinic = new Clinic();
+		clinic.setName("Clínica Norte");
+		clinic.setDirectorUserId("auth0|director-1");
+		clinic.setSubscription(subscription);
+		final Clinic savedClinic = clinicRepository.saveAndFlush(clinic);
+
+		final ClinicMember director = new ClinicMember();
+		director.setClinic(savedClinic);
+		director.setUserId("auth0|director-1");
+		director.setRole(ClinicMemberRole.DIRECTOR);
+		director.setMembershipStatus(MembershipStatus.ACTIVE);
+		clinicMemberRepository.saveAndFlush(director);
+
+		entityManager.clear();
+
+		final Clinic loadedClinic = clinicRepository.findByDirectorUserId("auth0|director-1").orElseThrow();
+		assertThat(loadedClinic.getSubscription().getPlanTier()).isEqualTo(PlanTier.CONSULTORIO);
+		assertThat(clinicMemberRepository.findByClinicIdAndUserId(loadedClinic.getId(), "auth0|director-1"))
+			.map(ClinicMember::getRole)
+			.contains(ClinicMemberRole.DIRECTOR);
+	}
+
+	@Test
+	void invitationsStoreTokenHashOnly() {
+		final Subscription subscription = subscriptionRepository.saveAndFlush(activeSubscription(PlanTier.BASICO));
+		final Clinic clinic = new Clinic();
+		clinic.setName("Solo Practice");
+		clinic.setDirectorUserId("auth0|solo-1");
+		clinic.setSubscription(subscription);
+		final Clinic savedClinic = clinicRepository.saveAndFlush(clinic);
+
+		final NutritionistInvitation adminInvite = new NutritionistInvitation();
+		adminInvite.setEmail("nutri@example.com");
+		adminInvite.setTokenHash(TOKEN_HASH);
+		adminInvite.setPlanTier(PlanTier.BASICO);
+		adminInvite.setStatus(InvitationStatus.PENDING);
+		adminInvite.setExpiresAt(Instant.now().plus(7, ChronoUnit.DAYS));
+		adminInvite.setCreatedByUserId("auth0|admin-1");
+		nutritionistInvitationRepository.saveAndFlush(adminInvite);
+
+		final ClinicInvitation clinicInvite = new ClinicInvitation();
+		clinicInvite.setClinic(savedClinic);
+		clinicInvite.setEmail("member@example.com");
+		clinicInvite.setTokenHash("b".repeat(64));
+		clinicInvite.setInvitedByUserId("auth0|director-1");
+		clinicInvite.setStatus(InvitationStatus.PENDING);
+		clinicInvite.setExpiresAt(Instant.now().plus(7, ChronoUnit.DAYS));
+		clinicInvitationRepository.saveAndFlush(clinicInvite);
+
+		entityManager.clear();
+
+		assertThat(nutritionistInvitationRepository.findByTokenHash(TOKEN_HASH)).isPresent();
+		assertThat(clinicInvitationRepository.findByTokenHash("b".repeat(64))).isPresent();
+	}
+
+	@Test
+	void auditEventPersistsStateTransition() {
+		final Subscription subscription = subscriptionRepository.saveAndFlush(activeSubscription(PlanTier.PLUS));
+
+		final SubscriptionAuditEvent event = new SubscriptionAuditEvent();
+		event.setSubscription(subscription);
+		event.setEventType(SubscriptionAuditEventType.STATE_TRANSITION);
+		event.setActorUserId("auth0|admin-1");
+		event.setPreviousStatus(SubscriptionStatus.ACTIVE);
+		event.setNewStatus(SubscriptionStatus.GRACE);
+		event.setReasonCode("PERIOD_EXPIRED");
+		event.setDetails("Grace period started");
+		subscriptionAuditEventRepository.saveAndFlush(event);
+
+		entityManager.clear();
+
+		final SubscriptionAuditEvent loaded = subscriptionAuditEventRepository.findAll().get(0);
+		assertThat(loaded.getEventType()).isEqualTo(SubscriptionAuditEventType.STATE_TRANSITION);
+		assertThat(loaded.getPreviousStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+		assertThat(loaded.getNewStatus()).isEqualTo(SubscriptionStatus.GRACE);
+		assertThat(loaded.getSubscription().getId()).isEqualTo(subscription.getId());
+	}
+
+	private static Subscription activeSubscription(final PlanTier planTier) {
+		final Subscription subscription = new Subscription();
+		subscription.setPlanTier(planTier);
+		subscription.setStatus(SubscriptionStatus.ACTIVE);
+		subscription.setPeriodStart(Instant.now());
+		subscription.setPeriodEnd(Instant.now().plus(30, ChronoUnit.DAYS));
+		subscription.setPaymentExempt(false);
+		subscription.setGracePeriodDays(7);
+		return subscription;
+	}
+
+}


### PR DESCRIPTION
## Description

Introduces the subscription data model and Liquibase schema for the `[Subscription]` enforcement track: plan tiers with entitlements, billing subscription rows, clinic hierarchy, invitation entities (token hash only), and audit events. No UI or runtime enforcement yet — schema foundation for #181+.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test addition or update
- [ ] 🔨 Build/CI changes

## Changes Made

- Add `PlanTier` enum with entitlements matrix aligned to `SUBSCRIPTION-ENFORCEMENT-PLAN.md`
- Add JPA entities: `Subscription`, `Clinic`, `ClinicMember`, `NutritionistInvitation`, `ClinicInvitation`, `SubscriptionAuditEvent`
- Add Liquibase changeset `003-subscription-schema.yaml` (6 tables, FKs, indexes)
- Add JPA repositories and unit/persistence tests
- Update `ISSUE-SUBSCRIPTION.md` and `SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md` registry

## Related Issues

Closes #180

## Spring Boot Specific Checklist

- [x] Code follows Spring Boot best practices
- [x] Proper use of `@Service`, `@Repository`, `@Controller`, `@RestController` annotations
- [x] Dependency injection is used correctly (constructor injection preferred)
- [ ] Configuration properties are properly externalized (if applicable)
- [x] Database migrations are included (if schema changes)
- [x] Transaction management is properly handled
- [ ] Exception handling follows Spring Boot patterns
- [ ] Security considerations addressed (if applicable)
- [ ] Actuator endpoints are not exposed in production (if modified)

## Thymeleaf Specific Checklist

- [ ] Thymeleaf templates use proper syntax (`th:*` attributes)
- [ ] Template fragments are used appropriately (`th:fragment`, `th:insert`, `th:replace`)
- [ ] Internationalization (i18n) is handled correctly (if applicable)
- [ ] Template expressions are safe and properly escaped
- [ ] No inline JavaScript with unescaped data
- [ ] Forms use proper Thymeleaf form binding (`th:object`, `th:field`)
- [ ] Template validation passes (run `ThymeleafValidator`)
- [ ] All template references are correct (no broken links)
- [ ] Responsive design is maintained (if UI changes)

_N/A — no template changes in this PR._

## Code Quality Checklist

- [x] Code is properly formatted (run `mvn spring-javaformat:apply`)
- [x] Checkstyle passes (run `mvn checkstyle:check`)
- [x] No SpotBugs warnings (run `mvn spotbugs:check`)
- [x] PMD checks pass (run `mvn pmd:check`)
- [x] All existing tests pass (`mvn test`)
- [x] New tests are added for new functionality
- [ ] Test coverage is maintained or improved
- [x] Code follows project naming conventions
- [x] No hardcoded values (use configuration properties)
- [x] Logging is appropriate (not too verbose, not too sparse)

## Testing

### Manual Testing
- [ ] Tested locally with `./dev-start.sh`
- [x] Database migrations work correctly (if applicable)
- [ ] All affected endpoints work as expected
- [ ] UI changes are tested in different browsers (if applicable)
- [ ] Mobile responsiveness verified (if UI changes)

_No UI changes. Optional manual check: confirm six subscription tables exist after Liquibase on PostgreSQL._

### Automated Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] All tests pass locally
- [x] Test coverage is adequate

```bash
mvn verify -Djacoco.skip=true
```

## Documentation

- [ ] README.md updated (if needed)
- [x] Code comments added for complex logic
- [ ] JavaDoc added for public APIs (if applicable)
- [ ] API documentation updated (if applicable)
- [ ] Changelog updated (if applicable)

## Database Changes

- [ ] No database changes
- [x] Migration script created
- [x] Migration tested on local database
- [x] Rollback strategy documented
- [ ] Data migration script included (if needed)

**Rollback:** Drop tables in reverse FK order (`subscription_audit_event` → `clinic_invitation` → `nutritionist_invitation` → `clinic_member` → `clinic` → `subscription`) or revert Liquibase changeset `003-subscription-schema`. No data migration — new empty tables only.

## Security Considerations

- [x] No sensitive data exposed in logs or responses
- [ ] Input validation is performed
- [x] SQL injection prevention (using parameterized queries)
- [ ] XSS prevention (proper escaping in templates)
- [ ] CSRF protection maintained (if forms modified)
- [ ] Authentication/authorization checks are in place (if applicable)
- [ ] Dependencies are up to date (no known vulnerabilities)

Invitation entities store SHA-256 token hashes only (no raw tokens persisted).

## Performance Considerations

- [x] Database queries are optimized (no N+1 problems)
- [ ] Appropriate use of caching (if applicable)
- [x] No memory leaks introduced
- [x] Large data sets are handled efficiently
- [ ] Pagination is used where appropriate

## Deployment Notes

- [ ] No special deployment steps required
- [ ] Environment variables need to be updated
- [x] Database migrations need to be run
- [ ] Configuration changes required
- [ ] Other:

Liquibase applies `003-subscription-schema` automatically on deploy (after #46 baseline).

## Screenshots (if applicable)

_N/A — backend/schema only._

## Additional Notes

- Unblocks #181 (`SubscriptionEntitlementService`) and downstream subscription issues.
- Patient mobile API track is untouched.

Made with [Cursor](https://cursor.com)