### PR TITLE
docs(subscription): mark #190 done after PR #216 merge

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -27,7 +27,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (mobile):** [#133 — Invitation token generation & hashing service](https://github.com/diego-torres/nutriconsultas/issues/133) (after [#132](https://github.com/diego-torres/nutriconsultas/issues/132) in-progress).
 
-**Current next issue (subscription):** [#187 — Gate report tiers and PDF export](https://github.com/diego-torres/nutriconsultas/issues/187) after [#190 PR #216](https://github.com/diego-torres/nutriconsultas/pull/216) merges. See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
+**Current next issue (subscription):** [#187 — Gate report tiers and PDF export](https://github.com/diego-torres/nutriconsultas/issues/187). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
 
 ---
 
@@ -417,6 +417,6 @@ gh pr create ...
 
 **GitHub drift (close when convenient):** #97, #111 done on `main` but open on GitHub (PRs #147, #151).
 
-**Subscription track (parallel):** [#180–#211](https://github.com/diego-torres/nutriconsultas/issues/180) — see [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#185~~ ✓ (PR #215); **#190** PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) pending merge. **NEXT:** #187 report/PDF gating (+ #210/#211, Stripe #207/#208).
+**Subscription track (parallel):** [#180–#211](https://github.com/diego-torres/nutriconsultas/issues/180) — see [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#185~~ ✓ (PR #215); ~~#190~~ ✓ (PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216)). **NEXT:** #187 report/PDF gating (+ #210/#211, Stripe #207/#208).
 
 See [`ISSUE.md`](ISSUE.md) Data contracts, [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) §F8, and [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) for per-endpoint and schema requirements.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -586,11 +586,11 @@ Issue registry: [`ISSUE.md`](ISSUE.md). Agent workflow: [`AGENT-WORKFLOW.md`](AG
 
 Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow: [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md). Design: [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md).
 
-**Epic #180–#211** (2026-06-18): ~~#46~~ Liquibase done; ~~#180–#185~~ on `main`. **#190** PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) pending merge. **NEXT:** #187 report/PDF gating (+ parallel #210/#211, Stripe #207/#208). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
+**Epic #180–#211** (2026-06-18): ~~#46~~ Liquibase done; ~~#180–#185~~, ~~#190~~ on `main` (PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216)). **NEXT:** #187 report/PDF gating (+ parallel #210/#211, Stripe #207/#208). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 
-**Next:** [#133](https://github.com/diego-torres/nutriconsultas/issues/133) invitation token hashing ([#132](https://github.com/diego-torres/nutriconsultas/issues/132) in-progress). ~~#114~~, ~~#116~~, ~~#115~~, ~~#112~~ **done** on `main`. Subscription track: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) — **#190** PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216); **NEXT** #187 after merge.
+**Next:** [#133](https://github.com/diego-torres/nutriconsultas/issues/133) invitation token hashing ([#132](https://github.com/diego-torres/nutriconsultas/issues/132) in-progress). ~~#114~~, ~~#116~~, ~~#115~~, ~~#112~~ **done** on `main`. Subscription track: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) — ~~#190~~ done (PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216)); **NEXT** #187.
 
 **Schema gate (post-#46):** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline is on `main` (PR #196). All new schema/catalog changes require **incremental Liquibase changesets** — see [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) and [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md). ~~#156~~ Phase C done before baseline.
 

--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -5,7 +5,7 @@ Living index of GitHub issues that implement **subscription enforcement**, platf
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Workflow:** [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md)  
 **Design doc:** [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md)  
-**Last updated:** 2026-06-18 — #190 **in-progress** PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) (merge pending; Closes #190).
+**Last updated:** 2026-06-18 — ~~#190~~ **done** (PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216)); **NEXT:** #187.
 
 > **Scope.** This registry tracks `[Subscription]` issues only. The patient mobile API lives in [`ISSUE.md`](ISSUE.md). Patient invitation onboarding (#132–#141) is orthogonal — do not merge nutritionist and patient invitation entities.
 
@@ -75,10 +75,10 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| 190 | Enforce patient and nutritionist limits per plan | https://github.com/diego-torres/nutriconsultas/issues/190 | **in-progress** | 181, ~~185~~ ✓ | PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216); branch `subscription/190-patient-nutritionist-limits` |
-| 187 | Gate report tiers and PDF export by plan | https://github.com/diego-torres/nutriconsultas/issues/187 | **NEXT** | 181, ~~185~~ ✓, ~~190~~ pending | Branded PDFs via `NutritionistProfile`; pick up after #216 merges |
+| 190 | Enforce patient and nutritionist limits per plan | https://github.com/diego-torres/nutriconsultas/issues/190 | **done** | 181, ~~185~~ ✓ | Merged PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) |
+| 187 | Gate report tiers and PDF export by plan | https://github.com/diego-torres/nutriconsultas/issues/187 | **NEXT** | 181, ~~185~~ ✓, ~~190~~ ✓ | Branded PDFs via `NutritionistProfile` |
 
-**Suggested order:** **#190** (PR #216 merge) → **#187** (enforcement); #210 / #211 (admin ops) and #207 (Stripe) in parallel.
+**Suggested order:** **#187** (enforcement); #210 / #211 (admin ops) and #207 (Stripe) in parallel.
 
 ---
 
@@ -91,7 +91,7 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 | 3. Admin paid invitations, payment, grace, payment override | #184, #189, #185 |
 | 3b. Admin revoke access and change plan tier | #210, #211 |
 | 4. Director invites nutritionists; enable/disable access | #186, #188 |
-| 5. Patient & nutritionist limits | #190 — PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) pending merge |
+| 5. Patient & nutritionist limits | #190 — PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) ✓ |
 | 6. Branded / tiered reports | #187 |
 | 7. PDF export by plan | #187 |
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-18):** Patient mobile API complete through #116; **NEXT:** #132 invitation onboarding. Parallel **subscription** track: #180–#185 on `main`; **#190** PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) pending merge; **NEXT:** #187 report/PDF gating.
+**On `main` (2026-06-18):** Patient mobile API complete through #116; **NEXT:** #132 invitation onboarding. Parallel **subscription** track: #180–#185, ~~#190~~ on `main` (PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216)); **NEXT:** #187 report/PDF gating.
 
 ## AWS (production infrastructure)
 

--- a/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
+++ b/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
@@ -199,9 +199,9 @@ cat docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md
 
 | Field | Value |
 |-------|-------|
-| **Next issue** | [#187 — Gate report tiers and PDF export](https://github.com/diego-torres/nutriconsultas/issues/187) (after #216 merges) |
-| **In progress** | [#190 Patient & nutritionist limits](https://github.com/diego-torres/nutriconsultas/issues/190) — PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216); merge when CI green |
-| **Just completed** | [#185 Subscription lifecycle](https://github.com/diego-torres/nutriconsultas/issues/185) — PR [#215](https://github.com/diego-torres/nutriconsultas/pull/215) |
+| **Next issue** | [#187 — Gate report tiers and PDF export](https://github.com/diego-torres/nutriconsultas/issues/187) |
+| **In progress** | — |
+| **Just completed** | [#190 Patient & nutritionist limits](https://github.com/diego-torres/nutriconsultas/issues/190) — PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) |
 
 See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) for full registry.
 
@@ -209,9 +209,8 @@ See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) for full registry.
 
 | Prioridad | Issue | Acción |
 |-----------|-------|--------|
-| 1 | **#190** | Mergear PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) a `main` (Closes #190); luego marcar **done** en registries |
-| 2 | **#187** | `hasEntitlement()` en reportes HTML y PDF (`PatientReportRestController`, `ReportController`) |
-| 3 | **#210** / **#211** | Revocar acceso y cambio de plan tier (admin platform; deps satisfechas) |
-| 4 | **#207** / **#208** | Migrar checkout Mercado Pago → Stripe; credenciales y webhooks operativos |
-| 5 | **#186** → **#188** | Modelo consultorio + invitaciones director (habilita `ClinicInvitationService` end-to-end) |
-| 6 | **#209** | Entrega de email de invitación (SES prod / console local) |
+| 1 | **#187** | `hasEntitlement()` en reportes HTML y PDF (`PatientReportRestController`, `ReportController`) |
+| 2 | **#210** / **#211** | Revocar acceso y cambio de plan tier (admin platform; deps satisfechas) |
+| 3 | **#207** / **#208** | Migrar checkout Mercado Pago → Stripe; credenciales y webhooks operativos |
+| 4 | **#186** → **#188** | Modelo consultorio + invitaciones director (habilita `ClinicInvitationService` end-to-end) |
+| 5 | **#209** | Entrega de email de invitación (SES prod / console local) |

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -31,7 +31,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`../../SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](../../SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md) | Subscription agent workflow |
 | [`../subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](../subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md) | Plan tiers, entitlements, lifecycle |
 
-**Subscription NEXT:** [#187](https://github.com/diego-torres/nutriconsultas/issues/187) report/PDF gating after [#190 PR #216](https://github.com/diego-torres/nutriconsultas/pull/216) merges (~~#185~~ PR #215 on `main`).
+**Subscription NEXT:** [#187](https://github.com/diego-torres/nutriconsultas/issues/187) report/PDF gating (~~#185~~ PR #215, ~~#190~~ PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) on `main`).
 
 ## Provenance / drift
 


### PR DESCRIPTION
## Summary
- Mark #190 **done** in subscription registries after PR #216 merged to `main`
- Advance sprint pointer: **NEXT** is #187 (report/PDF gating)

## Test plan
- [x] Markdown-only; no code changes

Made with [Cursor](https://cursor.com)