### PR TITLE
docs: register planning issues #232–#248

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -29,7 +29,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 | File | Purpose |
 |------|---------|
-| [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX; #232–#242 diet/branding/UX), states, dependencies |
+| [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX; #232–#242 epics; bug #250), states, dependencies |
 | [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md) | Patient registration export/import plan |
 
 **Parallel track (public booking — future; depends on #246+):**
@@ -42,7 +42,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (subscription):** [#207 — Stripe payment provider](https://github.com/diego-torres/nutriconsultas/issues/207). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#211~~ merged PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230).
 
-**Current next issue (nutritionist web):** [#221 — Export patient registration to .mpx](https://github.com/diego-torres/nutriconsultas/issues/221) → #222 → #223. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+**Current next issue (nutritionist web):** [#221 — Export patient registration to .mpx](https://github.com/diego-torres/nutriconsultas/issues/221) → #222 → #223. Bug [#250](https://github.com/diego-torres/nutriconsultas/issues/250) (diet platillo link) when touching diet UX. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
 ---
 

--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -29,8 +29,14 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 | File | Purpose |
 |------|---------|
-| [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX epic), states, dependencies |
+| [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX; #232–#242 diet/branding/UX), states, dependencies |
 | [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md) | Patient registration export/import plan |
+
+**Parallel track (public booking — future; depends on #246+):**
+
+| File | Purpose |
+|------|---------|
+| [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) | `[Public Booking]` epic #245–#248 |
 
 **Current next issue (mobile):** [#134 — POST /rest/mobile/invitations](https://github.com/diego-torres/nutriconsultas/issues/134). ~~#133~~ done (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -602,6 +602,8 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 **Epics #232–#242** (2026-06-19): diet catalog (#232–#235), branding (#236–#237), diet/platillo UX (#238–#240), patient UX (#241–#242). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
+**Bug #250** (2026-06-19): diet ingesta platillo name links to wrong catalog platillo — `PlatilloIngesta.id` vs `Platillo.id`. **NEXT** when fixing diet UX.
+
 ## Public booking (tracking)
 
 Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. **NEXT (when active):** [#246 working hours](https://github.com/diego-torres/nutriconsultas/issues/246) → #247 → #248.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -600,6 +600,12 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 **Epic #221–#223** (2026-06-18): export/import patient **registration** to `.mpx` (YAML, no history) + export/delete UI. **NEXT:** [#221 export](https://github.com/diego-torres/nutriconsultas/issues/221) → #222 → #223. Complements #190 patient caps; available all tiers.
 
+**Epics #232–#242** (2026-06-19): diet catalog (#232–#235), branding (#236–#237), diet/platillo UX (#238–#240), patient UX (#241–#242). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+
+## Public booking (tracking)
+
+Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. **NEXT (when active):** [#246 working hours](https://github.com/diego-torres/nutriconsultas/issues/246) → #247 → #248.
+
 ## Resources
 
 - [Spring Boot Documentation](https://spring.io/projects/spring-boot)

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-19 — Diet management epic **#232–#235**, branding **#236–#237**, diet/platillo UX **#238–#240**, patient UX **#241–#242** registered.
+**Last updated:** 2026-06-19 — Bug **#250** (diet platillo link); epics **#232–#242** registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -113,6 +113,18 @@ System template diets (`userId = system:template-dietas`), grid actions, and own
 |---|-------|-----|-------|-----------|-------|
 | 241 | Patient profile — selectable patient avatars | https://github.com/diego-torres/nutriconsultas/issues/241 | open | #46 | Liquibase `avatarId` on `Paciente` |
 | 242 | Anthropometrics — per-field correction with recalculation | https://github.com/diego-torres/nutriconsultas/issues/242 | open | #161 (context) | Edit icon per field; derived metrics |
+
+---
+
+## Bugs
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| **250** | Diet ingesta platillo link uses `PlatilloIngesta.id` instead of catalog `Platillo.id` | https://github.com/diego-torres/nutriconsultas/issues/250 | **NEXT** | #46 | `formulario.html` href; add `sourcePlatilloId` + Liquibase backfill |
+
+**Repro:** Menú vegetal 02 → Cena → "Frijoles con tortilla" links to `/admin/platillos/32` (wrong catalog row) instead of `/admin/platillos/97`. Name displays correctly; portion REST APIs unaffected.
+
+**Fix sketch:** persist `sourcePlatilloId` on `PlatilloIngesta` in `PlatilloIngestaMapping`; template uses catalog id for `/admin/platillos/{id}` only.
 
 ---
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -1,12 +1,12 @@
 # Issue Registry — `[Nutritionist Web]` track
 
-Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admin/**`) — patient roster, clinical workflows, and plan-slot management. Update when status changes (commit on the PR that closes work).
+Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admin/**`) — patient roster, clinical workflows, diet/platillo management, and plan-slot rotation. Update when status changes (commit on the PR that closes work).
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
-**Plan:** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-18 — MPX export/import epic **#221–#223** registered.
+**Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
+**Last updated:** 2026-06-19 — Diet management epic **#232–#235**, branding **#236–#237**, diet/platillo UX **#238–#240**, patient UX **#241–#242** registered.
 
-> **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix mobile JWT or subscription billing into patient MPX PRs unless explicitly coupled.
+> **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
 ---
 
@@ -44,6 +44,78 @@ Help nutritionists **rotate patient slots** (especially **plan básico** cap via
 
 ---
 
+## Epic — Diet catalog management
+
+System template diets (`userId = system:template-dietas`), grid actions, and ownership filters.
+
+| Requirement | Issues |
+|-------------|--------|
+| Platform admins edit system diets | #232 |
+| Grid: edit action | #233 |
+| Grid: delete with patient-assignment guard | #234 |
+| Grid: filter todas / sistema / propias | #235 |
+
+**Suggested order:** #232 → #233 + #234 + #235 (parallel after #232).
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| 232 | Platform admins can edit system template diets | https://github.com/diego-torres/nutriconsultas/issues/232 | open | #183 | Bypass `verifyDietOwnership` for `system:template-dietas` |
+| 233 | Diet list grid — edit action | https://github.com/diego-torres/nutriconsultas/issues/233 | open | — | Link to `/admin/dietas/{id}` |
+| 234 | Diet list grid — delete action with patient-usage guard | https://github.com/diego-torres/nutriconsultas/issues/234 | open | — | Block if `PacienteDieta` exists; SweetAlert |
+| 235 | Diet list grid — filter all, system, or own diets | https://github.com/diego-torres/nutriconsultas/issues/235 | open | — | Server-side filter on `/rest/dietas` grid |
+
+---
+
+## Epic — Nutritionist branding (profile & PDF)
+
+| Requirement | Issues |
+|-------------|--------|
+| Show logo on profile after upload | #236 |
+| PDF logo standard size (~1.5 × 1.5 in) | #237 |
+
+**Suggested order:** #236 → #237 (or parallel).
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| 236 | Show uploaded logo on nutritionist profile page | https://github.com/diego-torres/nutriconsultas/issues/236 | open | #187 (context) | `NutritionistProfile` / S3 preview |
+| 237 | PDF reports — standard logo size (~1.5 × 1.5 in) | https://github.com/diego-torres/nutriconsultas/issues/237 | open | #187 | `DietaPdfService`, Flying Saucer CSS |
+
+---
+
+## Epic — Diet & platillo authoring UX
+
+| Requirement | Issues |
+|-------------|--------|
+| Diet macro table below caloric distribution | #238 |
+| Add-ingredient dialog: recalc weight from portion qty | #239 |
+| Round fractions to ½, ¼, ⅓ in platillo table & PDFs | #240 |
+
+**Suggested order:** #238 independent; #239 → #240.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| 238 | Diet detail — macronutrients table below caloric distribution | https://github.com/diego-torres/nutriconsultas/issues/238 | open | — | Match platillo macro table style |
+| 239 | Add-ingredient dialog — recalculate weight from portion quantity | https://github.com/diego-torres/nutriconsultas/issues/239 | open | — | Platillo + dietas modals |
+| 240 | Round ingredient fractions to ½, ¼, or ⅓ in UI and meal-plan PDFs | https://github.com/diego-torres/nutriconsultas/issues/240 | open | — | Extend `AbstractFraccionable` |
+
+---
+
+## Epic — Patient profile & clinical corrections
+
+| Requirement | Issues |
+|-------------|--------|
+| Selectable patient avatars | #241 |
+| Per-field anthropometric correction + recalc | #242 |
+
+**Suggested order:** parallel.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| 241 | Patient profile — selectable patient avatars | https://github.com/diego-torres/nutriconsultas/issues/241 | open | #46 | Liquibase `avatarId` on `Paciente` |
+| 242 | Anthropometrics — per-field correction with recalculation | https://github.com/diego-torres/nutriconsultas/issues/242 | open | #161 (context) | Edit icon per field; derived metrics |
+
+---
+
 ## Cross-track links
 
 | Track | Interaction |
@@ -52,6 +124,11 @@ Help nutritionists **rotate patient slots** (especially **plan básico** cap via
 | #109 Mobile linkage | Delete clears `patientAuthSub`; not stored in `.mpx` |
 | #220 Retention purge | Platform admin purge of **revoked** nutritionists — orthogonal to nutritionist-initiated patient delete |
 | #132 Patient invitations | Onboarding `Paciente.status` — import creates `ACTIVE` patient unless product specifies otherwise |
+| #183 Platform admin | System diet edit (#232) |
+| #187 Branded PDF | Logo profile (#236) and PDF sizing (#237) |
+| #198 Diet templates | System diets seeded; editable by admin via #232 |
+| #243 / #244 Subscription | reCAPTCHA + Solicitar acceso pre-fill — public funnel, not admin UI |
+| #245–#248 Public booking | Nutritionist hours in profile (#246) — separate track |
 
 ---
 

--- a/ISSUE-PUBLIC-BOOKING.md
+++ b/ISSUE-PUBLIC-BOOKING.md
@@ -1,0 +1,61 @@
+# Issue Registry — `[Public Booking]` track
+
+Living index of GitHub issues for **public appointment scheduling** — shareable links, nutritionist availability, and patient self-booking. Update when status changes (commit on the PR that closes work).
+
+**Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
+**Last updated:** 2026-06-19 — Epic **#245** with child issues **#246–#248** registered.
+
+> **Scope.** Public routes (`/consultas/{id}/agendar-cita` or equivalent), availability configuration, and calendar blocks. Nutritionist admin UI pieces may live in `/admin/**` but this track owns the **public booking product**. Mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Nutritionist web (non-booking): [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+
+---
+
+## Legend
+
+| State | Meaning |
+|-------|---------|
+| `NEXT` | Active — pick this up now (if unblocked) |
+| `open` | Not started |
+| `in-progress` | Branch / PR open |
+| `done` | Merged to `main` |
+| `deferred` | Paused |
+
+---
+
+## Epic — Public appointment scheduling link
+
+Shareable URL for patients to book into a nutritionist's real availability:
+
+`https://minutriporcion.com/consultas/{nutritionist-public-id}/agendar-cita`
+
+| Requirement | Issues |
+|-------------|--------|
+| Epic umbrella | #245 |
+| Profile: working hours / availability | #246 |
+| Calendar: unavailable days & absence windows | #247 |
+| Public page: slot picker + booking | #248 |
+
+**Suggested order:** #246 → #247 → #248.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| **245** | Epic — public appointment scheduling link per nutritionist | https://github.com/diego-torres/nutriconsultas/issues/245 | open | — | New track; Liquibase for availability + public slug |
+| **246** | Nutritionist profile — configure working hours and availability | https://github.com/diego-torres/nutriconsultas/issues/246 | **NEXT** | **245** | Weekly schedule; slot duration |
+| 247 | Calendar — unavailable days and absence windows | https://github.com/diego-torres/nutriconsultas/issues/247 | open | **246** | Blocks subtract from public slots |
+| 248 | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | open | **246**, **247**, #243 | reCAPTCHA recommended; opaque public id |
+
+---
+
+## Cross-track links
+
+| Track | Interaction |
+|-------|-------------|
+| #243 reCAPTCHA | Bot protection on public booking form |
+| #244 Solicitar acceso | Orthogonal — nutritionist onboarding vs patient booking |
+| `CalendarEvent` | Existing appointments; clarify vs availability blocks |
+| #236 Nutritionist profile | Same profile area for hours (#246) and logo |
+
+---
+
+**How to update this file**
+
+Same convention as [`ISSUE.md`](ISSUE.md): mark `in-progress` when PR opens, `done` when merged. Add sprint pointer to [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) when this track becomes active.

--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -99,7 +99,7 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 |---|-------|-----|-------|-----------|-------|
 | 220 | Retention cleanup — purge revoked nutritionist data with S3 backup | https://github.com/diego-torres/nutriconsultas/issues/220 | open | 210, 183, 46 | 90 días post-revoke; UI mantenimiento; backup S3; bitácora |
 
-**Suggested order:** #220 after #210 merged (needs `access.revoke` audit + `CANCELLED` state).
+**Suggested order:** #220 after ~~#210~~ ✓ (needs `access.revoke` audit + `CANCELLED` state).
 
 ---
 

--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -5,7 +5,7 @@ Living index of GitHub issues that implement **subscription enforcement**, platf
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Workflow:** [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md)  
 **Design doc:** [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md)  
-**Last updated:** 2026-06-19 — ~~#211~~ **done** (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)); **NEXT:** #207 (Stripe provider). Patient MPX **#221–#223:** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Production **#226** fixed (PR [#227](https://github.com/diego-torres/nutriconsultas/pull/227), invitation base URL).
+**Last updated:** 2026-06-19 — ~~#211~~ **done** (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)); **NEXT:** #207 (Stripe provider). Public funnel: #243, #244 registered. Patient MPX **#221–#223:** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Production **#226** fixed (PR [#227](https://github.com/diego-torres/nutriconsultas/pull/227), invitation base URL).
 
 > **Scope.** This registry tracks `[Subscription]` issues only. The patient mobile API lives in [`ISSUE.md`](ISSUE.md). Patient invitation onboarding (#132–#141) is orthogonal — do not merge nutritionist and patient invitation entities.
 
@@ -82,7 +82,18 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 
 ---
 
-## Phase 4 — Retention & maintenance
+## Phase 4 — Public funnel (marketing → contact → invite)
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| 243 | Production reCAPTCHA keys for minutriporcion.com | https://github.com/diego-torres/nutriconsultas/issues/243 | open | — | Remove "testing purposes only" banner |
+| 244 | Pre-fill contact form when clicking Solicitar Acceso for a plan | https://github.com/diego-torres/nutriconsultas/issues/244 | open | — | Plan slug on `ContactInquiry`; pairs with #184 |
+
+**Suggested order:** #243 → #244 (or parallel). Blocks public booking form (#248) reCAPTCHA reuse.
+
+---
+
+## Phase 5 — Retention & maintenance
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
@@ -106,6 +117,8 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 | 5b. Patient slot rotation (export/import `.mpx`) | #221, #222, #223 — [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) |
 | 6. Branded / tiered reports | #187 — PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218) ✓ |
 | 7. PDF export by plan | #187 — PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218) ✓ |
+| 8. Production reCAPTCHA on contact form | #243 |
+| 9. Plan-aware Solicitar acceso CTA | #244 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ registro de consultorio de nutrición
 
 ### Patient mobile API
 
-**Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
+**Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
 **On `main` (2026-06-19):** Patient mobile API through #116; onboarding **#132** + token service **#133 done** (PR #229, EC2). **NEXT:** #134. **Subscription:** ~~#180–#185~~, ~~#187~~, ~~#190~~, ~~#210~~, ~~#211~~ on `main`; **NEXT:** #207. **Nutritionist web:** MPX epic #221–#223; **NEXT:** #221.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-19):** Patient mobile API through #116; onboarding **#132** + token service **#133 done** (PR #229, EC2). **NEXT:** #134. **Subscription:** ~~#180–#185~~, ~~#187~~, ~~#190~~, ~~#210~~, ~~#211~~ on `main`; **NEXT:** #207. **Nutritionist web:** MPX epic #221–#223; **NEXT:** #221.
+**On `main` (2026-06-19):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: MPX #221–#223; epics #232–#242; bug #250. Public booking #245–#248 (deferred).
 
 ## AWS (production infrastructure)
 


### PR DESCRIPTION
## Summary
- Register **17 new GitHub issues** across three tracks: Nutritionist Web (#232–#242), Subscription public funnel (#243–#244), and Public Booking (#245–#248).
- Expand `ISSUE-NUTRITIONIST-WEB.md` with epics for diet catalog, branding, diet/platillo UX, and patient profile/clinical corrections.
- Add new `ISSUE-PUBLIC-BOOKING.md` registry for the public appointment scheduling epic.
- Update `ISSUE-SUBSCRIPTION.md`, `AGENT-WORKFLOW.md`, `AGENTS.md`, and `README.md` with cross-track references.

## Issue map

| Track | Issues |
|-------|--------|
| Nutritionist Web | #232–#242 (diets, branding, UX, avatars, antropométricos) |
| Subscription | #243 (reCAPTCHA prod), #244 (Solicitar acceso pre-fill) |
| Public Booking | #245 epic → #246 hours → #247 blocks → #248 public page |

## Test plan
- [ ] Review `ISSUE-NUTRITIONIST-WEB.md` epic tables and links
- [ ] Review new `ISSUE-PUBLIC-BOOKING.md` suggested order
- [ ] Confirm `ISSUE-SUBSCRIPTION.md` Phase 4/5 renumbering reads correctly
- [ ] Spot-check GitHub issue URLs #232–#248 resolve


Made with [Cursor](https://cursor.com)