### PR TITLE
feat(subscription): platform admin revoke nutritionist access (#210)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -25,9 +25,18 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md) | Agent workflow for subscription enforcement |
 | [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md) | Plan tiers, entitlements, lifecycle, data model |
 
+**Parallel track (nutritionist web — do not mix into mobile/subscription PRs unless coupled):**
+
+| File | Purpose |
+|------|---------|
+| [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX epic), states, dependencies |
+| [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md) | Patient registration export/import plan |
+
 **Current next issue (mobile):** [#133 — Invitation token generation & hashing service](https://github.com/diego-torres/nutriconsultas/issues/133) (after [#132](https://github.com/diego-torres/nutriconsultas/issues/132) in-progress).
 
 **Current next issue (subscription):** [#210 — Platform admin revoke access](https://github.com/diego-torres/nutriconsultas/issues/210) / [#211 — change plan tier](https://github.com/diego-torres/nutriconsultas/issues/211). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
+
+**Current next issue (nutritionist web):** [#221 — Export patient registration to .mpx](https://github.com/diego-torres/nutriconsultas/issues/221) → #222 → #223. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -594,6 +594,12 @@ Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow
 
 **Schema gate (post-#46):** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline is on `main` (PR #196). All new schema/catalog changes require **incremental Liquibase changesets** — see [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) and [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md). ~~#156~~ Phase C done before baseline.
 
+## Nutritionist web — patient MPX (tracking)
+
+Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md).
+
+**Epic #221–#223** (2026-06-18): export/import patient **registration** to `.mpx` (YAML, no history) + export/delete UI. **NEXT:** [#221 export](https://github.com/diego-torres/nutriconsultas/issues/221) → #222 → #223. Complements #190 patient caps; available all tiers.
+
 ## Resources
 
 - [Spring Boot Documentation](https://spring.io/projects/spring-boot)

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -1,0 +1,60 @@
+# Issue Registry — `[Nutritionist Web]` track
+
+Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admin/**`) — patient roster, clinical workflows, and plan-slot management. Update when status changes (commit on the PR that closes work).
+
+**Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
+**Plan:** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
+**Last updated:** 2026-06-18 — MPX export/import epic **#221–#223** registered.
+
+> **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix mobile JWT or subscription billing into patient MPX PRs unless explicitly coupled.
+
+---
+
+## Legend
+
+| State | Meaning |
+|-------|---------|
+| `NEXT` | Active — pick this up now (if unblocked) |
+| `open` | Not started |
+| `in-progress` | Branch / PR open |
+| `done` | Merged to `main` |
+| `deferred` | Paused |
+
+---
+
+## Epic — Patient registration export/import (`.mpx`)
+
+Help nutritionists **rotate patient slots** (especially **plan básico** cap via #190) by exporting **registration profile only** to a portable file, deleting the in-app record (and clinical history), and re-importing later.
+
+| Requirement | Issues |
+|-------------|--------|
+| Export registration YAML to `.mpx` (no history) | #221 |
+| Import `.mpx` as new patient (counts toward cap) | #222 |
+| UI: Exportar / Eliminar with pre-delete export + history warning | #223 |
+
+**Suggested order:** #221 → #222 → #223.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| **221** | Export patient registration to .mpx (YAML, no history) | https://github.com/diego-torres/nutriconsultas/issues/221 | **NEXT** | #156, #190 (context) | Defines `mpxVersion: 1`; `docs/paciente/MPX-FORMAT.md` at implement time |
+| 222 | Import patient registration from .mpx file | https://github.com/diego-torres/nutriconsultas/issues/222 | open | **221**, #190 | New `Paciente`; no history restore |
+| 223 | Patient export and delete actions with pre-delete backup | https://github.com/diego-torres/nutriconsultas/issues/223 | open | **221**, **222**, #190 | SweetAlert; historial loss copy |
+
+**All tiers:** export/import/delete UI is **not** entitlement-gated; basic plan is the primary use case.
+
+---
+
+## Cross-track links
+
+| Track | Interaction |
+|-------|-------------|
+| #190 Patient limits | Import and manual alta call `assertCanCreatePatient`; delete frees a slot |
+| #109 Mobile linkage | Delete clears `patientAuthSub`; not stored in `.mpx` |
+| #220 Retention purge | Platform admin purge of **revoked** nutritionists — orthogonal to nutritionist-initiated patient delete |
+| #132 Patient invitations | Onboarding `Paciente.status` — import creates `ACTIVE` patient unless product specifies otherwise |
+
+---
+
+**How to update this file**
+
+Same convention as [`ISSUE.md`](ISSUE.md): mark `in-progress` when PR opens, `done` when merged. Reference this registry from [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) and [`AGENTS.md`](AGENTS.md) when adding nutritionist-web sprint pointers.

--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -5,7 +5,7 @@ Living index of GitHub issues that implement **subscription enforcement**, platf
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Workflow:** [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md)  
 **Design doc:** [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md)  
-**Last updated:** 2026-06-18 — #210 **in-progress** (revoke access); ~~#187~~ **done** (PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218)); **NEXT:** ~~#210~~ / #211 (admin ops) or #207 (Stripe).
+**Last updated:** 2026-06-18 — #220 registered (retention cleanup); #210 **in-progress**; **NEXT:** #211 / #207 / #220 (after #210 merged).
 
 > **Scope.** This registry tracks `[Subscription]` issues only. The patient mobile API lives in [`ISSUE.md`](ISSUE.md). Patient invitation onboarding (#132–#141) is orthogonal — do not merge nutritionist and patient invitation entities.
 
@@ -82,6 +82,16 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 
 ---
 
+## Phase 4 — Retention & maintenance
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| 220 | Retention cleanup — purge revoked nutritionist data with S3 backup | https://github.com/diego-torres/nutriconsultas/issues/220 | open | 210, 183, 46 | 90 días post-revoke; UI mantenimiento; backup S3; bitácora |
+
+**Suggested order:** #220 after #210 merged (needs `access.revoke` audit + `CANCELLED` state).
+
+---
+
 ## Epic mapping (user requirements → issues)
 
 | Requirement | Issues |
@@ -90,6 +100,7 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 | 2. Admin assigns nutriologo-* / director-consultorio | #182 |
 | 3. Admin paid invitations, payment, grace, payment override | #184, #189, #185 |
 | 3b. Admin revoke access and change plan tier | #210, #211 |
+| 3c. Retention purge + S3 backup after revoke | #220 |
 | 4. Director invites nutritionists; enable/disable access | #186, #188 |
 | 5. Patient & nutritionist limits | #190 — PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) ✓ |
 | 6. Branded / tiered reports | #187 — PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218) ✓ |

--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -5,7 +5,7 @@ Living index of GitHub issues that implement **subscription enforcement**, platf
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Workflow:** [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md)  
 **Design doc:** [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md)  
-**Last updated:** 2026-06-18 — ~~#187~~ **done** (PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218)); **NEXT:** #210 / #211 (admin ops) or #207 (Stripe).
+**Last updated:** 2026-06-18 — #210 **in-progress** (revoke access); ~~#187~~ **done** (PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218)); **NEXT:** ~~#210~~ / #211 (admin ops) or #207 (Stripe).
 
 > **Scope.** This registry tracks `[Subscription]` issues only. The patient mobile API lives in [`ISSUE.md`](ISSUE.md). Patient invitation onboarding (#132–#141) is orthogonal — do not merge nutritionist and patient invitation entities.
 
@@ -57,7 +57,7 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 | 184 | Admin invitations + payment checkout | https://github.com/diego-torres/nutriconsultas/issues/184 | **done** | 180, 182, 183 | Merged [PR #206](https://github.com/diego-torres/nutriconsultas/pull/206); GitHub closed 2026-06-17. Live checkout → Stripe (#207/#208); email delivery → #209 |
 | 209 | Invitation email — SES (Terraform) + localhost console sender | https://github.com/diego-torres/nutriconsultas/issues/209 | open | 184 | SES prod; `email.mode=console` for local dev |
 | 185 | Subscription lifecycle — grace, payment override, notifications | https://github.com/diego-torres/nutriconsultas/issues/185 | **done** | 180, ~~184~~ ✓ | Merged PR [#215](https://github.com/diego-torres/nutriconsultas/pull/215) |
-| 210 | Platform admin revoke nutritionist access and allow re-invite | https://github.com/diego-torres/nutriconsultas/issues/210 | open | 184, 182, ~~185~~ ✓ | Cancel access; new invite same email |
+| 210 | Platform admin revoke nutritionist access and allow re-invite | https://github.com/diego-torres/nutriconsultas/issues/210 | **in-progress** | 184, 182, ~~185~~ ✓ | Cancel access; new invite same email |
 | 211 | Platform admin change nutritionist subscription plan tier | https://github.com/diego-torres/nutriconsultas/issues/211 | open | 181, 182, 184 | Upgrade/downgrade + Auth0 sync |
 
 ---

--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -5,7 +5,7 @@ Living index of GitHub issues that implement **subscription enforcement**, platf
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Workflow:** [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md)  
 **Design doc:** [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md)  
-**Last updated:** 2026-06-18 — #220 registered (retention cleanup); #210 **in-progress**; **NEXT:** #211 / #207 / #220 (after #210 merged).
+**Last updated:** 2026-06-18 — #220 registered (retention cleanup); #210 **in-progress**; **NEXT:** #211 / #207 / #220 (after #210 merged). Patient MPX epic **#221–#223:** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
 > **Scope.** This registry tracks `[Subscription]` issues only. The patient mobile API lives in [`ISSUE.md`](ISSUE.md). Patient invitation onboarding (#132–#141) is orthogonal — do not merge nutritionist and patient invitation entities.
 
@@ -103,6 +103,7 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 | 3c. Retention purge + S3 backup after revoke | #220 |
 | 4. Director invites nutritionists; enable/disable access | #186, #188 |
 | 5. Patient & nutritionist limits | #190 — PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) ✓ |
+| 5b. Patient slot rotation (export/import `.mpx`) | #221, #222, #223 — [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) |
 | 6. Branded / tiered reports | #187 — PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218) ✓ |
 | 7. PDF export by plan | #187 — PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218) ✓ |
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -3,7 +3,7 @@
 Living index of the GitHub issues that build the **patient mobile API** (`/rest/mobile/patient/**`) on the Spring Boot backend. Update **local and remote** (via a commit on the PR that closes the work) whenever status changes.
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas) (Spring Boot · Java 21 · Maven)
-**Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md)
+**Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) · **Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
 **Last updated:** 2026-06-17 — #46 Liquibase **done** ([PR #196](https://github.com/diego-torres/nutriconsultas/pull/196)). **NEXT:** [#132 invitation onboarding](https://github.com/diego-torres/nutriconsultas/issues/132).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ registro de consultorio de nutrición
 
 ### Patient mobile API
 
-**Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
+**Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
 **On `main` (2026-06-18):** Patient mobile API complete through #116; **NEXT:** #132 invitation onboarding. Parallel **subscription** track: #180–#185, ~~#190~~, ~~#187~~ on `main` (PRs [#216](https://github.com/diego-torres/nutriconsultas/pull/216), [#218](https://github.com/diego-torres/nutriconsultas/pull/218)); **NEXT:** #210 / #211.
 

--- a/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
+++ b/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
@@ -212,4 +212,5 @@ See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) for full registry.
 | 1 | **#210** / **#211** | Revocar acceso y cambio de plan tier (admin platform; deps satisfechas) |
 | 2 | **#207** / **#208** | Migrar checkout Mercado Pago → Stripe; credenciales y webhooks operativos |
 | 3 | **#186** → **#188** | Modelo consultorio + invitaciones director (habilita `ClinicInvitationService` end-to-end) |
-| 4 | **#209** | Entrega de email de invitación (SES prod / console local) |
+| 4 | **#220** | Limpieza retención 90 días post-revoke + backup S3 + UI mantenimiento (deps: #210) |
+| 5 | **#209** | Entrega de email de invitación (SES prod / console local) |

--- a/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
+++ b/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
@@ -199,8 +199,8 @@ cat docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md
 
 | Field | Value |
 |-------|-------|
-| **Next issue** | [#210 — Platform admin revoke access](https://github.com/diego-torres/nutriconsultas/issues/210) / [#211 — change plan tier](https://github.com/diego-torres/nutriconsultas/issues/211) |
-| **In progress** | — |
+| **Next issue** | [#211 — change plan tier](https://github.com/diego-torres/nutriconsultas/issues/211) (after #210 PR) |
+| **In progress** | [#210 — Platform admin revoke access](https://github.com/diego-torres/nutriconsultas/issues/210) |
 | **Just completed** | [#187 — Gate report tiers and PDF export](https://github.com/diego-torres/nutriconsultas/issues/187) — PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218) |
 
 See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) for full registry.

--- a/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
+++ b/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
@@ -214,3 +214,4 @@ See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) for full registry.
 | 3 | **#186** → **#188** | Modelo consultorio + invitaciones director (habilita `ClinicInvitationService` end-to-end) |
 | 4 | **#220** | Limpieza retención 90 días post-revoke + backup S3 + UI mantenimiento (deps: #210) |
 | 5 | **#209** | Entrega de email de invitación (SES prod / console local) |
+| 6 | **#221** → **#223** | MPX export/import pacientes (rotación cupos; [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)) |

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -31,6 +31,15 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`../../SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](../../SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md) | Subscription agent workflow |
 | [`../subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](../subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md) | Plan tiers, entitlements, lifecycle |
 
+## Parallel track (nutritionist web)
+
+| File | What it is |
+|------|-----------|
+| [`../../ISSUE-NUTRITIONIST-WEB.md`](../../ISSUE-NUTRITIONIST-WEB.md) | Patient MPX epic (#221–#223) |
+| [`../paciente/PATIENT-MPX-PLAN.md`](../paciente/PATIENT-MPX-PLAN.md) | Export/import plan |
+
+**Nutritionist web NEXT:** [#221](https://github.com/diego-torres/nutriconsultas/issues/221) export → #222 import → #223 UI.
+
 **Subscription NEXT:** [#210](https://github.com/diego-torres/nutriconsultas/issues/210) / [#211](https://github.com/diego-torres/nutriconsultas/issues/211) admin ops (~~#187~~ PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218), ~~#190~~ PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) on `main`).
 
 ## Provenance / drift

--- a/docs/paciente/PATIENT-MPX-PLAN.md
+++ b/docs/paciente/PATIENT-MPX-PLAN.md
@@ -1,0 +1,70 @@
+# Patient registration export/import (`.mpx`)
+
+**Product:** Minutriporcion / nutriconsultas — nutritionist web app  
+**Status:** Planning (2026-06-18)  
+**Track:** `[Nutritionist Web]` — see [`ISSUE-NUTRITIONIST-WEB.md`](../../ISSUE-NUTRITIONIST-WEB.md)  
+**Issues:** [#221](https://github.com/diego-torres/nutriconsultas/issues/221) export · [#222](https://github.com/diego-torres/nutriconsultas/issues/222) import · [#223](https://github.com/diego-torres/nutriconsultas/issues/223) UI
+
+---
+
+## Goals
+
+1. **Slot rotation** — Nutritionists on capped plans (#190, e.g. básico = 10 patients) can remove inactive patients without retyping registration data.
+2. **Registration-only portable file** — `.mpx` holds YAML profile data suitable for re-import; **clinical history stays in the app until delete** and is **not** in the file.
+3. **Safe delete UX** — Deleting a patient warns that history is lost; optional export-before-delete uses the same `.mpx` format.
+4. **All plans** — Feature available to every tier; not a paid entitlement.
+
+---
+
+## Non-goals
+
+- Export/import consultation history, diet assignments, measurements over time, or messages
+- Patient mobile API endpoints for MPX
+- Merge import into an existing `Paciente` row (always creates new record)
+- Platform admin bulk retention (#220)
+
+---
+
+## `.mpx` contract (summary)
+
+Full spec: **`docs/paciente/MPX-FORMAT.md`** (authoritative once #221 ships).
+
+| Field | Rule |
+|-------|------|
+| Extension | `.mpx` |
+| Encoding | UTF-8 YAML |
+| Version | `mpxVersion: 1` required |
+| **In scope** | `Paciente` demographics + `PacienteBodySnapshot` + `PacienteEnergyPreferences` + `PacienteMedicalHistory` |
+| **Out of scope** | DB ids, `userId`, `patientAuthSub`, `registro`; all timeline/history entities |
+
+---
+
+## Implementation order
+
+```mermaid
+flowchart LR
+  E["#221 Export service + download"]
+  I["#222 Import upload + validation"]
+  U["#223 List/profile UI + delete flow"]
+  E --> I --> U
+```
+
+1. **#221** — `PacienteMpxExportService`, download endpoint, tests, `MPX-FORMAT.md`
+2. **#222** — parse/validate YAML, `assertCanCreatePatient`, save new entity graph
+3. **#223** — Exportar / Eliminar on `/admin/pacientes/**`, SweetAlert copy (Spanish), export-then-delete option
+
+---
+
+## Security & multi-tenant
+
+- Export/delete/import scoped to `paciente.userId == OAuth principal sub` (existing nutritionist tenant model)
+- Never log `.mpx` contents or patient names in application logs
+- Download over authenticated HTTPS session only
+
+---
+
+## Related docs
+
+- [`ISSUE-NUTRITIONIST-WEB.md`](../../ISSUE-NUTRITIONIST-WEB.md) — issue registry
+- [`SUBSCRIPTION-ENFORCEMENT-PLAN.md`](../subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md) — plan caps (#190)
+- [`docs/integration/paciente-er-phase-c.md`](../integration/paciente-er-phase-c.md) — entity decomposition (#156)

--- a/src/main/java/com/nutriconsultas/admin/NutritionistInvitationAdminController.java
+++ b/src/main/java/com/nutriconsultas/admin/NutritionistInvitationAdminController.java
@@ -102,6 +102,16 @@ public class NutritionistInvitationAdminController extends AbstractPlatformAdmin
 		return "redirect:/admin/platform/invitations";
 	}
 
+	@PostMapping("/{id}/revoke-access")
+	public String revokeAccess(@AuthenticationPrincipal final OidcUser principal, @PathVariable final Long id,
+			@RequestParam(required = false) final String reason, final RedirectAttributes redirectAttributes) {
+		requirePlatformAdmin(principal, "invitations.revoke");
+		invitationService.revokeNutritionistAccess(principal, id, reason);
+		redirectAttributes.addFlashAttribute("successMessage",
+				"Acceso revocado. Los datos del nutriólogo se conservan; puede enviar una nueva invitación.");
+		return "redirect:/admin/platform/invitations";
+	}
+
 	@PostMapping("/{id}/regenerate-link")
 	public String regenerateLink(@AuthenticationPrincipal final OidcUser principal, @PathVariable final Long id,
 			final RedirectAttributes redirectAttributes) {

--- a/src/main/java/com/nutriconsultas/admin/SubscriptionAdminController.java
+++ b/src/main/java/com/nutriconsultas/admin/SubscriptionAdminController.java
@@ -13,15 +13,20 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.nutriconsultas.controller.AbstractPlatformAdminController;
 import com.nutriconsultas.platform.PlatformAdminAuthorization;
 import com.nutriconsultas.subscription.Clinic;
 import com.nutriconsultas.subscription.ClinicRepository;
+import com.nutriconsultas.subscription.NutritionistInvitation;
+import com.nutriconsultas.subscription.NutritionistInvitationRepository;
 import com.nutriconsultas.subscription.Subscription;
 import com.nutriconsultas.subscription.SubscriptionRepository;
 import com.nutriconsultas.subscription.SubscriptionStatus;
+import com.nutriconsultas.subscription.invitation.NutritionistInvitationAccessRules;
+import com.nutriconsultas.subscription.invitation.NutritionistInvitationService;
 import com.nutriconsultas.subscription.lifecycle.AdminSubscriptionOverride;
 import com.nutriconsultas.subscription.lifecycle.SubscriptionLifecycleService;
 
@@ -40,13 +45,21 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 
 	private final SubscriptionLifecycleService lifecycleService;
 
+	private final NutritionistInvitationRepository invitationRepository;
+
+	private final NutritionistInvitationService invitationService;
+
 	public SubscriptionAdminController(final PlatformAdminAuthorization platformAdminAuthorization,
 			final SubscriptionRepository subscriptionRepository, final ClinicRepository clinicRepository,
-			final SubscriptionLifecycleService lifecycleService) {
+			final SubscriptionLifecycleService lifecycleService,
+			final NutritionistInvitationRepository invitationRepository,
+			final NutritionistInvitationService invitationService) {
 		super(platformAdminAuthorization);
 		this.subscriptionRepository = subscriptionRepository;
 		this.clinicRepository = clinicRepository;
 		this.lifecycleService = lifecycleService;
+		this.invitationRepository = invitationRepository;
+		this.invitationService = invitationService;
 	}
 
 	@GetMapping
@@ -68,6 +81,7 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 		}
 		model.addAttribute("subscription", subscription);
 		model.addAttribute("clinicName", clinicRepository.findBySubscriptionId(id).map(Clinic::getName).orElse("—"));
+		model.addAttribute("revocableInvitationId", resolveRevocableInvitationId(subscription));
 		model.addAttribute("subscriptionStatuses", SubscriptionStatus.values());
 		model.addAttribute("activeMenu", "subscriptions");
 		return "sbadmin/platform/subscriptions/edit";
@@ -84,6 +98,7 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 			model.addAttribute("subscription", subscription);
 			model.addAttribute("clinicName",
 					clinicRepository.findBySubscriptionId(id).map(Clinic::getName).orElse("—"));
+			model.addAttribute("revocableInvitationId", resolveRevocableInvitationId(subscription));
 			model.addAttribute("subscriptionStatuses", SubscriptionStatus.values());
 			model.addAttribute("activeMenu", "subscriptions");
 			return "sbadmin/platform/subscriptions/edit";
@@ -96,6 +111,23 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 		return "redirect:/admin/platform/subscriptions";
 	}
 
+	@PostMapping("/{id}/revoke-access")
+	public String revokeAccess(@AuthenticationPrincipal final OidcUser principal, @PathVariable final Long id,
+			@RequestParam(required = false) final String reason, final RedirectAttributes redirectAttributes) {
+		requirePlatformAdmin(principal, "subscriptions.revoke");
+		final Subscription subscription = subscriptionRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("Subscription not found"));
+		final NutritionistInvitation invitation = invitationRepository.findBySubscriptionId(id)
+			.orElseThrow(() -> new IllegalArgumentException("No invitation linked to subscription"));
+		if (!NutritionistInvitationAccessRules.canRevokeAccess(invitation)) {
+			throw new IllegalArgumentException("Subscription access cannot be revoked");
+		}
+		invitationService.revokeNutritionistAccess(principal, invitation.getId(), reason);
+		redirectAttributes.addFlashAttribute("successMessage",
+				"Acceso revocado para la suscripción #" + subscription.getId() + ".");
+		return "redirect:/admin/platform/subscriptions";
+	}
+
 	private static UpdateSubscriptionForm toForm(final Subscription subscription) {
 		final UpdateSubscriptionForm form = new UpdateSubscriptionForm();
 		form.setPaymentExempt(subscription.isPaymentExempt());
@@ -105,6 +137,13 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 		form.setGracePeriodDays(subscription.getGracePeriodDays());
 		form.setStatus(subscription.getStatus());
 		return form;
+	}
+
+	private Long resolveRevocableInvitationId(final Subscription subscription) {
+		return invitationRepository.findBySubscriptionId(subscription.getId())
+			.filter(NutritionistInvitationAccessRules::canRevokeAccess)
+			.map(NutritionistInvitation::getId)
+			.orElse(null);
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/auth0/Auth0RoleSyncClient.java
+++ b/src/main/java/com/nutriconsultas/auth0/Auth0RoleSyncClient.java
@@ -17,4 +17,9 @@ public interface Auth0RoleSyncClient {
 	 */
 	void syncPlanRole(String auth0UserId, PlanTier planTier);
 
+	/**
+	 * Removes all plan-tier Auth0 roles from the user without assigning a replacement.
+	 */
+	void revokePlanRoles(String auth0UserId);
+
 }

--- a/src/main/java/com/nutriconsultas/auth0/Auth0RoleSyncClientImpl.java
+++ b/src/main/java/com/nutriconsultas/auth0/Auth0RoleSyncClientImpl.java
@@ -64,6 +64,24 @@ public class Auth0RoleSyncClientImpl implements Auth0RoleSyncClient {
 		}
 	}
 
+	@Override
+	public void revokePlanRoles(final String auth0UserId) {
+		if (!isConfigured()) {
+			throw new IllegalStateException("Auth0 Management API is not configured");
+		}
+		if (!StringUtils.hasText(auth0UserId)) {
+			throw new IllegalArgumentException("auth0UserId is required");
+		}
+		final String token = tokenProvider.obtainToken();
+		final String encodedUserId = URLEncoder.encode(auth0UserId, StandardCharsets.UTF_8);
+		for (final PlanTier tier : PlanTier.values()) {
+			removeRoleIfPresent(token, encodedUserId, tier.getRoleSlug());
+		}
+		if (log.isInfoEnabled()) {
+			log.info("Revoked Auth0 plan roles: userId={}", auth0UserId);
+		}
+	}
+
 	private void removeRoleIfPresent(final String token, final String encodedUserId, final String roleSlug) {
 		final String roleId = resolveRoleId(token, roleSlug);
 		if (roleId == null) {

--- a/src/main/java/com/nutriconsultas/auth0/NoOpAuth0RoleSyncClient.java
+++ b/src/main/java/com/nutriconsultas/auth0/NoOpAuth0RoleSyncClient.java
@@ -20,4 +20,9 @@ public class NoOpAuth0RoleSyncClient implements Auth0RoleSyncClient {
 		throw new Auth0ManagementNotConfiguredException();
 	}
 
+	@Override
+	public void revokePlanRoles(final String auth0UserId) {
+		throw new Auth0ManagementNotConfiguredException();
+	}
+
 }

--- a/src/main/java/com/nutriconsultas/platform/PlatformAdminTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/platform/PlatformAdminTemplateValidator.java
@@ -29,6 +29,7 @@ public class PlatformAdminTemplateValidator extends BaseTemplateValidator {
 		variables.put("subscriptionStatuses", com.nutriconsultas.subscription.SubscriptionStatus.values());
 		variables.put("subscription", createMockSubscription());
 		variables.put("clinicName", "Consultorio demo");
+		variables.put("revocableInvitationId", 1L);
 		variables.put("subscriptionBanner", null);
 		variables.put("subscriptionStatus", com.nutriconsultas.subscription.SubscriptionStatus.SUSPENDED);
 		variables.put("updateSubscriptionForm", new UpdateSubscriptionForm());

--- a/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationAccessRules.java
+++ b/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationAccessRules.java
@@ -2,7 +2,6 @@ package com.nutriconsultas.subscription.invitation;
 
 import com.nutriconsultas.subscription.InvitationStatus;
 import com.nutriconsultas.subscription.NutritionistInvitation;
-import com.nutriconsultas.subscription.Subscription;
 import com.nutriconsultas.subscription.SubscriptionStatus;
 
 /**
@@ -19,14 +18,9 @@ public final class NutritionistInvitationAccessRules {
 	}
 
 	public static boolean canRevokeAccess(final NutritionistInvitation invitation) {
-		if (invitation == null || invitation.getStatus() != InvitationStatus.REDEEMED) {
-			return false;
-		}
-		final Subscription subscription = invitation.getSubscription();
-		if (subscription == null) {
-			return false;
-		}
-		return subscription.getStatus() != SubscriptionStatus.CANCELLED;
+		return invitation != null && invitation.getStatus() == InvitationStatus.REDEEMED
+				&& invitation.getSubscription() != null
+				&& invitation.getSubscription().getStatus() != SubscriptionStatus.CANCELLED;
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationAccessRules.java
+++ b/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationAccessRules.java
@@ -1,0 +1,32 @@
+package com.nutriconsultas.subscription.invitation;
+
+import com.nutriconsultas.subscription.InvitationStatus;
+import com.nutriconsultas.subscription.NutritionistInvitation;
+import com.nutriconsultas.subscription.Subscription;
+import com.nutriconsultas.subscription.SubscriptionStatus;
+
+/**
+ * Shared rules for nutritionist invitation access and admin revoke eligibility.
+ */
+public final class NutritionistInvitationAccessRules {
+
+	private NutritionistInvitationAccessRules() {
+	}
+
+	public static boolean blocksNewInvitation(final SubscriptionStatus status) {
+		return status == SubscriptionStatus.PENDING_PAYMENT || status == SubscriptionStatus.TRIAL
+				|| status == SubscriptionStatus.ACTIVE || status == SubscriptionStatus.GRACE;
+	}
+
+	public static boolean canRevokeAccess(final NutritionistInvitation invitation) {
+		if (invitation == null || invitation.getStatus() != InvitationStatus.REDEEMED) {
+			return false;
+		}
+		final Subscription subscription = invitation.getSubscription();
+		if (subscription == null) {
+			return false;
+		}
+		return subscription.getStatus() != SubscriptionStatus.CANCELLED;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationGridHtml.java
+++ b/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationGridHtml.java
@@ -50,19 +50,34 @@ public final class NutritionistInvitationGridHtml {
 	}
 
 	public static String actionsHtml(final NutritionistInvitation invitation) {
-		if (invitation.getStatus() != InvitationStatus.PENDING) {
+		final StringBuilder actions = new StringBuilder();
+		if (invitation.getStatus() == InvitationStatus.PENDING) {
+			final long id = invitation.getId();
+			actions
+				.append("""
+						<form action='/admin/platform/invitations/%d/regenerate-link' method='post' class='d-inline regenerate-invitation-link-form'>\
+						<button type='button' class='btn btn-sm btn-outline-primary regenerate-invitation-link-btn' title='Generar y ver enlace de invitación'>\
+						<i class='fas fa-link'></i> Enlace</button></form>\
+						<form action='/admin/platform/invitations/%d/cancel' method='post' class='d-inline cancel-invitation-form'>\
+						<button type='button' class='btn btn-sm btn-outline-danger cancel-invitation-btn' title='Cancelar invitación'>\
+						<i class='fas fa-times'></i> Cancelar</button></form>\
+						"""
+					.formatted(id, id));
+		}
+		if (NutritionistInvitationAccessRules.canRevokeAccess(invitation)) {
+			final long id = invitation.getId();
+			actions
+				.append("""
+						<form action='/admin/platform/invitations/%d/revoke-access' method='post' class='d-inline revoke-access-form'>\
+						<button type='button' class='btn btn-sm btn-outline-danger revoke-access-btn' title='Revocar acceso del nutriólogo'>\
+						<i class='fas fa-user-slash'></i> Revocar acceso</button></form>\
+						"""
+					.formatted(id));
+		}
+		if (actions.isEmpty()) {
 			return "<span class=\"text-muted small\">—</span>";
 		}
-		final long id = invitation.getId();
-		return """
-				<form action='/admin/platform/invitations/%d/regenerate-link' method='post' class='d-inline regenerate-invitation-link-form'>\
-				<button type='button' class='btn btn-sm btn-outline-primary regenerate-invitation-link-btn' title='Generar y ver enlace de invitación'>\
-				<i class='fas fa-link'></i> Enlace</button></form>\
-				<form action='/admin/platform/invitations/%d/cancel' method='post' class='d-inline cancel-invitation-form'>\
-				<button type='button' class='btn btn-sm btn-outline-danger cancel-invitation-btn' title='Cancelar invitación'>\
-				<i class='fas fa-times'></i> Cancelar</button></form>\
-				"""
-			.formatted(id, id);
+		return actions.toString();
 	}
 
 	public static String escape(final String value) {

--- a/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationService.java
+++ b/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationService.java
@@ -15,6 +15,12 @@ public interface NutritionistInvitationService {
 	void cancelInvitation(OidcUser adminPrincipal, Long invitationId);
 
 	/**
+	 * Revokes app access for a redeemed invitation: cancels subscription, external
+	 * billing, and Auth0 plan roles. Patient data is retained.
+	 */
+	void revokeNutritionistAccess(OidcUser adminPrincipal, Long invitationId, String reason);
+
+	/**
 	 * Issues a new redeem URL for a pending invitation (rotates token; previous links
 	 * stop working).
 	 */

--- a/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationServiceImpl.java
@@ -326,16 +326,10 @@ public class NutritionistInvitationServiceImpl implements NutritionistInvitation
 		event.setActorUserId(actorUserId);
 		event.setPreviousStatus(previousStatus);
 		event.setNewStatus(SubscriptionStatus.CANCELLED);
-		final StringBuilder details = new StringBuilder();
-		details.append("action=access.revoke,invitationId=").append(invitation.getId());
-		details.append(",targetUserId=").append(invitation.getRedeemedByUserId());
-		details.append(",email=").append(invitation.getEmail());
-		if (StringUtils.hasText(reason)) {
-			details.append(",reason=").append(reason.trim());
-		}
-		details.append(',').append(paymentCancelDetail);
-		details.append(',').append(auth0Detail);
-		event.setDetails(details.toString());
+		final String reasonSuffix = StringUtils.hasText(reason) ? ",reason=" + reason.trim() : "";
+		event.setDetails("action=access.revoke,invitationId=" + invitation.getId() + ",targetUserId="
+				+ invitation.getRedeemedByUserId() + ",email=" + invitation.getEmail() + reasonSuffix + ","
+				+ paymentCancelDetail + "," + auth0Detail);
 		auditEventRepository.save(event);
 	}
 

--- a/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
+import com.nutriconsultas.auth0.Auth0RoleSyncClient;
 import com.nutriconsultas.platform.PlatformAdminService;
 import com.nutriconsultas.subscription.InvitationStatus;
 import com.nutriconsultas.subscription.NutritionistInvitation;
@@ -20,6 +21,7 @@ import com.nutriconsultas.subscription.Subscription;
 import com.nutriconsultas.subscription.SubscriptionAuditEvent;
 import com.nutriconsultas.subscription.SubscriptionAuditEventRepository;
 import com.nutriconsultas.subscription.SubscriptionAuditEventType;
+import com.nutriconsultas.subscription.SubscriptionRepository;
 import com.nutriconsultas.subscription.SubscriptionStatus;
 import com.nutriconsultas.subscription.payment.BillingInterval;
 import com.nutriconsultas.subscription.payment.CheckoutSession;
@@ -46,13 +48,18 @@ public class NutritionistInvitationServiceImpl implements NutritionistInvitation
 
 	private final SubscriptionAuditEventRepository auditEventRepository;
 
+	private final SubscriptionRepository subscriptionRepository;
+
+	private final Auth0RoleSyncClient auth0RoleSyncClient;
+
 	public NutritionistInvitationServiceImpl(final PlatformAdminService platformAdminService,
 			final NutritionistInvitationRepository invitationRepository,
 			final NutritionistInvitationProperties invitationProperties,
 			final InvitationEmailSender invitationEmailSender,
 			final SubscriptionProvisioningService provisioningService,
 			final PaymentCheckoutService paymentCheckoutService,
-			final SubscriptionAuditEventRepository auditEventRepository) {
+			final SubscriptionAuditEventRepository auditEventRepository,
+			final SubscriptionRepository subscriptionRepository, final Auth0RoleSyncClient auth0RoleSyncClient) {
 		this.platformAdminService = platformAdminService;
 		this.invitationRepository = invitationRepository;
 		this.invitationProperties = invitationProperties;
@@ -60,6 +67,8 @@ public class NutritionistInvitationServiceImpl implements NutritionistInvitation
 		this.provisioningService = provisioningService;
 		this.paymentCheckoutService = paymentCheckoutService;
 		this.auditEventRepository = auditEventRepository;
+		this.subscriptionRepository = subscriptionRepository;
+		this.auth0RoleSyncClient = auth0RoleSyncClient;
 	}
 
 	@Override
@@ -114,6 +123,44 @@ public class NutritionistInvitationServiceImpl implements NutritionistInvitation
 		recordInvitationCancelAudit(platformAdminService.resolveActorUserId(adminPrincipal), invitation.getId());
 		if (log.isInfoEnabled()) {
 			log.info("Cancelled nutritionist invitation: invitationId={}", invitation.getId());
+		}
+	}
+
+	@Override
+	@Transactional
+	public void revokeNutritionistAccess(final OidcUser adminPrincipal, final Long invitationId, final String reason) {
+		platformAdminService.requirePlatformAdmin(adminPrincipal);
+		if (invitationId == null) {
+			throw new IllegalArgumentException("invitationId is required");
+		}
+		final NutritionistInvitation invitation = invitationRepository.findById(invitationId)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Invitation not found"));
+		if (invitation.getStatus() != InvitationStatus.REDEEMED) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT,
+					"Solo se puede revocar acceso de invitaciones aceptadas");
+		}
+		final Subscription subscription = invitation.getSubscription();
+		if (subscription == null) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, "La invitación no tiene suscripción asociada");
+		}
+		if (subscription.getStatus() == SubscriptionStatus.CANCELLED) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, "El acceso ya fue revocado");
+		}
+		if (!StringUtils.hasText(invitation.getRedeemedByUserId())) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, "La invitación no tiene usuario asociado");
+		}
+		final String actorUserId = platformAdminService.resolveActorUserId(adminPrincipal);
+		final String targetUserId = invitation.getRedeemedByUserId();
+		final SubscriptionStatus previousStatus = subscription.getStatus();
+		final String paymentCancelDetail = cancelExternalSubscriptionIfPresent(subscription);
+		subscription.setStatus(SubscriptionStatus.CANCELLED);
+		subscriptionRepository.save(subscription);
+		final String auth0Detail = revokeAuth0RolesIfConfigured(targetUserId);
+		recordAccessRevokeAudit(actorUserId, invitation, subscription, previousStatus, reason, paymentCancelDetail,
+				auth0Detail);
+		if (log.isInfoEnabled()) {
+			log.info("Revoked nutritionist access: invitationId={}, subscriptionId={}, targetUserId={}",
+					invitation.getId(), subscription.getId(), targetUserId);
 		}
 	}
 
