### PR TITLE
docs: mark #133 done, NEXT #134

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -32,7 +32,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX epic), states, dependencies |
 | [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md) | Patient registration export/import plan |
 
-**Current next issue (mobile):** [#133 — Invitation token generation & hashing service](https://github.com/diego-torres/nutriconsultas/issues/133) **in-progress** (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)). ~~#132~~ done (PR [#214](https://github.com/diego-torres/nutriconsultas/pull/214)).
+**Current next issue (mobile):** [#134 — POST /rest/mobile/invitations](https://github.com/diego-torres/nutriconsultas/issues/134). ~~#133~~ done (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)).
 
 **Current next issue (subscription):** [#207 — Stripe payment provider](https://github.com/diego-torres/nutriconsultas/issues/207). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#211~~ merged PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230).
 
@@ -48,7 +48,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | **API surface** | All mobile endpoints live under `/rest/mobile/patient/` as plain JSON (not DataTables-shaped like the admin `*RestController`s). |
 | **Identity (security-critical)** | JWT `sub` → **`Paciente.patientAuthSub`** (#107 ✓ PR #117). **Never `Paciente.userId`** — that is the NUTRITIONIST's Auth0 sub / tenant owner (ALIGNMENT-SPEC §F2). `PatientLinkageFilter` returns **403** if no linked `Paciente`. |
 | **Ownership / IDOR** | Return only the authenticated patient's rows. On an ownership miss prefer **404** (not 403) so existence isn't leaked (esp. #92). Never return cross-tenant data. |
-| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **Cross-cutting done** (#111–#116). **#156**, **#46**, **#132** done. **#133 in-progress** (token service). Requires `AUTH_AUDIENCE` env var. |
+| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **Cross-cutting done** (#111–#116). **#156**, **#46**, **#132**, **#133** done. **NEXT:** #134 invitation create. Requires `AUTH_AUDIENCE` env var. |
 | **DTO envelope** | `ApiResponse<T>`; lists in `PagedResponse<T>` or `CursorPagedResponse<T>` (messages); ISO-8601 date strings. See #110. |
 | **Schema ground truth** | ALIGNMENT-SPEC §F8 field-name map (`nombre→dietaName`, `energia→totalKcal`, `lipidos→totalGrasas`, `hidratosDeCarbono→totalCarbohidratos`, `Ingesta.nombre→tipo`); enums `EventStatus`/`PacienteDietaStatus` (no INACTIVE)/`NivelPeso`. Serialization aliases only — **no DB schema changes** for field renames. |
 | **PHI & logging** | No patient names/emails/DOB in unstructured logs. `LogRedaction` + `PhiLogTurboFilter`; CI runs `scripts/audit-logging.sh` and `scripts/audit-mobile-logging.sh` (#115 done). |
@@ -98,7 +98,7 @@ flowchart LR
    - **#113 (rate limit)** should land with or before **#97** (write endpoint).
    - **#114 (nutritionist reply) is web-only** — do not expose it under `/rest/mobile/**`.
    - **#46 (Liquibase)** ✓ — all schema/catalog changes are incremental changesets (see [Liquibase section](#liquibase--entity-schema-and-catalog-data)).
-   - **#132 (onboarding schema)** ✓ — `PacienteStatus` + `PatientInvitation` on `main` (PR #214, Liquibase `007`). **#133 in-progress** (PR #229 token hashing service).
+   - **#133 (token service)** ✓ — `PatientInvitationTokenService` on `main` (PR #229). **NEXT:** #134 create invitation endpoint.
    - If a dependency is still `open`, complete it first or document the blocker in the plan (Phase 2) and stop.
 5. **Update local registry** when remote state drifted (issue closed on GitHub but still `open` here, or vice versa). `ISSUE.md` must match GitHub before proceeding.
 
@@ -379,12 +379,12 @@ PR must include: changeset file(s), `db.changelog-master.yaml` include (if new f
 ```bash
 # Start of session
 git fetch origin && git checkout main && git pull origin main
-gh issue view 133
+gh issue view 134
 cat ISSUE.md
 cat docs/mobile-api/README.md
 
 # During work
-git checkout -b mobile-api/133-invitation-token-service
+git checkout -b mobile-api/134-create-invitation
 ./lint.sh && bash scripts/audit-logging.sh && bash scripts/audit-mobile-logging.sh && mvn -B verify
 ./dev-start.sh   # Java 21 — run locally when touching security, Liquibase, or startup
 
@@ -399,11 +399,11 @@ gh pr create ...
 
 | Field | Value |
 |-------|-------|
-| **Next issue** | [#133 — Invitation token generation & hashing service](https://github.com/diego-torres/nutriconsultas/issues/133) |
-| **Status** | **in-progress** — PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229); ~~#132~~ ✓ (PR #214) |
-| **Phase** | CSPRNG URL token + human code + hash; optional offline JWS for #140 |
-| **Just completed** | [#132 onboarding schema](https://github.com/diego-torres/nutriconsultas/issues/132) — PR #214 |
-| **In scope for #133** | `PatientInvitationTokenService`; reuse `InvitationTokenHasher`; `PATIENT_INVITATION_JWS_SECRET` for optional JWS |
+| **Next issue** | [#134 — POST /rest/mobile/invitations](https://github.com/diego-torres/nutriconsultas/issues/134) |
+| **Status** | **NEXT** — ~~#133~~ ✓ merged (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)) |
+| **Phase** | Nutritionist JWT creates `Paciente` + `PatientInvitation` with token hash |
+| **Just completed** | [#133 token service](https://github.com/diego-torres/nutriconsultas/issues/133) — PR #229, deployed EC2 |
+| **In scope for #134** | `POST /rest/mobile/invitations`; persist hash only; return invite URL + human code |
 
 ### Upcoming gates
 
@@ -414,13 +414,13 @@ gh pr create ...
 | Endpoints | ~~#91–#99~~ ✓ | **Done** (PR #153) |
 | Cross-cutting | ~~#111~~ ✓, ~~#112~~ ✓ (OpenAPI), ~~#115~~ ✓ (PHI audit) | **Done** |
 | Hardening / additive | ~~#113~~ ✓, ~~#116~~ ✓ (`senderDisplayName`), ~~#114~~ ✓ (nutritionist reply) | **Done** |
-| Schema / Liquibase | ~~**#46**~~ ✓ (PR #196) → ~~**#132**~~ ✓ (PR #214) → **#133–#141** | **#133 in-progress** (PR #229) — incremental changesets per [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) |
+| Schema / Liquibase | ~~**#46**~~ ✓ (PR #196) → ~~**#132**~~ ✓ (PR #214) → ~~**#133**~~ ✓ (PR #229) → **#134–#141** | **#134 NEXT** — incremental changesets per [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) |
 
-### Status snapshot (2026-06-18)
+### Status snapshot (2026-06-19)
 
-**Patient mobile API on `main`:** Phase 0 + endpoints **#91–#99** done; cross-cutting **#111–#116** done. Onboarding schema **#132 done** (PR #214: `PacienteStatus`, `PatientInvitation`, Liquibase `007`).
+**Patient mobile API on `main`:** Phase 0 + endpoints **#91–#99** done; cross-cutting **#111–#116** done. Onboarding **#132** + token service **#133 done** (PR #229, deployed EC2).
 
-**In progress (mobile):** **#133** invitation token service — PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229) awaiting review. **NEXT after merge:** #134–#141 onboarding endpoints.
+**Next (mobile):** **#134** nutritionist create invitation → #135 preview → #136 redeem.
 
 **Schema track:** ~~#46~~ Liquibase baseline (PR #196). Changesets **003–007** on `main` (subscription, patient invitation). All new edits → forward changesets only.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -590,7 +590,7 @@ Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 
-**Next:** [#133](https://github.com/diego-torres/nutriconsultas/issues/133) invitation token service **in-progress** (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229); ~~#132~~ PR [#214](https://github.com/diego-torres/nutriconsultas/pull/214)). ~~#114~~, ~~#116~~, ~~#115~~, ~~#112~~ **done**. Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) — ~~#211~~ done (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)); **NEXT** #207.
+**Next:** [#134](https://github.com/diego-torres/nutriconsultas/issues/134) create patient invitation (~~#133~~ PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229) on `main`). ~~#114~~, ~~#116~~, ~~#115~~, ~~#112~~ **done**. Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) — ~~#211~~ done (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)); **NEXT** #207.
 
 **Schema gate (post-#46):** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline is on `main` (PR #196). All new schema/catalog changes require **incremental Liquibase changesets** — see [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) and [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md). ~~#156~~ Phase C done before baseline.
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,11 +6,11 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) · **Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-18 — ~~#132~~ **done** (PR #214). **#133** **in-progress** (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)). **NEXT after merge:** #134/#135.
+**Last updated:** 2026-06-19 — ~~#133~~ **done** (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229), deployed EC2). **NEXT:** [#134 create invitation](https://github.com/diego-torres/nutriconsultas/issues/134).
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
-> **GitHub sync note (2026-06-18):** **#132** closed (PR #214). **#133** open (in-progress). Subscription **#183–#185**, **#187**, **#190**, **#210** closed. **#97** and **#111** done on `main` but open on GitHub. **#226** closed (PR #227).
+> **GitHub sync note (2026-06-19):** **#133** closed (PR #229). **NEXT:** #134. **#97** and **#111** done on `main` but open on GitHub — close when convenient.
 
 ---
 
@@ -49,7 +49,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156**, **#46**, and **#132** done on `main`. **#133** **in-progress**.
+Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156**, **#46**, **#132**, and **#133** done on `main`. **NEXT:** #134.
 
 ---
 
@@ -136,23 +136,23 @@ Schema-affecting work must respect mobile DTO contracts (§F8). These issues are
 
 ---
 
-## Phase 2 — Invitation onboarding (P1 · ~~#132~~ ✓ → #133–#141)
+## Phase 2 — Invitation onboarding (P1 · ~~#132~~ ✓ ~~#133~~ ✓ → #134–#141)
 
-Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Active sprint** — schema **#132 done** (PR #214); **#133 in-progress** (PR #229).
+Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Active sprint** — token service **#133 done** (PR #229); **NEXT:** #134 create invitation.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| 133 | Invitation token generation & hashing service | https://github.com/diego-torres/nutriconsultas/issues/133 | **in-progress** | ~~132~~ ✓ | PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229): CSPRNG + human code + SHA-256 hash; constant-time verify; optional offline JWS (#140) |
-| 134 | `POST /rest/mobile/invitations` — nutritionist creates patient + invitation | https://github.com/diego-torres/nutriconsultas/issues/134 | **NEXT** | ~~132~~ ✓, 133 | Nutritionist JWT (not patient); creates `Paciente` + `Invitation` |
-| 135 | `GET /rest/mobile/invitations/{token}/preview` — public rate-limited preview | https://github.com/diego-torres/nutriconsultas/issues/135 | open | 133 | Public; enumeration protection (#141) |
-| 136 | `POST /rest/mobile/invitations/{token}/redeem` — bind Auth0 sub → patient | https://github.com/diego-torres/nutriconsultas/issues/136 | open | ~~132~~ ✓, 133, 107 | **Authoritative** redeem gate; patient JWT required |
+| 133 | Invitation token generation & hashing service | https://github.com/diego-torres/nutriconsultas/issues/133 | **done** | ~~132~~ ✓ | Merged PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229): `PatientInvitationTokenService`, human code, SHA-256 hash, optional offline JWS (#140) |
+| 134 | `POST /rest/mobile/invitations` — nutritionist creates patient + invitation | https://github.com/diego-torres/nutriconsultas/issues/134 | **NEXT** | ~~132~~ ✓, ~~133~~ ✓ | Nutritionist JWT (not patient); creates `Paciente` + `Invitation` |
+| 135 | `GET /rest/mobile/invitations/{token}/preview` — public rate-limited preview | https://github.com/diego-torres/nutriconsultas/issues/135 | open | ~~133~~ ✓ | Public; enumeration protection (#141) |
+| 136 | `POST /rest/mobile/invitations/{token}/redeem` — bind Auth0 sub → patient | https://github.com/diego-torres/nutriconsultas/issues/136 | open | ~~132~~ ✓, ~~133~~ ✓, 107 | **Authoritative** redeem gate; patient JWT required |
 | 137 | CurrentPatient resolver + onboarding data gate (403 onboarding required) | https://github.com/diego-torres/nutriconsultas/issues/137 | open | ~~132~~ ✓, 107 | Centralizes `sub → Paciente`; 403 until onboarded |
 | 138 | `PATCH` & `GET /rest/mobile/patient/me` — onboarding profile + status→ACTIVE | https://github.com/diego-torres/nutriconsultas/issues/138 | open | ~~132~~ ✓, 137 | Patient completes profile; transitions to `ACTIVE` |
 | 139 | `POST /rest/mobile/invitations/{id}/revoke` — nutritionist invalidates invite | https://github.com/diego-torres/nutriconsultas/issues/139 | open | ~~132~~ ✓, 134 | Nutritionist JWT |
-| 140 | Auth0 Post-Login Action gate — first-login invitation validation | https://github.com/diego-torres/nutriconsultas/issues/140 | open | 133, 136 | **Post-Login** (not Pre-User-Registration — social logins skip PUR); docs + Action script |
-| 141 | Invitation security hardening — rate limits, enumeration protection, no-token logging | https://github.com/diego-torres/nutriconsultas/issues/141 | open | 133, 135, 136 | Relates #115; never log raw tokens |
+| 140 | Auth0 Post-Login Action gate — first-login invitation validation | https://github.com/diego-torres/nutriconsultas/issues/140 | open | ~~133~~ ✓, 136 | **Post-Login** (not Pre-User-Registration — social logins skip PUR); docs + Action script |
+| 141 | Invitation security hardening — rate limits, enumeration protection, no-token logging | https://github.com/diego-torres/nutriconsultas/issues/141 | open | ~~133~~ ✓, 135, 136 | Relates #115; never log raw tokens |
 
-**Suggested build order (after ~~#132~~ ✓):** #133 → #134/#135 → #136 → #137 → #138 → #139/#140 → #141.
+**Suggested build order (after ~~#133~~ ✓):** #134/#135 → #136 → #137 → #138 → #139/#140 → #141.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-19):** Patient mobile API through #116; onboarding schema **#132 done** (PR #214). **#133 in-progress** (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)). **Subscription:** ~~#180–#185~~, ~~#187~~, ~~#190~~, ~~#210~~, ~~#211~~ on `main`; **NEXT:** #207. **Nutritionist web:** MPX epic #221–#223; **NEXT:** #221.
+**On `main` (2026-06-19):** Patient mobile API through #116; onboarding **#132** + token service **#133 done** (PR #229, EC2). **NEXT:** #134. **Subscription:** ~~#180–#185~~, ~~#187~~, ~~#190~~, ~~#210~~, ~~#211~~ on `main`; **NEXT:** #207. **Nutritionist web:** MPX epic #221–#223; **NEXT:** #221.
 
 ## AWS (production infrastructure)
 

--- a/docs/mobile-api/ALIGNMENT-SPEC.md
+++ b/docs/mobile-api/ALIGNMENT-SPEC.md
@@ -160,7 +160,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 - **Phase 0 DONE:** #107 (PR #117), #109 (PR #142), #110 (DTO envelope).
 - **Endpoints on `main`:** #91–#99 (visits, diet plans + PDF, messages, progress snapshot + measurements time series); #96/#97 messaging with HTTP 201 + Resilience4j 10/min (#113, PR #151).
 - **i18n (#111) DONE** (PR #151): `LocaleContextFilter`, `MobileApiErrorResponses`, localized 403/404/400/429.
-- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). Onboarding **#132 done** (PR #214); **#133 in-progress** (PR #229).
+- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). Onboarding **#132** + **#133 done** (PRs #214, #229). **NEXT:** #134.
 - `deltaPeso`/`deltaImc` are computed-at-query, not stored.
 - Progress `grasa` ambiguity: prefer `bodyComposition.porcentajeGrasaCorporal` (patient-facing %) over `indiceGrasaCorporal`.
 - Template dietas (seed `system:template-dietas`) have 4 ingestas incl. Colación — contract examples show only 3.
@@ -172,7 +172,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 
 ### F8.6 — Invitation onboarding gate (#132–#141)
 - **Prerequisites done on `main`:** #156 Paciente decomposition (PRs #175/#176/#178); #46 Liquibase baseline (PR #196). All new schema → incremental changesets per [`docs/db/LIQUIBASE.md`](../db/LIQUIBASE.md).
-- **Active sprint:** ~~#132~~ **done** (PR #214); **#133 in-progress** (PR #229); then #134–#141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
+- **Active sprint:** ~~#132~~ ~~#133~~ **done** (PRs #214, #229); **NEXT:** #134–#141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
 - **Orthogonal:** nutritionist subscription invitations (`NutritionistInvitation` in subscription track) — see [`ISSUE-SUBSCRIPTION.md`](../../ISSUE-SUBSCRIPTION.md); do not conflate with patient `Invitation`.
 
 ### F8.5 — Design source of truth

--- a/docs/mobile-api/MOBILE-E2E-STATUS.md
+++ b/docs/mobile-api/MOBILE-E2E-STATUS.md
@@ -217,4 +217,4 @@ Optional backend script (requires access token from the app):
 
 ---
 
-*Updated 2026-06-18: ~~#132~~ onboarding schema on `main` (PR #214); **#133 in-progress** (PR #229 token hashing).*
+*Updated 2026-06-19: ~~#133~~ token service on `main` (PR #229, EC2); **NEXT:** #134 create invitation.*

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -12,7 +12,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`MOBILE-E2E-STATUS.md`](MOBILE-E2E-STATUS.md) | Live E2E status, Auth0 setup, HTTP code matrix |
 | [`../api/openapi-mobile.yaml`](../api/openapi-mobile.yaml) | OpenAPI 3.1 export (#112, PR #164); regen: `scripts/export-openapi-mobile.sh` |
 
-**Status (2026-06-18):** ~~#132~~ done (PR #214). **#133 in-progress** (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)). **NEXT after #133:** #134/#135.
+**Status (2026-06-19):** ~~#132~~ ~~#133~~ done on `main` (PRs #214, [#229](https://github.com/diego-torres/nutriconsultas/pull/229)). **NEXT:** [#134](https://github.com/diego-torres/nutriconsultas/issues/134) create invitation.
 
 ## Related registries (same repo)
 

--- a/docs/mobile-api/mobile-api-roadmap-v2.md
+++ b/docs/mobile-api/mobile-api-roadmap-v2.md
@@ -14,7 +14,7 @@
 
 > **State verification (2026-06-11):**
 >
-> - **Backend schema (2026-06-18):** Phase 0 **done** (#107, #109, #110). **All endpoints #91–#99 on `main`**. Cross-cutting **#111–#116 done**. Onboarding schema **#132 done** (PR #214). **#133 in-progress** (PR #229 token hashing). #106 dashboard IMC gauge **done**.
+> - **Backend schema (2026-06-19):** Phase 0 **done** (#107, #109, #110). **All endpoints #91–#99 on `main`**. Cross-cutting **#111–#116 done**. Onboarding **#132** + **#133 done** (PRs #214, #229). **NEXT:** #134. #106 dashboard IMC gauge **done**.
 > - **DTO field-name map (authoritative — ALIGNMENT-SPEC §F8):** `Dieta.nombre→dietaName`, `energia→totalKcal`, `proteina→totalProteina`, `lipidos→totalGrasas`, `hidratosDeCarbono→totalCarbohidratos`; `Ingesta.nombre→tipo`; `PlatilloIngesta.name/portions/energia→nombre/porciones/kcal`, `hidratosDeCarbono→carbohidratos`, `lipidos→grasas` (same for `AlimentoIngesta`). Enums: `EventStatus = SCHEDULED/COMPLETED/CANCELLED`; `PacienteDietaStatus = ACTIVE/COMPLETED/CANCELLED` (no INACTIVE); `NivelPeso = BAJO/NORMAL/ALTO/SOBREPESO` (translate to `imcLabel` server-side). `deltaPeso`/`deltaImc` are computed, not stored.
 > - **Mobile redesign branch state (style/editorial-redesign):** Auth dedup complete — `AuthFlowController` + login/signup/welcome screens canonical; PR #48's `AuthController`/`LoginView` retired (commit 3427612); `flutter analyze` clean, 146/146 tests pass. Canonical design source: `.claude/MiNutriporcion-2/` (light editorial palette; dark welcome/login PNGs are OLD, ignore). Mobile issues #13/#21/#31 done; #32/#33 in flight on branch.
 


### PR DESCRIPTION
## Summary
- Mark **#133** done (PR #229 merged + deployed to EC2 via CodePipeline `75e15831`)
- Advance mobile **NEXT** to **#134** across `ISSUE.md`, `AGENT-WORKFLOW.md`, `AGENTS.md`, `README.md`, and `docs/mobile-api/*`

## Test plan
- [x] Registry pointers consistent
- [x] Docs-only change


Made with [Cursor](https://cursor.com)