### PR TITLE
feat(subscription): platform admin change plan tier (#211)

### DIFF
--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -5,7 +5,7 @@ Living index of GitHub issues that implement **subscription enforcement**, platf
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Workflow:** [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md)  
 **Design doc:** [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md)  
-**Last updated:** 2026-06-18 — ~~#210~~ **done** (PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224)); **NEXT:** #211 (change plan tier). Patient MPX **#221–#223:** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+**Last updated:** 2026-06-18 — #211 **in-progress** (change plan tier); ~~#210~~ **done** (PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224)).
 
 > **Scope.** This registry tracks `[Subscription]` issues only. The patient mobile API lives in [`ISSUE.md`](ISSUE.md). Patient invitation onboarding (#132–#141) is orthogonal — do not merge nutritionist and patient invitation entities.
 
@@ -58,7 +58,7 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 | 209 | Invitation email — SES (Terraform) + localhost console sender | https://github.com/diego-torres/nutriconsultas/issues/209 | open | 184 | SES prod; `email.mode=console` for local dev |
 | 185 | Subscription lifecycle — grace, payment override, notifications | https://github.com/diego-torres/nutriconsultas/issues/185 | **done** | 180, ~~184~~ ✓ | Merged PR [#215](https://github.com/diego-torres/nutriconsultas/pull/215) |
 | 210 | Platform admin revoke nutritionist access and allow re-invite | https://github.com/diego-torres/nutriconsultas/issues/210 | **done** | 184, 182, ~~185~~ ✓ | Merged PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224) |
-| **211** | Platform admin change nutritionist subscription plan tier | https://github.com/diego-torres/nutriconsultas/issues/211 | **NEXT** | 181, 182, 184 | Upgrade/downgrade + Auth0 sync |
+| **211** | Platform admin change nutritionist subscription plan tier | https://github.com/diego-torres/nutriconsultas/issues/211 | **in-progress** | 181, 182, 184 | Upgrade/downgrade + Auth0 sync |
 
 ---
 

--- a/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
+++ b/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
@@ -200,7 +200,7 @@ cat docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md
 | Field | Value |
 |-------|-------|
 | **Next issue** | [#211 — change plan tier](https://github.com/diego-torres/nutriconsultas/issues/211) |
-| **In progress** | — |
+| **In progress** | [#211 — change plan tier](https://github.com/diego-torres/nutriconsultas/issues/211) |
 | **Just completed** | [#210 — Platform admin revoke access](https://github.com/diego-torres/nutriconsultas/issues/210) — PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224) |
 
 See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) for full registry.

--- a/docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md
+++ b/docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md
@@ -125,6 +125,15 @@ Enforcement: central `SubscriptionEntitlementService.hasEntitlement(userId, Enti
 - Use cases: prueba gratuita, prórroga comercial, cuenta interna.
 - Audit: `SubscriptionAuditEvent` (who set, when, reason code).
 
+### Platform admin plan tier change (#211)
+
+- **Who:** platform admins only, from `/admin/platform/subscriptions/{id}/edit`.
+- **States:** `TRIAL`, `ACTIVE`, `GRACE` only (not `PENDING_PAYMENT`, `SUSPENDED`, `CANCELLED`).
+- **Downgrade policy:** **block** when clinic usage exceeds the new plan caps (patient count or active nutritionist seats). Spanish `409` message; no read-only grace on downgrade.
+- **Paid subscriptions (MVP):** admin override only — no proration or new checkout (#207 deferred).
+- **Auth0:** sync role via Management API (#182); non-fatal failure surfaces admin warning; DB `Subscription.planTier` remains authoritative.
+- **Audit:** `PLATFORM_ADMIN_ACTION` with `action=plan.tier.change`, `previousTier`, `newTier`.
+
 ### Billing period
 
 - Monthly vigencia from successful payment webhook (or admin trial start).

--- a/src/main/java/com/nutriconsultas/SecurityConfig.java
+++ b/src/main/java/com/nutriconsultas/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
 			.headers(headers -> headers.frameOptions(options -> options.sameOrigin()))
 			.authorizeHttpRequests(ar -> ar.requestMatchers("/rest/subscription/payment/webhook")
 				.permitAll()
-				.requestMatchers("/invitation/nutritionist/redeem")
+				.requestMatchers("/invitation/nutritionist/redeem", "/invitation/nutritionist/dev-checkout")
 				.authenticated()
 				.requestMatchers("/invitation/**")
 				.permitAll()

--- a/src/main/java/com/nutriconsultas/admin/SubscriptionAdminAccessRules.java
+++ b/src/main/java/com/nutriconsultas/admin/SubscriptionAdminAccessRules.java
@@ -1,0 +1,15 @@
+package com.nutriconsultas.admin;
+
+import com.nutriconsultas.subscription.Subscription;
+import com.nutriconsultas.subscription.SubscriptionStatus;
+
+public final class SubscriptionAdminAccessRules {
+
+	private SubscriptionAdminAccessRules() {
+	}
+
+	public static boolean isEditable(final Subscription subscription) {
+		return subscription != null && subscription.getStatus() != SubscriptionStatus.CANCELLED;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/admin/SubscriptionAdminController.java
+++ b/src/main/java/com/nutriconsultas/admin/SubscriptionAdminController.java
@@ -84,10 +84,14 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 
 	@GetMapping("/{id}/edit")
 	public String editForm(@AuthenticationPrincipal final OidcUser principal, @PathVariable final Long id,
-			final Model model) {
+			final Model model, final RedirectAttributes redirectAttributes) {
 		requirePlatformAdmin(principal, "subscriptions.edit");
 		final Subscription subscription = subscriptionRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("Subscription not found"));
+		if (!SubscriptionAdminAccessRules.isEditable(subscription)) {
+			redirectAttributes.addFlashAttribute("errorMessage", "Las suscripciones revocadas no pueden editarse.");
+			return "redirect:/admin/platform/subscriptions";
+		}
 		if (!model.containsAttribute("form")) {
 			model.addAttribute("form", toForm(subscription));
 		}
@@ -107,9 +111,13 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 			@Valid @ModelAttribute("form") final UpdateSubscriptionForm form, final BindingResult bindingResult,
 			final Model model, final RedirectAttributes redirectAttributes) {
 		requirePlatformAdmin(principal, "subscriptions.edit");
+		final Subscription subscription = subscriptionRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("Subscription not found"));
+		if (!SubscriptionAdminAccessRules.isEditable(subscription)) {
+			redirectAttributes.addFlashAttribute("errorMessage", "Las suscripciones revocadas no pueden editarse.");
+			return "redirect:/admin/platform/subscriptions";
+		}
 		if (bindingResult.hasErrors()) {
-			final Subscription subscription = subscriptionRepository.findById(id)
-				.orElseThrow(() -> new IllegalArgumentException("Subscription not found"));
 			model.addAttribute("subscription", subscription);
 			model.addAttribute("subscriptionOwner", ownerResolver.resolve(id).orElse(null));
 			model.addAttribute("clinicName",
@@ -133,6 +141,12 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 	public String changePlanTier(@AuthenticationPrincipal final OidcUser principal, @PathVariable final Long id,
 			@RequestParam final PlanTier planTier, final RedirectAttributes redirectAttributes) {
 		requirePlatformAdmin(principal, "subscriptions.change-plan-tier");
+		final Subscription subscription = subscriptionRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("Subscription not found"));
+		if (!SubscriptionAdminAccessRules.isEditable(subscription)) {
+			redirectAttributes.addFlashAttribute("errorMessage", "Las suscripciones revocadas no pueden editarse.");
+			return "redirect:/admin/platform/subscriptions";
+		}
 		try {
 			final PlanTierChangeResult result = nutritionistRoleService.changeSubscriptionPlanTier(principal, id,
 					planTier);

--- a/src/main/java/com/nutriconsultas/admin/SubscriptionAdminController.java
+++ b/src/main/java/com/nutriconsultas/admin/SubscriptionAdminController.java
@@ -56,12 +56,14 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 
 	private final NutritionistRoleService nutritionistRoleService;
 
+	private final SubscriptionOwnerResolver ownerResolver;
+
 	public SubscriptionAdminController(final PlatformAdminAuthorization platformAdminAuthorization,
 			final SubscriptionRepository subscriptionRepository, final ClinicRepository clinicRepository,
 			final SubscriptionLifecycleService lifecycleService,
 			final NutritionistInvitationRepository invitationRepository,
 			final NutritionistInvitationService invitationService,
-			final NutritionistRoleService nutritionistRoleService) {
+			final NutritionistRoleService nutritionistRoleService, final SubscriptionOwnerResolver ownerResolver) {
 		super(platformAdminAuthorization);
 		this.subscriptionRepository = subscriptionRepository;
 		this.clinicRepository = clinicRepository;
@@ -69,6 +71,7 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 		this.invitationRepository = invitationRepository;
 		this.invitationService = invitationService;
 		this.nutritionistRoleService = nutritionistRoleService;
+		this.ownerResolver = ownerResolver;
 	}
 
 	@GetMapping
@@ -89,6 +92,7 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 			model.addAttribute("form", toForm(subscription));
 		}
 		model.addAttribute("subscription", subscription);
+		model.addAttribute("subscriptionOwner", ownerResolver.resolve(id).orElse(null));
 		model.addAttribute("clinicName", clinicRepository.findBySubscriptionId(id).map(Clinic::getName).orElse("—"));
 		model.addAttribute("revocableInvitationId", resolveRevocableInvitationId(subscription));
 		model.addAttribute("planTierChangeable", isPlanTierChangeable(subscription));
@@ -107,6 +111,7 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 			final Subscription subscription = subscriptionRepository.findById(id)
 				.orElseThrow(() -> new IllegalArgumentException("Subscription not found"));
 			model.addAttribute("subscription", subscription);
+			model.addAttribute("subscriptionOwner", ownerResolver.resolve(id).orElse(null));
 			model.addAttribute("clinicName",
 					clinicRepository.findBySubscriptionId(id).map(Clinic::getName).orElse("—"));
 			model.addAttribute("revocableInvitationId", resolveRevocableInvitationId(subscription));

--- a/src/main/java/com/nutriconsultas/admin/SubscriptionAdminController.java
+++ b/src/main/java/com/nutriconsultas/admin/SubscriptionAdminController.java
@@ -22,15 +22,20 @@ import com.nutriconsultas.subscription.Clinic;
 import com.nutriconsultas.subscription.ClinicRepository;
 import com.nutriconsultas.subscription.NutritionistInvitation;
 import com.nutriconsultas.subscription.NutritionistInvitationRepository;
+import com.nutriconsultas.subscription.PlanTier;
+import com.nutriconsultas.subscription.PlanTierChangeResult;
 import com.nutriconsultas.subscription.Subscription;
 import com.nutriconsultas.subscription.SubscriptionRepository;
 import com.nutriconsultas.subscription.SubscriptionStatus;
+import com.nutriconsultas.subscription.NutritionistRoleService;
 import com.nutriconsultas.subscription.invitation.NutritionistInvitationAccessRules;
 import com.nutriconsultas.subscription.invitation.NutritionistInvitationService;
 import com.nutriconsultas.subscription.lifecycle.AdminSubscriptionOverride;
 import com.nutriconsultas.subscription.lifecycle.SubscriptionLifecycleService;
 
 import jakarta.validation.Valid;
+
+import org.springframework.web.server.ResponseStatusException;
 
 @Controller
 @RequestMapping("/admin/platform/subscriptions")
@@ -49,17 +54,21 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 
 	private final NutritionistInvitationService invitationService;
 
+	private final NutritionistRoleService nutritionistRoleService;
+
 	public SubscriptionAdminController(final PlatformAdminAuthorization platformAdminAuthorization,
 			final SubscriptionRepository subscriptionRepository, final ClinicRepository clinicRepository,
 			final SubscriptionLifecycleService lifecycleService,
 			final NutritionistInvitationRepository invitationRepository,
-			final NutritionistInvitationService invitationService) {
+			final NutritionistInvitationService invitationService,
+			final NutritionistRoleService nutritionistRoleService) {
 		super(platformAdminAuthorization);
 		this.subscriptionRepository = subscriptionRepository;
 		this.clinicRepository = clinicRepository;
 		this.lifecycleService = lifecycleService;
 		this.invitationRepository = invitationRepository;
 		this.invitationService = invitationService;
+		this.nutritionistRoleService = nutritionistRoleService;
 	}
 
 	@GetMapping
@@ -82,6 +91,8 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 		model.addAttribute("subscription", subscription);
 		model.addAttribute("clinicName", clinicRepository.findBySubscriptionId(id).map(Clinic::getName).orElse("—"));
 		model.addAttribute("revocableInvitationId", resolveRevocableInvitationId(subscription));
+		model.addAttribute("planTierChangeable", isPlanTierChangeable(subscription));
+		model.addAttribute("planTiers", PlanTier.values());
 		model.addAttribute("subscriptionStatuses", SubscriptionStatus.values());
 		model.addAttribute("activeMenu", "subscriptions");
 		return "sbadmin/platform/subscriptions/edit";
@@ -99,6 +110,8 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 			model.addAttribute("clinicName",
 					clinicRepository.findBySubscriptionId(id).map(Clinic::getName).orElse("—"));
 			model.addAttribute("revocableInvitationId", resolveRevocableInvitationId(subscription));
+			model.addAttribute("planTierChangeable", isPlanTierChangeable(subscription));
+			model.addAttribute("planTiers", PlanTier.values());
 			model.addAttribute("subscriptionStatuses", SubscriptionStatus.values());
 			model.addAttribute("activeMenu", "subscriptions");
 			return "sbadmin/platform/subscriptions/edit";
@@ -109,6 +122,33 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 		lifecycleService.applyAdminOverride(principal.getSubject(), id, override);
 		redirectAttributes.addFlashAttribute("successMessage", "Suscripción actualizada correctamente.");
 		return "redirect:/admin/platform/subscriptions";
+	}
+
+	@PostMapping("/{id}/change-plan-tier")
+	public String changePlanTier(@AuthenticationPrincipal final OidcUser principal, @PathVariable final Long id,
+			@RequestParam final PlanTier planTier, final RedirectAttributes redirectAttributes) {
+		requirePlatformAdmin(principal, "subscriptions.change-plan-tier");
+		try {
+			final PlanTierChangeResult result = nutritionistRoleService.changeSubscriptionPlanTier(principal, id,
+					planTier);
+			if (result.previousTier() == result.newTier()) {
+				redirectAttributes.addFlashAttribute("successMessage", "El plan ya es " + planTier + ".");
+			}
+			else {
+				final StringBuilder message = new StringBuilder("Plan actualizado de ").append(result.previousTier())
+					.append(" a ")
+					.append(result.newTier())
+					.append(".");
+				if (!result.auth0SyncSucceeded()) {
+					message.append(" Advertencia: no se pudo sincronizar el rol en Auth0; reintente más tarde.");
+				}
+				redirectAttributes.addFlashAttribute("successMessage", message.toString());
+			}
+		}
+		catch (ResponseStatusException ex) {
+			redirectAttributes.addFlashAttribute("errorMessage", ex.getReason());
+		}
+		return "redirect:/admin/platform/subscriptions/" + id + "/edit";
 	}
 
 	@PostMapping("/{id}/revoke-access")
@@ -144,6 +184,12 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 			.filter(NutritionistInvitationAccessRules::canRevokeAccess)
 			.map(NutritionistInvitation::getId)
 			.orElse(null);
+	}
+
+	private static boolean isPlanTierChangeable(final Subscription subscription) {
+		return subscription.getStatus() == SubscriptionStatus.TRIAL
+				|| subscription.getStatus() == SubscriptionStatus.ACTIVE
+				|| subscription.getStatus() == SubscriptionStatus.GRACE;
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/admin/SubscriptionAdminController.java
+++ b/src/main/java/com/nutriconsultas/admin/SubscriptionAdminController.java
@@ -135,14 +135,11 @@ public class SubscriptionAdminController extends AbstractPlatformAdminController
 				redirectAttributes.addFlashAttribute("successMessage", "El plan ya es " + planTier + ".");
 			}
 			else {
-				final StringBuilder message = new StringBuilder("Plan actualizado de ").append(result.previousTier())
-					.append(" a ")
-					.append(result.newTier())
-					.append(".");
+				String message = "Plan actualizado de " + result.previousTier() + " a " + result.newTier() + ".";
 				if (!result.auth0SyncSucceeded()) {
-					message.append(" Advertencia: no se pudo sincronizar el rol en Auth0; reintente más tarde.");
+					message += " Advertencia: no se pudo sincronizar el rol en Auth0; reintente más tarde.";
 				}
-				redirectAttributes.addFlashAttribute("successMessage", message.toString());
+				redirectAttributes.addFlashAttribute("successMessage", message);
 			}
 		}
 		catch (ResponseStatusException ex) {

--- a/src/main/java/com/nutriconsultas/admin/SubscriptionAdminRestController.java
+++ b/src/main/java/com/nutriconsultas/admin/SubscriptionAdminRestController.java
@@ -52,12 +52,16 @@ public class SubscriptionAdminRestController extends AbstractGridController<Subs
 
 	private final ClinicRepository clinicRepository;
 
+	private final SubscriptionOwnerResolver ownerResolver;
+
 	private final PlatformAdminAuthorization platformAdminAuthorization;
 
 	public SubscriptionAdminRestController(final SubscriptionGridService gridService,
-			final ClinicRepository clinicRepository, final PlatformAdminAuthorization platformAdminAuthorization) {
+			final ClinicRepository clinicRepository, final SubscriptionOwnerResolver ownerResolver,
+			final PlatformAdminAuthorization platformAdminAuthorization) {
 		this.gridService = gridService;
 		this.clinicRepository = clinicRepository;
+		this.ownerResolver = ownerResolver;
 		this.platformAdminAuthorization = platformAdminAuthorization;
 	}
 
@@ -97,7 +101,8 @@ public class SubscriptionAdminRestController extends AbstractGridController<Subs
 			return Sort.by(Sort.Direction.DESC, "id");
 		}
 		final String columnName = pagingRequest.getColumns().get(order.getColumn()).getData();
-		if ("actions".equals(columnName) || "clinicName".equals(columnName)) {
+		if ("actions".equals(columnName) || "clinicName".equals(columnName) || "ownerEmail".equals(columnName)
+				|| "ownerUserId".equals(columnName)) {
 			return Sort.by(Sort.Direction.DESC, "id");
 		}
 		final String fieldName = COLUMN_TO_FIELD_MAP.getOrDefault(columnName, columnName);
@@ -110,7 +115,9 @@ public class SubscriptionAdminRestController extends AbstractGridController<Subs
 		final String clinicName = clinicRepository.findBySubscriptionId(row.getId())
 			.map(clinic -> clinic.getName())
 			.orElse("—");
-		return Arrays.asList(String.valueOf(row.getId()), clinicName,
+		final SubscriptionOwnerView owner = ownerResolver.resolve(row.getId()).orElse(null);
+		return Arrays.asList(String.valueOf(row.getId()), SubscriptionGridHtml.formatOwnerEmail(owner),
+				SubscriptionGridHtml.formatOwnerUserId(owner), clinicName,
 				SubscriptionGridHtml.planTierLabel(row.getPlanTier()),
 				SubscriptionGridHtml.statusBadge(row.getStatus()),
 				SubscriptionGridHtml.formatInstant(row.getPeriodEnd()),
@@ -135,7 +142,9 @@ public class SubscriptionAdminRestController extends AbstractGridController<Subs
 
 	@Override
 	protected List<Column> getColumns() {
-		return Stream.of("id", "clinicName", "planTier", "status", "periodEnd", "paymentExempt", "actions")
+		return Stream
+			.of("id", "ownerEmail", "ownerUserId", "clinicName", "planTier", "status", "periodEnd", "paymentExempt",
+					"actions")
 			.map(Column::new)
 			.collect(Collectors.toList());
 	}

--- a/src/main/java/com/nutriconsultas/admin/SubscriptionAdminRestController.java
+++ b/src/main/java/com/nutriconsultas/admin/SubscriptionAdminRestController.java
@@ -101,8 +101,7 @@ public class SubscriptionAdminRestController extends AbstractGridController<Subs
 			return Sort.by(Sort.Direction.DESC, "id");
 		}
 		final String columnName = pagingRequest.getColumns().get(order.getColumn()).getData();
-		if ("actions".equals(columnName) || "clinicName".equals(columnName) || "ownerEmail".equals(columnName)
-				|| "ownerUserId".equals(columnName)) {
+		if ("actions".equals(columnName) || "clinicName".equals(columnName) || "ownerEmail".equals(columnName)) {
 			return Sort.by(Sort.Direction.DESC, "id");
 		}
 		final String fieldName = COLUMN_TO_FIELD_MAP.getOrDefault(columnName, columnName);
@@ -116,13 +115,12 @@ public class SubscriptionAdminRestController extends AbstractGridController<Subs
 			.map(clinic -> clinic.getName())
 			.orElse("—");
 		final SubscriptionOwnerView owner = ownerResolver.resolve(row.getId()).orElse(null);
-		return Arrays.asList(String.valueOf(row.getId()), SubscriptionGridHtml.formatOwnerEmail(owner),
-				SubscriptionGridHtml.formatOwnerUserId(owner), clinicName,
+		return Arrays.asList(String.valueOf(row.getId()), SubscriptionGridHtml.formatOwnerEmail(owner), clinicName,
 				SubscriptionGridHtml.planTierLabel(row.getPlanTier()),
 				SubscriptionGridHtml.statusBadge(row.getStatus()),
 				SubscriptionGridHtml.formatInstant(row.getPeriodEnd()),
 				SubscriptionGridHtml.paymentExemptBadge(row.isPaymentExempt()),
-				SubscriptionGridHtml.editLink(row.getId()));
+				SubscriptionGridHtml.editLink(row.getId(), row.getStatus()));
 	}
 
 	@Override
@@ -143,8 +141,7 @@ public class SubscriptionAdminRestController extends AbstractGridController<Subs
 	@Override
 	protected List<Column> getColumns() {
 		return Stream
-			.of("id", "ownerEmail", "ownerUserId", "clinicName", "planTier", "status", "periodEnd", "paymentExempt",
-					"actions")
+			.of("id", "ownerEmail", "clinicName", "planTier", "status", "periodEnd", "paymentExempt", "actions")
 			.map(Column::new)
 			.collect(Collectors.toList());
 	}

--- a/src/main/java/com/nutriconsultas/admin/SubscriptionGridHtml.java
+++ b/src/main/java/com/nutriconsultas/admin/SubscriptionGridHtml.java
@@ -4,6 +4,8 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
+import org.springframework.web.util.HtmlUtils;
+
 import com.nutriconsultas.subscription.PlanTier;
 import com.nutriconsultas.subscription.SubscriptionStatus;
 
@@ -45,6 +47,20 @@ public final class SubscriptionGridHtml {
 	public static String editLink(final Long subscriptionId) {
 		return "<a class=\"btn btn-sm btn-primary\" href=\"/admin/platform/subscriptions/" + subscriptionId
 				+ "/edit\"><i class=\"fas fa-edit\"></i> Editar</a>";
+	}
+
+	public static String formatOwnerEmail(final SubscriptionOwnerView owner) {
+		if (owner == null || !owner.hasEmail()) {
+			return "—";
+		}
+		return HtmlUtils.htmlEscape(owner.email());
+	}
+
+	public static String formatOwnerUserId(final SubscriptionOwnerView owner) {
+		if (owner == null || !owner.hasUserId()) {
+			return "<span class=\"text-muted\">—</span>";
+		}
+		return "<code class=\"small\">" + HtmlUtils.htmlEscape(owner.userId()) + "</code>";
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/admin/SubscriptionGridHtml.java
+++ b/src/main/java/com/nutriconsultas/admin/SubscriptionGridHtml.java
@@ -44,7 +44,10 @@ public final class SubscriptionGridHtml {
 		return DISPLAY_FORMAT.format(instant);
 	}
 
-	public static String editLink(final Long subscriptionId) {
+	public static String editLink(final Long subscriptionId, final SubscriptionStatus status) {
+		if (status == SubscriptionStatus.CANCELLED) {
+			return "<span class=\"text-muted small\">Revocada</span>";
+		}
 		return "<a class=\"btn btn-sm btn-primary\" href=\"/admin/platform/subscriptions/" + subscriptionId
 				+ "/edit\"><i class=\"fas fa-edit\"></i> Editar</a>";
 	}
@@ -54,13 +57,6 @@ public final class SubscriptionGridHtml {
 			return "—";
 		}
 		return HtmlUtils.htmlEscape(owner.email());
-	}
-
-	public static String formatOwnerUserId(final SubscriptionOwnerView owner) {
-		if (owner == null || !owner.hasUserId()) {
-			return "<span class=\"text-muted\">—</span>";
-		}
-		return "<code class=\"small\">" + HtmlUtils.htmlEscape(owner.userId()) + "</code>";
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/admin/SubscriptionOwnerResolver.java
+++ b/src/main/java/com/nutriconsultas/admin/SubscriptionOwnerResolver.java
@@ -1,0 +1,48 @@
+package com.nutriconsultas.admin;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.subscription.Clinic;
+import com.nutriconsultas.subscription.ClinicRepository;
+import com.nutriconsultas.subscription.NutritionistInvitation;
+import com.nutriconsultas.subscription.NutritionistInvitationRepository;
+
+@Service
+public class SubscriptionOwnerResolver {
+
+	private final NutritionistInvitationRepository invitationRepository;
+
+	private final ClinicRepository clinicRepository;
+
+	public SubscriptionOwnerResolver(final NutritionistInvitationRepository invitationRepository,
+			final ClinicRepository clinicRepository) {
+		this.invitationRepository = invitationRepository;
+		this.clinicRepository = clinicRepository;
+	}
+
+	public Optional<SubscriptionOwnerView> resolve(final Long subscriptionId) {
+		if (subscriptionId == null) {
+			return Optional.empty();
+		}
+		final Optional<NutritionistInvitation> invitationOpt = invitationRepository
+			.findBySubscriptionId(subscriptionId);
+		if (invitationOpt.isPresent()) {
+			final NutritionistInvitation invitation = invitationOpt.get();
+			return Optional.of(new SubscriptionOwnerView(invitation.getEmail(),
+					resolveUserId(invitation, subscriptionId), invitation.getId()));
+		}
+		return clinicRepository.findBySubscriptionId(subscriptionId)
+			.map(clinic -> new SubscriptionOwnerView(null, clinic.getDirectorUserId(), null));
+	}
+
+	private String resolveUserId(final NutritionistInvitation invitation, final Long subscriptionId) {
+		if (StringUtils.hasText(invitation.getRedeemedByUserId())) {
+			return invitation.getRedeemedByUserId();
+		}
+		return clinicRepository.findBySubscriptionId(subscriptionId).map(Clinic::getDirectorUserId).orElse(null);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/admin/SubscriptionOwnerView.java
+++ b/src/main/java/com/nutriconsultas/admin/SubscriptionOwnerView.java
@@ -1,0 +1,17 @@
+package com.nutriconsultas.admin;
+
+/**
+ * Platform-admin view of who owns or will own a
+ * {@link com.nutriconsultas.subscription.Subscription}.
+ */
+public record SubscriptionOwnerView(String email, String userId, Long invitationId) {
+
+	public boolean hasEmail() {
+		return email != null && !email.isBlank();
+	}
+
+	public boolean hasUserId() {
+		return userId != null && !userId.isBlank();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/platform/PlatformAdminTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/platform/PlatformAdminTemplateValidator.java
@@ -30,6 +30,7 @@ public class PlatformAdminTemplateValidator extends BaseTemplateValidator {
 		variables.put("subscription", createMockSubscription());
 		variables.put("clinicName", "Consultorio demo");
 		variables.put("revocableInvitationId", 1L);
+		variables.put("planTierChangeable", true);
 		variables.put("subscriptionBanner", null);
 		variables.put("subscriptionStatus", com.nutriconsultas.subscription.SubscriptionStatus.SUSPENDED);
 		variables.put("updateSubscriptionForm", new UpdateSubscriptionForm());

--- a/src/main/java/com/nutriconsultas/platform/PlatformAdminTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/platform/PlatformAdminTemplateValidator.java
@@ -3,6 +3,7 @@ package com.nutriconsultas.platform;
 import java.util.Map;
 
 import com.nutriconsultas.admin.CreateNutritionistInvitationForm;
+import com.nutriconsultas.admin.SubscriptionOwnerView;
 import com.nutriconsultas.admin.UpdateSubscriptionForm;
 import com.nutriconsultas.subscription.InvitationStatus;
 import com.nutriconsultas.subscription.PlanTier;
@@ -31,6 +32,7 @@ public class PlatformAdminTemplateValidator extends BaseTemplateValidator {
 		variables.put("clinicName", "Consultorio demo");
 		variables.put("revocableInvitationId", 1L);
 		variables.put("planTierChangeable", true);
+		variables.put("subscriptionOwner", new SubscriptionOwnerView("admin@example.com", "auth0|owner-test", 1L));
 		variables.put("subscriptionBanner", null);
 		variables.put("subscriptionStatus", com.nutriconsultas.subscription.SubscriptionStatus.SUSPENDED);
 		variables.put("updateSubscriptionForm", new UpdateSubscriptionForm());

--- a/src/main/java/com/nutriconsultas/profile/NutritionistProfileController.java
+++ b/src/main/java/com/nutriconsultas/profile/NutritionistProfileController.java
@@ -1,8 +1,10 @@
 package com.nutriconsultas.profile;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Controller;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.nutriconsultas.controller.AbstractAuthorizedController;
+import com.nutriconsultas.subscription.lifecycle.SubscriptionAccessService;
 import com.nutriconsultas.util.LogRedaction;
 
 import lombok.extern.slf4j.Slf4j;
@@ -30,8 +33,18 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class NutritionistProfileController extends AbstractAuthorizedController {
 
-	@Autowired
-	private NutritionistProfileService profileService;
+	private static final DateTimeFormatter VIGENCIA_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+		.withZone(ZoneId.of("America/Mexico_City"));
+
+	private final NutritionistProfileService profileService;
+
+	private final SubscriptionAccessService subscriptionAccessService;
+
+	public NutritionistProfileController(final NutritionistProfileService profileService,
+			final SubscriptionAccessService subscriptionAccessService) {
+		this.profileService = profileService;
+		this.subscriptionAccessService = subscriptionAccessService;
+	}
 
 	/**
 	 * Renders the profile form.
@@ -43,10 +56,7 @@ public class NutritionistProfileController extends AbstractAuthorizedController 
 	public String perfil(@AuthenticationPrincipal final OidcUser principal, final Model model) {
 		log.debug("Loading profile page");
 		model.addAttribute("activeMenu", "perfil");
-		final String userId = principal.getSubject();
-		final NutritionistProfile profile = profileService.getOrCreateProfile(userId);
-		log.info("Loaded profile: {}", LogRedaction.redactNutritionistProfile(profile.getId()));
-		model.addAttribute("profile", profile);
+		populateProfileModel(model, principal.getSubject());
 		return "sbadmin/profile/formulario";
 	}
 
@@ -82,8 +92,7 @@ public class NutritionistProfileController extends AbstractAuthorizedController 
 		String result;
 		if (file.isEmpty()) {
 			log.error("Logo upload failed: file is empty");
-			final NutritionistProfile profile = profileService.getOrCreateProfile(userId);
-			model.addAttribute("profile", profile);
+			populateProfileModel(model, userId);
 			model.addAttribute("errorMessage", "El archivo está vacío");
 			result = "sbadmin/profile/formulario";
 		}
@@ -104,13 +113,31 @@ public class NutritionistProfileController extends AbstractAuthorizedController 
 			}
 			catch (final IOException e) {
 				log.error("Failed to upload logo for user: {}", LogRedaction.redactUserId(userId), e);
-				final NutritionistProfile profile = profileService.getOrCreateProfile(userId);
-				model.addAttribute("profile", profile);
+				populateProfileModel(model, userId);
 				model.addAttribute("errorMessage", "Error al subir el logo");
 				result = "sbadmin/profile/formulario";
 			}
 		}
 		return result;
+	}
+
+	private void populateProfileModel(final Model model, final String userId) {
+		final NutritionistProfile profile = profileService.getOrCreateProfile(userId);
+		log.info("Loaded profile: {}", LogRedaction.redactNutritionistProfile(profile.getId()));
+		model.addAttribute("profile", profile);
+		subscriptionAccessService.findGrantingSubscriptionForUser(userId).ifPresent(subscription -> {
+			model.addAttribute("subscriptionPlanLabel", subscription.getPlanTier().getDisplayName());
+			model.addAttribute("subscriptionStatus", subscription.getStatus());
+			model.addAttribute("subscriptionPeriodStartLabel", formatVigencia(subscription.getPeriodStart()));
+			model.addAttribute("subscriptionPeriodEndLabel", formatVigencia(subscription.getPeriodEnd()));
+		});
+	}
+
+	private static String formatVigencia(final Instant instant) {
+		if (instant == null) {
+			return null;
+		}
+		return VIGENCIA_FORMAT.format(instant);
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/profile/ProfileTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/profile/ProfileTemplateValidator.java
@@ -2,6 +2,7 @@ package com.nutriconsultas.profile;
 
 import java.util.Map;
 
+import com.nutriconsultas.subscription.SubscriptionStatus;
 import com.nutriconsultas.validation.template.BaseTemplateValidator;
 
 /**
@@ -23,6 +24,10 @@ public class ProfileTemplateValidator extends BaseTemplateValidator {
 		final Map<String, Object> variables = super.createMockModelVariables();
 		final NutritionistProfile mockProfile = createMockProfile();
 		variables.put("profile", mockProfile);
+		variables.put("subscriptionPlanLabel", "Profesional");
+		variables.put("subscriptionStatus", SubscriptionStatus.ACTIVE);
+		variables.put("subscriptionPeriodStartLabel", "01/06/2026");
+		variables.put("subscriptionPeriodEndLabel", "01/07/2026");
 		return variables;
 	}
 

--- a/src/main/java/com/nutriconsultas/subscription/NutritionistInvitationRepository.java
+++ b/src/main/java/com/nutriconsultas/subscription/NutritionistInvitationRepository.java
@@ -20,4 +20,7 @@ public interface NutritionistInvitationRepository
 	Optional<NutritionistInvitation> findFirstByEmailIgnoreCaseAndStatusOrderByRedeemedAtDesc(String email,
 			InvitationStatus status);
 
+	Optional<NutritionistInvitation> findFirstByRedeemedByUserIdAndStatusOrderByRedeemedAtDesc(String redeemedByUserId,
+			InvitationStatus status);
+
 }

--- a/src/main/java/com/nutriconsultas/subscription/NutritionistRoleService.java
+++ b/src/main/java/com/nutriconsultas/subscription/NutritionistRoleService.java
@@ -6,7 +6,6 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
  * Assigns nutritionist plan tiers. DB {@link Subscription#planTier} is authoritative;
  * Auth0 roles are synced as a cache for JWT/session claims.
  */
-@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface NutritionistRoleService {
 
 	void assignRole(OidcUser adminPrincipal, String targetUserId, PlanTier planTier);

--- a/src/main/java/com/nutriconsultas/subscription/NutritionistRoleService.java
+++ b/src/main/java/com/nutriconsultas/subscription/NutritionistRoleService.java
@@ -11,4 +11,11 @@ public interface NutritionistRoleService {
 
 	void assignRole(OidcUser adminPrincipal, String targetUserId, PlanTier planTier);
 
+	/**
+	 * Changes {@link Subscription#planTier} for an active subscription, syncs Auth0, and
+	 * records a platform-admin audit event. Blocks downgrades when clinic usage exceeds
+	 * the new plan limits.
+	 */
+	PlanTierChangeResult changeSubscriptionPlanTier(OidcUser adminPrincipal, Long subscriptionId, PlanTier newTier);
+
 }

--- a/src/main/java/com/nutriconsultas/subscription/NutritionistRoleServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/subscription/NutritionistRoleServiceImpl.java
@@ -1,6 +1,9 @@
 package com.nutriconsultas.subscription;
 
+import java.util.EnumSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
@@ -10,6 +13,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.nutriconsultas.auth0.Auth0RoleSyncClient;
+import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.platform.PlatformAdminService;
 
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +21,9 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @Slf4j
 public class NutritionistRoleServiceImpl implements NutritionistRoleService {
+
+	private static final Set<SubscriptionStatus> TIER_CHANGEABLE_STATUSES = EnumSet.of(SubscriptionStatus.TRIAL,
+			SubscriptionStatus.ACTIVE, SubscriptionStatus.GRACE);
 
 	private final PlatformAdminService platformAdminService;
 
@@ -26,18 +33,26 @@ public class NutritionistRoleServiceImpl implements NutritionistRoleService {
 
 	private final SubscriptionRepository subscriptionRepository;
 
+	private final NutritionistInvitationRepository invitationRepository;
+
+	private final PacienteRepository pacienteRepository;
+
 	private final Auth0RoleSyncClient auth0RoleSyncClient;
 
 	private final SubscriptionAuditEventRepository subscriptionAuditEventRepository;
 
 	public NutritionistRoleServiceImpl(final PlatformAdminService platformAdminService,
 			final ClinicRepository clinicRepository, final ClinicMemberRepository clinicMemberRepository,
-			final SubscriptionRepository subscriptionRepository, final Auth0RoleSyncClient auth0RoleSyncClient,
+			final SubscriptionRepository subscriptionRepository,
+			final NutritionistInvitationRepository invitationRepository, final PacienteRepository pacienteRepository,
+			final Auth0RoleSyncClient auth0RoleSyncClient,
 			final SubscriptionAuditEventRepository subscriptionAuditEventRepository) {
 		this.platformAdminService = platformAdminService;
 		this.clinicRepository = clinicRepository;
 		this.clinicMemberRepository = clinicMemberRepository;
 		this.subscriptionRepository = subscriptionRepository;
+		this.invitationRepository = invitationRepository;
+		this.pacienteRepository = pacienteRepository;
 		this.auth0RoleSyncClient = auth0RoleSyncClient;
 		this.subscriptionAuditEventRepository = subscriptionAuditEventRepository;
 	}
@@ -54,16 +69,110 @@ public class NutritionistRoleServiceImpl implements NutritionistRoleService {
 		}
 		final Subscription subscription = resolveSubscription(targetUserId)
 			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Subscription not found for user"));
-		final PlanTier previousTier = subscription.getPlanTier();
-		subscription.setPlanTier(planTier);
-		subscriptionRepository.save(subscription);
-		auth0RoleSyncClient.syncPlanRole(targetUserId, planTier);
-		recordRoleAssignment(platformAdminService.resolveActorUserId(adminPrincipal), targetUserId, previousTier,
-				planTier);
-		if (log.isInfoEnabled()) {
-			log.info("Assigned plan tier: targetUserId={}, previousTier={}, newTier={}", targetUserId, previousTier,
-					planTier);
+		if (!TIER_CHANGEABLE_STATUSES.contains(subscription.getStatus())) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT,
+					"Solo se puede cambiar el plan de suscripciones activas, en prueba o en periodo de gracia");
 		}
+		final Clinic clinic = clinicRepository.findBySubscriptionId(subscription.getId()).orElse(null);
+		assertUsageFitsPlanTier(clinic, planTier);
+		applyPlanTierChange(platformAdminService.resolveActorUserId(adminPrincipal), subscription, planTier,
+				SubscriptionAuditEventType.ROLE_ASSIGNED, targetUserId,
+				invitationRepository.findBySubscriptionId(subscription.getId()).orElse(null));
+	}
+
+	@Override
+	@Transactional
+	public PlanTierChangeResult changeSubscriptionPlanTier(final OidcUser adminPrincipal, final Long subscriptionId,
+			final PlanTier newTier) {
+		platformAdminService.requirePlatformAdmin(adminPrincipal);
+		if (subscriptionId == null) {
+			throw new IllegalArgumentException("subscriptionId is required");
+		}
+		if (newTier == null) {
+			throw new IllegalArgumentException("planTier is required");
+		}
+		final Subscription subscription = subscriptionRepository.findById(subscriptionId)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Subscription not found"));
+		if (!TIER_CHANGEABLE_STATUSES.contains(subscription.getStatus())) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT,
+					"Solo se puede cambiar el plan de suscripciones activas, en prueba o en periodo de gracia");
+		}
+		final PlanTier previousTier = subscription.getPlanTier();
+		if (previousTier == newTier) {
+			return new PlanTierChangeResult(previousTier, newTier, true);
+		}
+		final Clinic clinic = clinicRepository.findBySubscriptionId(subscriptionId).orElse(null);
+		assertUsageFitsPlanTier(clinic, newTier);
+		final String targetUserId = resolveTargetUserId(subscriptionId, clinic);
+		final boolean auth0SyncSucceeded = applyPlanTierChange(platformAdminService.resolveActorUserId(adminPrincipal),
+				subscription, newTier, SubscriptionAuditEventType.PLATFORM_ADMIN_ACTION, targetUserId,
+				invitationRepository.findBySubscriptionId(subscriptionId).orElse(null));
+		return new PlanTierChangeResult(previousTier, newTier, auth0SyncSucceeded);
+	}
+
+	private boolean applyPlanTierChange(final String actorUserId, final Subscription subscription,
+			final PlanTier newTier, final SubscriptionAuditEventType auditType, final String targetUserId,
+			final NutritionistInvitation invitation) {
+		final PlanTier previousTier = subscription.getPlanTier();
+		subscription.setPlanTier(newTier);
+		subscriptionRepository.save(subscription);
+		if (invitation != null) {
+			invitation.setPlanTier(newTier);
+		}
+		final boolean auth0SyncSucceeded = syncAuth0RoleIfConfigured(targetUserId, newTier);
+		recordPlanTierChange(actorUserId, subscription, previousTier, newTier, auditType, targetUserId,
+				auth0SyncSucceeded);
+		if (log.isInfoEnabled()) {
+			log.info("Changed plan tier: subscriptionId={}, previousTier={}, newTier={}, targetUserIdPresent={}",
+					subscription.getId(), previousTier, newTier, StringUtils.hasText(targetUserId));
+		}
+		return auth0SyncSucceeded;
+	}
+
+	private void assertUsageFitsPlanTier(final Clinic clinic, final PlanTier newTier) {
+		if (clinic == null) {
+			return;
+		}
+		final PlanEntitlements newEntitlements = PlanEntitlements.forTier(newTier);
+		final Integer maxPatients = newEntitlements.getMaxPatients();
+		if (maxPatients != null) {
+			final long patientCount = countPatientsInClinic(clinic.getId());
+			if (patientCount > maxPatients) {
+				throw new ResponseStatusException(HttpStatus.CONFLICT,
+						"No se puede cambiar al plan " + newTier + ": el consultorio tiene " + patientCount
+								+ " pacientes y el plan permite máximo " + maxPatients + ".");
+			}
+		}
+		final int maxNutritionists = newEntitlements.getMaxNutritionists();
+		final long activeMembers = clinicMemberRepository.countByClinicIdAndMembershipStatus(clinic.getId(),
+				MembershipStatus.ACTIVE);
+		if (activeMembers > maxNutritionists) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT,
+					"No se puede cambiar al plan " + newTier + ": el consultorio tiene " + activeMembers
+							+ " nutriólogos activos y el plan permite máximo " + maxNutritionists + ".");
+		}
+	}
+
+	private long countPatientsInClinic(final Long clinicId) {
+		final List<String> memberUserIds = clinicMemberRepository.findUserIdsByClinicIdAndMembershipStatus(clinicId,
+				MembershipStatus.ACTIVE);
+		if (memberUserIds.isEmpty()) {
+			return 0L;
+		}
+		return pacienteRepository.countByUserIdIn(memberUserIds);
+	}
+
+	private String resolveTargetUserId(final Long subscriptionId, final Clinic clinic) {
+		final Optional<String> redeemedUserId = invitationRepository.findBySubscriptionId(subscriptionId)
+			.map(NutritionistInvitation::getRedeemedByUserId)
+			.filter(StringUtils::hasText);
+		if (redeemedUserId.isPresent()) {
+			return redeemedUserId.get();
+		}
+		if (clinic != null && StringUtils.hasText(clinic.getDirectorUserId())) {
+			return clinic.getDirectorUserId();
+		}
+		return null;
 	}
 
 	private Optional<Subscription> resolveSubscription(final String userId) {
@@ -77,15 +186,52 @@ public class NutritionistRoleServiceImpl implements NutritionistRoleService {
 			.map(member -> member.getClinic().getSubscription());
 	}
 
-	private void recordRoleAssignment(final String actorUserId, final String targetUserId, final PlanTier previousTier,
-			final PlanTier newTier) {
+	private boolean syncAuth0RoleIfConfigured(final String targetUserId, final PlanTier planTier) {
+		if (!StringUtils.hasText(targetUserId)) {
+			return true;
+		}
+		if (!auth0RoleSyncClient.isConfigured()) {
+			if (log.isWarnEnabled()) {
+				log.warn("Auth0 role sync skipped: Management API not configured, targetUserId present={}",
+						StringUtils.hasText(targetUserId));
+			}
+			return true;
+		}
+		try {
+			auth0RoleSyncClient.syncPlanRole(targetUserId, planTier);
+			return true;
+		}
+		catch (RuntimeException ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("Auth0 role sync failed after plan tier change: targetUserId present={}, planTier={}",
+						StringUtils.hasText(targetUserId), planTier);
+			}
+			if (log.isDebugEnabled()) {
+				log.debug("Auth0 role sync failure", ex);
+			}
+			return false;
+		}
+	}
+
+	private void recordPlanTierChange(final String actorUserId, final Subscription subscription,
+			final PlanTier previousTier, final PlanTier newTier, final SubscriptionAuditEventType auditType,
+			final String targetUserId, final boolean auth0SyncSucceeded) {
 		if (!StringUtils.hasText(actorUserId)) {
 			return;
 		}
 		final SubscriptionAuditEvent event = new SubscriptionAuditEvent();
-		event.setEventType(SubscriptionAuditEventType.ROLE_ASSIGNED);
+		event.setSubscription(subscription);
+		event.setEventType(auditType);
 		event.setActorUserId(actorUserId);
-		event.setDetails("targetUserId=" + targetUserId + ",previousTier=" + previousTier + ",newTier=" + newTier);
+		if (auditType == SubscriptionAuditEventType.PLATFORM_ADMIN_ACTION) {
+			event.setDetails("action=plan.tier.change,subscriptionId=" + subscription.getId() + ",previousTier="
+					+ previousTier + ",newTier=" + newTier + ",targetUserId=" + targetUserId + ",auth0Synced="
+					+ auth0SyncSucceeded);
+		}
+		else {
+			event.setDetails("targetUserId=" + targetUserId + ",previousTier=" + previousTier + ",newTier=" + newTier
+					+ ",auth0Synced=" + auth0SyncSucceeded);
+		}
 		subscriptionAuditEventRepository.save(event);
 	}
 

--- a/src/main/java/com/nutriconsultas/subscription/PlanTier.java
+++ b/src/main/java/com/nutriconsultas/subscription/PlanTier.java
@@ -69,6 +69,15 @@ public enum PlanTier {
 		return entitlements.contains(entitlement);
 	}
 
+	public String getDisplayName() {
+		return switch (this) {
+			case BASICO -> "Básico";
+			case PROFESIONAL -> "Profesional";
+			case PLUS -> "Plus";
+			case CONSULTORIO -> "Consultorio";
+		};
+	}
+
 	public static PlanTier fromRoleSlug(final String roleSlug) {
 		for (final PlanTier tier : values()) {
 			if (tier.roleSlug.equals(roleSlug)) {

--- a/src/main/java/com/nutriconsultas/subscription/PlanTierChangeResult.java
+++ b/src/main/java/com/nutriconsultas/subscription/PlanTierChangeResult.java
@@ -1,0 +1,8 @@
+package com.nutriconsultas.subscription;
+
+/**
+ * Outcome of a platform-admin subscription plan tier change (#211).
+ */
+public record PlanTierChangeResult(PlanTier previousTier, PlanTier newTier, boolean auth0SyncSucceeded) {
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.subscription.lifecycle.SubscriptionAccessService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,14 +27,18 @@ public class SubscriptionEntitlementServiceImpl implements SubscriptionEntitleme
 
 	private final SubscriptionProperties subscriptionProperties;
 
+	private final SubscriptionAccessService subscriptionAccessService;
+
 	public SubscriptionEntitlementServiceImpl(final ClinicMemberRepository clinicMemberRepository,
 			final ClinicRepository clinicRepository, final ClinicInvitationRepository clinicInvitationRepository,
-			final PacienteRepository pacienteRepository, final SubscriptionProperties subscriptionProperties) {
+			final PacienteRepository pacienteRepository, final SubscriptionProperties subscriptionProperties,
+			final SubscriptionAccessService subscriptionAccessService) {
 		this.clinicMemberRepository = clinicMemberRepository;
 		this.clinicRepository = clinicRepository;
 		this.clinicInvitationRepository = clinicInvitationRepository;
 		this.pacienteRepository = pacienteRepository;
 		this.subscriptionProperties = subscriptionProperties;
+		this.subscriptionAccessService = subscriptionAccessService;
 	}
 
 	@Override
@@ -96,7 +101,9 @@ public class SubscriptionEntitlementServiceImpl implements SubscriptionEntitleme
 		final Clinic clinic = clinicRepository.findByDirectorUserIdWithSubscription(directorUserId)
 			.orElseThrow(() -> new SubscriptionLimitExceededException(
 					SubscriptionErrorResponses.KEY_NUTRITIONIST_INVITE_DENIED));
-		final PlanEntitlements planEntitlements = PlanEntitlements.forTier(clinic.getSubscription().getPlanTier());
+		final Subscription subscription = subscriptionAccessService.findGrantingSubscriptionForUser(directorUserId)
+			.orElse(clinic.getSubscription());
+		final PlanEntitlements planEntitlements = PlanEntitlements.forTier(subscription.getPlanTier());
 		final int maxNutritionists = planEntitlements.getMaxNutritionists();
 		final long activeMembers = clinicMemberRepository.countByClinicIdAndMembershipStatus(clinic.getId(),
 				MembershipStatus.ACTIVE);
@@ -144,8 +151,11 @@ public class SubscriptionEntitlementServiceImpl implements SubscriptionEntitleme
 	private Optional<UserAccessContext> resolveAccess(final String userId) {
 		final Optional<ClinicMember> memberOpt = clinicMemberRepository.findByUserIdWithClinicAndSubscription(userId);
 		if (memberOpt.isEmpty()) {
-			return clinicRepository.findByDirectorUserIdWithSubscription(userId)
-				.map(clinic -> new UserAccessContext(clinic.getSubscription(), clinic.getId(), true));
+			return clinicRepository.findByDirectorUserIdWithSubscription(userId).flatMap(clinic -> {
+				final Subscription subscription = subscriptionAccessService.findGrantingSubscriptionForUser(userId)
+					.orElse(clinic.getSubscription());
+				return Optional.of(new UserAccessContext(subscription, clinic.getId(), true));
+			});
 		}
 		final ClinicMember member = memberOpt.get();
 		if (member.getMembershipStatus() == MembershipStatus.SUSPENDED) {
@@ -153,8 +163,9 @@ public class SubscriptionEntitlementServiceImpl implements SubscriptionEntitleme
 			return Optional.empty();
 		}
 		final boolean director = member.getRole() == ClinicMemberRole.DIRECTOR;
-		return Optional
-			.of(new UserAccessContext(member.getClinic().getSubscription(), member.getClinic().getId(), director));
+		final Subscription subscription = subscriptionAccessService.findGrantingSubscriptionForUser(userId)
+			.orElse(member.getClinic().getSubscription());
+		return Optional.of(new UserAccessContext(subscription, member.getClinic().getId(), director));
 	}
 
 	private void logSuspendedMember(final String userId) {

--- a/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationDevCheckoutService.java
+++ b/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationDevCheckoutService.java
@@ -1,0 +1,113 @@
+package com.nutriconsultas.subscription.invitation;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nutriconsultas.subscription.InvitationStatus;
+import com.nutriconsultas.subscription.NutritionistInvitation;
+import com.nutriconsultas.subscription.NutritionistInvitationRepository;
+import com.nutriconsultas.subscription.Subscription;
+import com.nutriconsultas.subscription.SubscriptionAuditEvent;
+import com.nutriconsultas.subscription.SubscriptionAuditEventRepository;
+import com.nutriconsultas.subscription.SubscriptionAuditEventType;
+import com.nutriconsultas.subscription.SubscriptionRepository;
+import com.nutriconsultas.subscription.SubscriptionStatus;
+import com.nutriconsultas.subscription.payment.PaymentProperties;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Simulates a successful payment after stub checkout redirect (local dev without Mercado
+ * Pago).
+ */
+@Service
+@Slf4j
+public class NutritionistInvitationDevCheckoutService {
+
+	private final PaymentProperties paymentProperties;
+
+	private final NutritionistInvitationRepository invitationRepository;
+
+	private final SubscriptionRepository subscriptionRepository;
+
+	private final SubscriptionAuditEventRepository auditEventRepository;
+
+	private final SubscriptionProvisioningService provisioningService;
+
+	public NutritionistInvitationDevCheckoutService(final PaymentProperties paymentProperties,
+			final NutritionistInvitationRepository invitationRepository,
+			final SubscriptionRepository subscriptionRepository,
+			final SubscriptionAuditEventRepository auditEventRepository,
+			final SubscriptionProvisioningService provisioningService) {
+		this.paymentProperties = paymentProperties;
+		this.invitationRepository = invitationRepository;
+		this.subscriptionRepository = subscriptionRepository;
+		this.auditEventRepository = auditEventRepository;
+		this.provisioningService = provisioningService;
+	}
+
+	@Transactional
+	public void completeStubCheckout(final OidcUser principal, final Long invitationId) {
+		requireStubSimulateEnabled();
+		if (principal == null || !StringUtils.hasText(principal.getSubject())) {
+			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication required");
+		}
+		if (invitationId == null) {
+			throw new IllegalArgumentException("invitationId is required");
+		}
+		final NutritionistInvitation invitation = invitationRepository.findById(invitationId)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Invitation not found"));
+		if (invitation.getStatus() != InvitationStatus.REDEEMED) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, "La invitación no está lista para activar el pago");
+		}
+		if (!principal.getSubject().equals(invitation.getRedeemedByUserId())) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Solo el usuario invitado puede completar el pago");
+		}
+		final Subscription subscription = invitation.getSubscription();
+		if (subscription == null) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, "La invitación no tiene suscripción asociada");
+		}
+		if (subscription.getStatus() != SubscriptionStatus.PENDING_PAYMENT) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, "La suscripción ya fue activada");
+		}
+		final SubscriptionStatus previousStatus = subscription.getStatus();
+		subscription.setStatus(SubscriptionStatus.ACTIVE);
+		subscription.setPeriodStart(Instant.now());
+		subscription.setPeriodEnd(Instant.now().plus(30, ChronoUnit.DAYS));
+		subscription.setExternalSubscriptionId("stub-sub-" + invitationId);
+		subscription.setExternalCustomerId("stub-cust-" + invitationId);
+		subscriptionRepository.save(subscription);
+		recordStubPaymentAudit(subscription, previousStatus, principal.getSubject());
+		provisioningService.activatePaidAccess(invitation, subscription);
+		if (log.isInfoEnabled()) {
+			log.info("Completed stub checkout: invitationId={}, subscriptionId={}", invitationId, subscription.getId());
+		}
+	}
+
+	private void requireStubSimulateEnabled() {
+		if (!paymentProperties.isStubSimulateCheckout() || paymentProperties.isMercadoPagoConfigured()) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+		}
+	}
+
+	private void recordStubPaymentAudit(final Subscription subscription, final SubscriptionStatus previousStatus,
+			final String actorUserId) {
+		final SubscriptionAuditEvent auditEvent = new SubscriptionAuditEvent();
+		auditEvent.setSubscription(subscription);
+		auditEvent.setEventType(SubscriptionAuditEventType.WEBHOOK_PAYMENT_SUCCEEDED);
+		auditEvent.setActorUserId(actorUserId);
+		auditEvent.setPreviousStatus(previousStatus);
+		auditEvent.setNewStatus(SubscriptionStatus.ACTIVE);
+		auditEvent.setReasonCode("STUB_CHECKOUT");
+		auditEvent.setDetails("provider=stub");
+		auditEventRepository.save(auditEvent);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationRedeemController.java
+++ b/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationRedeemController.java
@@ -17,8 +17,12 @@ public class NutritionistInvitationRedeemController extends AbstractAuthorizedCo
 
 	private final NutritionistInvitationService invitationService;
 
-	public NutritionistInvitationRedeemController(final NutritionistInvitationService invitationService) {
+	private final NutritionistInvitationDevCheckoutService devCheckoutService;
+
+	public NutritionistInvitationRedeemController(final NutritionistInvitationService invitationService,
+			final NutritionistInvitationDevCheckoutService devCheckoutService) {
 		this.invitationService = invitationService;
+		this.devCheckoutService = devCheckoutService;
 	}
 
 	@GetMapping("/redeem")
@@ -33,6 +37,13 @@ public class NutritionistInvitationRedeemController extends AbstractAuthorizedCo
 		if (result instanceof RedeemNutritionistInvitationResult.CheckoutRedirect checkout) {
 			return "redirect:" + checkout.checkoutUrl();
 		}
+		return "redirect:/admin";
+	}
+
+	@GetMapping("/dev-checkout")
+	public String completeDevCheckout(@RequestParam("invitationId") final Long invitationId,
+			@AuthenticationPrincipal final OidcUser principal) {
+		devCheckoutService.completeStubCheckout(principal, invitationId);
 		return "redirect:/admin";
 	}
 

--- a/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationServiceImpl.java
@@ -218,7 +218,7 @@ public class NutritionistInvitationServiceImpl implements NutritionistInvitation
 		}
 		catch (PaymentProviderException ex) {
 			throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
-					"El pago en línea no está configurado. Solicite una invitación exenta de pago al administrador.");
+					"El pago en línea no está configurado. Solicite una invitación exenta de pago al administrador.", ex);
 		}
 	}
 

--- a/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationServiceImpl.java
@@ -26,6 +26,7 @@ import com.nutriconsultas.subscription.SubscriptionStatus;
 import com.nutriconsultas.subscription.payment.BillingInterval;
 import com.nutriconsultas.subscription.payment.CheckoutSession;
 import com.nutriconsultas.subscription.payment.PaymentCheckoutService;
+import com.nutriconsultas.subscription.payment.PaymentProviderException;
 import com.nutriconsultas.util.InvitationTokenHasher;
 
 import lombok.extern.slf4j.Slf4j;
@@ -210,9 +211,15 @@ public class NutritionistInvitationServiceImpl implements NutritionistInvitation
 		}
 		provisioningService.createPendingSubscription(invitation);
 		invitationRepository.save(invitation);
-		final CheckoutSession checkout = paymentCheckoutService.createCheckoutSession(invitation.getId(),
-				invitation.getPlanTier(), BillingInterval.MONTHLY);
-		return new RedeemNutritionistInvitationResult.CheckoutRedirect(checkout.checkoutUrl());
+		try {
+			final CheckoutSession checkout = paymentCheckoutService.createCheckoutSession(invitation.getId(),
+					invitation.getPlanTier(), BillingInterval.MONTHLY);
+			return new RedeemNutritionistInvitationResult.CheckoutRedirect(checkout.checkoutUrl());
+		}
+		catch (PaymentProviderException ex) {
+			throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+					"El pago en línea no está configurado. Solicite una invitación exenta de pago al administrador.");
+		}
 	}
 
 	NutritionistInvitation findValidInvitation(final String rawToken) {

--- a/src/main/java/com/nutriconsultas/subscription/invitation/SubscriptionProvisioningService.java
+++ b/src/main/java/com/nutriconsultas/subscription/invitation/SubscriptionProvisioningService.java
@@ -2,6 +2,7 @@ package com.nutriconsultas.subscription.invitation;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -106,12 +107,43 @@ public class SubscriptionProvisioningService {
 		subscription.setPeriodEnd(Instant.now().plus(TRIAL_PERIOD_DAYS, ChronoUnit.DAYS));
 	}
 
-	private void provisionClinicAccess(final String userId, final PlanTier planTier, final Subscription subscription,
-			final String invitedByUserId) {
-		if (clinicMemberRepository.findByUserIdWithClinicAndSubscription(userId).isPresent()) {
+	private void relinkClinicIfRevoked(final Clinic clinic, final ClinicMember member, final PlanTier planTier,
+			final Subscription subscription, final String userId) {
+		final Subscription existingSubscription = clinic.getSubscription();
+		if (existingSubscription != null && existingSubscription.getId().equals(subscription.getId())) {
 			return;
 		}
-		if (clinicRepository.findByDirectorUserId(userId).isPresent()) {
+		if (existingSubscription != null && grantsClinicAccess(existingSubscription.getStatus())) {
+			return;
+		}
+		clinic.setSubscription(subscription);
+		clinicRepository.save(clinic);
+		if (member != null) {
+			member.setMembershipStatus(MembershipStatus.ACTIVE);
+			clinicMemberRepository.save(member);
+		}
+		recordProvisioningAudit(subscription, userId, planTier);
+		if (log.isInfoEnabled()) {
+			log.info("Re-linked clinic to new subscription: userId={}, clinicId={}, subscriptionId={}, planTier={}",
+					userId, clinic.getId(), subscription.getId(), planTier);
+		}
+	}
+
+	private static boolean grantsClinicAccess(final SubscriptionStatus status) {
+		return status == SubscriptionStatus.TRIAL || status == SubscriptionStatus.ACTIVE
+				|| status == SubscriptionStatus.GRACE;
+	}
+
+	private void provisionClinicAccess(final String userId, final PlanTier planTier, final Subscription subscription,
+			final String invitedByUserId) {
+		final Optional<ClinicMember> memberOpt = clinicMemberRepository.findByUserIdWithClinicAndSubscription(userId);
+		if (memberOpt.isPresent()) {
+			relinkClinicIfRevoked(memberOpt.get().getClinic(), memberOpt.get(), planTier, subscription, userId);
+			return;
+		}
+		final Optional<Clinic> directorClinic = clinicRepository.findByDirectorUserIdWithSubscription(userId);
+		if (directorClinic.isPresent()) {
+			relinkClinicIfRevoked(directorClinic.get(), null, planTier, subscription, userId);
 			return;
 		}
 		final Clinic clinic = new Clinic();

--- a/src/main/java/com/nutriconsultas/subscription/lifecycle/SubscriptionAccessService.java
+++ b/src/main/java/com/nutriconsultas/subscription/lifecycle/SubscriptionAccessService.java
@@ -7,7 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.nutriconsultas.subscription.ClinicMemberRepository;
 import com.nutriconsultas.subscription.ClinicRepository;
+import com.nutriconsultas.subscription.InvitationStatus;
 import com.nutriconsultas.subscription.MembershipStatus;
+import com.nutriconsultas.subscription.NutritionistInvitationRepository;
 import com.nutriconsultas.subscription.Subscription;
 import com.nutriconsultas.subscription.SubscriptionStatus;
 
@@ -18,14 +20,46 @@ public class SubscriptionAccessService {
 
 	private final ClinicRepository clinicRepository;
 
+	private final NutritionistInvitationRepository invitationRepository;
+
 	public SubscriptionAccessService(final ClinicMemberRepository clinicMemberRepository,
-			final ClinicRepository clinicRepository) {
+			final ClinicRepository clinicRepository, final NutritionistInvitationRepository invitationRepository) {
 		this.clinicMemberRepository = clinicMemberRepository;
 		this.clinicRepository = clinicRepository;
+		this.invitationRepository = invitationRepository;
 	}
 
 	@Transactional(readOnly = true)
 	public Optional<Subscription> findSubscriptionForUser(final String userId) {
+		return findGrantingSubscriptionForUser(userId).or(() -> findLinkedSubscription(userId));
+	}
+
+	@Transactional(readOnly = true)
+	public Optional<Subscription> findGrantingSubscriptionForUser(final String userId) {
+		final Optional<Subscription> linked = findLinkedSubscription(userId);
+		if (linked.isPresent() && grantsAdminAccess(linked.get())) {
+			return linked;
+		}
+		return invitationRepository
+			.findFirstByRedeemedByUserIdAndStatusOrderByRedeemedAtDesc(userId, InvitationStatus.REDEEMED)
+			.map(invitation -> invitation.getSubscription())
+			.filter(this::grantsAdminAccess);
+	}
+
+	@Transactional(readOnly = true)
+	public boolean isAdminAccessBlocked(final String userId) {
+		if (findGrantingSubscriptionForUser(userId).isPresent()) {
+			return false;
+		}
+		return findLinkedSubscription(userId).map(this::isBlockedStatus).orElse(false);
+	}
+
+	@Transactional(readOnly = true)
+	public Optional<SubscriptionBanner> resolveBanner(final String userId) {
+		return findGrantingSubscriptionForUser(userId).flatMap(this::bannerForSubscription);
+	}
+
+	private Optional<Subscription> findLinkedSubscription(final String userId) {
 		return clinicMemberRepository.findByUserIdWithClinicAndSubscription(userId)
 			.filter(member -> member.getMembershipStatus() == MembershipStatus.ACTIVE)
 			.map(member -> member.getClinic().getSubscription())
@@ -33,14 +67,8 @@ public class SubscriptionAccessService {
 				.map(clinic -> clinic.getSubscription()));
 	}
 
-	@Transactional(readOnly = true)
-	public boolean isAdminAccessBlocked(final String userId) {
-		return findSubscriptionForUser(userId).map(this::isBlockedStatus).orElse(false);
-	}
-
-	@Transactional(readOnly = true)
-	public Optional<SubscriptionBanner> resolveBanner(final String userId) {
-		return findSubscriptionForUser(userId).flatMap(this::bannerForSubscription);
+	private boolean grantsAdminAccess(final Subscription subscription) {
+		return subscription != null && !isBlockedStatus(subscription);
 	}
 
 	private boolean isBlockedStatus(final Subscription subscription) {

--- a/src/main/java/com/nutriconsultas/subscription/lifecycle/SubscriptionAccessService.java
+++ b/src/main/java/com/nutriconsultas/subscription/lifecycle/SubscriptionAccessService.java
@@ -48,10 +48,8 @@ public class SubscriptionAccessService {
 
 	@Transactional(readOnly = true)
 	public boolean isAdminAccessBlocked(final String userId) {
-		if (findGrantingSubscriptionForUser(userId).isPresent()) {
-			return false;
-		}
-		return findLinkedSubscription(userId).map(this::isBlockedStatus).orElse(false);
+		return findGrantingSubscriptionForUser(userId).isEmpty()
+				&& findLinkedSubscription(userId).map(this::isBlockedStatus).orElse(false);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/nutriconsultas/subscription/payment/PaymentProperties.java
+++ b/src/main/java/com/nutriconsultas/subscription/payment/PaymentProperties.java
@@ -24,6 +24,8 @@ public class PaymentProperties {
 
 	private String currency = "MXN";
 
+	private boolean stubSimulateCheckout = true;
+
 	public String getProvider() {
 		return provider;
 	}
@@ -62,6 +64,14 @@ public class PaymentProperties {
 
 	public void setCurrency(final String currency) {
 		this.currency = currency;
+	}
+
+	public boolean isStubSimulateCheckout() {
+		return stubSimulateCheckout;
+	}
+
+	public void setStubSimulateCheckout(final boolean stubSimulateCheckout) {
+		this.stubSimulateCheckout = stubSimulateCheckout;
 	}
 
 	public boolean isMercadoPagoConfigured() {

--- a/src/main/java/com/nutriconsultas/subscription/payment/StubPaymentProvider.java
+++ b/src/main/java/com/nutriconsultas/subscription/payment/StubPaymentProvider.java
@@ -3,14 +3,29 @@ package com.nutriconsultas.subscription.payment;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.stereotype.Component;
 
+import com.nutriconsultas.subscription.NutritionistInvitation;
+import com.nutriconsultas.subscription.NutritionistInvitationRepository;
 import com.nutriconsultas.subscription.PlanTier;
 
 /**
- * Fallback provider used when Mercado Pago credentials are not configured.
+ * Fallback provider used when Mercado Pago credentials are not configured. Can simulate
+ * checkout locally when {@link PaymentProperties#isStubSimulateCheckout()} is enabled.
  */
 @Component
 @ConditionalOnMissingBean(MercadoPagoPaymentProvider.class)
 public class StubPaymentProvider implements PaymentProvider {
+
+	private static final String STUB_EXTERNAL_ID_PREFIX = "stub-sub-";
+
+	private final PaymentProperties paymentProperties;
+
+	private final NutritionistInvitationRepository invitationRepository;
+
+	public StubPaymentProvider(final PaymentProperties paymentProperties,
+			final NutritionistInvitationRepository invitationRepository) {
+		this.paymentProperties = paymentProperties;
+		this.invitationRepository = invitationRepository;
+	}
 
 	@Override
 	public String getProviderId() {
@@ -20,7 +35,18 @@ public class StubPaymentProvider implements PaymentProvider {
 	@Override
 	public CheckoutSession createCheckoutSession(final Long invitationId, final PlanTier planTier,
 			final BillingInterval billingInterval) {
-		throw new PaymentProviderException("Payment provider is not configured");
+		if (!paymentProperties.isStubSimulateCheckout()) {
+			throw new PaymentProviderException("Payment provider is not configured");
+		}
+		if (invitationId == null) {
+			throw new PaymentProviderException("invitationId is required");
+		}
+		final NutritionistInvitation invitation = invitationRepository.findById(invitationId)
+			.orElseThrow(() -> new PaymentProviderException("Invitation not found"));
+		final Long subscriptionId = invitation.getSubscription() != null ? invitation.getSubscription().getId() : null;
+		final String externalSubscriptionId = STUB_EXTERNAL_ID_PREFIX + invitationId;
+		final String checkoutUrl = "/invitation/nutritionist/dev-checkout?invitationId=" + invitationId;
+		return new CheckoutSession(subscriptionId, checkoutUrl, externalSubscriptionId, "stub-cust-" + invitationId);
 	}
 
 	@Override
@@ -35,7 +61,14 @@ public class StubPaymentProvider implements PaymentProvider {
 
 	@Override
 	public void cancelSubscription(final String externalSubscriptionId) {
+		if (paymentProperties.isStubSimulateCheckout() && isStubExternalId(externalSubscriptionId)) {
+			return;
+		}
 		throw new PaymentProviderException("Payment provider is not configured");
+	}
+
+	private static boolean isStubExternalId(final String externalSubscriptionId) {
+		return externalSubscriptionId != null && externalSubscriptionId.startsWith(STUB_EXTERNAL_ID_PREFIX);
 	}
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,6 +62,7 @@ nutriconsultas.subscription.payment.webhook-secret=${PAYMENT_WEBHOOK_SECRET:}
 nutriconsultas.subscription.payment.mercadopago-access-token=${MERCADOPAGO_ACCESS_TOKEN:}
 nutriconsultas.subscription.payment.mercadopago-back-url=${MERCADOPAGO_BACK_URL:https://minutriporcion.com/admin}
 nutriconsultas.subscription.payment.currency=${PAYMENT_CURRENCY:MXN}
+nutriconsultas.subscription.payment.stub-simulate-checkout=${PAYMENT_STUB_SIMULATE_CHECKOUT:true}
 nutriconsultas.subscription.invitation.expiry-days=${SUBSCRIPTION_INVITATION_EXPIRY_DAYS:7}
 # Production EC2: set APP_BASE_URL in app.env (Terraform user_data or ssm-remediate-app-host.sh).
 nutriconsultas.subscription.invitation.base-url=${APP_BASE_URL:http://localhost:3000}

--- a/src/main/resources/templates/sbadmin/platform/subscriptions/edit.html
+++ b/src/main/resources/templates/sbadmin/platform/subscriptions/edit.html
@@ -30,6 +30,29 @@
           </div>
           <div th:if="${successMessage}" class="alert alert-success" th:text="${successMessage}">Éxito</div>
           <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}">Error</div>
+          <div class="card shadow mb-4" th:if="${subscriptionOwner != null}">
+            <div class="card-header py-3">
+              <h6 class="m-0 font-weight-bold text-secondary">Titular de la suscripción</h6>
+            </div>
+            <div class="card-body">
+              <dl class="row mb-0">
+                <dt class="col-sm-3">Correo</dt>
+                <dd class="col-sm-9" th:text="${subscriptionOwner.hasEmail() ? subscriptionOwner.email() : '—'}">
+                  test@example.com</dd>
+                <dt class="col-sm-3">Usuario (Auth0)</dt>
+                <dd class="col-sm-9">
+                  <code th:if="${subscriptionOwner.hasUserId()}" th:text="${subscriptionOwner.userId()}">auth0|…</code>
+                  <span th:unless="${subscriptionOwner.hasUserId()}" class="text-muted">— (invitación no redimida)</span>
+                </dd>
+                <dt class="col-sm-3" th:if="${subscriptionOwner.invitationId() != null}">Invitación</dt>
+                <dd class="col-sm-9" th:if="${subscriptionOwner.invitationId() != null}">
+                  <a th:href="@{/admin/platform/invitations(highlight=${subscriptionOwner.invitationId()})}">
+                    Ver invitación #<span th:text="${subscriptionOwner.invitationId()}">1</span>
+                  </a>
+                </dd>
+              </dl>
+            </div>
+          </div>
           <div class="card shadow mb-4" th:if="${planTierChangeable}">
             <div class="card-header py-3">
               <h6 class="m-0 font-weight-bold text-primary">Cambiar plan</h6>

--- a/src/main/resources/templates/sbadmin/platform/subscriptions/edit.html
+++ b/src/main/resources/templates/sbadmin/platform/subscriptions/edit.html
@@ -29,6 +29,30 @@
             </a>
           </div>
           <div th:if="${successMessage}" class="alert alert-success" th:text="${successMessage}">Éxito</div>
+          <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}">Error</div>
+          <div class="card shadow mb-4" th:if="${planTierChangeable}">
+            <div class="card-header py-3">
+              <h6 class="m-0 font-weight-bold text-primary">Cambiar plan</h6>
+            </div>
+            <div class="card-body">
+              <p class="text-muted mb-3">Plan actual: <strong th:text="${subscription.planTier}">BASICO</strong>.
+                El cambio aplica de inmediato a los límites y permisos; no requiere nuevo checkout para suscripciones
+                de pago (override administrativo MVP).</p>
+              <form th:action="@{/admin/platform/subscriptions/{id}/change-plan-tier(id=${subscription.id})}"
+                method="post" class="change-plan-tier-form">
+                <div class="form-group">
+                  <label for="newPlanTier">Nuevo plan</label>
+                  <select class="form-control" id="newPlanTier" name="planTier" required>
+                    <option th:each="tier : ${planTiers}" th:value="${tier}" th:text="${tier}"
+                      th:selected="${tier == subscription.planTier}">BASICO</option>
+                  </select>
+                </div>
+                <button type="button" class="btn btn-primary change-plan-tier-btn">
+                  <i class="fas fa-exchange-alt"></i> Cambiar plan
+                </button>
+              </form>
+            </div>
+          </div>
           <div class="card shadow mb-4" th:if="${revocableInvitationId != null}">
             <div class="card-header py-3">
               <h6 class="m-0 font-weight-bold text-danger">Revocar acceso</h6>
@@ -49,8 +73,7 @@
               <h6 class="m-0 font-weight-bold text-primary">Override administrativo</h6>
             </div>
             <div class="card-body">
-              <p class="text-muted">Consultorio: <strong th:text="${clinicName}">—</strong> · Plan:
-                <strong th:text="${subscription.planTier}">BASICO</strong></p>
+              <p class="text-muted">Consultorio: <strong th:text="${clinicName}">—</strong></p>
               <form th:action="@{/admin/platform/subscriptions/{id}(id=${subscription.id})}" th:object="${form}"
                 method="post">
                 <div class="form-group">
@@ -104,6 +127,42 @@
   <script>
     'use strict';
     jQuery(document).ready(function ($) {
+      var currentPlanTier = /*[[${subscription.planTier}]]*/ 'BASICO';
+      var planTierOrder = { BASICO: 0, PROFESIONAL: 1, PLUS: 2, CONSULTORIO: 3 };
+
+      $('.change-plan-tier-btn').on('click', function () {
+        var $form = $(this).closest('.change-plan-tier-form');
+        var newPlanTier = $('#newPlanTier').val();
+        if (newPlanTier === currentPlanTier) {
+          swal({
+            title: 'Sin cambios',
+            text: 'El plan seleccionado es el mismo que el actual.',
+            type: 'info',
+            timer: 2500
+          });
+          return;
+        }
+        var isDowngrade = planTierOrder[newPlanTier] < planTierOrder[currentPlanTier];
+        var text = isDowngrade
+          ? 'Está reduciendo el plan. Si el consultorio supera los límites del nuevo plan, el cambio será rechazado. ¿Desea continuar?'
+          : 'Se actualizarán los permisos y límites del nutriólogo. ¿Desea continuar?';
+        swal({
+          title: 'Cambiar plan',
+          text: text,
+          type: isDowngrade ? 'warning' : 'info',
+          showCancelButton: true,
+          confirmButtonColor: isDowngrade ? '#d33' : '#3085d6',
+          cancelButtonColor: '#6c757d',
+          confirmButtonText: 'Sí, cambiar plan',
+          cancelButtonText: 'No',
+          closeOnConfirm: true
+        }, function (isConfirm) {
+          if (isConfirm) {
+            $form.submit();
+          }
+        });
+      });
+
       $('.revoke-subscription-access-btn').on('click', function () {
         var $form = $(this).closest('.revoke-subscription-access-form');
         swal({

--- a/src/main/resources/templates/sbadmin/platform/subscriptions/list.html
+++ b/src/main/resources/templates/sbadmin/platform/subscriptions/list.html
@@ -36,6 +36,8 @@
                   <thead>
                     <tr>
                       <th>ID</th>
+                      <th>Correo titular</th>
+                      <th>Usuario (Auth0)</th>
                       <th>Consultorio</th>
                       <th>Plan</th>
                       <th>Estado</th>
@@ -99,7 +101,7 @@
           }
         },
         columnDefs: [
-          { targets: 6, orderable: false, searchable: false }
+          { targets: 8, orderable: false, searchable: false }
         ]
       });
     });

--- a/src/main/resources/templates/sbadmin/platform/subscriptions/list.html
+++ b/src/main/resources/templates/sbadmin/platform/subscriptions/list.html
@@ -26,6 +26,7 @@
             <h1 class="h3 mb-0 text-gray-800">Suscripciones</h1>
           </div>
           <div th:if="${successMessage}" class="alert alert-success" th:text="${successMessage}">Éxito</div>
+          <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}">Error</div>
           <div class="card shadow mb-4">
             <div class="card-header py-3">
               <h6 class="m-0 font-weight-bold text-primary">Estado de suscripciones</h6>
@@ -37,7 +38,6 @@
                     <tr>
                       <th>ID</th>
                       <th>Correo titular</th>
-                      <th>Usuario (Auth0)</th>
                       <th>Consultorio</th>
                       <th>Plan</th>
                       <th>Estado</th>
@@ -101,7 +101,7 @@
           }
         },
         columnDefs: [
-          { targets: 8, orderable: false, searchable: false }
+          { targets: 7, orderable: false, searchable: false }
         ]
       });
     });

--- a/src/main/resources/templates/sbadmin/profile/formulario.html
+++ b/src/main/resources/templates/sbadmin/profile/formulario.html
@@ -51,6 +51,46 @@
             <!-- Content Row -->
             <div class="row">
 
+              <!-- Subscription Plan Card -->
+              <div class="col-12">
+                <div class="card shadow mb-4 border-left-primary">
+                  <div class="card-body py-3">
+                    <div class="row no-gutters align-items-center">
+                      <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">
+                          Plan de suscripción
+                        </div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800" th:if="${subscriptionPlanLabel != null}"
+                          th:text="${subscriptionPlanLabel}">Básico</div>
+                        <div class="text-muted" th:unless="${subscriptionPlanLabel != null}">
+                          No tiene una suscripción activa.
+                        </div>
+                        <div class="text-muted small mt-2" th:if="${subscriptionPlanLabel != null}">
+                          <span th:if="${subscriptionPeriodStartLabel != null && subscriptionPeriodEndLabel != null}">
+                            Vigencia del <strong th:text="${subscriptionPeriodStartLabel}">01/06/2026</strong>
+                            al <strong th:text="${subscriptionPeriodEndLabel}">01/07/2026</strong>
+                          </span>
+                          <span th:if="${subscriptionPeriodStartLabel == null && subscriptionPeriodEndLabel != null}">
+                            Vigente hasta el <strong th:text="${subscriptionPeriodEndLabel}">01/07/2026</strong>
+                          </span>
+                          <span th:if="${subscriptionPeriodStartLabel != null && subscriptionPeriodEndLabel == null}">
+                            Vigencia desde el <strong th:text="${subscriptionPeriodStartLabel}">01/06/2026</strong>
+                          </span>
+                          <span th:if="${subscriptionPeriodStartLabel == null && subscriptionPeriodEndLabel == null}">
+                            Vigencia no definida.
+                          </span>
+                        </div>
+                      </div>
+                      <div class="col-auto" th:if="${subscriptionStatus != null}">
+                        <span class="badge badge-pill"
+                          th:classappend="${subscriptionStatus.name() == 'ACTIVE' || subscriptionStatus.name() == 'TRIAL' ? ' badge-success' : (subscriptionStatus.name() == 'GRACE' ? ' badge-warning' : ' badge-secondary')}"
+                          th:text="${subscriptionStatus.name()}">ACTIVE</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
               <!-- Profile Text Fields Card -->
               <div class="col-xl-6 col-lg-7">
                 <div class="card shadow mb-4">

--- a/src/main/resources/templates/sbadmin/topbar.html
+++ b/src/main/resources/templates/sbadmin/topbar.html
@@ -57,9 +57,9 @@
         </a>
         <!-- Dropdown - User Information -->
         <div class="dropdown-menu dropdown-menu-right shadow animated--grow-in" aria-labelledby="userDropdown">
-          <a class="dropdown-item" href="#">
+          <a class="dropdown-item" th:href="@{/admin/perfil}">
             <i class="fas fa-user fa-sm fa-fw mr-2 text-gray-400"></i>
-            Profile
+            Perfil
           </a>
           <a class="dropdown-item" href="#">
             <i class="fas fa-cogs fa-sm fa-fw mr-2 text-gray-400"></i>

--- a/src/test/java/com/nutriconsultas/admin/SubscriptionAdminAccessRulesTest.java
+++ b/src/test/java/com/nutriconsultas/admin/SubscriptionAdminAccessRulesTest.java
@@ -1,0 +1,28 @@
+package com.nutriconsultas.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.subscription.Subscription;
+import com.nutriconsultas.subscription.SubscriptionStatus;
+
+class SubscriptionAdminAccessRulesTest {
+
+	@Test
+	void isEditable_falseWhenCancelled() {
+		final Subscription subscription = new Subscription();
+		subscription.setStatus(SubscriptionStatus.CANCELLED);
+
+		assertThat(SubscriptionAdminAccessRules.isEditable(subscription)).isFalse();
+	}
+
+	@Test
+	void isEditable_trueWhenActive() {
+		final Subscription subscription = new Subscription();
+		subscription.setStatus(SubscriptionStatus.ACTIVE);
+
+		assertThat(SubscriptionAdminAccessRules.isEditable(subscription)).isTrue();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/admin/SubscriptionAdminControllerTest.java
+++ b/src/test/java/com/nutriconsultas/admin/SubscriptionAdminControllerTest.java
@@ -58,6 +58,9 @@ class SubscriptionAdminControllerTest {
 	@Mock
 	private NutritionistRoleService nutritionistRoleService;
 
+	@Mock
+	private SubscriptionOwnerResolver ownerResolver;
+
 	@Test
 	void list_whenNotPlatformAdmin_throwsForbidden() {
 		final OidcUser principal = principal("auth0|user");

--- a/src/test/java/com/nutriconsultas/admin/SubscriptionAdminControllerTest.java
+++ b/src/test/java/com/nutriconsultas/admin/SubscriptionAdminControllerTest.java
@@ -23,9 +23,11 @@ import com.nutriconsultas.subscription.InvitationStatus;
 import com.nutriconsultas.subscription.NutritionistInvitation;
 import com.nutriconsultas.subscription.NutritionistInvitationRepository;
 import com.nutriconsultas.subscription.PlanTier;
+import com.nutriconsultas.subscription.PlanTierChangeResult;
 import com.nutriconsultas.subscription.Subscription;
 import com.nutriconsultas.subscription.SubscriptionRepository;
 import com.nutriconsultas.subscription.SubscriptionStatus;
+import com.nutriconsultas.subscription.NutritionistRoleService;
 import com.nutriconsultas.subscription.invitation.NutritionistInvitationService;
 import com.nutriconsultas.subscription.lifecycle.SubscriptionLifecycleService;
 
@@ -53,6 +55,9 @@ class SubscriptionAdminControllerTest {
 	@Mock
 	private NutritionistInvitationService invitationService;
 
+	@Mock
+	private NutritionistRoleService nutritionistRoleService;
+
 	@Test
 	void list_whenNotPlatformAdmin_throwsForbidden() {
 		final OidcUser principal = principal("auth0|user");
@@ -74,6 +79,22 @@ class SubscriptionAdminControllerTest {
 		verify(platformAdminAuthorization).requirePlatformAdmin(principal, "subscriptions.list");
 		assertThat(view).isEqualTo("sbadmin/platform/subscriptions/list");
 		assertThat(model.getAttribute("activeMenu")).isEqualTo("subscriptions");
+	}
+
+	@Test
+	void changePlanTier_whenPlatformAdmin_delegatesToRoleService() {
+		final OidcUser principal = principal("auth0|admin");
+		when(nutritionistRoleService.changeSubscriptionPlanTier(principal, 9L, PlanTier.PLUS))
+			.thenReturn(new PlanTierChangeResult(PlanTier.BASICO, PlanTier.PLUS, true));
+		final org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap redirectAttributes = new org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap();
+
+		final String view = controller.changePlanTier(principal, 9L, PlanTier.PLUS, redirectAttributes);
+
+		verify(platformAdminAuthorization).requirePlatformAdmin(principal, "subscriptions.change-plan-tier");
+		verify(nutritionistRoleService).changeSubscriptionPlanTier(principal, 9L, PlanTier.PLUS);
+		assertThat(view).isEqualTo("redirect:/admin/platform/subscriptions/9/edit");
+		assertThat(redirectAttributes.getFlashAttributes().get("successMessage")).asString()
+			.contains("Plan actualizado");
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/admin/SubscriptionAdminControllerTest.java
+++ b/src/test/java/com/nutriconsultas/admin/SubscriptionAdminControllerTest.java
@@ -85,8 +85,27 @@ class SubscriptionAdminControllerTest {
 	}
 
 	@Test
+	void editForm_whenSubscriptionCancelled_redirectsToList() {
+		final OidcUser principal = principal("auth0|admin");
+		final Subscription subscription = new Subscription();
+		subscription.setId(5L);
+		subscription.setStatus(SubscriptionStatus.CANCELLED);
+		when(subscriptionRepository.findById(5L)).thenReturn(java.util.Optional.of(subscription));
+		final org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap redirectAttributes = new org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap();
+
+		final String view = controller.editForm(principal, 5L, new ExtendedModelMap(), redirectAttributes);
+
+		assertThat(view).isEqualTo("redirect:/admin/platform/subscriptions");
+		assertThat(redirectAttributes.getFlashAttributes().get("errorMessage")).asString().contains("revocadas");
+	}
+
+	@Test
 	void changePlanTier_whenPlatformAdmin_delegatesToRoleService() {
 		final OidcUser principal = principal("auth0|admin");
+		final Subscription subscription = new Subscription();
+		subscription.setId(9L);
+		subscription.setStatus(SubscriptionStatus.ACTIVE);
+		when(subscriptionRepository.findById(9L)).thenReturn(java.util.Optional.of(subscription));
 		when(nutritionistRoleService.changeSubscriptionPlanTier(principal, 9L, PlanTier.PLUS))
 			.thenReturn(new PlanTierChangeResult(PlanTier.BASICO, PlanTier.PLUS, true));
 		final org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap redirectAttributes = new org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap();

--- a/src/test/java/com/nutriconsultas/admin/SubscriptionAdminRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/admin/SubscriptionAdminRestControllerTest.java
@@ -94,9 +94,27 @@ class SubscriptionAdminRestControllerTest {
 		assertThat(pageArray.getData()).hasSize(1);
 		assertThat(pageArray.getData().get(0).get(0)).isEqualTo("2");
 		assertThat(pageArray.getData().get(0).get(1)).isEqualTo("nutri@example.com");
-		assertThat(pageArray.getData().get(0).get(2)).contains("auth0|owner-1");
-		assertThat(pageArray.getData().get(0).get(3)).isEqualTo("Minutriporción");
-		assertThat(pageArray.getData().get(0).get(4)).isEqualTo("PROFESIONAL");
+		assertThat(pageArray.getData().get(0).get(2)).isEqualTo("Minutriporción");
+		assertThat(pageArray.getData().get(0).get(3)).isEqualTo("PROFESIONAL");
+	}
+
+	@Test
+	void getPageArray_whenSubscriptionCancelled_showsRevokedLabelInsteadOfEditLink() {
+		final Subscription subscription = new Subscription();
+		subscription.setId(4L);
+		subscription.setPlanTier(PlanTier.BASICO);
+		subscription.setStatus(SubscriptionStatus.CANCELLED);
+		when(gridService.findPage(any(Pageable.class))).thenReturn(new PageImpl<>(List.of(subscription)));
+		when(gridService.countAll()).thenReturn(1L);
+		when(ownerResolver.resolve(4L)).thenReturn(Optional.empty());
+		final PagingRequest pagingRequest = new PagingRequest();
+		pagingRequest.setDraw(1);
+		pagingRequest.setStart(0);
+		pagingRequest.setLength(25);
+
+		final PageArray pageArray = controller.getPageArray(pagingRequest);
+
+		assertThat(pageArray.getData().get(0).get(7)).contains("Revocada");
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/admin/SubscriptionAdminRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/admin/SubscriptionAdminRestControllerTest.java
@@ -42,6 +42,9 @@ class SubscriptionAdminRestControllerTest {
 	private ClinicRepository clinicRepository;
 
 	@Mock
+	private SubscriptionOwnerResolver ownerResolver;
+
+	@Mock
 	private PlatformAdminAuthorization platformAdminAuthorization;
 
 	@Mock
@@ -76,6 +79,8 @@ class SubscriptionAdminRestControllerTest {
 		final Clinic clinic = new Clinic();
 		clinic.setName("Minutriporción");
 		when(clinicRepository.findBySubscriptionId(2L)).thenReturn(Optional.of(clinic));
+		when(ownerResolver.resolve(2L))
+			.thenReturn(Optional.of(new SubscriptionOwnerView("nutri@example.com", "auth0|owner-1", 6L)));
 		final PagingRequest pagingRequest = new PagingRequest();
 		pagingRequest.setDraw(1);
 		pagingRequest.setStart(0);
@@ -88,8 +93,10 @@ class SubscriptionAdminRestControllerTest {
 		assertThat(pageArray.getRecordsFiltered()).isEqualTo(1);
 		assertThat(pageArray.getData()).hasSize(1);
 		assertThat(pageArray.getData().get(0).get(0)).isEqualTo("2");
-		assertThat(pageArray.getData().get(0).get(1)).isEqualTo("Minutriporción");
-		assertThat(pageArray.getData().get(0).get(2)).isEqualTo("PROFESIONAL");
+		assertThat(pageArray.getData().get(0).get(1)).isEqualTo("nutri@example.com");
+		assertThat(pageArray.getData().get(0).get(2)).contains("auth0|owner-1");
+		assertThat(pageArray.getData().get(0).get(3)).isEqualTo("Minutriporción");
+		assertThat(pageArray.getData().get(0).get(4)).isEqualTo("PROFESIONAL");
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/admin/SubscriptionOwnerResolverTest.java
+++ b/src/test/java/com/nutriconsultas/admin/SubscriptionOwnerResolverTest.java
@@ -1,0 +1,80 @@
+package com.nutriconsultas.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.subscription.Clinic;
+import com.nutriconsultas.subscription.ClinicRepository;
+import com.nutriconsultas.subscription.InvitationStatus;
+import com.nutriconsultas.subscription.NutritionistInvitation;
+import com.nutriconsultas.subscription.NutritionistInvitationRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionOwnerResolverTest {
+
+	@InjectMocks
+	private SubscriptionOwnerResolver resolver;
+
+	@Mock
+	private NutritionistInvitationRepository invitationRepository;
+
+	@Mock
+	private ClinicRepository clinicRepository;
+
+	@Test
+	void resolve_whenInvitationRedeemed_returnsEmailAndUserId() {
+		final NutritionistInvitation invitation = new NutritionistInvitation();
+		invitation.setId(7L);
+		invitation.setEmail("nutri@example.com");
+		invitation.setRedeemedByUserId("auth0|redeemed-user");
+		org.mockito.Mockito.when(invitationRepository.findBySubscriptionId(3L)).thenReturn(Optional.of(invitation));
+
+		final Optional<SubscriptionOwnerView> owner = resolver.resolve(3L);
+
+		assertThat(owner).isPresent();
+		assertThat(owner.get().email()).isEqualTo("nutri@example.com");
+		assertThat(owner.get().userId()).isEqualTo("auth0|redeemed-user");
+		assertThat(owner.get().invitationId()).isEqualTo(7L);
+	}
+
+	@Test
+	void resolve_whenInvitationPending_usesClinicDirectorAsFallbackUserId() {
+		final NutritionistInvitation invitation = new NutritionistInvitation();
+		invitation.setId(8L);
+		invitation.setEmail("pending@example.com");
+		invitation.setStatus(InvitationStatus.PENDING);
+		final Clinic clinic = new Clinic();
+		clinic.setDirectorUserId("auth0|director-fallback");
+		org.mockito.Mockito.when(invitationRepository.findBySubscriptionId(4L)).thenReturn(Optional.of(invitation));
+		org.mockito.Mockito.when(clinicRepository.findBySubscriptionId(4L)).thenReturn(Optional.of(clinic));
+
+		final Optional<SubscriptionOwnerView> owner = resolver.resolve(4L);
+
+		assertThat(owner).isPresent();
+		assertThat(owner.get().email()).isEqualTo("pending@example.com");
+		assertThat(owner.get().userId()).isEqualTo("auth0|director-fallback");
+	}
+
+	@Test
+	void resolve_whenNoInvitation_usesClinicDirectorOnly() {
+		final Clinic clinic = new Clinic();
+		clinic.setDirectorUserId("auth0|solo-director");
+		org.mockito.Mockito.when(invitationRepository.findBySubscriptionId(5L)).thenReturn(Optional.empty());
+		org.mockito.Mockito.when(clinicRepository.findBySubscriptionId(5L)).thenReturn(Optional.of(clinic));
+
+		final Optional<SubscriptionOwnerView> owner = resolver.resolve(5L);
+
+		assertThat(owner).isPresent();
+		assertThat(owner.get().email()).isNull();
+		assertThat(owner.get().userId()).isEqualTo("auth0|solo-director");
+		assertThat(owner.get().invitationId()).isNull();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/profile/NutritionistProfileControllerTest.java
+++ b/src/test/java/com/nutriconsultas/profile/NutritionistProfileControllerTest.java
@@ -5,6 +5,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
+import java.time.Instant;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +20,13 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+
+import com.nutriconsultas.subscription.PlanTier;
+import com.nutriconsultas.subscription.Subscription;
+import com.nutriconsultas.subscription.SubscriptionStatus;
+import com.nutriconsultas.subscription.lifecycle.SubscriptionAccessService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -37,6 +48,9 @@ public class NutritionistProfileControllerTest {
 	@Mock
 	private NutritionistProfileService profileService;
 
+	@Mock
+	private SubscriptionAccessService subscriptionAccessService;
+
 	private MockMvc mockMvc;
 
 	private NutritionistProfile mockProfile;
@@ -49,6 +63,33 @@ public class NutritionistProfileControllerTest {
 		mockProfile.setUserId("auth0|test123");
 		mockProfile.setCedulaProfesional("12345678");
 		mockProfile.setDisplayName("Dra. Test");
+	}
+
+	@Test
+	public void perfilAddsSubscriptionPlanToModel() {
+		when(profileService.getOrCreateProfile("auth0|test123")).thenReturn(mockProfile);
+		final Subscription subscription = new Subscription();
+		subscription.setPlanTier(PlanTier.BASICO);
+		subscription.setStatus(SubscriptionStatus.ACTIVE);
+		subscription.setPeriodStart(Instant.parse("2026-06-01T12:00:00Z"));
+		subscription.setPeriodEnd(Instant.parse("2026-07-01T12:00:00Z"));
+		when(subscriptionAccessService.findGrantingSubscriptionForUser("auth0|test123"))
+			.thenReturn(Optional.of(subscription));
+
+		final Model model = new ExtendedModelMap();
+		final String view = controller.perfil(org.mockito.Mockito.mock(
+				org.springframework.security.oauth2.core.oidc.user.OidcUser.class, invocation -> {
+					if ("getSubject".equals(invocation.getMethod().getName())) {
+						return "auth0|test123";
+					}
+					return org.mockito.Mockito.RETURNS_DEFAULTS.answer(invocation);
+				}), model);
+
+		assertThat(view).isEqualTo("sbadmin/profile/formulario");
+		assertThat(model.getAttribute("subscriptionPlanLabel")).isEqualTo("Básico");
+		assertThat(model.getAttribute("subscriptionStatus")).isEqualTo(SubscriptionStatus.ACTIVE);
+		assertThat(model.getAttribute("subscriptionPeriodStartLabel")).isEqualTo("01/06/2026");
+		assertThat(model.getAttribute("subscriptionPeriodEndLabel")).isEqualTo("01/07/2026");
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/subscription/NutritionistRoleServiceTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/NutritionistRoleServiceTest.java
@@ -3,11 +3,13 @@ package com.nutriconsultas.subscription;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -21,10 +23,15 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.nutriconsultas.auth0.Auth0RoleSyncClient;
+import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.platform.PlatformAdminService;
 
 @ExtendWith(MockitoExtension.class)
 class NutritionistRoleServiceTest {
+
+	private static final String TARGET_USER_ID = "auth0|target";
+
+	private static final String ADMIN_USER_ID = "auth0|admin-one";
 
 	@InjectMocks
 	private NutritionistRoleServiceImpl service;
@@ -42,6 +49,12 @@ class NutritionistRoleServiceTest {
 	private SubscriptionRepository subscriptionRepository;
 
 	@Mock
+	private NutritionistInvitationRepository invitationRepository;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Mock
 	private Auth0RoleSyncClient auth0RoleSyncClient;
 
 	@Mock
@@ -55,7 +68,7 @@ class NutritionistRoleServiceTest {
 		doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN)).when(platformAdminService)
 			.requirePlatformAdmin(adminPrincipal);
 
-		assertThatThrownBy(() -> service.assignRole(adminPrincipal, "auth0|target", PlanTier.BASICO))
+		assertThatThrownBy(() -> service.assignRole(adminPrincipal, TARGET_USER_ID, PlanTier.BASICO))
 			.isInstanceOf(ResponseStatusException.class)
 			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode().value())
 			.isEqualTo(403);
@@ -66,11 +79,10 @@ class NutritionistRoleServiceTest {
 
 	@Test
 	void assignRole_whenSubscriptionNotFound_throwsNotFound() {
-		when(clinicRepository.findByDirectorUserIdWithSubscription("auth0|missing")).thenReturn(Optional.empty());
-		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription("auth0|missing"))
-			.thenReturn(Optional.empty());
+		when(clinicRepository.findByDirectorUserIdWithSubscription(TARGET_USER_ID)).thenReturn(Optional.empty());
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(TARGET_USER_ID)).thenReturn(Optional.empty());
 
-		assertThatThrownBy(() -> service.assignRole(adminPrincipal, "auth0|missing", PlanTier.BASICO))
+		assertThatThrownBy(() -> service.assignRole(adminPrincipal, TARGET_USER_ID, PlanTier.BASICO))
 			.isInstanceOf(ResponseStatusException.class)
 			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode().value())
 			.isEqualTo(404);
@@ -78,47 +90,155 @@ class NutritionistRoleServiceTest {
 
 	@Test
 	void assignRole_whenDirector_updatesDbSyncsAuth0AndAudits() {
-		final Subscription subscription = new Subscription();
-		subscription.setId(1L);
-		subscription.setPlanTier(PlanTier.BASICO);
-		final Clinic clinic = new Clinic();
-		clinic.setSubscription(subscription);
-		when(clinicRepository.findByDirectorUserIdWithSubscription("auth0|target")).thenReturn(Optional.of(clinic));
-		when(platformAdminService.resolveActorUserId(adminPrincipal)).thenReturn("auth0|admin-one");
+		final Subscription subscription = activeSubscription(PlanTier.BASICO);
+		final Clinic clinic = clinicWithSubscription(subscription);
+		when(clinicRepository.findByDirectorUserIdWithSubscription(TARGET_USER_ID)).thenReturn(Optional.of(clinic));
+		when(clinicRepository.findBySubscriptionId(1L)).thenReturn(Optional.of(clinic));
+		when(invitationRepository.findBySubscriptionId(1L)).thenReturn(Optional.empty());
+		when(platformAdminService.resolveActorUserId(adminPrincipal)).thenReturn(ADMIN_USER_ID);
+		when(auth0RoleSyncClient.isConfigured()).thenReturn(true);
 
-		service.assignRole(adminPrincipal, "auth0|target", PlanTier.PROFESIONAL);
+		service.assignRole(adminPrincipal, TARGET_USER_ID, PlanTier.PROFESIONAL);
 
 		assertThat(subscription.getPlanTier()).isEqualTo(PlanTier.PROFESIONAL);
 		verify(subscriptionRepository).save(subscription);
-		verify(auth0RoleSyncClient).syncPlanRole("auth0|target", PlanTier.PROFESIONAL);
+		verify(auth0RoleSyncClient).syncPlanRole(TARGET_USER_ID, PlanTier.PROFESIONAL);
 		final ArgumentCaptor<SubscriptionAuditEvent> auditCaptor = ArgumentCaptor
 			.forClass(SubscriptionAuditEvent.class);
 		verify(subscriptionAuditEventRepository).save(auditCaptor.capture());
 		final SubscriptionAuditEvent audit = auditCaptor.getValue();
 		assertThat(audit.getEventType()).isEqualTo(SubscriptionAuditEventType.ROLE_ASSIGNED);
-		assertThat(audit.getActorUserId()).isEqualTo("auth0|admin-one");
-		assertThat(audit.getDetails()).contains("targetUserId=auth0|target");
+		assertThat(audit.getActorUserId()).isEqualTo(ADMIN_USER_ID);
+		assertThat(audit.getDetails()).contains("targetUserId=" + TARGET_USER_ID);
 		assertThat(audit.getDetails()).contains("previousTier=BASICO");
 		assertThat(audit.getDetails()).contains("newTier=PROFESIONAL");
 	}
 
 	@Test
 	void assignRole_whenClinicMember_resolvesSubscriptionViaMember() {
-		final Subscription subscription = new Subscription();
-		subscription.setPlanTier(PlanTier.PLUS);
-		final Clinic clinic = new Clinic();
-		clinic.setSubscription(subscription);
+		final Subscription subscription = activeSubscription(PlanTier.PLUS);
+		final Clinic clinic = clinicWithSubscription(subscription);
 		final ClinicMember member = new ClinicMember();
 		member.setClinic(clinic);
-		when(clinicRepository.findByDirectorUserIdWithSubscription("auth0|member")).thenReturn(Optional.empty());
-		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription("auth0|member"))
+		when(clinicRepository.findByDirectorUserIdWithSubscription(TARGET_USER_ID)).thenReturn(Optional.empty());
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(TARGET_USER_ID))
 			.thenReturn(Optional.of(member));
-		when(platformAdminService.resolveActorUserId(adminPrincipal)).thenReturn("auth0|admin-one");
+		when(clinicRepository.findBySubscriptionId(1L)).thenReturn(Optional.of(clinic));
+		when(invitationRepository.findBySubscriptionId(1L)).thenReturn(Optional.empty());
+		when(platformAdminService.resolveActorUserId(adminPrincipal)).thenReturn(ADMIN_USER_ID);
+		when(auth0RoleSyncClient.isConfigured()).thenReturn(true);
 
-		service.assignRole(adminPrincipal, "auth0|member", PlanTier.CONSULTORIO);
+		service.assignRole(adminPrincipal, TARGET_USER_ID, PlanTier.CONSULTORIO);
 
-		verify(auth0RoleSyncClient).syncPlanRole("auth0|member", PlanTier.CONSULTORIO);
+		verify(auth0RoleSyncClient).syncPlanRole(TARGET_USER_ID, PlanTier.CONSULTORIO);
 		assertThat(subscription.getPlanTier()).isEqualTo(PlanTier.CONSULTORIO);
+	}
+
+	@Test
+	void changeSubscriptionPlanTier_whenDowngradeExceedsPatientCap_throwsConflict() {
+		final Subscription subscription = activeSubscription(PlanTier.PROFESIONAL);
+		final Clinic clinic = clinicWithSubscription(subscription);
+		clinic.setId(5L);
+		when(subscriptionRepository.findById(1L)).thenReturn(Optional.of(subscription));
+		when(clinicRepository.findBySubscriptionId(1L)).thenReturn(Optional.of(clinic));
+		when(clinicMemberRepository.findUserIdsByClinicIdAndMembershipStatus(5L, MembershipStatus.ACTIVE))
+			.thenReturn(List.of(TARGET_USER_ID));
+		when(pacienteRepository.countByUserIdIn(List.of(TARGET_USER_ID))).thenReturn(25L);
+
+		assertThatThrownBy(() -> service.changeSubscriptionPlanTier(adminPrincipal, 1L, PlanTier.BASICO))
+			.isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode().value())
+			.isEqualTo(409);
+
+		verify(subscriptionRepository, never()).save(any());
+	}
+
+	@Test
+	void changeSubscriptionPlanTier_whenActive_upgradesAndAuditsPlatformAdminAction() {
+		final Subscription subscription = activeSubscription(PlanTier.BASICO);
+		final Clinic clinic = clinicWithSubscription(subscription);
+		clinic.setId(5L);
+		clinic.setDirectorUserId(TARGET_USER_ID);
+		final NutritionistInvitation invitation = new NutritionistInvitation();
+		invitation.setPlanTier(PlanTier.BASICO);
+		invitation.setRedeemedByUserId(TARGET_USER_ID);
+		when(subscriptionRepository.findById(1L)).thenReturn(Optional.of(subscription));
+		when(clinicRepository.findBySubscriptionId(1L)).thenReturn(Optional.of(clinic));
+		when(invitationRepository.findBySubscriptionId(1L)).thenReturn(Optional.of(invitation));
+		when(clinicMemberRepository.findUserIdsByClinicIdAndMembershipStatus(5L, MembershipStatus.ACTIVE))
+			.thenReturn(List.of(TARGET_USER_ID));
+		when(pacienteRepository.countByUserIdIn(List.of(TARGET_USER_ID))).thenReturn(3L);
+		when(clinicMemberRepository.countByClinicIdAndMembershipStatus(5L, MembershipStatus.ACTIVE)).thenReturn(1L);
+		when(platformAdminService.resolveActorUserId(adminPrincipal)).thenReturn(ADMIN_USER_ID);
+		when(auth0RoleSyncClient.isConfigured()).thenReturn(true);
+
+		final PlanTierChangeResult result = service.changeSubscriptionPlanTier(adminPrincipal, 1L,
+				PlanTier.PROFESIONAL);
+
+		assertThat(result.previousTier()).isEqualTo(PlanTier.BASICO);
+		assertThat(result.newTier()).isEqualTo(PlanTier.PROFESIONAL);
+		assertThat(result.auth0SyncSucceeded()).isTrue();
+		assertThat(subscription.getPlanTier()).isEqualTo(PlanTier.PROFESIONAL);
+		assertThat(invitation.getPlanTier()).isEqualTo(PlanTier.PROFESIONAL);
+		verify(auth0RoleSyncClient).syncPlanRole(TARGET_USER_ID, PlanTier.PROFESIONAL);
+		final ArgumentCaptor<SubscriptionAuditEvent> auditCaptor = ArgumentCaptor
+			.forClass(SubscriptionAuditEvent.class);
+		verify(subscriptionAuditEventRepository).save(auditCaptor.capture());
+		assertThat(auditCaptor.getValue().getEventType()).isEqualTo(SubscriptionAuditEventType.PLATFORM_ADMIN_ACTION);
+		assertThat(auditCaptor.getValue().getDetails()).contains("action=plan.tier.change");
+		assertThat(auditCaptor.getValue().getDetails()).contains("previousTier=BASICO");
+		assertThat(auditCaptor.getValue().getDetails()).contains("newTier=PROFESIONAL");
+	}
+
+	@Test
+	void changeSubscriptionPlanTier_whenAuth0SyncFails_stillPersistsTierAndReportsFailure() {
+		final Subscription subscription = activeSubscription(PlanTier.BASICO);
+		final Clinic clinic = clinicWithSubscription(subscription);
+		clinic.setId(5L);
+		clinic.setDirectorUserId(TARGET_USER_ID);
+		when(subscriptionRepository.findById(1L)).thenReturn(Optional.of(subscription));
+		when(clinicRepository.findBySubscriptionId(1L)).thenReturn(Optional.of(clinic));
+		when(invitationRepository.findBySubscriptionId(1L)).thenReturn(Optional.empty());
+		when(clinicMemberRepository.countByClinicIdAndMembershipStatus(5L, MembershipStatus.ACTIVE)).thenReturn(1L);
+		when(platformAdminService.resolveActorUserId(adminPrincipal)).thenReturn(ADMIN_USER_ID);
+		when(auth0RoleSyncClient.isConfigured()).thenReturn(true);
+		doThrow(new RuntimeException("Auth0 down")).when(auth0RoleSyncClient)
+			.syncPlanRole(eq(TARGET_USER_ID), eq(PlanTier.PLUS));
+
+		final PlanTierChangeResult result = service.changeSubscriptionPlanTier(adminPrincipal, 1L, PlanTier.PLUS);
+
+		assertThat(result.auth0SyncSucceeded()).isFalse();
+		assertThat(subscription.getPlanTier()).isEqualTo(PlanTier.PLUS);
+		final ArgumentCaptor<SubscriptionAuditEvent> auditCaptor = ArgumentCaptor
+			.forClass(SubscriptionAuditEvent.class);
+		verify(subscriptionAuditEventRepository).save(auditCaptor.capture());
+		assertThat(auditCaptor.getValue().getDetails()).contains("auth0Synced=false");
+	}
+
+	@Test
+	void changeSubscriptionPlanTier_whenCancelled_throwsConflict() {
+		final Subscription subscription = activeSubscription(PlanTier.BASICO);
+		subscription.setStatus(SubscriptionStatus.CANCELLED);
+		when(subscriptionRepository.findById(1L)).thenReturn(Optional.of(subscription));
+
+		assertThatThrownBy(() -> service.changeSubscriptionPlanTier(adminPrincipal, 1L, PlanTier.PLUS))
+			.isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode().value())
+			.isEqualTo(409);
+	}
+
+	private static Subscription activeSubscription(final PlanTier planTier) {
+		final Subscription subscription = new Subscription();
+		subscription.setId(1L);
+		subscription.setPlanTier(planTier);
+		subscription.setStatus(SubscriptionStatus.ACTIVE);
+		return subscription;
+	}
+
+	private static Clinic clinicWithSubscription(final Subscription subscription) {
+		final Clinic clinic = new Clinic();
+		clinic.setSubscription(subscription);
+		return clinic;
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/subscription/PlanTierTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/PlanTierTest.java
@@ -55,4 +55,12 @@ class PlanTierTest {
 			.hasMessageContaining("unknown-role");
 	}
 
+	@Test
+	void displayNameReturnsSpanishMarketingLabel() {
+		assertThat(PlanTier.BASICO.getDisplayName()).isEqualTo("Básico");
+		assertThat(PlanTier.PROFESIONAL.getDisplayName()).isEqualTo("Profesional");
+		assertThat(PlanTier.PLUS.getDisplayName()).isEqualTo("Plus");
+		assertThat(PlanTier.CONSULTORIO.getDisplayName()).isEqualTo("Consultorio");
+	}
+
 }

--- a/src/test/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceTest.java
@@ -350,6 +350,20 @@ class SubscriptionEntitlementServiceTest {
 			.isEqualTo(SubscriptionErrorResponses.KEY_NUTRITIONIST_LIMIT);
 	}
 
+	@Test
+	void hasEntitlementReflectsUpdatedSubscriptionPlanTierImmediately() {
+		final ClinicMember member = activeMember(SOLO_ID, PlanTier.PROFESIONAL);
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(SOLO_ID))
+			.thenReturn(Optional.of(member));
+
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.PDF_EXPORT)).isTrue();
+
+		member.getClinic().getSubscription().setPlanTier(PlanTier.BASICO);
+
+		assertThat(service.getEffectivePlanTier(SOLO_ID)).contains(PlanTier.BASICO);
+		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.PDF_EXPORT)).isFalse();
+	}
+
 	private static ClinicMember activeMember(final String userId, final PlanTier planTier) {
 		final Clinic clinic = clinicWithSubscription(DIRECTOR_ID, planTier);
 		final ClinicMember member = new ClinicMember();

--- a/src/test/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/SubscriptionEntitlementServiceTest.java
@@ -2,6 +2,7 @@ package com.nutriconsultas.subscription;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.util.EnumSet;
@@ -13,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.subscription.lifecycle.SubscriptionAccessService;
 
 @ExtendWith(MockitoExtension.class)
 class SubscriptionEntitlementServiceTest {
@@ -35,6 +38,9 @@ class SubscriptionEntitlementServiceTest {
 	@Mock
 	private com.nutriconsultas.paciente.PacienteRepository pacienteRepository;
 
+	@Mock
+	private SubscriptionAccessService subscriptionAccessService;
+
 	private SubscriptionProperties subscriptionProperties;
 
 	private SubscriptionEntitlementServiceImpl service;
@@ -42,8 +48,11 @@ class SubscriptionEntitlementServiceTest {
 	@BeforeEach
 	void setUp() {
 		subscriptionProperties = new SubscriptionProperties();
+		lenient()
+			.when(subscriptionAccessService.findGrantingSubscriptionForUser(org.mockito.ArgumentMatchers.anyString()))
+			.thenReturn(Optional.empty());
 		service = new SubscriptionEntitlementServiceImpl(clinicMemberRepository, clinicRepository,
-				clinicInvitationRepository, pacienteRepository, subscriptionProperties);
+				clinicInvitationRepository, pacienteRepository, subscriptionProperties, subscriptionAccessService);
 	}
 
 	@Test
@@ -130,7 +139,7 @@ class SubscriptionEntitlementServiceTest {
 	void graceDeniedEntitlementsAreConfigurable() {
 		subscriptionProperties.setGraceDeniedEntitlements(EnumSet.of(Entitlement.REPORTS_FULL));
 		service = new SubscriptionEntitlementServiceImpl(clinicMemberRepository, clinicRepository,
-				clinicInvitationRepository, pacienteRepository, subscriptionProperties);
+				clinicInvitationRepository, pacienteRepository, subscriptionProperties, subscriptionAccessService);
 
 		final ClinicMember member = activeMember(SOLO_ID, PlanTier.PROFESIONAL);
 		member.getClinic().getSubscription().setStatus(SubscriptionStatus.GRACE);
@@ -353,8 +362,7 @@ class SubscriptionEntitlementServiceTest {
 	@Test
 	void hasEntitlementReflectsUpdatedSubscriptionPlanTierImmediately() {
 		final ClinicMember member = activeMember(SOLO_ID, PlanTier.PROFESIONAL);
-		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(SOLO_ID))
-			.thenReturn(Optional.of(member));
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(SOLO_ID)).thenReturn(Optional.of(member));
 
 		assertThat(service.hasEntitlement(SOLO_ID, Entitlement.PDF_EXPORT)).isTrue();
 

--- a/src/test/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationDevCheckoutServiceTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationDevCheckoutServiceTest.java
@@ -1,0 +1,79 @@
+package com.nutriconsultas.subscription.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import com.nutriconsultas.subscription.InvitationStatus;
+import com.nutriconsultas.subscription.NutritionistInvitation;
+import com.nutriconsultas.subscription.NutritionistInvitationRepository;
+import com.nutriconsultas.subscription.PlanTier;
+import com.nutriconsultas.subscription.Subscription;
+import com.nutriconsultas.subscription.SubscriptionAuditEventRepository;
+import com.nutriconsultas.subscription.SubscriptionRepository;
+import com.nutriconsultas.subscription.SubscriptionStatus;
+import com.nutriconsultas.subscription.payment.PaymentProperties;
+
+@ExtendWith(MockitoExtension.class)
+class NutritionistInvitationDevCheckoutServiceTest {
+
+	@InjectMocks
+	private NutritionistInvitationDevCheckoutService service;
+
+	@Mock
+	private PaymentProperties paymentProperties;
+
+	@Mock
+	private NutritionistInvitationRepository invitationRepository;
+
+	@Mock
+	private SubscriptionRepository subscriptionRepository;
+
+	@Mock
+	private SubscriptionAuditEventRepository auditEventRepository;
+
+	@Mock
+	private SubscriptionProvisioningService provisioningService;
+
+	@Test
+	void completeStubCheckout_activatesSubscriptionAndProvisionsAccess() {
+		when(paymentProperties.isStubSimulateCheckout()).thenReturn(true);
+		when(paymentProperties.isMercadoPagoConfigured()).thenReturn(false);
+		final Subscription subscription = new Subscription();
+		subscription.setId(2L);
+		subscription.setPlanTier(PlanTier.BASICO);
+		subscription.setStatus(SubscriptionStatus.PENDING_PAYMENT);
+		final NutritionistInvitation invitation = new NutritionistInvitation();
+		invitation.setId(5L);
+		invitation.setStatus(InvitationStatus.REDEEMED);
+		invitation.setRedeemedByUserId("auth0|invitee");
+		invitation.setSubscription(subscription);
+		when(invitationRepository.findById(5L)).thenReturn(Optional.of(invitation));
+
+		service.completeStubCheckout(principal("auth0|invitee"), 5L);
+
+		assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+		assertThat(subscription.getExternalSubscriptionId()).isEqualTo("stub-sub-5");
+		verify(subscriptionRepository).save(subscription);
+		verify(provisioningService).activatePaidAccess(invitation, subscription);
+		verify(auditEventRepository).save(any());
+	}
+
+	private static OidcUser principal(final String subject) {
+		final OidcIdToken token = OidcIdToken.withTokenValue("token").claim("sub", subject).build();
+		return new DefaultOidcUser(java.util.List.of(), token);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationServiceTest.java
@@ -39,6 +39,7 @@ import com.nutriconsultas.subscription.SubscriptionStatus;
 import com.nutriconsultas.subscription.payment.BillingInterval;
 import com.nutriconsultas.subscription.payment.CheckoutSession;
 import com.nutriconsultas.subscription.payment.PaymentCheckoutService;
+import com.nutriconsultas.subscription.payment.PaymentProviderException;
 import com.nutriconsultas.util.InvitationTokenHasher;
 
 @ExtendWith(MockitoExtension.class)
@@ -297,6 +298,21 @@ class NutritionistInvitationServiceTest {
 		assertThat(((RedeemNutritionistInvitationResult.CheckoutRedirect) result).checkoutUrl())
 			.isEqualTo("https://pay.test/checkout");
 		verify(provisioningService).createPendingSubscription(invitation);
+	}
+
+	@Test
+	void redeemPaidInvitation_whenPaymentProviderUnavailable_returnsServiceUnavailable() {
+		final NutritionistInvitation invitation = pendingInvitation();
+		invitation.setPaymentExempt(false);
+		when(invitationRepository.findByTokenHash(InvitationTokenHasher.hashToken(rawToken)))
+			.thenReturn(Optional.of(invitation));
+		when(paymentCheckoutService.createCheckoutSession(1L, PlanTier.PROFESIONAL, BillingInterval.MONTHLY))
+			.thenThrow(new PaymentProviderException("Payment provider is not configured"));
+
+		assertThatThrownBy(() -> invitationService.redeemInvitation(inviteePrincipal, rawToken))
+			.isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode().value())
+			.isEqualTo(503);
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/subscription/invitation/SubscriptionProvisioningServiceTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/invitation/SubscriptionProvisioningServiceTest.java
@@ -15,10 +15,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.nutriconsultas.auth0.Auth0RoleSyncClient;
+import com.nutriconsultas.subscription.Clinic;
+import com.nutriconsultas.subscription.ClinicMember;
 import com.nutriconsultas.subscription.ClinicMemberRepository;
 import com.nutriconsultas.subscription.ClinicMemberRole;
 import com.nutriconsultas.subscription.ClinicRepository;
 import com.nutriconsultas.subscription.InvitationStatus;
+import com.nutriconsultas.subscription.MembershipStatus;
 import com.nutriconsultas.subscription.NutritionistInvitation;
 import com.nutriconsultas.subscription.PlanTier;
 import com.nutriconsultas.subscription.Subscription;
@@ -51,7 +54,7 @@ class SubscriptionProvisioningServiceTest {
 	void activateTrialAccessCreatesClinicAndSyncsRole() {
 		final NutritionistInvitation invitation = invitation(PlanTier.BASICO, true);
 		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription("auth0|user-1")).thenReturn(Optional.empty());
-		when(clinicRepository.findByDirectorUserId("auth0|user-1")).thenReturn(Optional.empty());
+		when(clinicRepository.findByDirectorUserIdWithSubscription("auth0|user-1")).thenReturn(Optional.empty());
 		when(subscriptionRepository.save(org.mockito.ArgumentMatchers.any(Subscription.class)))
 			.thenAnswer(invocation -> {
 				final Subscription subscription = invocation.getArgument(0);
@@ -76,10 +79,42 @@ class SubscriptionProvisioningServiceTest {
 	}
 
 	@Test
+	void activatePaidAccessRelinksClinicWhenPreviousSubscriptionCancelled() {
+		final Subscription cancelled = new Subscription();
+		cancelled.setId(2L);
+		cancelled.setPlanTier(PlanTier.PROFESIONAL);
+		cancelled.setStatus(SubscriptionStatus.CANCELLED);
+		final Subscription active = new Subscription();
+		active.setId(5L);
+		active.setPlanTier(PlanTier.BASICO);
+		active.setStatus(SubscriptionStatus.ACTIVE);
+		final Clinic clinic = new Clinic();
+		clinic.setId(2L);
+		clinic.setSubscription(cancelled);
+		final ClinicMember member = new ClinicMember();
+		member.setClinic(clinic);
+		member.setUserId("auth0|user-1");
+		member.setRole(ClinicMemberRole.NUTRITIONIST);
+		member.setMembershipStatus(MembershipStatus.ACTIVE);
+		final NutritionistInvitation invitation = invitation(PlanTier.BASICO, false);
+		invitation.setSubscription(active);
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription("auth0|user-1"))
+			.thenReturn(Optional.of(member));
+		when(clinicRepository.save(org.mockito.ArgumentMatchers.any())).thenAnswer(invocation -> invocation.getArgument(0));
+		when(auth0RoleSyncClient.isConfigured()).thenReturn(false);
+
+		provisioningService.activatePaidAccess(invitation, active);
+
+		assertThat(clinic.getSubscription()).isEqualTo(active);
+		verify(clinicRepository).save(clinic);
+		verify(clinicMemberRepository).save(member);
+	}
+
+	@Test
 	void activateTrialAccessContinuesWhenAuth0SyncFails() {
 		final NutritionistInvitation invitation = invitation(PlanTier.BASICO, true);
 		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription("auth0|user-1")).thenReturn(Optional.empty());
-		when(clinicRepository.findByDirectorUserId("auth0|user-1")).thenReturn(Optional.empty());
+		when(clinicRepository.findByDirectorUserIdWithSubscription("auth0|user-1")).thenReturn(Optional.empty());
 		when(subscriptionRepository.save(org.mockito.ArgumentMatchers.any(Subscription.class)))
 			.thenAnswer(invocation -> {
 				final Subscription subscription = invocation.getArgument(0);

--- a/src/test/java/com/nutriconsultas/subscription/lifecycle/SubscriptionAccessServiceTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/lifecycle/SubscriptionAccessServiceTest.java
@@ -1,0 +1,105 @@
+package com.nutriconsultas.subscription.lifecycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.subscription.Clinic;
+import com.nutriconsultas.subscription.ClinicMember;
+import com.nutriconsultas.subscription.ClinicMemberRepository;
+import com.nutriconsultas.subscription.ClinicMemberRole;
+import com.nutriconsultas.subscription.ClinicRepository;
+import com.nutriconsultas.subscription.InvitationStatus;
+import com.nutriconsultas.subscription.MembershipStatus;
+import com.nutriconsultas.subscription.NutritionistInvitation;
+import com.nutriconsultas.subscription.NutritionistInvitationRepository;
+import com.nutriconsultas.subscription.PlanTier;
+import com.nutriconsultas.subscription.Subscription;
+import com.nutriconsultas.subscription.SubscriptionStatus;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionAccessServiceTest {
+
+	private static final String USER_ID = "auth0|reinvited-user";
+
+	@Mock
+	private ClinicMemberRepository clinicMemberRepository;
+
+	@Mock
+	private ClinicRepository clinicRepository;
+
+	@Mock
+	private NutritionistInvitationRepository invitationRepository;
+
+	@InjectMocks
+	private SubscriptionAccessService subscriptionAccessService;
+
+	@Test
+	void isAdminAccessBlockedWhenClinicSubscriptionCancelled() {
+		final Subscription cancelled = subscription(2L, PlanTier.PROFESIONAL, SubscriptionStatus.CANCELLED);
+		stubActiveMemberWithSubscription(cancelled);
+		when(invitationRepository.findFirstByRedeemedByUserIdAndStatusOrderByRedeemedAtDesc(USER_ID,
+				InvitationStatus.REDEEMED)).thenReturn(Optional.empty());
+
+		assertThat(subscriptionAccessService.isAdminAccessBlocked(USER_ID)).isTrue();
+	}
+
+	@Test
+	void isAdminAccessNotBlockedWhenRedeemedInvitationHasActiveSubscription() {
+		final Subscription cancelled = subscription(2L, PlanTier.PROFESIONAL, SubscriptionStatus.CANCELLED);
+		final Subscription activeBasic = subscription(5L, PlanTier.BASICO, SubscriptionStatus.ACTIVE);
+		stubActiveMemberWithSubscription(cancelled);
+		when(invitationRepository.findFirstByRedeemedByUserIdAndStatusOrderByRedeemedAtDesc(USER_ID,
+				InvitationStatus.REDEEMED)).thenReturn(Optional.of(invitation(activeBasic)));
+
+		assertThat(subscriptionAccessService.isAdminAccessBlocked(USER_ID)).isFalse();
+		assertThat(subscriptionAccessService.findGrantingSubscriptionForUser(USER_ID)).contains(activeBasic);
+	}
+
+	@Test
+	void findSubscriptionForUserPrefersGrantingInvitationOverCancelledClinicLink() {
+		final Subscription cancelled = subscription(2L, PlanTier.PROFESIONAL, SubscriptionStatus.CANCELLED);
+		final Subscription activeBasic = subscription(5L, PlanTier.BASICO, SubscriptionStatus.ACTIVE);
+		stubActiveMemberWithSubscription(cancelled);
+		when(invitationRepository.findFirstByRedeemedByUserIdAndStatusOrderByRedeemedAtDesc(USER_ID,
+				InvitationStatus.REDEEMED)).thenReturn(Optional.of(invitation(activeBasic)));
+
+		assertThat(subscriptionAccessService.findSubscriptionForUser(USER_ID)).contains(activeBasic);
+	}
+
+	private void stubActiveMemberWithSubscription(final Subscription subscription) {
+		final Clinic clinic = new Clinic();
+		clinic.setId(2L);
+		clinic.setSubscription(subscription);
+		final ClinicMember member = new ClinicMember();
+		member.setClinic(clinic);
+		member.setUserId(USER_ID);
+		member.setRole(ClinicMemberRole.NUTRITIONIST);
+		member.setMembershipStatus(MembershipStatus.ACTIVE);
+		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription(USER_ID)).thenReturn(Optional.of(member));
+	}
+
+	private static Subscription subscription(final Long id, final PlanTier planTier, final SubscriptionStatus status) {
+		final Subscription subscription = new Subscription();
+		subscription.setId(id);
+		subscription.setPlanTier(planTier);
+		subscription.setStatus(status);
+		return subscription;
+	}
+
+	private static NutritionistInvitation invitation(final Subscription subscription) {
+		final NutritionistInvitation invitation = new NutritionistInvitation();
+		invitation.setId(8L);
+		invitation.setStatus(InvitationStatus.REDEEMED);
+		invitation.setSubscription(subscription);
+		return invitation;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/subscription/payment/StubPaymentProviderTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/payment/StubPaymentProviderTest.java
@@ -1,0 +1,64 @@
+package com.nutriconsultas.subscription.payment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.subscription.NutritionistInvitation;
+import com.nutriconsultas.subscription.NutritionistInvitationRepository;
+import com.nutriconsultas.subscription.PlanTier;
+import com.nutriconsultas.subscription.Subscription;
+
+@ExtendWith(MockitoExtension.class)
+class StubPaymentProviderTest {
+
+	@InjectMocks
+	private StubPaymentProvider provider;
+
+	@Mock
+	private PaymentProperties paymentProperties;
+
+	@Mock
+	private NutritionistInvitationRepository invitationRepository;
+
+	@Test
+	void createCheckoutSession_whenSimulateEnabled_returnsDevCheckoutUrl() {
+		final NutritionistInvitation invitation = new NutritionistInvitation();
+		invitation.setId(9L);
+		final Subscription subscription = new Subscription();
+		subscription.setId(3L);
+		invitation.setSubscription(subscription);
+		when(paymentProperties.isStubSimulateCheckout()).thenReturn(true);
+		when(invitationRepository.findById(9L)).thenReturn(Optional.of(invitation));
+
+		final CheckoutSession session = provider.createCheckoutSession(9L, PlanTier.BASICO, BillingInterval.MONTHLY);
+
+		assertThat(session.checkoutUrl()).isEqualTo("/invitation/nutritionist/dev-checkout?invitationId=9");
+		assertThat(session.externalSubscriptionId()).isEqualTo("stub-sub-9");
+	}
+
+	@Test
+	void createCheckoutSession_whenSimulateDisabled_throws() {
+		when(paymentProperties.isStubSimulateCheckout()).thenReturn(false);
+
+		assertThatThrownBy(() -> provider.createCheckoutSession(9L, PlanTier.BASICO, BillingInterval.MONTHLY))
+			.isInstanceOf(PaymentProviderException.class)
+			.hasMessageContaining("not configured");
+	}
+
+	@Test
+	void cancelSubscription_whenStubExternalId_noops() {
+		when(paymentProperties.isStubSimulateCheckout()).thenReturn(true);
+
+		provider.cancelSubscription("stub-sub-9");
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add platform-admin plan tier change from `/admin/platform/subscriptions/{id}/edit` with SweetAlert confirmation (extra warning on downgrade).
- Implement `NutritionistRoleService.changeSubscriptionPlanTier()` with downgrade validation (patient/nutritionist caps), non-fatal Auth0 sync, and `PLATFORM_ADMIN_ACTION` audit (`action=plan.tier.change`).
- Document MVP policy: block downgrade when usage exceeds new limits; paid subscriptions use admin override only (no checkout/proration until #207).

## Test plan
- [x] `NutritionistRoleServiceTest` — upgrade, downgrade blocked, Auth0 failure, cancelled subscription
- [x] `SubscriptionAdminControllerTest` — change-plan-tier endpoint
- [x] `SubscriptionEntitlementServiceTest` — entitlements reflect updated tier immediately
- [x] `mvn verify` locally
- [ ] Manual: edit subscription in admin UI, confirm tier change and downgrade rejection

Closes #211

Made with [Cursor](https://cursor.com)