@@ -225,12 +272,71 @@ public class NutritionistInvitationServiceImpl implements NutritionistInvitation
 
 	private boolean hasActiveSubscriptionAccess(final NutritionistInvitation redeemedInvitation) {
 		final Subscription subscription = redeemedInvitation.getSubscription();
-		return subscription != null && blocksNewInvitation(subscription.getStatus());
+		return subscription != null && NutritionistInvitationAccessRules.blocksNewInvitation(subscription.getStatus());
 	}
 
-	private static boolean blocksNewInvitation(final SubscriptionStatus status) {
-		return status == SubscriptionStatus.PENDING_PAYMENT || status == SubscriptionStatus.TRIAL
-				|| status == SubscriptionStatus.ACTIVE || status == SubscriptionStatus.GRACE;
+	private String cancelExternalSubscriptionIfPresent(final Subscription subscription) {
+		if (!StringUtils.hasText(subscription.getExternalSubscriptionId())) {
+			return "externalSubscriptionCancelled=skipped";
+		}
+		try {
+			paymentCheckoutService.cancelSubscription(subscription.getExternalSubscriptionId());
+			return "externalSubscriptionCancelled=true";
+		}
+		catch (RuntimeException ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("External subscription cancel failed: subscriptionId={}", subscription.getId());
+			}
+			if (log.isDebugEnabled()) {
+				log.debug("External subscription cancel failure", ex);
+			}
+			return "externalSubscriptionCancelled=false";
+		}
+	}
+
+	private String revokeAuth0RolesIfConfigured(final String targetUserId) {
+		if (!auth0RoleSyncClient.isConfigured()) {
+			return "auth0Revoked=skipped";
+		}
+		try {
+			auth0RoleSyncClient.revokePlanRoles(targetUserId);
+			return "auth0Revoked=true";
+		}
+		catch (RuntimeException ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("Auth0 role revoke failed after subscription cancel: targetUserId present={}",
+						StringUtils.hasText(targetUserId));
+			}
+			if (log.isDebugEnabled()) {
+				log.debug("Auth0 role revoke failure", ex);
+			}
+			return "auth0Revoked=false";
+		}
+	}
+
+	private void recordAccessRevokeAudit(final String actorUserId, final NutritionistInvitation invitation,
+			final Subscription subscription, final SubscriptionStatus previousStatus, final String reason,
+			final String paymentCancelDetail, final String auth0Detail) {
+		if (!StringUtils.hasText(actorUserId)) {
+			return;
+		}
+		final SubscriptionAuditEvent event = new SubscriptionAuditEvent();
+		event.setSubscription(subscription);
+		event.setEventType(SubscriptionAuditEventType.PLATFORM_ADMIN_ACTION);
+		event.setActorUserId(actorUserId);
+		event.setPreviousStatus(previousStatus);
+		event.setNewStatus(SubscriptionStatus.CANCELLED);
+		final StringBuilder details = new StringBuilder();
+		details.append("action=access.revoke,invitationId=").append(invitation.getId());
+		details.append(",targetUserId=").append(invitation.getRedeemedByUserId());
+		details.append(",email=").append(invitation.getEmail());
+		if (StringUtils.hasText(reason)) {
+			details.append(",reason=").append(reason.trim());
+		}
+		details.append(',').append(paymentCancelDetail);
+		details.append(',').append(auth0Detail);
+		event.setDetails(details.toString());
+		auditEventRepository.save(event);
 	}
 
 	private void recordInvitationLinkRegeneratedAudit(final String actorUserId, final Long invitationId) {

--- a/src/main/resources/templates/sbadmin/platform/invitations/list.html
+++ b/src/main/resources/templates/sbadmin/platform/invitations/list.html
@@ -233,6 +233,25 @@
           }
         });
       });
