### PR TITLE
feat(subscription): add SubscriptionEntitlementService (#181)

### DIFF
--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -5,7 +5,7 @@ Living index of GitHub issues that implement **subscription enforcement**, platf
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Workflow:** [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md)  
 **Design doc:** [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md)  
-**Last updated:** 2026-06-16 — epic created; issues #180–#190 (+ #191 closed duplicate).
+**Last updated:** 2026-06-16 — #180 done; #181 in progress on `subscription/181-entitlement-service`.
 
 > **Scope.** This registry tracks `[Subscription]` issues only. The patient mobile API lives in [`ISSUE.md`](ISSUE.md). Patient invitation onboarding (#132–#141) is orthogonal — do not merge nutritionist and patient invitation entities.
 
@@ -37,8 +37,8 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| **180** | Plan catalog, subscription schema & Liquibase | https://github.com/diego-torres/nutriconsultas/issues/180 | **in-progress** | **46** | `PlanTier`, `Subscription`, `Clinic`, invitations — branch `subscription/180-plan-catalog-schema` |
-| 181 | SubscriptionEntitlementService — plan tier resolution | https://github.com/diego-torres/nutriconsultas/issues/181 | **NEXT** | 180 | Central `hasEntitlement()` |
+| **180** | Plan catalog, subscription schema & Liquibase | https://github.com/diego-torres/nutriconsultas/issues/180 | **done** | **46** | Merged PR #197 |
+| 181 | SubscriptionEntitlementService — plan tier resolution | https://github.com/diego-torres/nutriconsultas/issues/181 | **in-progress** | 180 | Branch `subscription/181-entitlement-service` — central `hasEntitlement()` |
 | 182 | Auth0 role sync — nutriologo-* and director-consultorio | https://github.com/diego-torres/nutriconsultas/issues/182 | open | 181, 108 | Management API group assign |
 | 183 | Platform admin RBAC — enforce admin allowlist | https://github.com/diego-torres/nutriconsultas/issues/183 | open | — | Extends `PlatformAdminService`; can start early |
 

--- a/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
+++ b/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
@@ -200,7 +200,7 @@ cat docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md
 | Field | Value |
 |-------|-------|
 | **Next issue** | [#181 — SubscriptionEntitlementService](https://github.com/diego-torres/nutriconsultas/issues/181) |
-| **Status** | **Blocked** by #180 (in progress on `subscription/180-plan-catalog-schema`) |
+| **Status** | **in-progress** on `subscription/181-entitlement-service` |
 | **Early start** | [#183 — Platform admin RBAC](https://github.com/diego-torres/nutriconsultas/issues/183) (no schema) |
 
 See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) for full registry.

--- a/src/main/java/com/nutriconsultas/subscription/ClinicMemberRepository.java
+++ b/src/main/java/com/nutriconsultas/subscription/ClinicMemberRepository.java
@@ -4,11 +4,17 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ClinicMemberRepository extends JpaRepository<ClinicMember, Long> {
 
 	List<ClinicMember> findByClinicIdAndMembershipStatus(Long clinicId, MembershipStatus membershipStatus);
 
 	Optional<ClinicMember> findByClinicIdAndUserId(Long clinicId, String userId);
+
+	@Query("SELECT cm FROM ClinicMember cm JOIN FETCH cm.clinic c JOIN FETCH c.subscription "
+			+ "WHERE cm.userId = :userId")
+	Optional<ClinicMember> findByUserIdWithClinicAndSubscription(@Param("userId") String userId);
 
 }

--- a/src/main/java/com/nutriconsultas/subscription/ClinicRepository.java
+++ b/src/main/java/com/nutriconsultas/subscription/ClinicRepository.java
@@ -3,9 +3,14 @@ package com.nutriconsultas.subscription;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ClinicRepository extends JpaRepository<Clinic, Long> {
 
 	Optional<Clinic> findByDirectorUserId(String directorUserId);
+
+	@Query("SELECT c FROM Clinic c JOIN FETCH c.subscription WHERE c.directorUserId = :directorUserId")
+	Optional<Clinic> findByDirectorUserIdWithSubscription(@Param("directorUserId") String directorUserId);
 
 }

--- a/src/main/java/com/nutriconsultas/subscription/PlanEntitlements.java
+++ b/src/main/java/com/nutriconsultas/subscription/PlanEntitlements.java
@@ -1,0 +1,102 @@
+package com.nutriconsultas.subscription;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Immutable plan limits and feature flags aligned with marketing pricing on
+ * {@code eterna/index.html}. Canonical matrix:
+ * {@code docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md}.
+ */
+public final class PlanEntitlements {
+
+	public static final PlanEntitlements BASICO = new PlanEntitlements(PlanTier.BASICO, "nutriologo-basico", 10, 1,
+			EnumSet.of(Entitlement.PATIENT_MANAGEMENT, Entitlement.DIET_PLANS, Entitlement.CALENDAR,
+					Entitlement.REPORTS_BASIC));
+
+	public static final PlanEntitlements PROFESIONAL = new PlanEntitlements(PlanTier.PROFESIONAL,
+			"nutriologo-profesional", 50, 1,
+			EnumSet.of(Entitlement.PATIENT_MANAGEMENT, Entitlement.DIET_PLANS, Entitlement.CALENDAR,
+					Entitlement.REPORTS_BASIC, Entitlement.REPORTS_ADVANCED, Entitlement.REPORTS_FULL,
+					Entitlement.PDF_EXPORT, Entitlement.REPORTS_BRANDED));
+
+	public static final PlanEntitlements PLUS = new PlanEntitlements(PlanTier.PLUS, "nutriologo-plus", null, 1,
+			EnumSet.of(Entitlement.PATIENT_MANAGEMENT, Entitlement.DIET_PLANS, Entitlement.CALENDAR,
+					Entitlement.REPORTS_BASIC, Entitlement.REPORTS_ADVANCED, Entitlement.REPORTS_FULL,
+					Entitlement.PDF_EXPORT, Entitlement.REPORTS_BRANDED, Entitlement.PRIORITY_SUPPORT));
+
+	public static final PlanEntitlements CONSULTORIO = new PlanEntitlements(PlanTier.CONSULTORIO,
+			"director-consultorio", null, 20,
+			EnumSet.of(Entitlement.PATIENT_MANAGEMENT, Entitlement.DIET_PLANS, Entitlement.CALENDAR,
+					Entitlement.REPORTS_BASIC, Entitlement.REPORTS_ADVANCED, Entitlement.REPORTS_FULL,
+					Entitlement.PDF_EXPORT, Entitlement.REPORTS_BRANDED, Entitlement.PRIORITY_SUPPORT,
+					Entitlement.USER_ADMINISTRATION));
+
+	private final PlanTier planTier;
+
+	private final String roleSlug;
+
+	private final Integer maxPatients;
+
+	private final int maxNutritionists;
+
+	private final Set<Entitlement> entitlements;
+
+	private PlanEntitlements(final PlanTier planTier, final String roleSlug, final Integer maxPatients,
+			final int maxNutritionists, final Set<Entitlement> entitlements) {
+		this.planTier = planTier;
+		this.roleSlug = roleSlug;
+		this.maxPatients = maxPatients;
+		this.maxNutritionists = maxNutritionists;
+		this.entitlements = Collections.unmodifiableSet(EnumSet.copyOf(entitlements));
+	}
+
+	public PlanTier getPlanTier() {
+		return planTier;
+	}
+
+	public String getRoleSlug() {
+		return roleSlug;
+	}
+
+	/**
+	 * Maximum patients allowed for the plan, or {@code null} for unlimited.
+	 */
+	public Integer getMaxPatients() {
+		return maxPatients;
+	}
+
+	public int getMaxNutritionists() {
+		return maxNutritionists;
+	}
+
+	public Set<Entitlement> getEntitlements() {
+		return entitlements;
+	}
+
+	public boolean hasEntitlement(final Entitlement entitlement) {
+		return entitlements.contains(entitlement);
+	}
+
+	public static PlanEntitlements forTier(final PlanTier planTier) {
+		Objects.requireNonNull(planTier, "planTier");
+		return switch (planTier) {
+			case BASICO -> BASICO;
+			case PROFESIONAL -> PROFESIONAL;
+			case PLUS -> PLUS;
+			case CONSULTORIO -> CONSULTORIO;
+		};
+	}
+
+	public static PlanEntitlements fromRoleSlug(final String roleSlug) {
+		for (final PlanEntitlements config : new PlanEntitlements[] { BASICO, PROFESIONAL, PLUS, CONSULTORIO }) {
+			if (config.roleSlug.equals(roleSlug)) {
+				return config;
+			}
+		}
+		throw new IllegalArgumentException("Unknown plan role slug: " + roleSlug);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionConfig.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionConfig.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.subscription;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(SubscriptionProperties.class)
+public class SubscriptionConfig {
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionEntitlementService.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionEntitlementService.java
@@ -1,0 +1,17 @@
+package com.nutriconsultas.subscription;
+
+import java.util.Optional;
+
+import org.springframework.lang.NonNull;
+
+/**
+ * Resolves effective plan tier and entitlements for a nutritionist user (solo or clinic
+ * member).
+ */
+public interface SubscriptionEntitlementService {
+
+	Optional<PlanTier> getEffectivePlanTier(@NonNull String userId);
+
+	boolean hasEntitlement(@NonNull String userId, @NonNull Entitlement entitlement);
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceImpl.java
@@ -54,28 +54,29 @@ public class SubscriptionEntitlementServiceImpl implements SubscriptionEntitleme
 		if (entitlement == Entitlement.USER_ADMINISTRATION && !access.director()) {
 			return false;
 		}
-		if (subscription.getStatus() == SubscriptionStatus.GRACE
-				&& subscriptionProperties.getGraceDeniedEntitlements().contains(entitlement)) {
-			return false;
-		}
-		return true;
+		return subscription.getStatus() != SubscriptionStatus.GRACE
+				|| !subscriptionProperties.getGraceDeniedEntitlements().contains(entitlement);
 	}
 
 	private Optional<UserAccessContext> resolveAccess(final String userId) {
 		final Optional<ClinicMember> memberOpt = clinicMemberRepository.findByUserIdWithClinicAndSubscription(userId);
-		if (memberOpt.isPresent()) {
-			final ClinicMember member = memberOpt.get();
-			if (member.getMembershipStatus() == MembershipStatus.SUSPENDED) {
-				if (log.isDebugEnabled()) {
-					log.debug("Clinic member suspended; no subscription entitlements for userId={}", userId);
-				}
-				return Optional.empty();
-			}
-			final boolean director = member.getRole() == ClinicMemberRole.DIRECTOR;
-			return Optional.of(new UserAccessContext(member.getClinic().getSubscription(), director));
+		if (memberOpt.isEmpty()) {
+			return clinicRepository.findByDirectorUserIdWithSubscription(userId)
+				.map(clinic -> new UserAccessContext(clinic.getSubscription(), true));
 		}
-		return clinicRepository.findByDirectorUserIdWithSubscription(userId)
-			.map(clinic -> new UserAccessContext(clinic.getSubscription(), true));
+		final ClinicMember member = memberOpt.get();
+		if (member.getMembershipStatus() == MembershipStatus.SUSPENDED) {
+			logSuspendedMember(userId);
+			return Optional.empty();
+		}
+		final boolean director = member.getRole() == ClinicMemberRole.DIRECTOR;
+		return Optional.of(new UserAccessContext(member.getClinic().getSubscription(), director));
+	}
+
+	private void logSuspendedMember(final String userId) {
+		if (log.isDebugEnabled()) {
+			log.debug("Clinic member suspended; no subscription entitlements for userId={}", userId);
+		}
 	}
 
 	private record UserAccessContext(Subscription subscription, boolean director) {

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceImpl.java
@@ -1,0 +1,89 @@
+package com.nutriconsultas.subscription;
+
+import java.util.Optional;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class SubscriptionEntitlementServiceImpl implements SubscriptionEntitlementService {
+
+	private final ClinicMemberRepository clinicMemberRepository;
+
+	private final ClinicRepository clinicRepository;
+
+	private final SubscriptionProperties subscriptionProperties;
+
+	public SubscriptionEntitlementServiceImpl(final ClinicMemberRepository clinicMemberRepository,
+			final ClinicRepository clinicRepository, final SubscriptionProperties subscriptionProperties) {
+		this.clinicMemberRepository = clinicMemberRepository;
+		this.clinicRepository = clinicRepository;
+		this.subscriptionProperties = subscriptionProperties;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Optional<PlanTier> getEffectivePlanTier(@NonNull final String userId) {
+		return resolveAccess(userId).map(access -> access.subscription().getPlanTier());
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public boolean hasEntitlement(@NonNull final String userId, @NonNull final Entitlement entitlement) {
+		if (!StringUtils.hasText(userId)) {
+			return false;
+		}
+		final Optional<UserAccessContext> accessOpt = resolveAccess(userId);
+		if (accessOpt.isEmpty()) {
+			return false;
+		}
+		final UserAccessContext access = accessOpt.get();
+		final Subscription subscription = access.subscription();
+		if (!grantsEntitlements(subscription.getStatus())) {
+			return false;
+		}
+		final PlanEntitlements planEntitlements = PlanEntitlements.forTier(subscription.getPlanTier());
+		if (!planEntitlements.hasEntitlement(entitlement)) {
+			return false;
+		}
+		if (entitlement == Entitlement.USER_ADMINISTRATION && !access.director()) {
+			return false;
+		}
+		if (subscription.getStatus() == SubscriptionStatus.GRACE
+				&& subscriptionProperties.getGraceDeniedEntitlements().contains(entitlement)) {
+			return false;
+		}
+		return true;
+	}
+
+	private Optional<UserAccessContext> resolveAccess(final String userId) {
+		final Optional<ClinicMember> memberOpt = clinicMemberRepository.findByUserIdWithClinicAndSubscription(userId);
+		if (memberOpt.isPresent()) {
+			final ClinicMember member = memberOpt.get();
+			if (member.getMembershipStatus() == MembershipStatus.SUSPENDED) {
+				if (log.isDebugEnabled()) {
+					log.debug("Clinic member suspended; no subscription entitlements for userId={}", userId);
+				}
+				return Optional.empty();
+			}
+			final boolean director = member.getRole() == ClinicMemberRole.DIRECTOR;
+			return Optional.of(new UserAccessContext(member.getClinic().getSubscription(), director));
+		}
+		return clinicRepository.findByDirectorUserIdWithSubscription(userId)
+			.map(clinic -> new UserAccessContext(clinic.getSubscription(), true));
+	}
+
+	private record UserAccessContext(Subscription subscription, boolean director) {
+	}
+
+	private static boolean grantsEntitlements(final SubscriptionStatus status) {
+		return status == SubscriptionStatus.TRIAL || status == SubscriptionStatus.ACTIVE
+				|| status == SubscriptionStatus.GRACE;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionProperties.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionProperties.java
@@ -1,0 +1,30 @@
+package com.nutriconsultas.subscription;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Subscription enforcement configuration. Grace denied entitlements default to blocking
+ * PDF export and user administration while allowing read-only access per plan doc.
+ */
+@ConfigurationProperties(prefix = "nutriconsultas.subscription")
+public class SubscriptionProperties {
+
+	private Set<Entitlement> graceDeniedEntitlements = EnumSet.of(Entitlement.PDF_EXPORT,
+			Entitlement.USER_ADMINISTRATION);
+
+	public Set<Entitlement> getGraceDeniedEntitlements() {
+		return graceDeniedEntitlements;
+	}
+
+	public void setGraceDeniedEntitlements(final Set<Entitlement> graceDeniedEntitlements) {
+		if (graceDeniedEntitlements == null || graceDeniedEntitlements.isEmpty()) {
+			this.graceDeniedEntitlements = EnumSet.noneOf(Entitlement.class);
+			return;
+		}
+		this.graceDeniedEntitlements = EnumSet.copyOf(graceDeniedEntitlements);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/subscription/PlanEntitlementsTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/PlanEntitlementsTest.java
@@ -1,0 +1,89 @@
+package com.nutriconsultas.subscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PlanEntitlementsTest {
+
+	@Test
+	void basicoLimitsMatchMarketingTable() {
+		final PlanEntitlements basico = PlanEntitlements.BASICO;
+		assertThat(basico.getPlanTier()).isEqualTo(PlanTier.BASICO);
+		assertThat(basico.getRoleSlug()).isEqualTo("nutriologo-basico");
+		assertThat(basico.getMaxPatients()).isEqualTo(10);
+		assertThat(basico.getMaxNutritionists()).isEqualTo(1);
+	}
+
+	@Test
+	void consultorioLimitsMatchMarketingTable() {
+		final PlanEntitlements consultorio = PlanEntitlements.CONSULTORIO;
+		assertThat(consultorio.getMaxPatients()).isNull();
+		assertThat(consultorio.getMaxNutritionists()).isEqualTo(20);
+		assertThat(consultorio.getRoleSlug()).isEqualTo("director-consultorio");
+	}
+
+	@ParameterizedTest
+	@MethodSource("planTierEntitlementMatrix")
+	void fullPlanTierEntitlementMatrix(final PlanTier tier, final Entitlement entitlement, final boolean expected) {
+		assertThat(PlanEntitlements.forTier(tier).hasEntitlement(entitlement)).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@EnumSource(PlanTier.class)
+	void forTierReturnsImmutableEntitlementSet(final PlanTier tier) {
+		final Set<Entitlement> first = PlanEntitlements.forTier(tier).getEntitlements();
+		final Set<Entitlement> second = PlanEntitlements.forTier(tier).getEntitlements();
+		assertThat(first).isUnmodifiable().isEqualTo(second);
+	}
+
+	@Test
+	void fromRoleSlugResolvesKnownTiers() {
+		assertThat(PlanEntitlements.fromRoleSlug("nutriologo-plus").getPlanTier()).isEqualTo(PlanTier.PLUS);
+		assertThat(PlanEntitlements.fromRoleSlug("director-consultorio").getPlanTier()).isEqualTo(PlanTier.CONSULTORIO);
+	}
+
+	@Test
+	void fromRoleSlugRejectsUnknownSlug() {
+		assertThatThrownBy(() -> PlanEntitlements.fromRoleSlug("unknown-role"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("unknown-role");
+	}
+
+	private static Stream<Arguments> planTierEntitlementMatrix() {
+		return Stream.of(PlanTier.values())
+			.flatMap(tier -> Stream.of(Entitlement.values())
+				.map(entitlement -> Arguments.of(tier, entitlement, expectedEntitlement(tier, entitlement))));
+	}
+
+	private static boolean expectedEntitlement(final PlanTier tier, final Entitlement entitlement) {
+		return expectedForTier(tier).contains(entitlement);
+	}
+
+	private static Set<Entitlement> expectedForTier(final PlanTier tier) {
+		return switch (tier) {
+			case BASICO -> EnumSet.of(Entitlement.PATIENT_MANAGEMENT, Entitlement.DIET_PLANS, Entitlement.CALENDAR,
+					Entitlement.REPORTS_BASIC);
+			case PROFESIONAL -> EnumSet.of(Entitlement.PATIENT_MANAGEMENT, Entitlement.DIET_PLANS, Entitlement.CALENDAR,
+					Entitlement.REPORTS_BASIC, Entitlement.REPORTS_ADVANCED, Entitlement.REPORTS_FULL,
+					Entitlement.PDF_EXPORT, Entitlement.REPORTS_BRANDED);
+			case PLUS -> EnumSet.of(Entitlement.PATIENT_MANAGEMENT, Entitlement.DIET_PLANS, Entitlement.CALENDAR,
+					Entitlement.REPORTS_BASIC, Entitlement.REPORTS_ADVANCED, Entitlement.REPORTS_FULL,
+					Entitlement.PDF_EXPORT, Entitlement.REPORTS_BRANDED, Entitlement.PRIORITY_SUPPORT);
+			case CONSULTORIO -> EnumSet.of(Entitlement.PATIENT_MANAGEMENT, Entitlement.DIET_PLANS, Entitlement.CALENDAR,
+					Entitlement.REPORTS_BASIC, Entitlement.REPORTS_ADVANCED, Entitlement.REPORTS_FULL,
+					Entitlement.PDF_EXPORT, Entitlement.REPORTS_BRANDED, Entitlement.PRIORITY_SUPPORT,
+					Entitlement.USER_ADMINISTRATION);
+		};
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceTest.java
@@ -1,0 +1,185 @@
+package com.nutriconsultas.subscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.EnumSet;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionEntitlementServiceTest {
+
+	private static final String DIRECTOR_ID = "auth0|director-1";
+
+	private static final String NUTRITIONIST_ID = "auth0|nutri-1";
+
+	private static final String SOLO_ID = "auth0|solo-1";
+
+	@Mock
+	private ClinicMemberRepository clinicMemberRepository;
+
+	@Mock
+	private ClinicRepository clinicRepository;
+
+	private SubscriptionProperties subscriptionProperties;
+
+	private SubscriptionEntitlementServiceImpl service;
+
+	@BeforeEach
+	void setUp() {
+		subscriptionProperties = new SubscriptionProperties();
+		service = new SubscriptionEntitlementServiceImpl(clinicMemberRepository, clinicRepository,
+				subscriptionProperties);
+	}
+
+	@Test
+	void getEffectivePlanTierReturnsTierForActiveClinicMember() {
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(NUTRITIONIST_ID))
+			.thenReturn(Optional.of(activeMember(NUTRITIONIST_ID, PlanTier.CONSULTORIO)));
+
+		assertThat(service.getEffectivePlanTier(NUTRITIONIST_ID)).contains(PlanTier.CONSULTORIO);
+	}
+
+	@Test
+	void getEffectivePlanTierFallsBackToDirectorClinic() {
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(SOLO_ID)).thenReturn(Optional.empty());
+		when(clinicRepository.findByDirectorUserIdWithSubscription(SOLO_ID))
+			.thenReturn(Optional.of(clinicWithSubscription(SOLO_ID, PlanTier.BASICO)));
+
+		assertThat(service.getEffectivePlanTier(SOLO_ID)).contains(PlanTier.BASICO);
+	}
+
+	@Test
+	void getEffectivePlanTierEmptyWhenMemberSuspended() {
+		final ClinicMember suspended = activeMember(NUTRITIONIST_ID, PlanTier.PROFESIONAL);
+		suspended.setMembershipStatus(MembershipStatus.SUSPENDED);
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(NUTRITIONIST_ID))
+			.thenReturn(Optional.of(suspended));
+
+		assertThat(service.getEffectivePlanTier(NUTRITIONIST_ID)).isEmpty();
+	}
+
+	@Test
+	void hasEntitlementTrueForActiveSubscriptionEntitlement() {
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(SOLO_ID))
+			.thenReturn(Optional.of(activeMember(SOLO_ID, PlanTier.PROFESIONAL)));
+
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.PDF_EXPORT)).isTrue();
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.REPORTS_BRANDED)).isTrue();
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.PRIORITY_SUPPORT)).isFalse();
+	}
+
+	@Test
+	void directorMemberGetsUserAdministrationOnConsultorioPlan() {
+		final ClinicMember director = activeMember(DIRECTOR_ID, PlanTier.CONSULTORIO);
+		director.setRole(ClinicMemberRole.DIRECTOR);
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(DIRECTOR_ID))
+			.thenReturn(Optional.of(director));
+
+		assertThat(service.hasEntitlement(DIRECTOR_ID, Entitlement.USER_ADMINISTRATION)).isTrue();
+	}
+
+	@Test
+	void clinicMemberInheritsClinicSubscriptionTier() {
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(NUTRITIONIST_ID))
+			.thenReturn(Optional.of(activeMember(NUTRITIONIST_ID, PlanTier.CONSULTORIO)));
+
+		assertThat(service.hasEntitlement(NUTRITIONIST_ID, Entitlement.USER_ADMINISTRATION)).isFalse();
+		assertThat(service.hasEntitlement(NUTRITIONIST_ID, Entitlement.PDF_EXPORT)).isTrue();
+	}
+
+	@Test
+	void suspendedMemberHasNoEntitlements() {
+		final ClinicMember suspended = activeMember(NUTRITIONIST_ID, PlanTier.CONSULTORIO);
+		suspended.setMembershipStatus(MembershipStatus.SUSPENDED);
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(NUTRITIONIST_ID))
+			.thenReturn(Optional.of(suspended));
+
+		assertThat(service.hasEntitlement(NUTRITIONIST_ID, Entitlement.PATIENT_MANAGEMENT)).isFalse();
+		assertThat(service.hasEntitlement(NUTRITIONIST_ID, Entitlement.PDF_EXPORT)).isFalse();
+	}
+
+	@Test
+	void graceStateDeniesConfiguredWriteEntitlements() {
+		final ClinicMember member = activeMember(SOLO_ID, PlanTier.PLUS);
+		member.getClinic().getSubscription().setStatus(SubscriptionStatus.GRACE);
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(SOLO_ID)).thenReturn(Optional.of(member));
+
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.PDF_EXPORT)).isFalse();
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.USER_ADMINISTRATION)).isFalse();
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.REPORTS_BASIC)).isTrue();
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.PRIORITY_SUPPORT)).isTrue();
+	}
+
+	@Test
+	void graceDeniedEntitlementsAreConfigurable() {
+		subscriptionProperties.setGraceDeniedEntitlements(EnumSet.of(Entitlement.REPORTS_FULL));
+		service = new SubscriptionEntitlementServiceImpl(clinicMemberRepository, clinicRepository,
+				subscriptionProperties);
+
+		final ClinicMember member = activeMember(SOLO_ID, PlanTier.PROFESIONAL);
+		member.getClinic().getSubscription().setStatus(SubscriptionStatus.GRACE);
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(SOLO_ID)).thenReturn(Optional.of(member));
+
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.REPORTS_FULL)).isFalse();
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.PDF_EXPORT)).isTrue();
+	}
+
+	@Test
+	void pendingPaymentSubscriptionHasNoEntitlements() {
+		final ClinicMember member = activeMember(SOLO_ID, PlanTier.BASICO);
+		member.getClinic().getSubscription().setStatus(SubscriptionStatus.PENDING_PAYMENT);
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(SOLO_ID)).thenReturn(Optional.of(member));
+
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.PATIENT_MANAGEMENT)).isFalse();
+	}
+
+	@Test
+	void trialSubscriptionGrantsFullPlanEntitlements() {
+		final ClinicMember member = activeMember(SOLO_ID, PlanTier.PROFESIONAL);
+		member.getClinic().getSubscription().setStatus(SubscriptionStatus.TRIAL);
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(SOLO_ID)).thenReturn(Optional.of(member));
+
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.PDF_EXPORT)).isTrue();
+	}
+
+	@Test
+	void hasEntitlementFalseWhenUserUnknown() {
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription("auth0|unknown"))
+			.thenReturn(Optional.empty());
+		when(clinicRepository.findByDirectorUserIdWithSubscription("auth0|unknown")).thenReturn(Optional.empty());
+
+		assertThat(service.hasEntitlement("auth0|unknown", Entitlement.CALENDAR)).isFalse();
+	}
+
+	private static ClinicMember activeMember(final String userId, final PlanTier planTier) {
+		final Clinic clinic = clinicWithSubscription(DIRECTOR_ID, planTier);
+		final ClinicMember member = new ClinicMember();
+		member.setClinic(clinic);
+		member.setUserId(userId);
+		member.setRole(ClinicMemberRole.NUTRITIONIST);
+		member.setMembershipStatus(MembershipStatus.ACTIVE);
+		return member;
+	}
+
+	private static Clinic clinicWithSubscription(final String directorUserId, final PlanTier planTier) {
+		final Subscription subscription = new Subscription();
+		subscription.setId(1L);
+		subscription.setPlanTier(planTier);
+		subscription.setStatus(SubscriptionStatus.ACTIVE);
+
+		final Clinic clinic = new Clinic();
+		clinic.setId(1L);
+		clinic.setName("Test Clinic");
+		clinic.setDirectorUserId(directorUserId);
+		clinic.setSubscription(subscription);
+		return clinic;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add central `SubscriptionEntitlementService` with `getEffectivePlanTier(userId)` and `hasEntitlement(userId, Entitlement)` for solo and clinic members.
- Introduce immutable `PlanEntitlements` config aligned with the marketing/pricing matrix (10/50/unlimited patients, feature flags).
- Support grace-period read-only restrictions via configurable `SubscriptionProperties` (default denies `PDF_EXPORT` and `USER_ADMINISTRATION`).
- Directors inherit clinic subscription; suspended members receive no entitlements; `USER_ADMINISTRATION` is director-only on Consultorio plans.

## Test plan
- [x] `PlanEntitlementsTest` — full PlanTier × Entitlement matrix (48 cases)
- [x] `SubscriptionEntitlementServiceTest` — grace, suspend, director vs nutritionist, trial, unknown user
- [x] `./lint.sh && mvn verify` pass locally
- [x] Spring context loads `SubscriptionEntitlementService` bean (Java 21)


Made with [Cursor](https://cursor.com)