### PR TITLE
docs(subscription): mark #210 done, #211 NEXT

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -34,7 +34,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (mobile):** [#133 — Invitation token generation & hashing service](https://github.com/diego-torres/nutriconsultas/issues/133) (after [#132](https://github.com/diego-torres/nutriconsultas/issues/132) in-progress).
 
-**Current next issue (subscription):** [#210 — Platform admin revoke access](https://github.com/diego-torres/nutriconsultas/issues/210) / [#211 — change plan tier](https://github.com/diego-torres/nutriconsultas/issues/211). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
+**Current next issue (subscription):** [#211 — change plan tier](https://github.com/diego-torres/nutriconsultas/issues/211). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#210~~ merged PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224).
 
 **Current next issue (nutritionist web):** [#221 — Export patient registration to .mpx](https://github.com/diego-torres/nutriconsultas/issues/221) → #222 → #223. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
@@ -426,6 +426,6 @@ gh pr create ...
 
 **GitHub drift (close when convenient):** #97, #111 done on `main` but open on GitHub (PRs #147, #151).
 
-**Subscription track (parallel):** [#180–#211](https://github.com/diego-torres/nutriconsultas/issues/180) — see [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#185~~ ✓ (PR #215); ~~#190~~ ✓ (PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216)); ~~#187~~ ✓ (PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218)). **NEXT:** #210 / #211 (+ Stripe #207/#208).
+**Subscription track (parallel):** [#180–#211](https://github.com/diego-torres/nutriconsultas/issues/180) — see [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#185~~ ✓ (PR #215); ~~#190~~ ✓ (PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216)); ~~#187~~ ✓ (PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218)); ~~#210~~ ✓ (PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224)). **NEXT:** #211 (+ Stripe #207/#208).
 
 See [`ISSUE.md`](ISSUE.md) Data contracts, [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) §F8, and [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) for per-endpoint and schema requirements.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -586,11 +586,11 @@ Issue registry: [`ISSUE.md`](ISSUE.md). Agent workflow: [`AGENT-WORKFLOW.md`](AG
 
 Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow: [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md). Design: [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md).
 
-**Epic #180–#211** (2026-06-18): ~~#46~~ Liquibase done; ~~#180–#185~~, ~~#190~~, ~~#187~~ on `main` (PRs [#216](https://github.com/diego-torres/nutriconsultas/pull/216), [#218](https://github.com/diego-torres/nutriconsultas/pull/218)). **NEXT:** #210 / #211 (+ Stripe #207/#208). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
+**Epic #180–#211** (2026-06-18): ~~#46~~ Liquibase done; ~~#180–#185~~, ~~#190~~, ~~#187~~, ~~#210~~ on `main` (PRs [#216](https://github.com/diego-torres/nutriconsultas/pull/216), [#218](https://github.com/diego-torres/nutriconsultas/pull/218), [#224](https://github.com/diego-torres/nutriconsultas/pull/224)). **NEXT:** #211 (+ Stripe #207/#208). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 
-**Next:** [#133](https://github.com/diego-torres/nutriconsultas/issues/133) invitation token hashing ([#132](https://github.com/diego-torres/nutriconsultas/issues/132) in-progress). ~~#114~~, ~~#116~~, ~~#115~~, ~~#112~~ **done** on `main`. Subscription track: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) — ~~#187~~ done (PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218)); **NEXT** #210 / #211.
+**Next:** [#133](https://github.com/diego-torres/nutriconsultas/issues/133) invitation token hashing ([#132](https://github.com/diego-torres/nutriconsultas/issues/132) in-progress). ~~#114~~, ~~#116~~, ~~#115~~, ~~#112~~ **done** on `main`. Subscription track: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) — ~~#210~~ done (PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224)); **NEXT** #211.
 
 **Schema gate (post-#46):** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline is on `main` (PR #196). All new schema/catalog changes require **incremental Liquibase changesets** — see [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) and [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md). ~~#156~~ Phase C done before baseline.
 

--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -5,7 +5,7 @@ Living index of GitHub issues that implement **subscription enforcement**, platf
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Workflow:** [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md)  
 **Design doc:** [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md)  
-**Last updated:** 2026-06-18 — #220 registered (retention cleanup); #210 **in-progress**; **NEXT:** #211 / #207 / #220 (after #210 merged). Patient MPX epic **#221–#223:** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+**Last updated:** 2026-06-18 — ~~#210~~ **done** (PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224)); **NEXT:** #211 (change plan tier). Patient MPX **#221–#223:** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
 > **Scope.** This registry tracks `[Subscription]` issues only. The patient mobile API lives in [`ISSUE.md`](ISSUE.md). Patient invitation onboarding (#132–#141) is orthogonal — do not merge nutritionist and patient invitation entities.
 
@@ -57,8 +57,8 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 | 184 | Admin invitations + payment checkout | https://github.com/diego-torres/nutriconsultas/issues/184 | **done** | 180, 182, 183 | Merged [PR #206](https://github.com/diego-torres/nutriconsultas/pull/206); GitHub closed 2026-06-17. Live checkout → Stripe (#207/#208); email delivery → #209 |
 | 209 | Invitation email — SES (Terraform) + localhost console sender | https://github.com/diego-torres/nutriconsultas/issues/209 | open | 184 | SES prod; `email.mode=console` for local dev |
 | 185 | Subscription lifecycle — grace, payment override, notifications | https://github.com/diego-torres/nutriconsultas/issues/185 | **done** | 180, ~~184~~ ✓ | Merged PR [#215](https://github.com/diego-torres/nutriconsultas/pull/215) |
-| 210 | Platform admin revoke nutritionist access and allow re-invite | https://github.com/diego-torres/nutriconsultas/issues/210 | **in-progress** | 184, 182, ~~185~~ ✓ | Cancel access; new invite same email |
-| 211 | Platform admin change nutritionist subscription plan tier | https://github.com/diego-torres/nutriconsultas/issues/211 | open | 181, 182, 184 | Upgrade/downgrade + Auth0 sync |
+| 210 | Platform admin revoke nutritionist access and allow re-invite | https://github.com/diego-torres/nutriconsultas/issues/210 | **done** | 184, 182, ~~185~~ ✓ | Merged PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224) |
+| **211** | Platform admin change nutritionist subscription plan tier | https://github.com/diego-torres/nutriconsultas/issues/211 | **NEXT** | 181, 182, 184 | Upgrade/downgrade + Auth0 sync |
 
 ---
 
@@ -78,7 +78,7 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 | 190 | Enforce patient and nutritionist limits per plan | https://github.com/diego-torres/nutriconsultas/issues/190 | **done** | 181, ~~185~~ ✓ | Merged PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) |
 | 187 | Gate report tiers and PDF export by plan | https://github.com/diego-torres/nutriconsultas/issues/187 | **done** | 181, ~~185~~ ✓, ~~190~~ ✓ | Merged PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218) |
 
-**Suggested order:** #210 / #211 (admin ops) and #207 (Stripe) in parallel.
+**Suggested order:** #211 (admin ops) and #207 (Stripe) in parallel; #220 unblocked after ~~#210~~ ✓.
 
 ---
 
@@ -99,7 +99,7 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 | 1. Platform admin allowlist only | #183 (+ existing `PlatformAdminService`) |
 | 2. Admin assigns nutriologo-* / director-consultorio | #182 |
 | 3. Admin paid invitations, payment, grace, payment override | #184, #189, #185 |
-| 3b. Admin revoke access and change plan tier | #210, #211 |
+| 3b. Admin revoke access and change plan tier | ~~#210~~ ✓ PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224), **#211** |
 | 3c. Retention purge + S3 backup after revoke | #220 |
 | 4. Director invites nutritionists; enable/disable access | #186, #188 |
 | 5. Patient & nutritionist limits | #190 — PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) ✓ |

--- a/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
+++ b/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
@@ -199,9 +199,9 @@ cat docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md
 
 | Field | Value |
 |-------|-------|
-| **Next issue** | [#211 — change plan tier](https://github.com/diego-torres/nutriconsultas/issues/211) (after #210 PR) |
-| **In progress** | [#210 — Platform admin revoke access](https://github.com/diego-torres/nutriconsultas/issues/210) |
-| **Just completed** | [#187 — Gate report tiers and PDF export](https://github.com/diego-torres/nutriconsultas/issues/187) — PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218) |
+| **Next issue** | [#211 — change plan tier](https://github.com/diego-torres/nutriconsultas/issues/211) |
+| **In progress** | — |
+| **Just completed** | [#210 — Platform admin revoke access](https://github.com/diego-torres/nutriconsultas/issues/210) — PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224) |
 
 See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) for full registry.
 
@@ -209,7 +209,7 @@ See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) for full registry.
 
 | Prioridad | Issue | Acción |
 |-----------|-------|--------|
-| 1 | **#210** / **#211** | Revocar acceso y cambio de plan tier (admin platform; deps satisfechas) |
+| 1 | **#211** | Cambio de plan tier (admin platform) |
 | 2 | **#207** / **#208** | Migrar checkout Mercado Pago → Stripe; credenciales y webhooks operativos |
 | 3 | **#186** → **#188** | Modelo consultorio + invitaciones director (habilita `ClinicInvitationService` end-to-end) |
 | 4 | **#220** | Limpieza retención 90 días post-revoke + backup S3 + UI mantenimiento (deps: #210) |

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -40,7 +40,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 
 **Nutritionist web NEXT:** [#221](https://github.com/diego-torres/nutriconsultas/issues/221) export → #222 import → #223 UI.
 
-**Subscription NEXT:** [#210](https://github.com/diego-torres/nutriconsultas/issues/210) / [#211](https://github.com/diego-torres/nutriconsultas/issues/211) admin ops (~~#187~~ PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218), ~~#190~~ PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) on `main`).
+**Subscription NEXT:** [#211](https://github.com/diego-torres/nutriconsultas/issues/211) change plan tier (~~#210~~ PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224), ~~#187~~ PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218), ~~#190~~ PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) on `main`).
 
 ## Provenance / drift
 


### PR DESCRIPTION
## Summary
- Mark #210 done (PR #224 merged and deployed to EC2)
- Set #211 as NEXT in subscription registries and workflow docs

## Test plan
- [x] Registry rows match GitHub issue #210 closed state


Made with [Cursor](https://cursor.com)