### PR TITLE
feat(subscription): gate report tiers and PDF export by plan (#187)

### DIFF
--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -5,7 +5,7 @@ Living index of GitHub issues that implement **subscription enforcement**, platf
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Workflow:** [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md)  
 **Design doc:** [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md)  
-**Last updated:** 2026-06-18 — ~~#190~~ **done** (PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216)); **NEXT:** #187.
+**Last updated:** 2026-06-18 — ~~#190~~ **done** (PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216)); **NEXT:** #210 / #211 (admin ops) or #207 (Stripe). ~~#187~~ **in-progress** on `subscription/187-report-pdf-gating`.
 
 > **Scope.** This registry tracks `[Subscription]` issues only. The patient mobile API lives in [`ISSUE.md`](ISSUE.md). Patient invitation onboarding (#132–#141) is orthogonal — do not merge nutritionist and patient invitation entities.
 
@@ -76,9 +76,9 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | 190 | Enforce patient and nutritionist limits per plan | https://github.com/diego-torres/nutriconsultas/issues/190 | **done** | 181, ~~185~~ ✓ | Merged PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) |
-| 187 | Gate report tiers and PDF export by plan | https://github.com/diego-torres/nutriconsultas/issues/187 | **NEXT** | 181, ~~185~~ ✓, ~~190~~ ✓ | Branded PDFs via `NutritionistProfile` |
+| 187 | Gate report tiers and PDF export by plan | https://github.com/diego-torres/nutriconsultas/issues/187 | **in-progress** | 181, ~~185~~ ✓, ~~190~~ ✓ | Branch `subscription/187-report-pdf-gating` |
 
-**Suggested order:** **#187** (enforcement); #210 / #211 (admin ops) and #207 (Stripe) in parallel.
+**Suggested order:** ~~#187~~ (enforcement — in progress); #210 / #211 (admin ops) and #207 (Stripe) in parallel.
 
 ---
 

--- a/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
+++ b/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
@@ -199,8 +199,8 @@ cat docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md
 
 | Field | Value |
 |-------|-------|
-| **Next issue** | [#187 — Gate report tiers and PDF export](https://github.com/diego-torres/nutriconsultas/issues/187) |
-| **In progress** | — |
+| **Next issue** | [#210 — Platform admin revoke access](https://github.com/diego-torres/nutriconsultas/issues/210) / [#211 — change plan tier](https://github.com/diego-torres/nutriconsultas/issues/211) (after #187 PR) |
+| **In progress** | [#187 — Gate report tiers and PDF export](https://github.com/diego-torres/nutriconsultas/issues/187) — branch `subscription/187-report-pdf-gating` |
 | **Just completed** | [#190 Patient & nutritionist limits](https://github.com/diego-torres/nutriconsultas/issues/190) — PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) |
 
 See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) for full registry.
@@ -209,7 +209,7 @@ See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) for full registry.
 
 | Prioridad | Issue | Acción |
 |-----------|-------|--------|
-| 1 | **#187** | `hasEntitlement()` en reportes HTML y PDF (`PatientReportRestController`, `ReportController`) |
+| 1 | **#187** | ~~`hasEntitlement()` en reportes HTML y PDF~~ — branch `subscription/187-report-pdf-gating` |
 | 2 | **#210** / **#211** | Revocar acceso y cambio de plan tier (admin platform; deps satisfechas) |
 | 3 | **#207** / **#208** | Migrar checkout Mercado Pago → Stripe; credenciales y webhooks operativos |
 | 4 | **#186** → **#188** | Modelo consultorio + invitaciones director (habilita `ClinicInvitationService` end-to-end) |

--- a/src/main/java/com/nutriconsultas/reports/PatientReportRestController.java
+++ b/src/main/java/com/nutriconsultas/reports/PatientReportRestController.java
@@ -2,7 +2,6 @@ package com.nutriconsultas.reports;
 
 import java.util.Date;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -18,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteService;
+import com.nutriconsultas.subscription.SubscriptionEntitlementService;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
@@ -36,14 +36,22 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 @Slf4j
 public class PatientReportRestController {
 
-	@Autowired
-	private PatientReportService reportService;
+	private final PatientReportService reportService;
 
-	@Autowired
-	private PacienteService pacienteService;
+	private final PacienteService pacienteService;
 
-	@Autowired
-	private ClinicStatisticsService clinicStatisticsService;
+	private final ClinicStatisticsService clinicStatisticsService;
+
+	private final SubscriptionEntitlementService subscriptionEntitlementService;
+
+	public PatientReportRestController(final PatientReportService reportService, final PacienteService pacienteService,
+			final ClinicStatisticsService clinicStatisticsService,
+			final SubscriptionEntitlementService subscriptionEntitlementService) {
+		this.reportService = reportService;
+		this.pacienteService = pacienteService;
+		this.clinicStatisticsService = clinicStatisticsService;
+		this.subscriptionEntitlementService = subscriptionEntitlementService;
+	}
 
 	/**
 	 * Gets the user ID from the OAuth2 principal.
@@ -119,6 +127,9 @@ public class PatientReportRestController {
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 		}
 
+		subscriptionEntitlementService.assertCanExportPdf(userId);
+		subscriptionEntitlementService.assertCanAccessFullReports(userId);
+
 		try {
 			// Get patient to use name in filename
 			final Paciente paciente = pacienteService.findByIdAndUserId(pacienteId, userId);
@@ -186,6 +197,9 @@ public class PatientReportRestController {
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 		}
 
+		subscriptionEntitlementService.assertCanExportPdf(userId);
+		subscriptionEntitlementService.assertCanAccessAdvancedReports(userId);
+
 		try {
 			final byte[] pdfBytes = reportService.generateNutritionReport(dietaId, userId);
 
@@ -241,6 +255,8 @@ public class PatientReportRestController {
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 		}
 
+		subscriptionEntitlementService.assertCanAccessAdvancedReports(userId);
+
 		try {
 			final ClinicStatistics statistics = clinicStatisticsService.generateStatistics(userId, startDate, endDate);
 			log.info("Successfully generated clinic statistics for user: {}", userId);
@@ -289,6 +305,9 @@ public class PatientReportRestController {
 			log.error("Cannot generate clinic statistics PDF: user ID is null");
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 		}
+
+		subscriptionEntitlementService.assertCanExportPdf(userId);
+		subscriptionEntitlementService.assertCanAccessAdvancedReports(userId);
 
 		try {
 			final byte[] pdfBytes = reportService.generateClinicStatisticsReport(userId, startDate, endDate);

--- a/src/main/java/com/nutriconsultas/reports/PatientReportService.java
+++ b/src/main/java/com/nutriconsultas/reports/PatientReportService.java
@@ -30,6 +30,8 @@ import com.nutriconsultas.paciente.PacienteService;
 import com.nutriconsultas.profile.NutritionistBrandingHelper;
 import com.nutriconsultas.profile.NutritionistProfile;
 import com.nutriconsultas.profile.NutritionistProfileService;
+import com.nutriconsultas.subscription.Entitlement;
+import com.nutriconsultas.subscription.SubscriptionEntitlementService;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -103,6 +105,9 @@ public class PatientReportService {
 	@Autowired
 	private NutritionistProfileService nutritionistProfileService;
 
+	@Autowired
+	private SubscriptionEntitlementService subscriptionEntitlementService;
+
 	/**
 	 * Generates a PDF progress report for a patient.
 	 * @param pacienteId the ID of the patient
@@ -145,10 +150,8 @@ public class PatientReportService {
 		context.setVariable("endDate", endDate);
 		context.setVariable("reportDate", new Date());
 
-		// Inject nutritionist profile branding
-		final NutritionistProfile profile = nutritionistProfileService.getOrCreateProfile(userId);
-		final String logoBase64 = nutritionistProfileService.getLogoAsBase64DataUri(userId);
-		NutritionistBrandingHelper.addBrandingVariables(context, profile, logoBase64);
+		// Inject nutritionist profile branding when plan includes branded reports
+		addBrandingIfAllowed(context, userId);
 
 		// Render Thymeleaf template to HTML
 		final String html = templateEngine.process("sbadmin/reports/patient-progress", context);
@@ -272,10 +275,8 @@ public class PatientReportService {
 		context.setVariable("analysis", analysis);
 		context.setVariable("reportDate", new Date());
 
-		// Inject nutritionist profile branding
-		final NutritionistProfile nutritionAnalysisProfile = nutritionistProfileService.getOrCreateProfile(userId);
-		final String nutritionLogoBase64 = nutritionistProfileService.getLogoAsBase64DataUri(userId);
-		NutritionistBrandingHelper.addBrandingVariables(context, nutritionAnalysisProfile, nutritionLogoBase64);
+		// Inject nutritionist profile branding when plan includes branded reports
+		addBrandingIfAllowed(context, userId);
 
 		// Render Thymeleaf template to HTML
 		final String html = templateEngine.process("sbadmin/reports/nutrition-analysis", context);
@@ -306,16 +307,23 @@ public class PatientReportService {
 		context.setVariable("endDate", endDate);
 		context.setVariable("reportDate", new Date());
 
-		// Inject nutritionist profile branding
-		final NutritionistProfile clinicProfile = nutritionistProfileService.getOrCreateProfile(userId);
-		final String clinicLogoBase64 = nutritionistProfileService.getLogoAsBase64DataUri(userId);
-		NutritionistBrandingHelper.addBrandingVariables(context, clinicProfile, clinicLogoBase64);
+		// Inject nutritionist profile branding when plan includes branded reports
+		addBrandingIfAllowed(context, userId);
 
 		// Render Thymeleaf template to HTML
 		final String html = templateEngine.process("sbadmin/reports/clinic-statistics-pdf", context);
 
 		// Convert HTML to PDF using Flying Saucer
 		return htmlToPdf(html);
+	}
+
+	private void addBrandingIfAllowed(final Context context, final String userId) {
+		if (!subscriptionEntitlementService.hasEntitlement(userId, Entitlement.REPORTS_BRANDED)) {
+			return;
+		}
+		final NutritionistProfile profile = nutritionistProfileService.getOrCreateProfile(userId);
+		final String logoBase64 = nutritionistProfileService.getLogoAsBase64DataUri(userId);
+		NutritionistBrandingHelper.addBrandingVariables(context, profile, logoBase64);
 	}
 
 	private byte[] htmlToPdf(final String html) {

--- a/src/main/java/com/nutriconsultas/reports/ReportController.java
+++ b/src/main/java/com/nutriconsultas/reports/ReportController.java
@@ -2,7 +2,6 @@ package com.nutriconsultas.reports;
 
 import java.util.Date;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
@@ -14,6 +13,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.nutriconsultas.controller.AbstractAuthorizedController;
 import com.nutriconsultas.dieta.DietaRepository;
 import com.nutriconsultas.paciente.PacienteService;
+import com.nutriconsultas.subscription.Entitlement;
+import com.nutriconsultas.subscription.SubscriptionEntitlementService;
+import com.nutriconsultas.subscription.SubscriptionErrorResponses;
+import com.nutriconsultas.subscription.SubscriptionLimitExceededException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,14 +34,26 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ReportController extends AbstractAuthorizedController {
 
-	@Autowired
-	private PacienteService pacienteService;
+	private final PacienteService pacienteService;
 
-	@Autowired
-	private DietaRepository dietaRepository;
+	private final DietaRepository dietaRepository;
 
-	@Autowired
-	private ClinicStatisticsService clinicStatisticsService;
+	private final ClinicStatisticsService clinicStatisticsService;
+
+	private final SubscriptionEntitlementService subscriptionEntitlementService;
+
+	private final SubscriptionErrorResponses subscriptionErrorResponses;
+
+	public ReportController(final PacienteService pacienteService, final DietaRepository dietaRepository,
+			final ClinicStatisticsService clinicStatisticsService,
+			final SubscriptionEntitlementService subscriptionEntitlementService,
+			final SubscriptionErrorResponses subscriptionErrorResponses) {
+		this.pacienteService = pacienteService;
+		this.dietaRepository = dietaRepository;
+		this.clinicStatisticsService = clinicStatisticsService;
+		this.subscriptionEntitlementService = subscriptionEntitlementService;
+		this.subscriptionErrorResponses = subscriptionErrorResponses;
+	}
 
 	/**
 	 * Gets the user ID from the OAuth2 principal.
@@ -53,6 +68,15 @@ public class ReportController extends AbstractAuthorizedController {
 		final String userId = principal.getSubject();
 		log.debug("Retrieved user ID: {}", userId);
 		return userId;
+	}
+
+	private void addReportEntitlementFlags(final Model model, final String userId) {
+		model.addAttribute("canExportPdf",
+				subscriptionEntitlementService.hasEntitlement(userId, Entitlement.PDF_EXPORT));
+		model.addAttribute("canAdvancedReports",
+				subscriptionEntitlementService.hasEntitlement(userId, Entitlement.REPORTS_ADVANCED));
+		model.addAttribute("canFullReports",
+				subscriptionEntitlementService.hasEntitlement(userId, Entitlement.REPORTS_FULL));
 	}
 
 	/**
@@ -71,6 +95,13 @@ public class ReportController extends AbstractAuthorizedController {
 		if (userId == null) {
 			log.error("Cannot display reports: user ID is null");
 			model.addAttribute("error", "No se pudo identificar al usuario");
+			return "sbadmin/reports/listado";
+		}
+
+		addReportEntitlementFlags(model, userId);
+
+		if (!subscriptionEntitlementService.hasEntitlement(userId, Entitlement.REPORTS_BASIC)) {
+			model.addAttribute("error", "Los reportes no están disponibles con tu suscripción actual.");
 			return "sbadmin/reports/listado";
 		}
 
@@ -102,6 +133,14 @@ public class ReportController extends AbstractAuthorizedController {
 		if (userId == null) {
 			log.error("Cannot display clinic statistics: user ID is null");
 			model.addAttribute("error", "No se pudo identificar al usuario");
+			return "sbadmin/reports/estadisticas";
+		}
+
+		addReportEntitlementFlags(model, userId);
+
+		if (!subscriptionEntitlementService.hasEntitlement(userId, Entitlement.REPORTS_ADVANCED)) {
+			model.addAttribute("error", subscriptionErrorResponses.resolve(
+					new SubscriptionLimitExceededException(SubscriptionErrorResponses.KEY_REPORTS_ADVANCED_DENIED)));
 			return "sbadmin/reports/estadisticas";
 		}
 

--- a/src/main/java/com/nutriconsultas/reports/ReportTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/reports/ReportTemplateValidator.java
@@ -90,6 +90,11 @@ public class ReportTemplateValidator extends BaseTemplateValidator {
 		variables.put("nutritionistDisplayName", "Lic. María García López");
 		variables.put("logoBase64", null);
 
+		// Report entitlement flags for listado and estadisticas templates (#187)
+		variables.put("canExportPdf", true);
+		variables.put("canAdvancedReports", true);
+		variables.put("canFullReports", true);
+
 		return variables;
 	}
 

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionEntitlementService.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionEntitlementService.java
@@ -28,4 +28,23 @@ public interface SubscriptionEntitlementService {
 	 */
 	void assertCanInviteNutritionist(@NonNull String directorUserId);
 
+	/**
+	 * Verifies the user may export reports as PDF (entitlement and grace policy).
+	 * @throws SubscriptionLimitExceededException when blocked
+	 */
+	void assertCanExportPdf(@NonNull String userId);
+
+	/**
+	 * Verifies the user may access advanced report analytics (clinic statistics,
+	 * nutrition analysis).
+	 * @throws SubscriptionLimitExceededException when blocked
+	 */
+	void assertCanAccessAdvancedReports(@NonNull String userId);
+
+	/**
+	 * Verifies the user may generate full patient progress reports.
+	 * @throws SubscriptionLimitExceededException when blocked
+	 */
+	void assertCanAccessFullReports(@NonNull String userId);
+
 }

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceImpl.java
@@ -108,6 +108,30 @@ public class SubscriptionEntitlementServiceImpl implements SubscriptionEntitleme
 		}
 	}
 
+	@Override
+	@Transactional(readOnly = true)
+	public void assertCanExportPdf(@NonNull final String userId) {
+		if (!hasEntitlement(userId, Entitlement.PDF_EXPORT)) {
+			throw new SubscriptionLimitExceededException(SubscriptionErrorResponses.KEY_PDF_EXPORT_DENIED);
+		}
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public void assertCanAccessAdvancedReports(@NonNull final String userId) {
+		if (!hasEntitlement(userId, Entitlement.REPORTS_ADVANCED)) {
+			throw new SubscriptionLimitExceededException(SubscriptionErrorResponses.KEY_REPORTS_ADVANCED_DENIED);
+		}
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public void assertCanAccessFullReports(@NonNull final String userId) {
+		if (!hasEntitlement(userId, Entitlement.REPORTS_FULL)) {
+			throw new SubscriptionLimitExceededException(SubscriptionErrorResponses.KEY_REPORTS_FULL_DENIED);
+		}
+	}
+
 	private long countPatientsInClinicScope(final Long clinicId) {
 		final List<String> memberUserIds = clinicMemberRepository.findUserIdsByClinicIdAndMembershipStatus(clinicId,
 				MembershipStatus.ACTIVE);

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionErrorResponses.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionErrorResponses.java
@@ -6,8 +6,8 @@ import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Component;
 
 /**
- * Subscription limit and entitlement error messages in Spanish for the nutritionist web app
- * (#190).
+ * Subscription limit and entitlement error messages in Spanish for the nutritionist web
+ * app (#190).
  */
 @Component
 public final class SubscriptionErrorResponses {
@@ -21,6 +21,12 @@ public final class SubscriptionErrorResponses {
 	public static final String KEY_NUTRITIONIST_LIMIT = "error.subscription.nutritionist_limit";
 
 	public static final String KEY_NUTRITIONIST_INVITE_DENIED = "error.subscription.nutritionist_invite_denied";
+
+	public static final String KEY_PDF_EXPORT_DENIED = "error.subscription.pdf_export_denied";
+
+	public static final String KEY_REPORTS_ADVANCED_DENIED = "error.subscription.reports_advanced_denied";
+
+	public static final String KEY_REPORTS_FULL_DENIED = "error.subscription.reports_full_denied";
 
 	private final MessageSource messageSource;
 

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionLimitExceededException.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionLimitExceededException.java
@@ -22,7 +22,7 @@ public class SubscriptionLimitExceededException extends RuntimeException {
 	public SubscriptionLimitExceededException(final String messageKey, final Object arg) {
 		super(messageKey);
 		this.messageKey = messageKey;
-		this.messageArgs = new Object[] {arg};
+		this.messageArgs = new Object[] { arg };
 	}
 
 	public String getMessageKey() {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -8,3 +8,6 @@ error.subscription.patient_limit=Your plan allows up to {0} patients. Upgrade yo
 error.subscription.create_patient_denied=You cannot add patients with your current subscription status.
 error.subscription.nutritionist_limit=Your plan allows up to {0} nutritionists in the clinic.
 error.subscription.nutritionist_invite_denied=You cannot invite nutritionists with your current subscription.
+error.subscription.pdf_export_denied=PDF export is not included in your plan or is unavailable during the grace period.
+error.subscription.reports_advanced_denied=Advanced reports require the Profesional plan or higher.
+error.subscription.reports_full_denied=Full patient reports require the Profesional plan or higher.

--- a/src/main/resources/messages_es_MX.properties
+++ b/src/main/resources/messages_es_MX.properties
@@ -8,3 +8,6 @@ error.subscription.patient_limit=Tu plan permite hasta {0} pacientes. Actualiza 
 error.subscription.create_patient_denied=No puedes agregar pacientes con el estado actual de tu suscripción.
 error.subscription.nutritionist_limit=Tu plan permite hasta {0} nutriólogos en el consultorio.
 error.subscription.nutritionist_invite_denied=No puedes invitar nutriólogos con tu suscripción actual.
+error.subscription.pdf_export_denied=La exportación PDF no está incluida en tu plan o no está disponible durante el periodo de gracia.
+error.subscription.reports_advanced_denied=Los reportes avanzados requieren el plan Profesional o superior.
+error.subscription.reports_full_denied=Los reportes completos de paciente requieren el plan Profesional o superior.

--- a/src/main/resources/templates/sbadmin/reports/estadisticas.html
+++ b/src/main/resources/templates/sbadmin/reports/estadisticas.html
@@ -45,7 +45,7 @@
               <a th:href="@{/admin/reportes}" class="btn btn-secondary btn-sm">
                 <i class="fas fa-arrow-left"></i> Volver a Reportes
               </a>
-              <button type="button" class="btn btn-primary btn-sm" onclick="generatePdfReport()">
+              <button type="button" class="btn btn-primary btn-sm" th:if="${canExportPdf}" onclick="generatePdfReport()">
                 <i class="fas fa-file-pdf"></i> Exportar PDF
               </button>
             </div>

--- a/src/main/resources/templates/sbadmin/reports/listado.html
+++ b/src/main/resources/templates/sbadmin/reports/listado.html
@@ -45,8 +45,25 @@
             <h1 class="h3 mb-0 text-gray-800">Reportes</h1>
           </div>
 
+          <div class="row" th:if="${error != null}">
+            <div class="col-12">
+              <div class="alert alert-danger" role="alert">
+                <i class="fas fa-exclamation-triangle"></i> <span th:text="${error}"></span>
+              </div>
+            </div>
+          </div>
+
+          <div class="row" th:if="${canExportPdf != null and !canExportPdf}">
+            <div class="col-12">
+              <div class="alert alert-info" role="alert">
+                <i class="fas fa-info-circle"></i>
+                La exportación PDF y los reportes avanzados requieren el plan Profesional o superior.
+              </div>
+            </div>
+          </div>
+
           <!-- Clinic Statistics Card -->
-          <div class="row">
+          <div class="row" th:if="${canAdvancedReports}">
             <div class="col-12">
               <div class="card shadow mb-4">
                 <div class="card-header py-3">
@@ -63,7 +80,7 @@
           </div>
 
           <!-- Content Row -->
-          <div class="row">
+          <div class="row" th:if="${canExportPdf and canFullReports}">
             <div class="col-12">
               <div class="card shadow mb-4">
                 <div class="card-header py-3">
@@ -101,7 +118,7 @@
           </div>
 
           <!-- Nutrition Analysis Report -->
-          <div class="row">
+          <div class="row" th:if="${canExportPdf and canAdvancedReports}">
             <div class="col-12">
               <div class="card shadow mb-4">
                 <div class="card-header py-3">
@@ -156,6 +173,7 @@
                           <td th:text="${paciente.phone != null ? paciente.phone : 'N/A'}"></td>
                           <td>
                             <button type="button" class="btn btn-sm btn-primary generate-patient-report-btn"
+                              th:if="${canExportPdf and canFullReports}"
                               th:data-paciente-id="${paciente.id}" th:data-paciente-name="${paciente.name}">
                               <i class="fas fa-file-pdf"></i> Generar Reporte
                             </button>

--- a/src/test/java/com/nutriconsultas/reports/PatientReportRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/reports/PatientReportRestControllerTest.java
@@ -1,8 +1,10 @@
 package com.nutriconsultas.reports;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -21,6 +23,9 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteService;
+import com.nutriconsultas.subscription.SubscriptionEntitlementService;
+import com.nutriconsultas.subscription.SubscriptionErrorResponses;
+import com.nutriconsultas.subscription.SubscriptionLimitExceededException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,6 +43,12 @@ public class PatientReportRestControllerTest {
 
 	@Mock
 	private PacienteService pacienteService;
+
+	@Mock
+	private ClinicStatisticsService clinicStatisticsService;
+
+	@Mock
+	private SubscriptionEntitlementService subscriptionEntitlementService;
 
 	@Mock
 	private OidcUser principal;
@@ -69,7 +80,21 @@ public class PatientReportRestControllerTest {
 		final var contentType = response.getHeaders().getContentType();
 		assertThat(contentType).isNotNull();
 		assertThat(contentType.toString()).contains("application/pdf");
+		verify(subscriptionEntitlementService).assertCanExportPdf(userId);
+		verify(subscriptionEntitlementService).assertCanAccessFullReports(userId);
 		verify(reportService).generateReport(1L, userId, null, null);
+	}
+
+	@Test
+	public void testGeneratePatientReportDeniedBySubscription() {
+		final String userId = "user123";
+		when(principal.getSubject()).thenReturn(userId);
+		doThrow(new SubscriptionLimitExceededException(SubscriptionErrorResponses.KEY_PDF_EXPORT_DENIED))
+			.when(subscriptionEntitlementService)
+			.assertCanExportPdf(userId);
+
+		assertThatThrownBy(() -> restController.generatePatientReport(1L, null, null, principal))
+			.isInstanceOf(SubscriptionLimitExceededException.class);
 	}
 
 	@Test
@@ -143,7 +168,21 @@ public class PatientReportRestControllerTest {
 		final var contentType = response.getHeaders().getContentType();
 		assertThat(contentType).isNotNull();
 		assertThat(contentType.toString()).contains("application/pdf");
+		verify(subscriptionEntitlementService).assertCanExportPdf(userId);
+		verify(subscriptionEntitlementService).assertCanAccessAdvancedReports(userId);
 		verify(reportService).generateNutritionReport(dietaId, userId);
+	}
+
+	@Test
+	public void testGenerateNutritionReportDeniedBySubscription() {
+		final String userId = "user123";
+		when(principal.getSubject()).thenReturn(userId);
+		doThrow(new SubscriptionLimitExceededException(SubscriptionErrorResponses.KEY_REPORTS_ADVANCED_DENIED))
+			.when(subscriptionEntitlementService)
+			.assertCanAccessAdvancedReports(userId);
+
+		assertThatThrownBy(() -> restController.generateNutritionReport(1L, principal))
+			.isInstanceOf(SubscriptionLimitExceededException.class);
 	}
 
 	@Test
@@ -184,6 +223,30 @@ public class PatientReportRestControllerTest {
 		assertThat(response).isNotNull();
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
 		verify(reportService).generateNutritionReport(dietaId, userId);
+	}
+
+	@Test
+	public void testGetClinicStatisticsDeniedBySubscription() {
+		final String userId = "user123";
+		when(principal.getSubject()).thenReturn(userId);
+		doThrow(new SubscriptionLimitExceededException(SubscriptionErrorResponses.KEY_REPORTS_ADVANCED_DENIED))
+			.when(subscriptionEntitlementService)
+			.assertCanAccessAdvancedReports(userId);
+
+		assertThatThrownBy(() -> restController.getClinicStatistics(null, null, principal))
+			.isInstanceOf(SubscriptionLimitExceededException.class);
+	}
+
+	@Test
+	public void testGenerateClinicStatisticsPdfDeniedInGrace() {
+		final String userId = "user123";
+		when(principal.getSubject()).thenReturn(userId);
+		doThrow(new SubscriptionLimitExceededException(SubscriptionErrorResponses.KEY_PDF_EXPORT_DENIED))
+			.when(subscriptionEntitlementService)
+			.assertCanExportPdf(userId);
+
+		assertThatThrownBy(() -> restController.generateClinicStatisticsPdf(null, null, principal))
+			.isInstanceOf(SubscriptionLimitExceededException.class);
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/reports/PatientReportServiceTest.java
+++ b/src/test/java/com/nutriconsultas/reports/PatientReportServiceTest.java
@@ -38,6 +38,8 @@ import com.nutriconsultas.paciente.PacienteDietaStatus;
 import com.nutriconsultas.paciente.PacienteService;
 import com.nutriconsultas.profile.NutritionistProfile;
 import com.nutriconsultas.profile.NutritionistProfileService;
+import com.nutriconsultas.subscription.Entitlement;
+import com.nutriconsultas.subscription.SubscriptionEntitlementService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -73,6 +75,9 @@ public class PatientReportServiceTest {
 	@Mock
 	private ClinicStatisticsService clinicStatisticsService;
 
+	@Mock
+	private SubscriptionEntitlementService subscriptionEntitlementService;
+
 	private Paciente paciente;
 
 	@BeforeEach
@@ -94,6 +99,8 @@ public class PatientReportServiceTest {
 		emptyProfile.setUserId("user123");
 		lenient().when(nutritionistProfileService.getOrCreateProfile(anyString())).thenReturn(emptyProfile);
 		lenient().when(nutritionistProfileService.getLogoAsBase64DataUri(anyString())).thenReturn(null);
+		lenient().when(subscriptionEntitlementService.hasEntitlement(anyString(), eq(Entitlement.REPORTS_BRANDED)))
+			.thenReturn(true);
 	}
 
 	@Test
@@ -292,6 +299,25 @@ public class PatientReportServiceTest {
 		assertThat(contextCaptor.getValue().getVariable("nutritionistDisplayName"))
 			.isEqualTo("Lic. María García López");
 		assertThat(contextCaptor.getValue().getVariable("nutritionistProfile")).isSameAs(profile);
+	}
+
+	@Test
+	public void testGenerateReportOmitsBrandingWhenPlanExcludesIt() {
+		when(subscriptionEntitlementService.hasEntitlement("user123", Entitlement.REPORTS_BRANDED)).thenReturn(false);
+
+		when(pacienteService.findByIdAndUserId(1L, "user123")).thenReturn(paciente);
+		when(calendarEventService.findByPacienteId(1L)).thenReturn(new ArrayList<>());
+		when(anthropometricMeasurementService.findByPacienteId(1L)).thenReturn(new ArrayList<>());
+		when(clinicalExamService.findByPacienteId(1L)).thenReturn(new ArrayList<>());
+		when(pacienteDietaRepository.findByPacienteIdOrderByStartDateDesc(1L)).thenReturn(new ArrayList<>());
+		when(templateEngine.process(eq("sbadmin/reports/patient-progress"), any(Context.class)))
+			.thenReturn("<html><body>Test Report</body></html>");
+
+		reportService.generateReport(1L, "user123", null, null);
+
+		final ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+		verify(templateEngine).process(eq("sbadmin/reports/patient-progress"), contextCaptor.capture());
+		assertThat(contextCaptor.getValue().containsVariable("nutritionistDisplayName")).isFalse();
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/reports/ReportControllerTest.java
+++ b/src/test/java/com/nutriconsultas/reports/ReportControllerTest.java
@@ -1,0 +1,119 @@
+package com.nutriconsultas.reports;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+
+import com.nutriconsultas.dieta.DietaRepository;
+import com.nutriconsultas.paciente.PacienteService;
+import com.nutriconsultas.subscription.Entitlement;
+import com.nutriconsultas.subscription.SubscriptionEntitlementService;
+import com.nutriconsultas.subscription.SubscriptionErrorResponses;
+
+@ExtendWith(MockitoExtension.class)
+class ReportControllerTest {
+
+	private static final String USER_ID = "auth0|user-1";
+
+	@InjectMocks
+	private ReportController reportController;
+
+	@Mock
+	private PacienteService pacienteService;
+
+	@Mock
+	private DietaRepository dietaRepository;
+
+	@Mock
+	private ClinicStatisticsService clinicStatisticsService;
+
+	@Mock
+	private SubscriptionEntitlementService subscriptionEntitlementService;
+
+	@Mock
+	private SubscriptionErrorResponses subscriptionErrorResponses;
+
+	@Mock
+	private OidcUser principal;
+
+	@Test
+	void listadoExposesEntitlementFlagsForBasicoUser() {
+		when(principal.getSubject()).thenReturn(USER_ID);
+		when(subscriptionEntitlementService.hasEntitlement(USER_ID, Entitlement.REPORTS_BASIC)).thenReturn(true);
+		when(subscriptionEntitlementService.hasEntitlement(USER_ID, Entitlement.PDF_EXPORT)).thenReturn(false);
+		when(subscriptionEntitlementService.hasEntitlement(USER_ID, Entitlement.REPORTS_ADVANCED)).thenReturn(false);
+		when(subscriptionEntitlementService.hasEntitlement(USER_ID, Entitlement.REPORTS_FULL)).thenReturn(false);
+		when(pacienteService.findAllByUserId(USER_ID)).thenReturn(Collections.emptyList());
+		when(dietaRepository.findByUserId(USER_ID)).thenReturn(Collections.emptyList());
+
+		final Model model = new ExtendedModelMap();
+		final String view = reportController.listado(model, principal);
+
+		assertThat(view).isEqualTo("sbadmin/reports/listado");
+		assertThat(model.getAttribute("canExportPdf")).isEqualTo(false);
+		assertThat(model.getAttribute("canAdvancedReports")).isEqualTo(false);
+		assertThat(model.getAttribute("canFullReports")).isEqualTo(false);
+	}
+
+	@Test
+	void listadoBlocksWhenReportsBasicUnavailable() {
+		when(principal.getSubject()).thenReturn(USER_ID);
+		when(subscriptionEntitlementService.hasEntitlement(USER_ID, Entitlement.REPORTS_BASIC)).thenReturn(false);
+		when(subscriptionEntitlementService.hasEntitlement(USER_ID, Entitlement.PDF_EXPORT)).thenReturn(false);
+		when(subscriptionEntitlementService.hasEntitlement(USER_ID, Entitlement.REPORTS_ADVANCED)).thenReturn(false);
+		when(subscriptionEntitlementService.hasEntitlement(USER_ID, Entitlement.REPORTS_FULL)).thenReturn(false);
+
+		final Model model = new ExtendedModelMap();
+		final String view = reportController.listado(model, principal);
+
+		assertThat(view).isEqualTo("sbadmin/reports/listado");
+		assertThat(model.getAttribute("error"))
+			.isEqualTo("Los reportes no están disponibles con tu suscripción actual.");
+	}
+
+	@Test
+	void estadisticasBlocksWhenAdvancedReportsUnavailable() {
+		when(principal.getSubject()).thenReturn(USER_ID);
+		when(subscriptionEntitlementService.hasEntitlement(USER_ID, Entitlement.PDF_EXPORT)).thenReturn(false);
+		when(subscriptionEntitlementService.hasEntitlement(USER_ID, Entitlement.REPORTS_ADVANCED)).thenReturn(false);
+		when(subscriptionEntitlementService.hasEntitlement(USER_ID, Entitlement.REPORTS_FULL)).thenReturn(false);
+		when(subscriptionErrorResponses.resolve(org.mockito.ArgumentMatchers.any())).thenReturn("advanced denied");
+
+		final Model model = new ExtendedModelMap();
+		final String view = reportController.estadisticas(model, principal, null, null);
+
+		assertThat(view).isEqualTo("sbadmin/reports/estadisticas");
+		assertThat(model.getAttribute("error")).isEqualTo("advanced denied");
+		assertThat(model.getAttribute("statistics")).isNull();
+	}
+
+	@Test
+	void estadisticasLoadsStatisticsForProfesionalUser() {
+		when(principal.getSubject()).thenReturn(USER_ID);
+		when(subscriptionEntitlementService.hasEntitlement(USER_ID, Entitlement.PDF_EXPORT)).thenReturn(true);
+		when(subscriptionEntitlementService.hasEntitlement(USER_ID, Entitlement.REPORTS_ADVANCED)).thenReturn(true);
+		when(subscriptionEntitlementService.hasEntitlement(USER_ID, Entitlement.REPORTS_FULL)).thenReturn(true);
+		final ClinicStatistics statistics = new ClinicStatistics();
+		statistics.setTotalPatients(3L);
+		when(clinicStatisticsService.generateStatistics(USER_ID, null, null)).thenReturn(statistics);
+
+		final Model model = new ExtendedModelMap();
+		final String view = reportController.estadisticas(model, principal, null, null);
+
+		assertThat(view).isEqualTo("sbadmin/reports/estadisticas");
+		assertThat(model.getAttribute("statistics")).isSameAs(statistics);
+		verify(clinicStatisticsService).generateStatistics(USER_ID, null, null);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceTest.java
@@ -168,6 +168,59 @@ class SubscriptionEntitlementServiceTest {
 	}
 
 	@Test
+	void hasEntitlementFalseForBasicoPdfExport() {
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(SOLO_ID))
+			.thenReturn(Optional.of(activeMember(SOLO_ID, PlanTier.BASICO)));
+
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.PDF_EXPORT)).isFalse();
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.REPORTS_ADVANCED)).isFalse();
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.REPORTS_FULL)).isFalse();
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.REPORTS_BASIC)).isTrue();
+	}
+
+	@Test
+	void assertCanExportPdfThrowsForBasicoPlan() {
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(SOLO_ID))
+			.thenReturn(Optional.of(activeMember(SOLO_ID, PlanTier.BASICO)));
+
+		assertThatThrownBy(() -> service.assertCanExportPdf(SOLO_ID))
+			.isInstanceOf(SubscriptionLimitExceededException.class)
+			.extracting(ex -> ((SubscriptionLimitExceededException) ex).getMessageKey())
+			.isEqualTo(SubscriptionErrorResponses.KEY_PDF_EXPORT_DENIED);
+	}
+
+	@Test
+	void assertCanExportPdfThrowsInGraceState() {
+		final ClinicMember member = activeMember(SOLO_ID, PlanTier.PROFESIONAL);
+		member.getClinic().getSubscription().setStatus(SubscriptionStatus.GRACE);
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(SOLO_ID)).thenReturn(Optional.of(member));
+
+		assertThatThrownBy(() -> service.assertCanExportPdf(SOLO_ID))
+			.isInstanceOf(SubscriptionLimitExceededException.class)
+			.extracting(ex -> ((SubscriptionLimitExceededException) ex).getMessageKey())
+			.isEqualTo(SubscriptionErrorResponses.KEY_PDF_EXPORT_DENIED);
+	}
+
+	@Test
+	void assertCanAccessAdvancedReportsThrowsForBasicoPlan() {
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(SOLO_ID))
+			.thenReturn(Optional.of(activeMember(SOLO_ID, PlanTier.BASICO)));
+
+		assertThatThrownBy(() -> service.assertCanAccessAdvancedReports(SOLO_ID))
+			.isInstanceOf(SubscriptionLimitExceededException.class)
+			.extracting(ex -> ((SubscriptionLimitExceededException) ex).getMessageKey())
+			.isEqualTo(SubscriptionErrorResponses.KEY_REPORTS_ADVANCED_DENIED);
+	}
+
+	@Test
+	void assertCanAccessFullReportsAllowsProfesionalPlan() {
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(SOLO_ID))
+			.thenReturn(Optional.of(activeMember(SOLO_ID, PlanTier.PROFESIONAL)));
+
+		service.assertCanAccessFullReports(SOLO_ID);
+	}
+
+	@Test
 	void assertCanCreatePatientAllowsWhenBelowBasicoCap() {
 		final ClinicMember member = activeMember(SOLO_ID, PlanTier.BASICO);
 		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(SOLO_ID)).thenReturn(Optional.of(member));


### PR DESCRIPTION
## Summary
- Enforce subscription entitlements on report REST endpoints (`PDF_EXPORT`, `REPORTS_ADVANCED`, `REPORTS_FULL`) with localized 403 responses.
- Gate admin report UI in Thymeleaf (hide PDF/advanced actions for Básico; block estadísticas without Profesional+).
- Apply branded PDF headers (`NutritionistProfile`) only when `REPORTS_BRANDED` is granted; PDF blocked during grace period.

Closes #187

## Test plan
- [x] `SubscriptionEntitlementServiceTest` — Básico, Profesional, grace tier matrix
- [x] `PatientReportRestControllerTest` — PDF/advanced denied paths
- [x] `ReportControllerTest` — entitlement flags and estadísticas gating
- [x] `PatientReportServiceTest` — branding omitted without `REPORTS_BRANDED`
- [x] `mvn verify` passes locally


Made with [Cursor](https://cursor.com)