### PR TITLE
docs: full registry sync 2026-06-17/18

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -32,7 +32,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX epic), states, dependencies |
 | [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md) | Patient registration export/import plan |
 
-**Current next issue (mobile):** [#133 — Invitation token generation & hashing service](https://github.com/diego-torres/nutriconsultas/issues/133) (after [#132](https://github.com/diego-torres/nutriconsultas/issues/132) in-progress).
+**Current next issue (mobile):** [#133 — Invitation token generation & hashing service](https://github.com/diego-torres/nutriconsultas/issues/133). ~~#132~~ done (PR [#214](https://github.com/diego-torres/nutriconsultas/pull/214)).
 
 **Current next issue (subscription):** [#211 — change plan tier](https://github.com/diego-torres/nutriconsultas/issues/211). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#210~~ merged PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224).
 
@@ -48,7 +48,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | **API surface** | All mobile endpoints live under `/rest/mobile/patient/` as plain JSON (not DataTables-shaped like the admin `*RestController`s). |
 | **Identity (security-critical)** | JWT `sub` → **`Paciente.patientAuthSub`** (#107 ✓ PR #117). **Never `Paciente.userId`** — that is the NUTRITIONIST's Auth0 sub / tenant owner (ALIGNMENT-SPEC §F2). `PatientLinkageFilter` returns **403** if no linked `Paciente`. |
 | **Ownership / IDOR** | Return only the authenticated patient's rows. On an ownership miss prefer **404** (not 403) so existence isn't leaked (esp. #92). Never return cross-tenant data. |
-| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **Cross-cutting done** (#111–#116). **#156** and **#46** done on `main`. **NEXT:** #132 invitation onboarding. Requires `AUTH_AUDIENCE` env var. |
+| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **Cross-cutting done** (#111–#116). **#156**, **#46**, **#132** done on `main`. **NEXT:** #133 invitation token hashing. Requires `AUTH_AUDIENCE` env var. |
 | **DTO envelope** | `ApiResponse<T>`; lists in `PagedResponse<T>` or `CursorPagedResponse<T>` (messages); ISO-8601 date strings. See #110. |
 | **Schema ground truth** | ALIGNMENT-SPEC §F8 field-name map (`nombre→dietaName`, `energia→totalKcal`, `lipidos→totalGrasas`, `hidratosDeCarbono→totalCarbohidratos`, `Ingesta.nombre→tipo`); enums `EventStatus`/`PacienteDietaStatus` (no INACTIVE)/`NivelPeso`. Serialization aliases only — **no DB schema changes** for field renames. |
 | **PHI & logging** | No patient names/emails/DOB in unstructured logs. `LogRedaction` + `PhiLogTurboFilter`; CI runs `scripts/audit-logging.sh` and `scripts/audit-mobile-logging.sh` (#115 done). |
@@ -98,7 +98,7 @@ flowchart LR
    - **#113 (rate limit)** should land with or before **#97** (write endpoint).
    - **#114 (nutritionist reply) is web-only** — do not expose it under `/rest/mobile/**`.
    - **#46 (Liquibase)** ✓ — all schema/catalog changes are incremental changesets (see [Liquibase section](#liquibase--entity-schema-and-catalog-data)).
-   - **#132 (onboarding schema)** — extend the decomposed `Paciente` model + Liquibase migration; link issue in PR.
+   - **#132 (onboarding schema)** ✓ — `PacienteStatus` + `PatientInvitation` on `main` (PR #214, Liquibase `007`). **NEXT:** #133 token hashing service.
    - If a dependency is still `open`, complete it first or document the blocker in the plan (Phase 2) and stop.
 5. **Update local registry** when remote state drifted (issue closed on GitHub but still `open` here, or vice versa). `ISSUE.md` must match GitHub before proceeding.
 
@@ -384,7 +384,7 @@ cat ISSUE.md
 cat docs/mobile-api/README.md
 
 # During work
-git checkout -b mobile-api/132-invitation-schema
+git checkout -b mobile-api/133-invitation-token-service
 ./lint.sh && bash scripts/audit-logging.sh && bash scripts/audit-mobile-logging.sh && mvn -B verify
 ./dev-start.sh   # Java 21 — run locally when touching security, Liquibase, or startup
 
@@ -400,10 +400,10 @@ gh pr create ...
 | Field | Value |
 |-------|-------|
 | **Next issue** | [#133 — Invitation token generation & hashing service](https://github.com/diego-torres/nutriconsultas/issues/133) |
-| **Status** | **NEXT** — [#132](https://github.com/diego-torres/nutriconsultas/issues/132) **in-progress** (schema + Liquibase) |
-| **Phase** | Invitation / onboarding — token service after #132 merges |
-| **Just completed** | Prerequisites ~~#156~~ ✓ and ~~#46~~ ✓ (PR #196) |
-| **In scope for #132** | `PacienteStatus` + `PatientInvitation` entity; Liquibase `007-patient-invitation-onboarding.yaml` |
+| **Status** | **NEXT** — ~~#132~~ ✓ merged (PR [#214](https://github.com/diego-torres/nutriconsultas/pull/214)) |
+| **Phase** | Invitation / onboarding — CSPRNG + SHA-256 hash + constant-time verify |
+| **Just completed** | [#132 onboarding schema](https://github.com/diego-torres/nutriconsultas/issues/132) — `PacienteStatus`, `PatientInvitation`, Liquibase `007-patient-invitation-onboarding.yaml` |
+| **In scope for #133** | Token generation service; hash-only persistence; reuse pattern from subscription `NutritionistInvitation` |
 
 ### Upcoming gates
 
@@ -414,18 +414,22 @@ gh pr create ...
 | Endpoints | ~~#91–#99~~ ✓ | **Done** (PR #153) |
 | Cross-cutting | ~~#111~~ ✓, ~~#112~~ ✓ (OpenAPI), ~~#115~~ ✓ (PHI audit) | **Done** |
 | Hardening / additive | ~~#113~~ ✓, ~~#116~~ ✓ (`senderDisplayName`), ~~#114~~ ✓ (nutritionist reply) | **Done** |
-| Schema / Liquibase | ~~**#46**~~ ✓ (PR #196) → **#132–#141** (invitation onboarding) | #132 **NEXT** — use incremental changesets per [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) |
+| Schema / Liquibase | ~~**#46**~~ ✓ (PR #196) → ~~**#132**~~ ✓ (PR #214) → **#133–#141** | **#133 NEXT** — incremental changesets per [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) |
 
-### Status snapshot (2026-06-17)
+### Status snapshot (2026-06-18)
 
-**Patient mobile API on `main`:** Phase 0 + endpoints **#91–#99** done; cross-cutting **#111–#116** done (OpenAPI #112, PHI audit #115, `senderDisplayName` #116, nutritionist reply #114). Dashboard IMC gauge (#106) done for web tablero.
+**Patient mobile API on `main`:** Phase 0 + endpoints **#91–#99** done; cross-cutting **#111–#116** done. Onboarding schema **#132 done** (PR #214: `PacienteStatus`, `PatientInvitation`, Liquibase `007`).
 
-**Next:** #132 invitation onboarding data model (+ Liquibase migration for new columns/tables).
+**Next (mobile):** **#133** invitation token generation & hashing → #134–#141 onboarding endpoints.
 
-**Schema track:** ~~#46~~ Liquibase baseline merged (PR #196). All entity/schema/catalog edits → forward changesets ([`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md)).
+**Schema track:** ~~#46~~ Liquibase baseline (PR #196). Changesets **003–007** on `main` (subscription, patient invitation). All new edits → forward changesets only.
 
 **GitHub drift (close when convenient):** #97, #111 done on `main` but open on GitHub (PRs #147, #151).
 
-**Subscription track (parallel):** [#180–#211](https://github.com/diego-torres/nutriconsultas/issues/180) — see [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#185~~ ✓ (PR #215); ~~#190~~ ✓ (PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216)); ~~#187~~ ✓ (PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218)); ~~#210~~ ✓ (PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224)). **NEXT:** #211 (+ Stripe #207/#208).
+**Subscription track (parallel):** see [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#180–#185~~, ~~#187~~ (PR #218), ~~#190~~ (PR #216), ~~#210~~ (PR #224) on `main`. **NEXT:** #211 plan tier change (+ Stripe #207/#208, email #209, retention #220).
+
+**Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) — MPX epic **#221–#223** registered; **NEXT:** #221 export.
+
+**Production (2026-06-18):** ~~#226~~ invitation base URL fix (PR #227) — `APP_BASE_URL` / host remediation on EC2.
 
 See [`ISSUE.md`](ISSUE.md) Data contracts, [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) §F8, and [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) for per-endpoint and schema requirements.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -590,7 +590,7 @@ Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 
-**Next:** [#133](https://github.com/diego-torres/nutriconsultas/issues/133) invitation token hashing ([#132](https://github.com/diego-torres/nutriconsultas/issues/132) in-progress). ~~#114~~, ~~#116~~, ~~#115~~, ~~#112~~ **done** on `main`. Subscription track: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) — ~~#210~~ done (PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224)); **NEXT** #211.
+**Next:** [#133](https://github.com/diego-torres/nutriconsultas/issues/133) invitation token hashing (~~#132~~ PR [#214](https://github.com/diego-torres/nutriconsultas/pull/214) on `main`). ~~#114~~, ~~#116~~, ~~#115~~, ~~#112~~ **done**. Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) — **NEXT** #211 (~~#210~~ PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224)).
 
 **Schema gate (post-#46):** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline is on `main` (PR #196). All new schema/catalog changes require **incremental Liquibase changesets** — see [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) and [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md). ~~#156~~ Phase C done before baseline.
 

--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -5,7 +5,7 @@ Living index of GitHub issues that implement **subscription enforcement**, platf
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Workflow:** [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md)  
 **Design doc:** [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md)  
-**Last updated:** 2026-06-18 — ~~#210~~ **done** (PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224)); **NEXT:** #211 (change plan tier). Patient MPX **#221–#223:** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+**Last updated:** 2026-06-18 — ~~#210~~ **done** (PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224)); **NEXT:** #211 (change plan tier). Patient MPX **#221–#223:** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Production **#226** fixed (PR [#227](https://github.com/diego-torres/nutriconsultas/pull/227), invitation base URL).
 
 > **Scope.** This registry tracks `[Subscription]` issues only. The patient mobile API lives in [`ISSUE.md`](ISSUE.md). Patient invitation onboarding (#132–#141) is orthogonal — do not merge nutritionist and patient invitation entities.
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,11 +6,11 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) · **Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-17 — #46 Liquibase **done** ([PR #196](https://github.com/diego-torres/nutriconsultas/pull/196)). **NEXT:** [#132 invitation onboarding](https://github.com/diego-torres/nutriconsultas/issues/132).
+**Last updated:** 2026-06-18 — ~~#132~~ **done** ([PR #214](https://github.com/diego-torres/nutriconsultas/pull/214), Liquibase `007-patient-invitation-onboarding.yaml`). **NEXT:** [#133 token hashing](https://github.com/diego-torres/nutriconsultas/issues/133).
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
-> **GitHub sync note (2026-06-17):** **#46**, **#115**, **#116**, **#114** closed on GitHub (merged PRs #196, #168, #173, #174). **#97** and **#111** are **done on `main`** (PRs #147, #151) but remain **open on GitHub** — close when convenient. **#183** and **#184** (subscription) merged (PRs #200, #206) but GitHub issues still **open**.
+> **GitHub sync note (2026-06-18):** **#132** closed (PR #214). Subscription **#183**, **#184**, **#185**, **#187**, **#190**, **#210** closed on GitHub. **#97** and **#111** are **done on `main`** (PRs #147, #151) but remain **open on GitHub** — close when convenient. Production fix **#226** closed (PR #227, invitation base URL).
 
 ---
 
@@ -49,7 +49,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156** and **#46** done on `main`. **NEXT:** #132 invitation onboarding.
+Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156**, **#46**, and **#132** done on `main`. **NEXT:** #133 invitation token hashing.
 
 ---
 
@@ -132,27 +132,27 @@ Schema-affecting work must respect mobile DTO contracts (§F8). These issues are
 |---|-------|-----|-------|-----------|--------|-------|
 | **156** | `[Integration]` Paciente domain refactor — incremental decomposition | https://github.com/diego-torres/nutriconsultas/issues/156 | **done** | [#121](https://github.com/diego-torres/nutriconsultas/issues/121) GET/TDEE | — (unblocked #46) | Merged PRs [#175](https://github.com/diego-torres/nutriconsultas/pull/175) (projections), [#176](https://github.com/diego-torres/nutriconsultas/pull/176) (embeddables), [#178](https://github.com/diego-torres/nutriconsultas/pull/178) (satellite tables). ER: [`paciente-er-phase-c.md`](docs/integration/paciente-er-phase-c.md). Mobile DTOs unchanged. |
 | 46 | Implement Liquibase for database change management | https://github.com/diego-torres/nutriconsultas/issues/46 | **done** | ~~156~~ ✓ | — | Merged [PR #196](https://github.com/diego-torres/nutriconsultas/pull/196): Liquibase baseline (PG + H2), catalog seed changelogs, `ddl-auto=none`. Docs: [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md). |
-| 132 | Invitation & patient onboarding data model | https://github.com/diego-torres/nutriconsultas/issues/132 | **in-progress** | #107, ~~156~~ ✓, ~~46~~ ✓ | — | `PacienteStatus` + `PatientInvitation` entity; Liquibase `007-patient-invitation-onboarding.yaml`. |
+| 132 | Invitation & patient onboarding data model | https://github.com/diego-torres/nutriconsultas/issues/132 | **done** | #107, ~~156~~ ✓, ~~46~~ ✓ | — | Merged [PR #214](https://github.com/diego-torres/nutriconsultas/pull/214): `PacienteStatus`, `PatientInvitation`, Liquibase `007-patient-invitation-onboarding.yaml`. |
 
 ---
 
-## Phase 2 — Invitation onboarding (P1 · gated by #156 → #46 → #132)
+## Phase 2 — Invitation onboarding (P1 · ~~#132~~ ✓ → #133–#141)
 
-Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Active sprint** — #156 and #46 prerequisites are **done** on `main`.
+Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Active sprint** — schema **#132 done** (PR #214); **NEXT:** #133 token service.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| 133 | Invitation token generation & hashing service | https://github.com/diego-torres/nutriconsultas/issues/133 | **NEXT** | 132 | CSPRNG token; store hash only; constant-time verify; optional signed JWS for Auth0 Action |
-| 134 | `POST /rest/mobile/invitations` — nutritionist creates patient + invitation | https://github.com/diego-torres/nutriconsultas/issues/134 | open | 132, 133 | Nutritionist JWT (not patient); creates `Paciente` + `Invitation` |
+| 133 | Invitation token generation & hashing service | https://github.com/diego-torres/nutriconsultas/issues/133 | **NEXT** | ~~132~~ ✓ | CSPRNG token; store hash only; constant-time verify; optional signed JWS for Auth0 Action |
+| 134 | `POST /rest/mobile/invitations` — nutritionist creates patient + invitation | https://github.com/diego-torres/nutriconsultas/issues/134 | open | ~~132~~ ✓, 133 | Nutritionist JWT (not patient); creates `Paciente` + `Invitation` |
 | 135 | `GET /rest/mobile/invitations/{token}/preview` — public rate-limited preview | https://github.com/diego-torres/nutriconsultas/issues/135 | open | 133 | Public; enumeration protection (#141) |
-| 136 | `POST /rest/mobile/invitations/{token}/redeem` — bind Auth0 sub → patient | https://github.com/diego-torres/nutriconsultas/issues/136 | open | 132, 133, 107 | **Authoritative** redeem gate; patient JWT required |
-| 137 | CurrentPatient resolver + onboarding data gate (403 onboarding required) | https://github.com/diego-torres/nutriconsultas/issues/137 | open | 132, 107 | Centralizes `sub → Paciente`; 403 until onboarded |
-| 138 | `PATCH` & `GET /rest/mobile/patient/me` — onboarding profile + status→ACTIVE | https://github.com/diego-torres/nutriconsultas/issues/138 | open | 132, 137 | Patient completes profile; transitions to `ACTIVE` |
-| 139 | `POST /rest/mobile/invitations/{id}/revoke` — nutritionist invalidates invite | https://github.com/diego-torres/nutriconsultas/issues/139 | open | 132, 134 | Nutritionist JWT |
+| 136 | `POST /rest/mobile/invitations/{token}/redeem` — bind Auth0 sub → patient | https://github.com/diego-torres/nutriconsultas/issues/136 | open | ~~132~~ ✓, 133, 107 | **Authoritative** redeem gate; patient JWT required |
+| 137 | CurrentPatient resolver + onboarding data gate (403 onboarding required) | https://github.com/diego-torres/nutriconsultas/issues/137 | open | ~~132~~ ✓, 107 | Centralizes `sub → Paciente`; 403 until onboarded |
+| 138 | `PATCH` & `GET /rest/mobile/patient/me` — onboarding profile + status→ACTIVE | https://github.com/diego-torres/nutriconsultas/issues/138 | open | ~~132~~ ✓, 137 | Patient completes profile; transitions to `ACTIVE` |
+| 139 | `POST /rest/mobile/invitations/{id}/revoke` — nutritionist invalidates invite | https://github.com/diego-torres/nutriconsultas/issues/139 | open | ~~132~~ ✓, 134 | Nutritionist JWT |
 | 140 | Auth0 Post-Login Action gate — first-login invitation validation | https://github.com/diego-torres/nutriconsultas/issues/140 | open | 133, 136 | **Post-Login** (not Pre-User-Registration — social logins skip PUR); docs + Action script |
 | 141 | Invitation security hardening — rate limits, enumeration protection, no-token logging | https://github.com/diego-torres/nutriconsultas/issues/141 | open | 133, 135, 136 | Relates #115; never log raw tokens |
 
-**Suggested build order (after #132):** #133 → #134/#135 → #136 → #137 → #138 → #139/#140 → #141.
+**Suggested build order (after ~~#132~~ ✓):** #133 → #134/#135 → #136 → #137 → #138 → #139/#140 → #141.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-18):** Patient mobile API complete through #116; **NEXT:** #132 invitation onboarding. Parallel **subscription** track: #180–#185, ~~#190~~, ~~#187~~ on `main` (PRs [#216](https://github.com/diego-torres/nutriconsultas/pull/216), [#218](https://github.com/diego-torres/nutriconsultas/pull/218)); **NEXT:** #210 / #211.
+**On `main` (2026-06-18):** Patient mobile API through #116; onboarding schema **#132 done** (PR #214). **NEXT:** #133 token hashing. **Subscription:** ~~#180–#185~~, ~~#187~~, ~~#190~~, ~~#210~~ on `main`; **NEXT:** #211. **Nutritionist web:** MPX epic #221–#223; **NEXT:** #221.
 
 ## AWS (production infrastructure)
 

--- a/docs/db/LIQUIBASE.md
+++ b/docs/db/LIQUIBASE.md
@@ -9,6 +9,11 @@ Nutriconsultas uses [Liquibase](https://www.liquibase.org/) for schema and catal
 | `src/main/resources/db/changelog/db.changelog-master.yaml` | Root changelog |
 | `changes/001-baseline-schema.{postgresql,h2}.sql` | Full schema baseline (post-#156 Phase C) |
 | `changes/002-seed-data.yaml` | Catalog seed: alimentos, platillos, template dietas |
+| `changes/003-subscription-schema.yaml` | Subscription, clinic, invitation tables (#180) |
+| `changes/004-payment-webhook-idempotency.yaml` | Payment webhook idempotency (#189) |
+| `changes/005-nutritionist-invitation-payment-exempt.yaml` | `payment_exempt` on `nutritionist_invitation` (#184) |
+| `changes/006-subscription-notification-log.yaml` | Lifecycle notification log (#185, PR #215) |
+| `changes/007-patient-invitation-onboarding.yaml` | `PacienteStatus` columns + `patient_invitation` table (#132, PR #214) |
 | `data/alimentos-seed.sql` | SMAE alimentos catalog (from `alimentos.sql`) |
 | `data/platillos-seed.sql` | Catalog `platillo` + `ingrediente` rows |
 | `data/dieta-templates-seed.sql` | 20 template `dieta` rows (`system:template-dietas`) and child ingestas |

--- a/docs/mobile-api/ALIGNMENT-SPEC.md
+++ b/docs/mobile-api/ALIGNMENT-SPEC.md
@@ -160,7 +160,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 - **Phase 0 DONE:** #107 (PR #117), #109 (PR #142), #110 (DTO envelope).
 - **Endpoints on `main`:** #91–#99 (visits, diet plans + PDF, messages, progress snapshot + measurements time series); #96/#97 messaging with HTTP 201 + Resilience4j 10/min (#113, PR #151).
 - **i18n (#111) DONE** (PR #151): `LocaleContextFilter`, `MobileApiErrorResponses`, localized 403/404/400/429.
-- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). **NEXT:** #132 invitation onboarding.
+- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). **NEXT:** #133 invitation token hashing (~~#132~~ schema done, PR #214).
 - `deltaPeso`/`deltaImc` are computed-at-query, not stored.
 - Progress `grasa` ambiguity: prefer `bodyComposition.porcentajeGrasaCorporal` (patient-facing %) over `indiceGrasaCorporal`.
 - Template dietas (seed `system:template-dietas`) have 4 ingestas incl. Colación — contract examples show only 3.
@@ -172,7 +172,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 
 ### F8.6 — Invitation onboarding gate (#132–#141)
 - **Prerequisites done on `main`:** #156 Paciente decomposition (PRs #175/#176/#178); #46 Liquibase baseline (PR #196). All new schema → incremental changesets per [`docs/db/LIQUIBASE.md`](../db/LIQUIBASE.md).
-- **Active sprint:** #132 data model (`PacienteStatus`, `PatientInvitation` entity) **in-progress**; then #133–#141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
+- **Active sprint:** ~~#132~~ data model **done** (PR #214: `PacienteStatus`, `PatientInvitation`, Liquibase `007`); **NEXT:** #133–#141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
 - **Orthogonal:** nutritionist subscription invitations (`NutritionistInvitation` in subscription track) — see [`ISSUE-SUBSCRIPTION.md`](../../ISSUE-SUBSCRIPTION.md); do not conflate with patient `Invitation`.
 
 ### F8.5 — Design source of truth

--- a/docs/mobile-api/MOBILE-E2E-STATUS.md
+++ b/docs/mobile-api/MOBILE-E2E-STATUS.md
@@ -217,4 +217,4 @@ Optional backend script (requires access token from the app):
 
 ---
 
-*Updated 2026-06-17: mobile cross-cutting done (#111–#116); **NEXT:** #132 invitation onboarding.*
+*Updated 2026-06-18: ~~#132~~ onboarding schema on `main` (PR #214); **NEXT:** #133 token hashing.*

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -12,7 +12,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`MOBILE-E2E-STATUS.md`](MOBILE-E2E-STATUS.md) | Live E2E status, Auth0 setup, HTTP code matrix |
 | [`../api/openapi-mobile.yaml`](../api/openapi-mobile.yaml) | OpenAPI 3.1 export (#112, PR #164); regen: `scripts/export-openapi-mobile.sh` |
 
-**Status (2026-06-17):** Phase 0 + endpoints **#91–#99 done** on `main`. Cross-cutting **#111–#116 done**. Integration **#156** + **#46** done. **#132** in-progress (onboarding schema); **NEXT:** [#133](https://github.com/diego-torres/nutriconsultas/issues/133) token hashing.
+**Status (2026-06-18):** Phase 0 + endpoints **#91–#99 done** on `main`. Cross-cutting **#111–#116 done**. Integration **#156** + **#46** + onboarding schema **#132 done** (PR #214, Liquibase `007`). **NEXT:** [#133](https://github.com/diego-torres/nutriconsultas/issues/133) token hashing.
 
 ## Related registries (same repo)
 

--- a/docs/mobile-api/mobile-api-roadmap-v2.md
+++ b/docs/mobile-api/mobile-api-roadmap-v2.md
@@ -14,7 +14,7 @@
 
 > **State verification (2026-06-11):**
 >
-> - **Backend schema (2026-06-17):** Phase 0 **done** (#107, #109, #110). **All endpoints #91–#99 on `main`**. Cross-cutting **#111–#116 done** (OpenAPI #112, PHI #115, `senderDisplayName` #116, nutritionist reply #114). **NEXT:** #132 invitation onboarding. #106 dashboard IMC gauge **done**.
+> - **Backend schema (2026-06-18):** Phase 0 **done** (#107, #109, #110). **All endpoints #91–#99 on `main`**. Cross-cutting **#111–#116 done**. Onboarding schema **#132 done** (PR #214). **NEXT:** #133 token hashing. #106 dashboard IMC gauge **done**.
 > - **DTO field-name map (authoritative — ALIGNMENT-SPEC §F8):** `Dieta.nombre→dietaName`, `energia→totalKcal`, `proteina→totalProteina`, `lipidos→totalGrasas`, `hidratosDeCarbono→totalCarbohidratos`; `Ingesta.nombre→tipo`; `PlatilloIngesta.name/portions/energia→nombre/porciones/kcal`, `hidratosDeCarbono→carbohidratos`, `lipidos→grasas` (same for `AlimentoIngesta`). Enums: `EventStatus = SCHEDULED/COMPLETED/CANCELLED`; `PacienteDietaStatus = ACTIVE/COMPLETED/CANCELLED` (no INACTIVE); `NivelPeso = BAJO/NORMAL/ALTO/SOBREPESO` (translate to `imcLabel` server-side). `deltaPeso`/`deltaImc` are computed, not stored.
 > - **Mobile redesign branch state (style/editorial-redesign):** Auth dedup complete — `AuthFlowController` + login/signup/welcome screens canonical; PR #48's `AuthController`/`LoginView` retired (commit 3427612); `flutter analyze` clean, 146/146 tests pass. Canonical design source: `.claude/MiNutriporcion-2/` (light editorial palette; dark welcome/login PNGs are OLD, ignore). Mobile issues #13/#21/#31 done; #32/#33 in flight on branch.
 


### PR DESCRIPTION
## Summary

Comprehensive registry sync after Diego’s merge sprint (2026-06-17 evening through 2026-06-18).

### Mobile track
- **#132 done** — PR #214 merged (`PacienteStatus`, `PatientInvitation`, Liquibase `007-patient-invitation-onboarding.yaml`)
- **NEXT → #133** token generation & hashing
- Updated: `ISSUE.md`, `AGENT-WORKFLOW.md`, `AGENTS.md`, `README.md`, `docs/mobile-api/*`

### Subscription track (already largely synced by Diego on `main`; minor touch-up)
- **Done on `main`:** #184 (PR #206), #185 (PR #215), #190 (PR #216), #187 (PR #218), #210 (PR #224)
- **NEXT → #211** change plan tier
- **#226** production invitation URL fix (PR #227) noted in `ISSUE-SUBSCRIPTION.md`

### Nutritionist web (new epic, Diego registered 2026-06-18)
- **#221–#223** MPX export/import — `ISSUE-NUTRITIONIST-WEB.md` already on `main`; pointers aligned in `AGENT-WORKFLOW.md` / `README.md`

### Liquibase
- Documented incremental changesets **003–007** in `docs/db/LIQUIBASE.md`

### GitHub drift (unchanged — close when convenient)
- **#97**, **#111** done on `main`, still open on GitHub

## Test plan
- [x] Registry pointers consistent across `ISSUE.md`, `AGENT-WORKFLOW.md`, `AGENTS.md`, `README.md`, mobile-api docs
- [x] No code changes

Made with [Cursor](https://cursor.com)