+
+      $(document).on('click', '.revoke-access-btn', function () {
+        var $form = $(this).closest('.revoke-access-form');
+        swal({
+          title: 'Revocar acceso',
+          text: 'El nutriólogo perderá acceso a Minutriporcion. Sus datos de pacientes se conservarán. ¿Desea continuar?',
+          type: 'warning',
+          showCancelButton: true,
+          confirmButtonColor: '#d33',
+          cancelButtonColor: '#6c757d',
+          confirmButtonText: 'Sí, revocar acceso',
+          cancelButtonText: 'No',
+          closeOnConfirm: true
+        }, function (isConfirm) {
+          if (isConfirm) {
+            $form.submit();
+          }
+        });
+      });
     });
   </script>
 </body>

--- a/src/main/resources/templates/sbadmin/platform/subscriptions/edit.html
+++ b/src/main/resources/templates/sbadmin/platform/subscriptions/edit.html
@@ -12,6 +12,7 @@
     href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
     rel="stylesheet">
   <link th:href="@{/sbadmin/css/sb-admin-2.min.css}" rel="stylesheet">
+  <link th:href="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.css}" rel="stylesheet">
 </head>
 
 <body id="page-top">
@@ -26,6 +27,22 @@
             <a class="btn btn-secondary btn-sm" th:href="@{/admin/platform/subscriptions}">
               <i class="fas fa-arrow-left"></i> Volver al listado
             </a>
