### PR TITLE
Fix invitation links pointing to localhost on production (#226)

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -131,6 +131,7 @@ Set `AUTH_*` (including `AUTH_AUDIENCE` for `/rest/mobile/**` JWT validation), `
 | `PAYMENT_PROVIDER` | Provider id (target default `stripe`; `mercadopago` legacy until #207 merges). |
 | `STRIPE_SUCCESS_URL` | Post-checkout redirect (default `https://minutriporcion.com/admin`). |
 | `PAYMENT_CURRENCY` | Billing currency (default `MXN`). |
+| `APP_BASE_URL` | Public site URL for invitation redeem links (e.g. `https://minutriporcion.com`). Set automatically from Terraform `public_site_domain` on new app instances; use `ssm-remediate-app-host.sh` or edit `app.env` on brownfield hosts. |
 
 Webhook URL to configure in the [Stripe Dashboard](https://dashboard.stripe.com/webhooks): `https://<your-domain>/rest/subscription/payment/webhook`. No card data is stored in the application database.
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -51,6 +51,7 @@ locals {
   app_nginx_server_names = length(local.app_certbot_hostnames) > 0 ? join(" ", local.app_certbot_hostnames) : "_"
   app_certbot_d_flags    = length(local.app_certbot_hostnames) > 0 ? join(" ", [for h in local.app_certbot_hostnames : "-d ${h}"]) : ""
   app_certbot_enabled    = length(local.app_certbot_hostnames) > 0 && trimspace(var.certbot_admin_email) != ""
+  app_base_url           = trimspace(var.public_site_domain) != "" ? "https://${trimspace(var.public_site_domain)}" : ""
 }
 
 # -----------------------------------------------------------------------------
@@ -263,6 +264,7 @@ resource "aws_instance" "app" {
         certbot_run_flag  = local.app_certbot_enabled ? "1" : "0"
         certbot_d_flags   = local.app_certbot_d_flags
         certbot_email_b64 = base64encode(trimspace(var.certbot_admin_email))
+        app_base_url      = local.app_base_url
       }
     )
   )

--- a/infrastructure/scripts/remediate-app-host-remote.sh
+++ b/infrastructure/scripts/remediate-app-host-remote.sh
@@ -7,6 +7,13 @@ REGION="us-east-1"
 BUCKET="$(aws ssm get-parameter --name /nutriconsultas/deploy/s3_bucket --query Parameter.Value --output text --region "$REGION")"
 KEY="$(aws ssm get-parameter --name /nutriconsultas/deploy/s3_key --query Parameter.Value --output text --region "$REGION")"
 
+APP_BASE_URL="https://minutriporcion.com"
+if grep -q '^APP_BASE_URL=' /opt/nutriconsultas/app.env 2>/dev/null; then
+	sudo sed -i "s|^APP_BASE_URL=.*|APP_BASE_URL=${APP_BASE_URL}|" /opt/nutriconsultas/app.env
+else
+	echo "APP_BASE_URL=${APP_BASE_URL}" | sudo tee -a /opt/nutriconsultas/app.env >/dev/null
+fi
+
 aws s3 cp "s3://${BUCKET}/${KEY}" /tmp/nutriconsultas-web.jar --region "$REGION" --no-progress
 
 sudo install -o nutri -g nutri -m 640 /tmp/nutriconsultas-web.jar /opt/nutriconsultas/app.jar

--- a/infrastructure/templates/app.user_data.sh
+++ b/infrastructure/templates/app.user_data.sh
@@ -64,6 +64,9 @@ install -d -o root -g nutri -m 750 /opt/nutriconsultas
   echo -n "AUTH0_MGMT_DOMAIN="
   printf '%s' '${auth0_mgmt_domain_b64}' | base64 -d
   echo
+%{ if app_base_url != "" ~}
+  echo "APP_BASE_URL=${app_base_url}"
+%{ endif ~}
 } > /opt/nutriconsultas/app.env
 chown root:nutri /opt/nutriconsultas/app.env
 chmod 640 /opt/nutriconsultas/app.env

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -63,6 +63,7 @@ nutriconsultas.subscription.payment.mercadopago-access-token=${MERCADOPAGO_ACCES
 nutriconsultas.subscription.payment.mercadopago-back-url=${MERCADOPAGO_BACK_URL:https://minutriporcion.com/admin}
 nutriconsultas.subscription.payment.currency=${PAYMENT_CURRENCY:MXN}
 nutriconsultas.subscription.invitation.expiry-days=${SUBSCRIPTION_INVITATION_EXPIRY_DAYS:7}
+# Production EC2: set APP_BASE_URL in app.env (Terraform user_data or ssm-remediate-app-host.sh).
 nutriconsultas.subscription.invitation.base-url=${APP_BASE_URL:http://localhost:3000}
 nutriconsultas.subscription.default-grace-period-days=${SUBSCRIPTION_GRACE_PERIOD_DAYS:7}
 nutriconsultas.subscription.expiry-reminder-days=7,3,1

--- a/src/test/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationPropertiesTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationPropertiesTest.java
@@ -1,0 +1,27 @@
+package com.nutriconsultas.subscription.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class NutritionistInvitationPropertiesTest {
+
+	@Test
+	void buildRedeemUrlUsesConfiguredBaseUrl() {
+		final NutritionistInvitationProperties properties = new NutritionistInvitationProperties();
+		properties.setBaseUrl("https://minutriporcion.com");
+
+		assertThat(properties.buildRedeemUrl("abc123"))
+			.isEqualTo("https://minutriporcion.com/invitation/nutritionist/redeem?token=abc123");
+	}
+
+	@Test
+	void buildRedeemUrlStripsTrailingSlashFromBaseUrl() {
+		final NutritionistInvitationProperties properties = new NutritionistInvitationProperties();
+		properties.setBaseUrl("https://minutriporcion.com/");
+
+		assertThat(properties.buildRedeemUrl("abc123"))
+			.isEqualTo("https://minutriporcion.com/invitation/nutritionist/redeem?token=abc123");
+	}
+
+}


### PR DESCRIPTION
## Summary
- Fixes #226
- Sets `APP_BASE_URL=https://<public_site_domain>` in Terraform `app.user_data.sh` when `public_site_domain` is configured, so Spring resolves `nutriconsultas.subscription.invitation.base-url` to the public site instead of `http://localhost:3000`.
- Updates `ssm-remediate-app-host.sh` remote script to ensure `APP_BASE_URL=https://minutriporcion.com` on brownfield EC2 before restarting the app.
- Adds unit tests for `NutritionistInvitationProperties.buildRedeemUrl`.

## Root cause
Production EC2 `app.env` did not define `APP_BASE_URL`, so invitation redeem links defaulted to localhost.

## Test plan
- [x] `mvn test -Dtest=NutritionistInvitationPropertiesTest`
- [ ] After merge: run `AWS_PROFILE=minutriporcion bash infrastructure/scripts/ssm-remediate-app-host.sh` (or add `APP_BASE_URL` manually via SSM) and restart `nutriconsultas`
- [ ] Create a nutritionist invitation in admin UI and verify link uses `https://minutriporcion.com/invitation/nutritionist/redeem?token=...`


Made with [Cursor](https://cursor.com)