### PR TITLE
feat(mobile-api): patient invitation token service (#133)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -32,7 +32,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX epic), states, dependencies |
 | [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md) | Patient registration export/import plan |
 
-**Current next issue (mobile):** [#133 — Invitation token generation & hashing service](https://github.com/diego-torres/nutriconsultas/issues/133) (after [#132](https://github.com/diego-torres/nutriconsultas/issues/132) in-progress).
+**Current next issue (mobile):** [#133 — Invitation token generation & hashing service](https://github.com/diego-torres/nutriconsultas/issues/133) **in-progress**. ~~#132~~ done (PR [#214](https://github.com/diego-torres/nutriconsultas/pull/214)).
 
 **Current next issue (subscription):** [#207 — Stripe payment provider](https://github.com/diego-torres/nutriconsultas/issues/207). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#211~~ merged PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230).
 
@@ -48,7 +48,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | **API surface** | All mobile endpoints live under `/rest/mobile/patient/` as plain JSON (not DataTables-shaped like the admin `*RestController`s). |
 | **Identity (security-critical)** | JWT `sub` → **`Paciente.patientAuthSub`** (#107 ✓ PR #117). **Never `Paciente.userId`** — that is the NUTRITIONIST's Auth0 sub / tenant owner (ALIGNMENT-SPEC §F2). `PatientLinkageFilter` returns **403** if no linked `Paciente`. |
 | **Ownership / IDOR** | Return only the authenticated patient's rows. On an ownership miss prefer **404** (not 403) so existence isn't leaked (esp. #92). Never return cross-tenant data. |
-| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **Cross-cutting done** (#111–#116). **#156** and **#46** done on `main`. **NEXT:** #132 invitation onboarding. Requires `AUTH_AUDIENCE` env var. |
+| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **Cross-cutting done** (#111–#116). **#156**, **#46**, **#132** done. **#133 in-progress** (token service). Requires `AUTH_AUDIENCE` env var. |
 | **DTO envelope** | `ApiResponse<T>`; lists in `PagedResponse<T>` or `CursorPagedResponse<T>` (messages); ISO-8601 date strings. See #110. |
 | **Schema ground truth** | ALIGNMENT-SPEC §F8 field-name map (`nombre→dietaName`, `energia→totalKcal`, `lipidos→totalGrasas`, `hidratosDeCarbono→totalCarbohidratos`, `Ingesta.nombre→tipo`); enums `EventStatus`/`PacienteDietaStatus` (no INACTIVE)/`NivelPeso`. Serialization aliases only — **no DB schema changes** for field renames. |
 | **PHI & logging** | No patient names/emails/DOB in unstructured logs. `LogRedaction` + `PhiLogTurboFilter`; CI runs `scripts/audit-logging.sh` and `scripts/audit-mobile-logging.sh` (#115 done). |
@@ -400,10 +400,10 @@ gh pr create ...
 | Field | Value |
 |-------|-------|
 | **Next issue** | [#133 — Invitation token generation & hashing service](https://github.com/diego-torres/nutriconsultas/issues/133) |
-| **Status** | **NEXT** — [#132](https://github.com/diego-torres/nutriconsultas/issues/132) **in-progress** (schema + Liquibase) |
-| **Phase** | Invitation / onboarding — token service after #132 merges |
-| **Just completed** | Prerequisites ~~#156~~ ✓ and ~~#46~~ ✓ (PR #196) |
-| **In scope for #132** | `PacienteStatus` + `PatientInvitation` entity; Liquibase `007-patient-invitation-onboarding.yaml` |
+| **Status** | **in-progress** — ~~#132~~ ✓ (PR #214) |
+| **Phase** | CSPRNG URL token + human code + hash; optional offline JWS for #140 |
+| **Just completed** | [#132 onboarding schema](https://github.com/diego-torres/nutriconsultas/issues/132) — PR #214 |
+| **In scope for #133** | `PatientInvitationTokenService`; reuse `InvitationTokenHasher`; `PATIENT_INVITATION_JWS_SECRET` for optional JWS |
 
 ### Upcoming gates
 

--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -32,7 +32,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX epic), states, dependencies |
 | [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md) | Patient registration export/import plan |
 
-**Current next issue (mobile):** [#133 — Invitation token generation & hashing service](https://github.com/diego-torres/nutriconsultas/issues/133) **in-progress**. ~~#132~~ done (PR [#214](https://github.com/diego-torres/nutriconsultas/pull/214)).
+**Current next issue (mobile):** [#133 — Invitation token generation & hashing service](https://github.com/diego-torres/nutriconsultas/issues/133) **in-progress** (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)). ~~#132~~ done (PR [#214](https://github.com/diego-torres/nutriconsultas/pull/214)).
 
 **Current next issue (subscription):** [#207 — Stripe payment provider](https://github.com/diego-torres/nutriconsultas/issues/207). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#211~~ merged PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230).
 
@@ -98,7 +98,7 @@ flowchart LR
    - **#113 (rate limit)** should land with or before **#97** (write endpoint).
    - **#114 (nutritionist reply) is web-only** — do not expose it under `/rest/mobile/**`.
    - **#46 (Liquibase)** ✓ — all schema/catalog changes are incremental changesets (see [Liquibase section](#liquibase--entity-schema-and-catalog-data)).
-   - **#132 (onboarding schema)** — extend the decomposed `Paciente` model + Liquibase migration; link issue in PR.
+   - **#132 (onboarding schema)** ✓ — `PacienteStatus` + `PatientInvitation` on `main` (PR #214, Liquibase `007`). **#133 in-progress** (PR #229 token hashing service).
    - If a dependency is still `open`, complete it first or document the blocker in the plan (Phase 2) and stop.
 5. **Update local registry** when remote state drifted (issue closed on GitHub but still `open` here, or vice versa). `ISSUE.md` must match GitHub before proceeding.
 
@@ -379,12 +379,12 @@ PR must include: changeset file(s), `db.changelog-master.yaml` include (if new f
 ```bash
 # Start of session
 git fetch origin && git checkout main && git pull origin main
-gh issue view 132
+gh issue view 133
 cat ISSUE.md
 cat docs/mobile-api/README.md
 
 # During work
-git checkout -b mobile-api/132-invitation-schema
+git checkout -b mobile-api/133-invitation-token-service
 ./lint.sh && bash scripts/audit-logging.sh && bash scripts/audit-mobile-logging.sh && mvn -B verify
 ./dev-start.sh   # Java 21 — run locally when touching security, Liquibase, or startup
 
@@ -400,7 +400,7 @@ gh pr create ...
 | Field | Value |
 |-------|-------|
 | **Next issue** | [#133 — Invitation token generation & hashing service](https://github.com/diego-torres/nutriconsultas/issues/133) |
-| **Status** | **in-progress** — ~~#132~~ ✓ (PR #214) |
+| **Status** | **in-progress** — PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229); ~~#132~~ ✓ (PR #214) |
 | **Phase** | CSPRNG URL token + human code + hash; optional offline JWS for #140 |
 | **Just completed** | [#132 onboarding schema](https://github.com/diego-torres/nutriconsultas/issues/132) — PR #214 |
 | **In scope for #133** | `PatientInvitationTokenService`; reuse `InvitationTokenHasher`; `PATIENT_INVITATION_JWS_SECRET` for optional JWS |
@@ -414,18 +414,22 @@ gh pr create ...
 | Endpoints | ~~#91–#99~~ ✓ | **Done** (PR #153) |
 | Cross-cutting | ~~#111~~ ✓, ~~#112~~ ✓ (OpenAPI), ~~#115~~ ✓ (PHI audit) | **Done** |
 | Hardening / additive | ~~#113~~ ✓, ~~#116~~ ✓ (`senderDisplayName`), ~~#114~~ ✓ (nutritionist reply) | **Done** |
-| Schema / Liquibase | ~~**#46**~~ ✓ (PR #196) → **#132–#141** (invitation onboarding) | #132 **NEXT** — use incremental changesets per [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) |
+| Schema / Liquibase | ~~**#46**~~ ✓ (PR #196) → ~~**#132**~~ ✓ (PR #214) → **#133–#141** | **#133 in-progress** (PR #229) — incremental changesets per [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) |
 
-### Status snapshot (2026-06-17)
+### Status snapshot (2026-06-18)
 
-**Patient mobile API on `main`:** Phase 0 + endpoints **#91–#99** done; cross-cutting **#111–#116** done (OpenAPI #112, PHI audit #115, `senderDisplayName` #116, nutritionist reply #114). Dashboard IMC gauge (#106) done for web tablero.
+**Patient mobile API on `main`:** Phase 0 + endpoints **#91–#99** done; cross-cutting **#111–#116** done. Onboarding schema **#132 done** (PR #214: `PacienteStatus`, `PatientInvitation`, Liquibase `007`).
 
-**Next:** #132 invitation onboarding data model (+ Liquibase migration for new columns/tables).
+**In progress (mobile):** **#133** invitation token service — PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229) awaiting review. **NEXT after merge:** #134–#141 onboarding endpoints.
 
-**Schema track:** ~~#46~~ Liquibase baseline merged (PR #196). All entity/schema/catalog edits → forward changesets ([`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md)).
+**Schema track:** ~~#46~~ Liquibase baseline (PR #196). Changesets **003–007** on `main` (subscription, patient invitation). All new edits → forward changesets only.
 
 **GitHub drift (close when convenient):** #97, #111 done on `main` but open on GitHub (PRs #147, #151).
 
-**Subscription track (parallel):** [#180–#211](https://github.com/diego-torres/nutriconsultas/issues/180) — see [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#185~~ ✓ (PR #215); ~~#190~~ ✓ (PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216)); ~~#187~~ ✓ (PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218)); ~~#210~~ ✓ (PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224)); ~~#211~~ ✓ (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)). **NEXT:** #207 (+ #208 Stripe ops).
+**Subscription track (parallel):** see [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#180–#185~~, ~~#187~~ (PR #218), ~~#190~~ (PR #216), ~~#210~~ (PR #224), ~~#211~~ (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)) on `main`. **NEXT:** #207 (+ #208 Stripe ops, email #209, retention #220).
+
+**Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) — MPX epic **#221–#223** registered; **NEXT:** #221 export.
+
+**Production (2026-06-18):** ~~#226~~ invitation base URL fix (PR #227) — `APP_BASE_URL` / host remediation on EC2.
 
 See [`ISSUE.md`](ISSUE.md) Data contracts, [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) §F8, and [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) for per-endpoint and schema requirements.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -590,7 +590,7 @@ Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 
-**Next:** [#133](https://github.com/diego-torres/nutriconsultas/issues/133) invitation token hashing ([#132](https://github.com/diego-torres/nutriconsultas/issues/132) in-progress). ~~#114~~, ~~#116~~, ~~#115~~, ~~#112~~ **done** on `main`. Subscription track: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) — ~~#211~~ done (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)); **NEXT** #207.
+**Next:** [#133](https://github.com/diego-torres/nutriconsultas/issues/133) invitation token service **in-progress** (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229); ~~#132~~ PR [#214](https://github.com/diego-torres/nutriconsultas/pull/214)). ~~#114~~, ~~#116~~, ~~#115~~, ~~#112~~ **done**. Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) — ~~#211~~ done (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)); **NEXT** #207.
 
 **Schema gate (post-#46):** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline is on `main` (PR #196). All new schema/catalog changes require **incremental Liquibase changesets** — see [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) and [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md). ~~#156~~ Phase C done before baseline.
 

--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -5,7 +5,7 @@ Living index of GitHub issues that implement **subscription enforcement**, platf
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Workflow:** [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md)  
 **Design doc:** [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md)  
-**Last updated:** 2026-06-19 — ~~#211~~ **done** (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)); **NEXT:** #207 (Stripe provider).
+**Last updated:** 2026-06-19 — ~~#211~~ **done** (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)); **NEXT:** #207 (Stripe provider). Patient MPX **#221–#223:** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Production **#226** fixed (PR [#227](https://github.com/diego-torres/nutriconsultas/pull/227), invitation base URL).
 
 > **Scope.** This registry tracks `[Subscription]` issues only. The patient mobile API lives in [`ISSUE.md`](ISSUE.md). Patient invitation onboarding (#132–#141) is orthogonal — do not merge nutritionist and patient invitation entities.
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,11 +6,11 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) · **Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-17 — #46 Liquibase **done** ([PR #196](https://github.com/diego-torres/nutriconsultas/pull/196)). **NEXT:** [#132 invitation onboarding](https://github.com/diego-torres/nutriconsultas/issues/132).
+**Last updated:** 2026-06-18 — ~~#132~~ **done** (PR #214). **#133** **in-progress** (token service). **NEXT after merge:** #134/#135.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
-> **GitHub sync note (2026-06-17):** **#46**, **#115**, **#116**, **#114** closed on GitHub (merged PRs #196, #168, #173, #174). **#97** and **#111** are **done on `main`** (PRs #147, #151) but remain **open on GitHub** — close when convenient. **#183** and **#184** (subscription) merged (PRs #200, #206) but GitHub issues still **open**.
+> **GitHub sync note (2026-06-18):** **#132** closed (PR #214). **#133** open (in-progress). Subscription **#183–#185**, **#187**, **#190**, **#210** closed. **#97** and **#111** done on `main` but open on GitHub. **#226** closed (PR #227).
 
 ---
 
@@ -49,7 +49,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156** and **#46** done on `main`. **NEXT:** #132 invitation onboarding.
+Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156**, **#46**, and **#132** done on `main`. **#133** **in-progress**.
 
 ---
 
@@ -132,7 +132,7 @@ Schema-affecting work must respect mobile DTO contracts (§F8). These issues are
 |---|-------|-----|-------|-----------|--------|-------|
 | **156** | `[Integration]` Paciente domain refactor — incremental decomposition | https://github.com/diego-torres/nutriconsultas/issues/156 | **done** | [#121](https://github.com/diego-torres/nutriconsultas/issues/121) GET/TDEE | — (unblocked #46) | Merged PRs [#175](https://github.com/diego-torres/nutriconsultas/pull/175) (projections), [#176](https://github.com/diego-torres/nutriconsultas/pull/176) (embeddables), [#178](https://github.com/diego-torres/nutriconsultas/pull/178) (satellite tables). ER: [`paciente-er-phase-c.md`](docs/integration/paciente-er-phase-c.md). Mobile DTOs unchanged. |
 | 46 | Implement Liquibase for database change management | https://github.com/diego-torres/nutriconsultas/issues/46 | **done** | ~~156~~ ✓ | — | Merged [PR #196](https://github.com/diego-torres/nutriconsultas/pull/196): Liquibase baseline (PG + H2), catalog seed changelogs, `ddl-auto=none`. Docs: [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md). |
-| 132 | Invitation & patient onboarding data model | https://github.com/diego-torres/nutriconsultas/issues/132 | **in-progress** | #107, ~~156~~ ✓, ~~46~~ ✓ | — | `PacienteStatus` + `PatientInvitation` entity; Liquibase `007-patient-invitation-onboarding.yaml`. |
+| 132 | Invitation & patient onboarding data model | https://github.com/diego-torres/nutriconsultas/issues/132 | **done** | #107, ~~156~~ ✓, ~~46~~ ✓ | — | Merged [PR #214](https://github.com/diego-torres/nutriconsultas/pull/214): `PacienteStatus`, `PatientInvitation`, Liquibase `007`. |
 
 ---
 
@@ -142,8 +142,8 @@ Invite-only patient onboarding replaces manual Afiliación linkage (#109) for ne
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| 133 | Invitation token generation & hashing service | https://github.com/diego-torres/nutriconsultas/issues/133 | **NEXT** | 132 | CSPRNG token; store hash only; constant-time verify; optional signed JWS for Auth0 Action |
-| 134 | `POST /rest/mobile/invitations` — nutritionist creates patient + invitation | https://github.com/diego-torres/nutriconsultas/issues/134 | open | 132, 133 | Nutritionist JWT (not patient); creates `Paciente` + `Invitation` |
+| 133 | Invitation token generation & hashing service | https://github.com/diego-torres/nutriconsultas/issues/133 | **in-progress** | ~~132~~ ✓ | CSPRNG + human code + SHA-256 hash; constant-time verify; optional offline JWS (#140) |
+| 134 | `POST /rest/mobile/invitations` — nutritionist creates patient + invitation | https://github.com/diego-torres/nutriconsultas/issues/134 | **NEXT** | ~~132~~ ✓, 133 | Nutritionist JWT (not patient); creates `Paciente` + `Invitation` |
 | 135 | `GET /rest/mobile/invitations/{token}/preview` — public rate-limited preview | https://github.com/diego-torres/nutriconsultas/issues/135 | open | 133 | Public; enumeration protection (#141) |
 | 136 | `POST /rest/mobile/invitations/{token}/redeem` — bind Auth0 sub → patient | https://github.com/diego-torres/nutriconsultas/issues/136 | open | 132, 133, 107 | **Authoritative** redeem gate; patient JWT required |
 | 137 | CurrentPatient resolver + onboarding data gate (403 onboarding required) | https://github.com/diego-torres/nutriconsultas/issues/137 | open | 132, 107 | Centralizes `sub → Paciente`; 403 until onboarded |

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) · **Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-18 — ~~#132~~ **done** (PR #214). **#133** **in-progress** (token service). **NEXT after merge:** #134/#135.
+**Last updated:** 2026-06-18 — ~~#132~~ **done** (PR #214). **#133** **in-progress** (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)). **NEXT after merge:** #134/#135.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -142,7 +142,7 @@ Invite-only patient onboarding replaces manual Afiliación linkage (#109) for ne
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| 133 | Invitation token generation & hashing service | https://github.com/diego-torres/nutriconsultas/issues/133 | **in-progress** | ~~132~~ ✓ | CSPRNG + human code + SHA-256 hash; constant-time verify; optional offline JWS (#140) |
+| 133 | Invitation token generation & hashing service | https://github.com/diego-torres/nutriconsultas/issues/133 | **in-progress** | ~~132~~ ✓ | PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229): CSPRNG + human code + SHA-256 hash; constant-time verify; optional offline JWS (#140) |
 | 134 | `POST /rest/mobile/invitations` — nutritionist creates patient + invitation | https://github.com/diego-torres/nutriconsultas/issues/134 | **NEXT** | ~~132~~ ✓, 133 | Nutritionist JWT (not patient); creates `Paciente` + `Invitation` |
 | 135 | `GET /rest/mobile/invitations/{token}/preview` — public rate-limited preview | https://github.com/diego-torres/nutriconsultas/issues/135 | open | 133 | Public; enumeration protection (#141) |
 | 136 | `POST /rest/mobile/invitations/{token}/redeem` — bind Auth0 sub → patient | https://github.com/diego-torres/nutriconsultas/issues/136 | open | 132, 133, 107 | **Authoritative** redeem gate; patient JWT required |

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -136,23 +136,23 @@ Schema-affecting work must respect mobile DTO contracts (§F8). These issues are
 
 ---
 
-## Phase 2 — Invitation onboarding (P1 · gated by #156 → #46 → #132)
+## Phase 2 — Invitation onboarding (P1 · ~~#132~~ ✓ → #133–#141)
 
-Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Active sprint** — #156 and #46 prerequisites are **done** on `main`.
+Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Active sprint** — schema **#132 done** (PR #214); **#133 in-progress** (PR #229).
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | 133 | Invitation token generation & hashing service | https://github.com/diego-torres/nutriconsultas/issues/133 | **in-progress** | ~~132~~ ✓ | PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229): CSPRNG + human code + SHA-256 hash; constant-time verify; optional offline JWS (#140) |
 | 134 | `POST /rest/mobile/invitations` — nutritionist creates patient + invitation | https://github.com/diego-torres/nutriconsultas/issues/134 | **NEXT** | ~~132~~ ✓, 133 | Nutritionist JWT (not patient); creates `Paciente` + `Invitation` |
 | 135 | `GET /rest/mobile/invitations/{token}/preview` — public rate-limited preview | https://github.com/diego-torres/nutriconsultas/issues/135 | open | 133 | Public; enumeration protection (#141) |
-| 136 | `POST /rest/mobile/invitations/{token}/redeem` — bind Auth0 sub → patient | https://github.com/diego-torres/nutriconsultas/issues/136 | open | 132, 133, 107 | **Authoritative** redeem gate; patient JWT required |
-| 137 | CurrentPatient resolver + onboarding data gate (403 onboarding required) | https://github.com/diego-torres/nutriconsultas/issues/137 | open | 132, 107 | Centralizes `sub → Paciente`; 403 until onboarded |
-| 138 | `PATCH` & `GET /rest/mobile/patient/me` — onboarding profile + status→ACTIVE | https://github.com/diego-torres/nutriconsultas/issues/138 | open | 132, 137 | Patient completes profile; transitions to `ACTIVE` |
-| 139 | `POST /rest/mobile/invitations/{id}/revoke` — nutritionist invalidates invite | https://github.com/diego-torres/nutriconsultas/issues/139 | open | 132, 134 | Nutritionist JWT |
+| 136 | `POST /rest/mobile/invitations/{token}/redeem` — bind Auth0 sub → patient | https://github.com/diego-torres/nutriconsultas/issues/136 | open | ~~132~~ ✓, 133, 107 | **Authoritative** redeem gate; patient JWT required |
+| 137 | CurrentPatient resolver + onboarding data gate (403 onboarding required) | https://github.com/diego-torres/nutriconsultas/issues/137 | open | ~~132~~ ✓, 107 | Centralizes `sub → Paciente`; 403 until onboarded |
+| 138 | `PATCH` & `GET /rest/mobile/patient/me` — onboarding profile + status→ACTIVE | https://github.com/diego-torres/nutriconsultas/issues/138 | open | ~~132~~ ✓, 137 | Patient completes profile; transitions to `ACTIVE` |
+| 139 | `POST /rest/mobile/invitations/{id}/revoke` — nutritionist invalidates invite | https://github.com/diego-torres/nutriconsultas/issues/139 | open | ~~132~~ ✓, 134 | Nutritionist JWT |
 | 140 | Auth0 Post-Login Action gate — first-login invitation validation | https://github.com/diego-torres/nutriconsultas/issues/140 | open | 133, 136 | **Post-Login** (not Pre-User-Registration — social logins skip PUR); docs + Action script |
 | 141 | Invitation security hardening — rate limits, enumeration protection, no-token logging | https://github.com/diego-torres/nutriconsultas/issues/141 | open | 133, 135, 136 | Relates #115; never log raw tokens |
 
-**Suggested build order (after #132):** #133 → #134/#135 → #136 → #137 → #138 → #139/#140 → #141.
+**Suggested build order (after ~~#132~~ ✓):** #133 → #134/#135 → #136 → #137 → #138 → #139/#140 → #141.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-18):** Patient mobile API complete through #116; **NEXT:** #132 invitation onboarding. Parallel **subscription** track: #180–#185, ~~#190~~, ~~#187~~ on `main` (PRs [#216](https://github.com/diego-torres/nutriconsultas/pull/216), [#218](https://github.com/diego-torres/nutriconsultas/pull/218)); **NEXT:** #210 / #211.
+**On `main` (2026-06-18):** Patient mobile API through #116; onboarding schema **#132 done** (PR #214). **#133 in-progress** (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)). **Subscription:** ~~#180–#185~~, ~~#187~~, ~~#190~~, ~~#210~~ on `main`; **NEXT:** #211. **Nutritionist web:** MPX epic #221–#223; **NEXT:** #221.
 
 ## AWS (production infrastructure)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-18):** Patient mobile API through #116; onboarding schema **#132 done** (PR #214). **#133 in-progress** (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)). **Subscription:** ~~#180–#185~~, ~~#187~~, ~~#190~~, ~~#210~~ on `main`; **NEXT:** #211. **Nutritionist web:** MPX epic #221–#223; **NEXT:** #221.
+**On `main` (2026-06-19):** Patient mobile API through #116; onboarding schema **#132 done** (PR #214). **#133 in-progress** (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)). **Subscription:** ~~#180–#185~~, ~~#187~~, ~~#190~~, ~~#210~~, ~~#211~~ on `main`; **NEXT:** #207. **Nutritionist web:** MPX epic #221–#223; **NEXT:** #221.
 
 ## AWS (production infrastructure)
 

--- a/docs/db/LIQUIBASE.md
+++ b/docs/db/LIQUIBASE.md
@@ -9,6 +9,11 @@ Nutriconsultas uses [Liquibase](https://www.liquibase.org/) for schema and catal
 | `src/main/resources/db/changelog/db.changelog-master.yaml` | Root changelog |
 | `changes/001-baseline-schema.{postgresql,h2}.sql` | Full schema baseline (post-#156 Phase C) |
 | `changes/002-seed-data.yaml` | Catalog seed: alimentos, platillos, template dietas |
+| `changes/003-subscription-schema.yaml` | Subscription, clinic, invitation tables (#180) |
+| `changes/004-payment-webhook-idempotency.yaml` | Payment webhook idempotency (#189) |
+| `changes/005-nutritionist-invitation-payment-exempt.yaml` | `payment_exempt` on `nutritionist_invitation` (#184) |
+| `changes/006-subscription-notification-log.yaml` | Lifecycle notification log (#185, PR #215) |
+| `changes/007-patient-invitation-onboarding.yaml` | `PacienteStatus` columns + `patient_invitation` table (#132, PR #214) |
 | `data/alimentos-seed.sql` | SMAE alimentos catalog (from `alimentos.sql`) |
 | `data/platillos-seed.sql` | Catalog `platillo` + `ingrediente` rows |
 | `data/dieta-templates-seed.sql` | 20 template `dieta` rows (`system:template-dietas`) and child ingestas |

--- a/docs/mobile-api/ALIGNMENT-SPEC.md
+++ b/docs/mobile-api/ALIGNMENT-SPEC.md
@@ -160,7 +160,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 - **Phase 0 DONE:** #107 (PR #117), #109 (PR #142), #110 (DTO envelope).
 - **Endpoints on `main`:** #91–#99 (visits, diet plans + PDF, messages, progress snapshot + measurements time series); #96/#97 messaging with HTTP 201 + Resilience4j 10/min (#113, PR #151).
 - **i18n (#111) DONE** (PR #151): `LocaleContextFilter`, `MobileApiErrorResponses`, localized 403/404/400/429.
-- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). **NEXT:** #132 invitation onboarding.
+- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). Onboarding **#132 done** (PR #214); **#133 in-progress** (PR #229).
 - `deltaPeso`/`deltaImc` are computed-at-query, not stored.
 - Progress `grasa` ambiguity: prefer `bodyComposition.porcentajeGrasaCorporal` (patient-facing %) over `indiceGrasaCorporal`.
 - Template dietas (seed `system:template-dietas`) have 4 ingestas incl. Colación — contract examples show only 3.
@@ -172,7 +172,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 
 ### F8.6 — Invitation onboarding gate (#132–#141)
 - **Prerequisites done on `main`:** #156 Paciente decomposition (PRs #175/#176/#178); #46 Liquibase baseline (PR #196). All new schema → incremental changesets per [`docs/db/LIQUIBASE.md`](../db/LIQUIBASE.md).
-- **Active sprint:** ~~#132~~ **done** (PR #214); **#133 in-progress** (token service); then #134–#141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
+- **Active sprint:** ~~#132~~ **done** (PR #214); **#133 in-progress** (PR #229); then #134–#141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
 - **Orthogonal:** nutritionist subscription invitations (`NutritionistInvitation` in subscription track) — see [`ISSUE-SUBSCRIPTION.md`](../../ISSUE-SUBSCRIPTION.md); do not conflate with patient `Invitation`.
 
 ### F8.5 — Design source of truth

--- a/docs/mobile-api/ALIGNMENT-SPEC.md
+++ b/docs/mobile-api/ALIGNMENT-SPEC.md
@@ -172,7 +172,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 
 ### F8.6 — Invitation onboarding gate (#132–#141)
 - **Prerequisites done on `main`:** #156 Paciente decomposition (PRs #175/#176/#178); #46 Liquibase baseline (PR #196). All new schema → incremental changesets per [`docs/db/LIQUIBASE.md`](../db/LIQUIBASE.md).
-- **Active sprint:** #132 data model (`PacienteStatus`, `PatientInvitation` entity) **in-progress**; then #133–#141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
+- **Active sprint:** ~~#132~~ **done** (PR #214); **#133 in-progress** (token service); then #134–#141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
 - **Orthogonal:** nutritionist subscription invitations (`NutritionistInvitation` in subscription track) — see [`ISSUE-SUBSCRIPTION.md`](../../ISSUE-SUBSCRIPTION.md); do not conflate with patient `Invitation`.
 
 ### F8.5 — Design source of truth

--- a/docs/mobile-api/MOBILE-E2E-STATUS.md
+++ b/docs/mobile-api/MOBILE-E2E-STATUS.md
@@ -217,4 +217,4 @@ Optional backend script (requires access token from the app):
 
 ---
 
-*Updated 2026-06-17: mobile cross-cutting done (#111–#116); **NEXT:** #132 invitation onboarding.*
+*Updated 2026-06-18: ~~#132~~ onboarding schema on `main` (PR #214); **#133 in-progress** (PR #229 token hashing).*

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -12,7 +12,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`MOBILE-E2E-STATUS.md`](MOBILE-E2E-STATUS.md) | Live E2E status, Auth0 setup, HTTP code matrix |
 | [`../api/openapi-mobile.yaml`](../api/openapi-mobile.yaml) | OpenAPI 3.1 export (#112, PR #164); regen: `scripts/export-openapi-mobile.sh` |
 
-**Status (2026-06-17):** Phase 0 + endpoints **#91–#99 done** on `main`. Cross-cutting **#111–#116 done**. Integration **#156** + **#46** done. **#132** in-progress (onboarding schema); **NEXT:** [#133](https://github.com/diego-torres/nutriconsultas/issues/133) token hashing.
+**Status (2026-06-18):** ~~#132~~ done (PR #214). **#133 in-progress** (token service). **NEXT after #133:** #134/#135.
 
 ## Related registries (same repo)
 

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -12,7 +12,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`MOBILE-E2E-STATUS.md`](MOBILE-E2E-STATUS.md) | Live E2E status, Auth0 setup, HTTP code matrix |
 | [`../api/openapi-mobile.yaml`](../api/openapi-mobile.yaml) | OpenAPI 3.1 export (#112, PR #164); regen: `scripts/export-openapi-mobile.sh` |
 
-**Status (2026-06-18):** ~~#132~~ done (PR #214). **#133 in-progress** (token service). **NEXT after #133:** #134/#135.
+**Status (2026-06-18):** ~~#132~~ done (PR #214). **#133 in-progress** (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)). **NEXT after #133:** #134/#135.
 
 ## Related registries (same repo)
 

--- a/docs/mobile-api/mobile-api-roadmap-v2.md
+++ b/docs/mobile-api/mobile-api-roadmap-v2.md
@@ -14,7 +14,7 @@
 
 > **State verification (2026-06-11):**
 >
-> - **Backend schema (2026-06-17):** Phase 0 **done** (#107, #109, #110). **All endpoints #91–#99 on `main`**. Cross-cutting **#111–#116 done** (OpenAPI #112, PHI #115, `senderDisplayName` #116, nutritionist reply #114). **NEXT:** #132 invitation onboarding. #106 dashboard IMC gauge **done**.
+> - **Backend schema (2026-06-18):** Phase 0 **done** (#107, #109, #110). **All endpoints #91–#99 on `main`**. Cross-cutting **#111–#116 done**. Onboarding schema **#132 done** (PR #214). **#133 in-progress** (PR #229 token hashing). #106 dashboard IMC gauge **done**.
 > - **DTO field-name map (authoritative — ALIGNMENT-SPEC §F8):** `Dieta.nombre→dietaName`, `energia→totalKcal`, `proteina→totalProteina`, `lipidos→totalGrasas`, `hidratosDeCarbono→totalCarbohidratos`; `Ingesta.nombre→tipo`; `PlatilloIngesta.name/portions/energia→nombre/porciones/kcal`, `hidratosDeCarbono→carbohidratos`, `lipidos→grasas` (same for `AlimentoIngesta`). Enums: `EventStatus = SCHEDULED/COMPLETED/CANCELLED`; `PacienteDietaStatus = ACTIVE/COMPLETED/CANCELLED` (no INACTIVE); `NivelPeso = BAJO/NORMAL/ALTO/SOBREPESO` (translate to `imcLabel` server-side). `deltaPeso`/`deltaImc` are computed, not stored.
 > - **Mobile redesign branch state (style/editorial-redesign):** Auth dedup complete — `AuthFlowController` + login/signup/welcome screens canonical; PR #48's `AuthController`/`LoginView` retired (commit 3427612); `flutter analyze` clean, 146/146 tests pass. Canonical design source: `.claude/MiNutriporcion-2/` (light editorial palette; dark welcome/login PNGs are OLD, ignore). Mobile issues #13/#21/#31 done; #32/#33 in flight on branch.
 

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationConfig.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationConfig.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.paciente.invitation;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(PatientInvitationProperties.class)
+public class PatientInvitationConfig {
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationHumanCode.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationHumanCode.java
@@ -25,7 +25,9 @@ final class PatientInvitationHumanCode {
 		int secretIndex = 0;
 		for (int index = 0; index < 7; index++) {
 			while (bitCount < 5) {
-				bitBuffer = (bitBuffer << 8) | (secret[secretIndex++] & 0xFF);
+				final int byteValue = secret[secretIndex] & 0xFF;
+				secretIndex++;
+				bitBuffer = (bitBuffer << 8) | byteValue;
 				bitCount += 8;
 			}
 			bitCount -= 5;
@@ -45,7 +47,7 @@ final class PatientInvitationHumanCode {
 				humanCode.trim().toUpperCase().getBytes(StandardCharsets.UTF_8));
 	}
 
-	private static char checksum(final char[] payload) {
+	private static char checksum(final char... payload) {
 		int sum = 0;
 		for (int index = 0; index < 7; index++) {
 			sum += ALPHABET.indexOf(payload[index]);

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationHumanCode.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationHumanCode.java
@@ -1,0 +1,56 @@
+package com.nutriconsultas.paciente.invitation;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+/**
+ * Crockford-style human invitation codes (e.g. {@code NUTRI-7F3K-9Q2X}) derived from the
+ * same CSPRNG secret as the URL token (#133).
+ */
+final class PatientInvitationHumanCode {
+
+	private static final String ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+	private PatientInvitationHumanCode() {
+	}
+
+	static String format(final byte[] secret, final String prefix) {
+		if (secret == null || secret.length < 5) {
+			throw new IllegalArgumentException("secret must be at least 5 bytes");
+		}
+		final String normalizedPrefix = prefix == null || prefix.isBlank() ? "NUTRI" : prefix.trim().toUpperCase();
+		final char[] payload = new char[8];
+		int bitBuffer = 0;
+		int bitCount = 0;
+		int secretIndex = 0;
+		for (int index = 0; index < 7; index++) {
+			while (bitCount < 5) {
+				bitBuffer = (bitBuffer << 8) | (secret[secretIndex++] & 0xFF);
+				bitCount += 8;
+			}
+			bitCount -= 5;
+			final int value = (bitBuffer >> bitCount) & 0x1F;
+			payload[index] = ALPHABET.charAt(value);
+		}
+		payload[7] = checksum(payload);
+		return normalizedPrefix + "-" + new String(payload, 0, 4) + "-" + new String(payload, 4, 4);
+	}
+
+	static boolean matchesSecret(final byte[] secret, final String prefix, final String humanCode) {
+		if (humanCode == null || humanCode.isBlank()) {
+			return false;
+		}
+		final String expected = format(secret, prefix);
+		return MessageDigest.isEqual(expected.getBytes(StandardCharsets.UTF_8),
+				humanCode.trim().toUpperCase().getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static char checksum(final char[] payload) {
+		int sum = 0;
+		for (int index = 0; index < 7; index++) {
+			sum += ALPHABET.indexOf(payload[index]);
+		}
+		return ALPHABET.charAt(sum % ALPHABET.length());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationJws.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationJws.java
@@ -29,10 +29,10 @@ final class PatientInvitationJws {
 	private PatientInvitationJws() {
 	}
 
-	static String sign(final String secret, final long pacienteId, final Instant expiresAt) {
+	static String sign(final String secret, final long pacienteId, final String tokenHash, final Instant expiresAt) {
 		final String header = BASE64_URL
 			.encodeToString("{\"alg\":\"HS256\",\"typ\":\"JWT\"}".getBytes(StandardCharsets.UTF_8));
-		final String payloadJson = buildPayload(pacienteId, expiresAt);
+		final String payloadJson = buildPayload(pacienteId, tokenHash, expiresAt);
 		final String payload = BASE64_URL.encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
 		final String signingInput = header + "." + payload;
 		final String signature = BASE64_URL.encodeToString(hmacSha256(secret, signingInput));
@@ -45,6 +45,9 @@ final class PatientInvitationJws {
 		}
 		final String[] parts = compactJws.split("\\.");
 		if (parts.length != 3) {
+			return Optional.empty();
+		}
+		if (!isHs256Header(parts[0])) {
 			return Optional.empty();
 		}
 		final String signingInput = parts[0] + "." + parts[1];
@@ -77,12 +80,23 @@ final class PatientInvitationJws {
 		}
 	}
 
-	private static String buildPayload(final long pacienteId, final Instant expiresAt) {
+	private static String buildPayload(final long pacienteId, final String tokenHash, final Instant expiresAt) {
 		try {
-			return MAPPER.writeValueAsString(new Payload(pacienteId, expiresAt.getEpochSecond()));
+			return MAPPER.writeValueAsString(new Payload(pacienteId, tokenHash, expiresAt.getEpochSecond()));
 		}
 		catch (JsonProcessingException ex) {
 			throw new IllegalStateException("Failed to serialize JWS payload", ex);
+		}
+	}
+
+	private static boolean isHs256Header(final String encodedHeader) {
+		try {
+			final JsonNode header = MAPPER
+				.readTree(new String(BASE64_URL_DECODER.decode(encodedHeader), StandardCharsets.UTF_8));
+			return "HS256".equals(header.path("alg").asText());
+		}
+		catch (IllegalArgumentException | JsonProcessingException ex) {
+			return false;
 		}
 	}
 
@@ -97,7 +111,7 @@ final class PatientInvitationJws {
 		}
 	}
 
-	private record Payload(long patientId, long exp) {
+	private record Payload(long patientId, String tokenHash, long exp) {
 
 	}
 

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationJws.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationJws.java
@@ -1,0 +1,104 @@
+package com.nutriconsultas.paciente.invitation;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Optional;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Minimal HS256 JWS for optional Auth0 Post-Login offline verification (#133 / #140).
+ */
+final class PatientInvitationJws {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	private static final Base64.Encoder BASE64_URL = Base64.getUrlEncoder().withoutPadding();
+
+	private static final Base64.Decoder BASE64_URL_DECODER = Base64.getUrlDecoder();
+
+	private PatientInvitationJws() {
+	}
+
+	static String sign(final String secret, final long pacienteId, final Instant expiresAt) {
+		final String header = BASE64_URL
+			.encodeToString("{\"alg\":\"HS256\",\"typ\":\"JWT\"}".getBytes(StandardCharsets.UTF_8));
+		final String payloadJson = buildPayload(pacienteId, expiresAt);
+		final String payload = BASE64_URL.encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
+		final String signingInput = header + "." + payload;
+		final String signature = BASE64_URL.encodeToString(hmacSha256(secret, signingInput));
+		return signingInput + "." + signature;
+	}
+
+	static Optional<Long> verify(final String secret, final String compactJws) {
+		if (compactJws == null || compactJws.isBlank()) {
+			return Optional.empty();
+		}
+		final String[] parts = compactJws.split("\\.");
+		if (parts.length != 3) {
+			return Optional.empty();
+		}
+		final String signingInput = parts[0] + "." + parts[1];
+		final byte[] expected = hmacSha256(secret, signingInput);
+		final byte[] actual;
+		try {
+			actual = BASE64_URL_DECODER.decode(parts[2]);
+		}
+		catch (IllegalArgumentException ex) {
+			return Optional.empty();
+		}
+		if (!MessageDigest.isEqual(expected, actual)) {
+			return Optional.empty();
+		}
+		try {
+			final JsonNode payload = MAPPER
+				.readTree(new String(BASE64_URL_DECODER.decode(parts[1]), StandardCharsets.UTF_8));
+			final long exp = payload.path("exp").asLong(0L);
+			if (exp <= Instant.now().getEpochSecond()) {
+				return Optional.empty();
+			}
+			final long patientId = payload.path("patientId").asLong(-1L);
+			if (patientId < 1L) {
+				return Optional.empty();
+			}
+			return Optional.of(patientId);
+		}
+		catch (IllegalArgumentException | JsonProcessingException ex) {
+			return Optional.empty();
+		}
+	}
+
+	private static String buildPayload(final long pacienteId, final Instant expiresAt) {
+		try {
+			return MAPPER.writeValueAsString(new Payload(pacienteId, expiresAt.getEpochSecond()));
+		}
+		catch (JsonProcessingException ex) {
+			throw new IllegalStateException("Failed to serialize JWS payload", ex);
+		}
+	}
+
+	private static byte[] hmacSha256(final String secret, final String signingInput) {
+		try {
+			final Mac mac = Mac.getInstance("HmacSHA256");
+			mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+			return mac.doFinal(signingInput.getBytes(StandardCharsets.UTF_8));
+		}
+		catch (NoSuchAlgorithmException | InvalidKeyException ex) {
+			throw new IllegalStateException("HmacSHA256 not available", ex);
+		}
+	}
+
+	private record Payload(long patientId, long exp) {
+
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationProperties.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationProperties.java
@@ -1,0 +1,50 @@
+package com.nutriconsultas.paciente.invitation;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configuration for patient onboarding invitations (#132–#141).
+ */
+@ConfigurationProperties(prefix = "nutriconsultas.patient.invitation")
+public class PatientInvitationProperties {
+
+	private int expiryDays = 14;
+
+	private String humanCodePrefix = "NUTRI";
+
+	/**
+	 * HMAC secret for optional offline JWS (Auth0 Post-Login Action, #140). Empty
+	 * disables JWS helpers.
+	 */
+	private String jwsSecret = "";
+
+	public int getExpiryDays() {
+		return expiryDays;
+	}
+
+	public void setExpiryDays(final int expiryDays) {
+		this.expiryDays = expiryDays;
+	}
+
+	public String getHumanCodePrefix() {
+		return humanCodePrefix;
+	}
+
+	public void setHumanCodePrefix(final String humanCodePrefix) {
+		this.humanCodePrefix = humanCodePrefix;
+	}
+
+	public String getJwsSecret() {
+		return jwsSecret;
+	}
+
+	public void setJwsSecret(final String jwsSecret) {
+		this.jwsSecret = jwsSecret;
+	}
+
+	public boolean isJwsEnabled() {
+		return StringUtils.hasText(jwsSecret);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationTokenBundle.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationTokenBundle.java
@@ -1,0 +1,9 @@
+package com.nutriconsultas.paciente.invitation;
+
+/**
+ * One-time invitation credentials returned to the issuer (#133). The raw {@code urlToken}
+ * must never be logged or persisted — only {@link #tokenHash()} is stored.
+ */
+public record PatientInvitationTokenBundle(String urlToken, String humanCode, String tokenHash) {
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationTokenService.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationTokenService.java
@@ -1,0 +1,32 @@
+package com.nutriconsultas.paciente.invitation;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * CSPRNG invitation token generation and verification for patient onboarding (#133).
+ */
+public interface PatientInvitationTokenService {
+
+	/**
+	 * Generates a URL-safe token, human-readable code, and SHA-256 hash for persistence.
+	 */
+	PatientInvitationTokenBundle generate();
+
+	/**
+	 * Constant-time verification against a stored hash.
+	 */
+	boolean verify(String rawUrlToken, String storedTokenHash);
+
+	/**
+	 * Optional compact JWS for Auth0 Post-Login offline checks (#140). Authoritative
+	 * redemption remains the DB gate (#136).
+	 */
+	Optional<String> createOfflineJws(Long pacienteId, String rawUrlToken, Instant expiresAt);
+
+	/**
+	 * Verifies offline JWS signature and expiry; returns embedded {@code patientId}.
+	 */
+	Optional<Long> verifyOfflineJws(String compactJws);
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationTokenServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationTokenServiceImpl.java
@@ -45,6 +45,9 @@ public class PatientInvitationTokenServiceImpl implements PatientInvitationToken
 
 	@Override
 	public boolean verify(final String rawUrlToken, final String storedTokenHash) {
+		if (!StringUtils.hasText(rawUrlToken) || !StringUtils.hasText(storedTokenHash)) {
+			return false;
+		}
 		return InvitationTokenHasher.verifyToken(rawUrlToken, storedTokenHash);
 	}
 
@@ -56,7 +59,8 @@ public class PatientInvitationTokenServiceImpl implements PatientInvitationToken
 		if (pacienteId == null || pacienteId < 1L || !StringUtils.hasText(rawUrlToken) || expiresAt == null) {
 			throw new IllegalArgumentException("pacienteId, rawUrlToken, and expiresAt are required");
 		}
-		return Optional.of(PatientInvitationJws.sign(properties.getJwsSecret(), pacienteId, expiresAt));
+		final String tokenHash = InvitationTokenHasher.hashToken(rawUrlToken);
+		return Optional.of(PatientInvitationJws.sign(properties.getJwsSecret(), pacienteId, tokenHash, expiresAt));
 	}
 
 	@Override

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationTokenServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationTokenServiceImpl.java
@@ -1,0 +1,70 @@
+package com.nutriconsultas.paciente.invitation;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.util.InvitationTokenHasher;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Patient invitation token service (#133). Reuses {@link InvitationTokenHasher} for URL
+ * token hashing and constant-time verification shared with subscription invitations.
+ */
+@Service
+@Slf4j
+public class PatientInvitationTokenServiceImpl implements PatientInvitationTokenService {
+
+	private static final int SECRET_BYTES = 32;
+
+	private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+	private final PatientInvitationProperties properties;
+
+	public PatientInvitationTokenServiceImpl(final PatientInvitationProperties properties) {
+		this.properties = properties;
+	}
+
+	@Override
+	public PatientInvitationTokenBundle generate() {
+		final byte[] secret = new byte[SECRET_BYTES];
+		SECURE_RANDOM.nextBytes(secret);
+		final String urlToken = Base64.getUrlEncoder().withoutPadding().encodeToString(secret);
+		final String humanCode = PatientInvitationHumanCode.format(secret, properties.getHumanCodePrefix());
+		final String tokenHash = InvitationTokenHasher.hashToken(urlToken);
+		if (log.isDebugEnabled()) {
+			log.debug("Generated patient invitation token hash (patient onboarding)");
+		}
+		return new PatientInvitationTokenBundle(urlToken, humanCode, tokenHash);
+	}
+
+	@Override
+	public boolean verify(final String rawUrlToken, final String storedTokenHash) {
+		return InvitationTokenHasher.verifyToken(rawUrlToken, storedTokenHash);
+	}
+
+	@Override
+	public Optional<String> createOfflineJws(final Long pacienteId, final String rawUrlToken, final Instant expiresAt) {
+		if (!properties.isJwsEnabled()) {
+			return Optional.empty();
+		}
+		if (pacienteId == null || pacienteId < 1L || !StringUtils.hasText(rawUrlToken) || expiresAt == null) {
+			throw new IllegalArgumentException("pacienteId, rawUrlToken, and expiresAt are required");
+		}
+		return Optional.of(PatientInvitationJws.sign(properties.getJwsSecret(), pacienteId, expiresAt));
+	}
+
+	@Override
+	public Optional<Long> verifyOfflineJws(final String compactJws) {
+		if (!properties.isJwsEnabled()) {
+			return Optional.empty();
+		}
+		return PatientInvitationJws.verify(properties.getJwsSecret(), compactJws);
+	}
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -66,6 +66,10 @@ nutriconsultas.subscription.payment.stub-simulate-checkout=${PAYMENT_STUB_SIMULA
 nutriconsultas.subscription.invitation.expiry-days=${SUBSCRIPTION_INVITATION_EXPIRY_DAYS:7}
 # Production EC2: set APP_BASE_URL in app.env (Terraform user_data or ssm-remediate-app-host.sh).
 nutriconsultas.subscription.invitation.base-url=${APP_BASE_URL:http://localhost:3000}
+nutriconsultas.patient.invitation.expiry-days=${PATIENT_INVITATION_EXPIRY_DAYS:14}
+nutriconsultas.patient.invitation.human-code-prefix=NUTRI
+# TODO: move PATIENT_INVITATION_JWS_SECRET to GCP Secret Manager in production
+nutriconsultas.patient.invitation.jws-secret=${PATIENT_INVITATION_JWS_SECRET:}
 nutriconsultas.subscription.default-grace-period-days=${SUBSCRIPTION_GRACE_PERIOD_DAYS:7}
 nutriconsultas.subscription.expiry-reminder-days=7,3,1
 nutriconsultas.subscription.lifecycle-job-enabled=${SUBSCRIPTION_LIFECYCLE_JOB_ENABLED:true}

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationHumanCodeTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationHumanCodeTest.java
@@ -1,0 +1,45 @@
+package com.nutriconsultas.paciente.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+
+import org.junit.jupiter.api.Test;
+
+class PatientInvitationHumanCodeTest {
+
+	@Test
+	void format_producesPrefixedGroupsWithChecksum() {
+		final byte[] secret = new byte[32];
+		for (int index = 0; index < secret.length; index++) {
+			secret[index] = (byte) index;
+		}
+
+		final String code = PatientInvitationHumanCode.format(secret, "NUTRI");
+
+		assertThat(code).startsWith("NUTRI-");
+		assertThat(code.split("-")).hasSize(3);
+		assertThat(code.split("-")[1]).hasSize(4);
+		assertThat(code.split("-")[2]).hasSize(4);
+	}
+
+	@Test
+	void matchesSecret_validatesFormattedCode() {
+		final byte[] secret = Base64.getUrlDecoder().decode("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
+		final String code = PatientInvitationHumanCode.format(secret, "NUTRI");
+
+		assertThat(PatientInvitationHumanCode.matchesSecret(secret, "NUTRI", code)).isTrue();
+		assertThat(PatientInvitationHumanCode.matchesSecret(secret, "NUTRI", code.substring(0, code.length() - 1) + "Z"))
+			.isFalse();
+	}
+
+	@Test
+	void format_rejectsShortSecret() {
+		assertThatThrownBy(() -> PatientInvitationHumanCode.format(new byte[2], "NUTRI"))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationJwsTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationJwsTest.java
@@ -1,0 +1,63 @@
+package com.nutriconsultas.paciente.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.util.InvitationTokenHasher;
+
+class PatientInvitationJwsTest {
+
+	private static final String SECRET = "test-jws-secret-at-least-32-chars-long";
+
+	@Test
+	void signAndVerify_returnsPatientId() {
+		final String tokenHash = InvitationTokenHasher.hashToken("sample-url-token");
+		final Instant expiresAt = Instant.now().plus(7, ChronoUnit.DAYS);
+
+		final String jws = PatientInvitationJws.sign(SECRET, 42L, tokenHash, expiresAt);
+
+		assertThat(PatientInvitationJws.verify(SECRET, jws)).contains(42L);
+	}
+
+	@Test
+	void verify_rejectsExpiredJws() {
+		final String tokenHash = InvitationTokenHasher.hashToken("sample-url-token");
+		final String jws = PatientInvitationJws.sign(SECRET, 1L, tokenHash, Instant.now().minus(1, ChronoUnit.SECONDS));
+
+		assertThat(PatientInvitationJws.verify(SECRET, jws)).isEmpty();
+	}
+
+	@Test
+	void verify_rejectsTamperedSignature() {
+		final String tokenHash = InvitationTokenHasher.hashToken("sample-url-token");
+		final String jws = PatientInvitationJws.sign(SECRET, 1L, tokenHash, Instant.now().plus(1, ChronoUnit.DAYS));
+		final String tampered = jws.substring(0, jws.lastIndexOf('.') + 1) + "bad-signature";
+
+		assertThat(PatientInvitationJws.verify(SECRET, tampered)).isEmpty();
+	}
+
+	@Test
+	void verify_rejectsNonHs256Header() {
+		final String tokenHash = InvitationTokenHasher.hashToken("sample-url-token");
+		final String payload = Base64.getUrlEncoder()
+			.withoutPadding()
+			.encodeToString(("{\"patientId\":1,\"tokenHash\":\"" + tokenHash + "\",\"exp\":"
+					+ Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond() + "}")
+				.getBytes());
+		final String noneAlgHeader = Base64.getUrlEncoder()
+			.withoutPadding()
+			.encodeToString("{\"alg\":\"none\",\"typ\":\"JWT\"}".getBytes());
+		final String jws = noneAlgHeader + "." + payload + ".signature";
+
+		final Optional<Long> result = PatientInvitationJws.verify(SECRET, jws);
+
+		assertThat(result).isEmpty();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationTokenServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationTokenServiceTest.java
@@ -1,0 +1,66 @@
+package com.nutriconsultas.paciente.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PatientInvitationTokenServiceTest {
+
+	private PatientInvitationTokenService service;
+
+	@BeforeEach
+	void setUp() {
+		final PatientInvitationProperties properties = new PatientInvitationProperties();
+		properties.setJwsSecret("test-jws-secret-at-least-32-chars-long");
+		service = new PatientInvitationTokenServiceImpl(properties);
+	}
+
+	@Test
+	void generate_returnsUrlTokenHumanCodeAndHash() {
+		final PatientInvitationTokenBundle bundle = service.generate();
+
+		assertThat(bundle.urlToken()).isNotBlank();
+		assertThat(bundle.humanCode()).startsWith("NUTRI-");
+		assertThat(bundle.tokenHash()).hasSize(64);
+		assertThat(service.verify(bundle.urlToken(), bundle.tokenHash())).isTrue();
+	}
+
+	@Test
+	void verify_rejectsWrongToken() {
+		final PatientInvitationTokenBundle bundle = service.generate();
+
+		assertThat(service.verify("not-the-token", bundle.tokenHash())).isFalse();
+	}
+
+	@Test
+	void offlineJws_roundTripsPatientId() {
+		final PatientInvitationTokenBundle bundle = service.generate();
+		final Instant expiresAt = Instant.now().plus(7, ChronoUnit.DAYS);
+
+		final String jws = service.createOfflineJws(42L, bundle.urlToken(), expiresAt).orElseThrow();
+
+		assertThat(service.verifyOfflineJws(jws)).contains(42L);
+	}
+
+	@Test
+	void offlineJws_disabledWhenSecretMissing() {
+		final PatientInvitationProperties properties = new PatientInvitationProperties();
+		final PatientInvitationTokenService disabled = new PatientInvitationTokenServiceImpl(properties);
+		final PatientInvitationTokenBundle bundle = disabled.generate();
+
+		assertThat(disabled.createOfflineJws(1L, bundle.urlToken(), Instant.now().plus(1, ChronoUnit.DAYS))).isEmpty();
+		assertThat(disabled.verifyOfflineJws("a.b.c")).isEmpty();
+	}
+
+	@Test
+	void createOfflineJws_requiresPacienteId() {
+		assertThatThrownBy(() -> service.createOfflineJws(null, "token", Instant.now().plus(1, ChronoUnit.DAYS)))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationTokenServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationTokenServiceTest.java
@@ -38,6 +38,23 @@ class PatientInvitationTokenServiceTest {
 	}
 
 	@Test
+	void generate_humanCodeMatchesUrlTokenSecret() {
+		final PatientInvitationTokenBundle bundle = service.generate();
+		final byte[] secret = java.util.Base64.getUrlDecoder().decode(bundle.urlToken());
+
+		assertThat(PatientInvitationHumanCode.matchesSecret(secret, "NUTRI", bundle.humanCode())).isTrue();
+	}
+
+	@Test
+	void verify_rejectsBlankInputs() {
+		final PatientInvitationTokenBundle bundle = service.generate();
+
+		assertThat(service.verify("", bundle.tokenHash())).isFalse();
+		assertThat(service.verify(bundle.urlToken(), "")).isFalse();
+		assertThat(service.verify(null, bundle.tokenHash())).isFalse();
+	}
+
+	@Test
 	void offlineJws_roundTripsPatientId() {
 		final PatientInvitationTokenBundle bundle = service.generate();
 		final Instant expiresAt = Instant.now().plus(7, ChronoUnit.DAYS);


### PR DESCRIPTION
## Summary
- Adds `PatientInvitationTokenService` — CSPRNG URL token (256-bit), checksummed human code (`NUTRI-XXXX-XXXX`), SHA-256 hash via shared `InvitationTokenHasher`, constant-time verify
- Optional HS256 compact JWS for Auth0 Post-Login offline checks (#140) when `PATIENT_INVITATION_JWS_SECRET` is set — DB redeem (#136) remains authoritative
- Config: `nutriconsultas.patient.invitation.*` (`expiry-days`, `human-code-prefix`, `jws-secret`)
- Registry sync: #132 **done**, #133 **in-progress**, #134 **NEXT**

## Test plan
- [x] `PatientInvitationTokenServiceTest` — generate/verify, JWS round-trip, disabled JWS without secret
- [x] `PatientInvitationHumanCodeTest` — format + checksum validation
- [x] `InvitationTokenHasherTest` (existing) still passes
- [ ] CI `mvn verify` green

Closes #133

Made with [Cursor](https://cursor.com)