+          </div>
+          <div th:if="${successMessage}" class="alert alert-success" th:text="${successMessage}">Éxito</div>
+          <div class="card shadow mb-4" th:if="${revocableInvitationId != null}">
+            <div class="card-header py-3">
+              <h6 class="m-0 font-weight-bold text-danger">Revocar acceso</h6>
+            </div>
+            <div class="card-body">
+              <p class="text-muted mb-3">Revoca el acceso del nutriólogo a Minutriporcion. Los datos de pacientes se
+                conservan; podrá enviarse una nueva invitación después.</p>
+              <form th:action="@{/admin/platform/subscriptions/{id}/revoke-access(id=${subscription.id})}" method="post"
+                class="revoke-subscription-access-form">
+                <button type="button" class="btn btn-danger revoke-subscription-access-btn">
+                  <i class="fas fa-user-slash"></i> Revocar acceso
+                </button>
+              </form>
+            </div>
           </div>
           <div class="card shadow mb-4">
             <div class="card-header py-3">
@@ -83,6 +100,30 @@
   <script th:src="@{/sbadmin/vendor/jquery/jquery.min.js}"></script>
   <script th:src="@{/sbadmin/vendor/bootstrap/js/bootstrap.bundle.min.js}"></script>
   <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.js}"></script>
+  <script>
+    'use strict';
+    jQuery(document).ready(function ($) {
+      $('.revoke-subscription-access-btn').on('click', function () {
+        var $form = $(this).closest('.revoke-subscription-access-form');
+        swal({
+          title: 'Revocar acceso',
+          text: 'El nutriólogo perderá acceso a Minutriporcion. Sus datos de pacientes se conservarán. ¿Desea continuar?',
+          type: 'warning',
+          showCancelButton: true,
+          confirmButtonColor: '#d33',
+          cancelButtonColor: '#6c757d',
+          confirmButtonText: 'Sí, revocar acceso',
+          cancelButtonText: 'No',
+          closeOnConfirm: true
+        }, function (isConfirm) {
+          if (isConfirm) {
+            $form.submit();
+          }
+        });
+      });
+    });
+  </script>
 </body>
 
 </html>

--- a/src/test/java/com/nutriconsultas/admin/NutritionistInvitationAdminControllerTest.java
+++ b/src/test/java/com/nutriconsultas/admin/NutritionistInvitationAdminControllerTest.java
@@ -111,6 +111,18 @@ class NutritionistInvitationAdminControllerTest {
 	}
 
 	@Test
+	void revokeAccess_whenPlatformAdmin_redirectsToList() {
+		final OidcUser principal = principal("auth0|admin");
+		final org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap redirectAttributes = new org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap();
+
+		final String view = controller.revokeAccess(principal, 5L, "motivo", redirectAttributes);
+
+		verify(invitationService).revokeNutritionistAccess(principal, 5L, "motivo");
+		assertThat(view).isEqualTo("redirect:/admin/platform/invitations");
+		assertThat(redirectAttributes.getFlashAttributes().get("successMessage")).asString().contains("revocado");
+	}
+
+	@Test
 	void regenerateLink_whenPlatformAdmin_redirectsWithInviteUrl() {
 		final OidcUser principal = principal("auth0|admin");
 		final org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap redirectAttributes = new org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap();

--- a/src/test/java/com/nutriconsultas/admin/SubscriptionAdminControllerTest.java
+++ b/src/test/java/com/nutriconsultas/admin/SubscriptionAdminControllerTest.java
@@ -19,7 +19,14 @@ import org.springframework.web.server.ResponseStatusException;
 
 import com.nutriconsultas.platform.PlatformAdminAuthorization;
 import com.nutriconsultas.subscription.ClinicRepository;
+import com.nutriconsultas.subscription.InvitationStatus;
+import com.nutriconsultas.subscription.NutritionistInvitation;
+import com.nutriconsultas.subscription.NutritionistInvitationRepository;
+import com.nutriconsultas.subscription.PlanTier;
+import com.nutriconsultas.subscription.Subscription;
 import com.nutriconsultas.subscription.SubscriptionRepository;
+import com.nutriconsultas.subscription.SubscriptionStatus;
+import com.nutriconsultas.subscription.invitation.NutritionistInvitationService;
 import com.nutriconsultas.subscription.lifecycle.SubscriptionLifecycleService;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,6 +46,12 @@ class SubscriptionAdminControllerTest {
 
 	@Mock
 	private SubscriptionLifecycleService lifecycleService;
+
+	@Mock
+	private NutritionistInvitationRepository invitationRepository;
+
+	@Mock
+	private NutritionistInvitationService invitationService;
 
 	@Test
 	void list_whenNotPlatformAdmin_throwsForbidden() {
@@ -61,6 +74,27 @@ class SubscriptionAdminControllerTest {
 		verify(platformAdminAuthorization).requirePlatformAdmin(principal, "subscriptions.list");
 		assertThat(view).isEqualTo("sbadmin/platform/subscriptions/list");
 		assertThat(model.getAttribute("activeMenu")).isEqualTo("subscriptions");
+	}
+
+	@Test
+	void revokeAccess_whenPlatformAdmin_delegatesToInvitationService() {
+		final OidcUser principal = principal("auth0|admin");
+		final Subscription subscription = new Subscription();
+		subscription.setId(9L);
+		final NutritionistInvitation invitation = new NutritionistInvitation();
+		invitation.setId(3L);
+		invitation.setStatus(InvitationStatus.REDEEMED);
+		invitation.setSubscription(subscription);
+		subscription.setStatus(SubscriptionStatus.ACTIVE);
+		when(subscriptionRepository.findById(9L)).thenReturn(java.util.Optional.of(subscription));
+		when(invitationRepository.findBySubscriptionId(9L)).thenReturn(java.util.Optional.of(invitation));
+		final org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap redirectAttributes = new org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap();
+
+		final String view = controller.revokeAccess(principal, 9L, "ADMIN", redirectAttributes);
+
+		verify(platformAdminAuthorization).requirePlatformAdmin(principal, "subscriptions.revoke");
+		verify(invitationService).revokeNutritionistAccess(principal, 3L, "ADMIN");
+		assertThat(view).isEqualTo("redirect:/admin/platform/subscriptions");
 	}
 
 	private static OidcUser principal(final String subject) {

--- a/src/test/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationAccessRulesTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationAccessRulesTest.java
@@ -1,0 +1,50 @@
+package com.nutriconsultas.subscription.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.subscription.InvitationStatus;
+import com.nutriconsultas.subscription.NutritionistInvitation;
+import com.nutriconsultas.subscription.Subscription;
+import com.nutriconsultas.subscription.SubscriptionStatus;
+
+class NutritionistInvitationAccessRulesTest {
+
+	@Test
+	void blocksNewInvitationForActiveStatuses() {
+		assertThat(NutritionistInvitationAccessRules.blocksNewInvitation(SubscriptionStatus.ACTIVE)).isTrue();
+		assertThat(NutritionistInvitationAccessRules.blocksNewInvitation(SubscriptionStatus.GRACE)).isTrue();
+		assertThat(NutritionistInvitationAccessRules.blocksNewInvitation(SubscriptionStatus.TRIAL)).isTrue();
+		assertThat(NutritionistInvitationAccessRules.blocksNewInvitation(SubscriptionStatus.PENDING_PAYMENT)).isTrue();
+	}
+
+	@Test
+	void allowsNewInvitationForCancelledOrSuspended() {
+		assertThat(NutritionistInvitationAccessRules.blocksNewInvitation(SubscriptionStatus.CANCELLED)).isFalse();
+		assertThat(NutritionistInvitationAccessRules.blocksNewInvitation(SubscriptionStatus.SUSPENDED)).isFalse();
+	}
+
+	@Test
+	void canRevokeAccessForRedeemedActiveSubscription() {
+		final NutritionistInvitation invitation = new NutritionistInvitation();
+		invitation.setStatus(InvitationStatus.REDEEMED);
+		final Subscription subscription = new Subscription();
+		subscription.setStatus(SubscriptionStatus.ACTIVE);
+		invitation.setSubscription(subscription);
+
+		assertThat(NutritionistInvitationAccessRules.canRevokeAccess(invitation)).isTrue();
+	}
+
+	@Test
+	void cannotRevokeAccessWhenAlreadyCancelled() {
+		final NutritionistInvitation invitation = new NutritionistInvitation();
+		invitation.setStatus(InvitationStatus.REDEEMED);
+		final Subscription subscription = new Subscription();
+		subscription.setStatus(SubscriptionStatus.CANCELLED);
+		invitation.setSubscription(subscription);
+
+		assertThat(NutritionistInvitationAccessRules.canRevokeAccess(invitation)).isFalse();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationServiceTest.java
@@ -24,13 +24,17 @@ import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.web.server.ResponseStatusException;
 
+import com.nutriconsultas.auth0.Auth0RoleSyncClient;
 import com.nutriconsultas.platform.PlatformAdminService;
 import com.nutriconsultas.subscription.InvitationStatus;
 import com.nutriconsultas.subscription.NutritionistInvitation;
 import com.nutriconsultas.subscription.NutritionistInvitationRepository;
 import com.nutriconsultas.subscription.PlanTier;
 import com.nutriconsultas.subscription.Subscription;
+import com.nutriconsultas.subscription.SubscriptionAuditEvent;
 import com.nutriconsultas.subscription.SubscriptionAuditEventRepository;
+import com.nutriconsultas.subscription.SubscriptionAuditEventType;
+import com.nutriconsultas.subscription.SubscriptionRepository;
 import com.nutriconsultas.subscription.SubscriptionStatus;
 import com.nutriconsultas.subscription.payment.BillingInterval;
 import com.nutriconsultas.subscription.payment.CheckoutSession;
@@ -66,6 +70,12 @@ class NutritionistInvitationServiceTest {
 
 	@Mock
 	private SubscriptionAuditEventRepository auditEventRepository;
+
+	@Mock
+	private SubscriptionRepository subscriptionRepository;
+
+	@Mock
+	private Auth0RoleSyncClient auth0RoleSyncClient;
 
 	@InjectMocks
 	private NutritionistInvitationServiceImpl invitationService;
@@ -187,6 +197,60 @@ class NutritionistInvitationServiceTest {
 	}
 
 	@Test
+	void revokeNutritionistAccessCancelsSubscriptionAndRevokesAuth0() {
+		final NutritionistInvitation invitation = redeemedInvitationWithSubscription(SubscriptionStatus.ACTIVE);
+		invitation.getSubscription().setExternalSubscriptionId("mp-sub-1");
+		when(platformAdminService.resolveActorUserId(adminPrincipal)).thenReturn(ADMIN_USER_ID);
+		when(invitationRepository.findById(1L)).thenReturn(Optional.of(invitation));
+		when(auth0RoleSyncClient.isConfigured()).thenReturn(true);
+
+		invitationService.revokeNutritionistAccess(adminPrincipal, 1L, "ADMIN_REVOKE");
+
+		assertThat(invitation.getSubscription().getStatus()).isEqualTo(SubscriptionStatus.CANCELLED);
+		verify(paymentCheckoutService).cancelSubscription("mp-sub-1");
+		verify(auth0RoleSyncClient).revokePlanRoles(INVITEE_USER_ID);
+		verify(subscriptionRepository).save(invitation.getSubscription());
+		final ArgumentCaptor<SubscriptionAuditEvent> auditCaptor = ArgumentCaptor
+			.forClass(SubscriptionAuditEvent.class);
+		verify(auditEventRepository).save(auditCaptor.capture());
+		assertThat(auditCaptor.getValue().getEventType()).isEqualTo(SubscriptionAuditEventType.PLATFORM_ADMIN_ACTION);
+		assertThat(auditCaptor.getValue().getDetails()).contains("action=access.revoke");
+		assertThat(auditCaptor.getValue().getDetails()).contains("reason=ADMIN_REVOKE");
+	}
+
+	@Test
+	void revokeNutritionistAccessAllowsReInviteAfterCancelled() {
+		final NutritionistInvitation redeemed = redeemedInvitationWithSubscription(SubscriptionStatus.CANCELLED);
+		when(platformAdminService.resolveActorUserId(adminPrincipal)).thenReturn(ADMIN_USER_ID);
+		when(invitationProperties.getExpiryDays()).thenReturn(7);
+		when(invitationProperties.buildRedeemUrl(any()))
+			.thenAnswer(invocation -> "https://app.test/redeem?token=" + invocation.getArgument(0));
+		when(invitationRepository.findByEmailIgnoreCaseAndStatus(INVITEE_EMAIL, InvitationStatus.PENDING))
+			.thenReturn(Optional.empty());
+		when(invitationRepository.findFirstByEmailIgnoreCaseAndStatusOrderByRedeemedAtDesc(INVITEE_EMAIL,
+				InvitationStatus.REDEEMED))
+			.thenReturn(Optional.of(redeemed));
+		when(invitationRepository.save(any(NutritionistInvitation.class))).thenAnswer(invocation -> {
+			final NutritionistInvitation invitation = invocation.getArgument(0);
+			invitation.setId(2L);
+			return invitation;
+		});
+
+		final CreatedNutritionistInvitation created = invitationService.createInvitation(adminPrincipal, INVITEE_EMAIL,
+				PlanTier.BASICO, false);
+
+		assertThat(created.invitationId()).isEqualTo(2L);
+	}
+
+	@Test
+	void revokeNutritionistAccessRejectsPendingInvitation() {
+		when(invitationRepository.findById(1L)).thenReturn(Optional.of(pendingInvitation()));
+
+		assertThatThrownBy(() -> invitationService.revokeNutritionistAccess(adminPrincipal, 1L, null))
+			.isInstanceOf(ResponseStatusException.class);
+	}
+
+	@Test
 	void regenerateInvitationLinkRotatesTokenForPendingInvitation() {
 		final NutritionistInvitation invitation = pendingInvitation();
 		when(platformAdminService.resolveActorUserId(adminPrincipal)).thenReturn(ADMIN_USER_ID);
@@ -256,6 +320,19 @@ class NutritionistInvitationServiceTest {
 		invitation.setExpiresAt(Instant.now().plus(2, ChronoUnit.DAYS));
 		invitation.setCreatedByUserId(ADMIN_USER_ID);
 		invitation.setPaymentExempt(true);
+		return invitation;
+	}
+
+	private NutritionistInvitation redeemedInvitationWithSubscription(final SubscriptionStatus status) {
+		final NutritionistInvitation invitation = pendingInvitation();
+		invitation.setStatus(InvitationStatus.REDEEMED);
+		invitation.setRedeemedAt(Instant.now());
+		invitation.setRedeemedByUserId(INVITEE_USER_ID);
+		final Subscription subscription = new Subscription();
+		subscription.setId(10L);
+		subscription.setStatus(status);
+		subscription.setPlanTier(PlanTier.PROFESIONAL);
+		invitation.setSubscription(subscription);
 		return invitation;
 	}
 


### PR DESCRIPTION
## Summary
- Platform admins can revoke nutritionist access from redeemed invitations or subscription edit UI
- Cancels subscription (`CANCELLED`), external billing when present, and Auth0 plan roles with audit trail
- Re-invite same email allowed after revoke; patient data retained
- Docs: #220 retention registry, #221–#223 patient MPX epic registry

## Test plan
- [x] Manual UI: revoke from invitations (SweetAlert + success)
- [x] Manual UI: revoke from subscription edit
- [x] Manual UI: re-invite same email after revoke
- [x] Manual UI: revoked nutritionist blocked from `/admin`
- [x] `mvn verify` passed locally

Closes #210


Made with [Cursor](https://cursor.com)