### PR TITLE
feat(paciente): export patient registration to .mpx YAML (#221)

### DIFF
--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-19 — Bug **#250** (diet platillo link); epics **#232–#242** registered.
+**Last updated:** 2026-06-19 — #221 MPX export in progress; bug **#250** (diet platillo link); epics **#232–#242** registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -36,8 +36,8 @@ Help nutritionists **rotate patient slots** (especially **plan básico** cap via
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| **221** | Export patient registration to .mpx (YAML, no history) | https://github.com/diego-torres/nutriconsultas/issues/221 | **NEXT** | #156, #190 (context) | Defines `mpxVersion: 1`; `docs/paciente/MPX-FORMAT.md` at implement time |
-| 222 | Import patient registration from .mpx file | https://github.com/diego-torres/nutriconsultas/issues/222 | open | **221**, #190 | New `Paciente`; no history restore |
+| **221** | Export patient registration to .mpx (YAML, no history) | https://github.com/diego-torres/nutriconsultas/issues/221 | **in-progress** | #156, #190 (context) | `PacienteMpxExportService`; `docs/paciente/MPX-FORMAT.md` |
+| 222 | Import patient registration from .mpx file | https://github.com/diego-torres/nutriconsultas/issues/222 | **NEXT** | **221**, #190 | New `Paciente`; no history restore |
 | 223 | Patient export and delete actions with pre-delete backup | https://github.com/diego-torres/nutriconsultas/issues/223 | open | **221**, **222**, #190 | SweetAlert; historial loss copy |
 
 **All tiers:** export/import/delete UI is **not** entitlement-gated; basic plan is the primary use case.

--- a/docs/paciente/MPX-FORMAT.md
+++ b/docs/paciente/MPX-FORMAT.md
@@ -1,0 +1,149 @@
+# MPX file format (v1)
+
+**Product:** Minutriporcion / nutriconsultas  
+**Track:** `[Nutritionist Web]` — export/import patient registration  
+**Issues:** [#221](https://github.com/diego-torres/nutriconsultas/issues/221) export · [#222](https://github.com/diego-torres/nutriconsultas/issues/222) import · [#223](https://github.com/diego-torres/nutriconsultas/issues/223) UI
+
+---
+
+## Overview
+
+An **`.mpx`** (Minutriporción patient export) file is a UTF-8 YAML document that holds a nutritionist-owned **registration profile only**. It lets nutritionists rotate patient slots on capped plans without retyping demographics, body snapshot, energy preferences, and medical history.
+
+Clinical timeline data (consultations, exams, measurements, diet assignments, messages, mobile linkage) is **never** included.
+
+---
+
+## File rules
+
+| Topic | Rule |
+|-------|------|
+| Extension | `.mpx` |
+| Encoding | UTF-8 |
+| Format | YAML, block style |
+| Version | Required top-level `mpxVersion: 1` |
+| Download | Authenticated HTTPS session (`GET /admin/pacientes/{id}/export.mpx`) |
+| Filename | `{assignedId-or-slug}-{yyyyMMdd-HHmmss}.mpx` (UTC), slug derived from `assignedId` or patient name |
+| PHI | File contains PHI — do not log contents |
+
+---
+
+## Top-level envelope
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mpxVersion` | integer | yes | Must be `1` for this spec |
+| `exportedAt` | string (ISO-8601 instant) | yes | UTC export timestamp, e.g. `2026-06-18T12:00:00Z` |
+| `sourceApp` | string | yes | Always `nutriconsultas` |
+| `patient` | object | yes | Registration payload (see below) |
+
+---
+
+## `patient` object
+
+Maps to the same data shown on patient alta/edición: core demographics plus embedded satellites.
+
+### Core demographics
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | string | Required in app; export preserves value |
+| `dob` | string (`yyyy-MM-dd`) | Date of birth |
+| `email` | string | Optional |
+| `phone` | string | Optional |
+| `gender` | string | `M` or `F` |
+| `responsibleName` | string | Optional |
+| `parentesco` | string | Optional |
+| `pregnancy` | boolean | Optional; default `false` |
+
+### Excluded from export (by design)
+
+| Field | Reason |
+|-------|--------|
+| `id` | DB primary key — import creates a new row |
+| `userId` | Nutritionist tenant — set from authenticated user on import |
+| `patientAuthSub` | Mobile Auth0 linkage — not portable |
+| `registro` | Server registration timestamp |
+| `status` | Onboarding lifecycle — import sets `ACTIVE` (#222) |
+| `assignedId` | Clinic identifier — reassigned on import |
+| `displayName`, `emailHint` | Mobile/onboarding hints |
+
+### `bodySnapshot` object
+
+Cached metrics from `PacienteBodySnapshot`:
+
+| Field | Type |
+|-------|------|
+| `peso` | number |
+| `estatura` | number |
+| `imc` | number |
+| `bmr` | number |
+| `getKcal` | number |
+| `nivelPeso` | enum string (`NivelPeso` name) |
+| `tefKcal` | number |
+| `totalAdjustedKcal` | number |
+| `stressKcal` | number |
+| `finalTotalKcal` | number |
+
+### `energyPreferences` object
+
+All fields from `PacienteEnergyPreferences` except `id` and `paciente` FK. Enum fields serialize as enum **names** (e.g. `HARRIS_BENEDICT`, `PROMEDIO`, `FIXED`). Date fields `stressValidFrom` / `stressValidUntil` use `yyyy-MM-dd`.
+
+### `medicalHistory` object
+
+All fields from `PacienteMedicalHistory` except `id` and `paciente` FK — text antecedents, `tipoSanguineo`, pathology booleans, `historialAlimenticio`, `desarrolloPsicomotor`, `alergias`.
+
+---
+
+## Example (illustrative)
+
+```yaml
+mpxVersion: 1
+exportedAt: "2026-06-18T12:00:00Z"
+sourceApp: nutriconsultas
+patient:
+  name: Juan Perez
+  dob: "1990-01-15"
+  email: juan@example.com
+  phone: "5551234"
+  gender: M
+  responsibleName: Maria Perez
+  parentesco: Madre
+  pregnancy: false
+  bodySnapshot:
+    peso: 72.5
+    estatura: 1.75
+    imc: 23.7
+    bmr: 1650.0
+    getKcal: 2275.0
+    nivelPeso: NORMAL
+    tefKcal: 182.0
+    totalAdjustedKcal: 2457.0
+    stressKcal: 0.0
+    finalTotalKcal: 2457.0
+  energyPreferences:
+    activityFactorScale: HARRIS_BENEDICT
+    preferredBmrFormula: PROMEDIO
+    physicalActivityLevel: MODERATE
+    activityFactor: 1.55
+    tefMethod: FIXED
+  medicalHistory:
+    tipoSanguineo: O+
+    antecedentesPatologicosPersonales: Ninguno
+    hipertension: false
+    diabetes: false
+```
+
+---
+
+## Versioning
+
+- Importers must reject unknown `mpxVersion` values.
+- Future versions may add optional fields; v1 importers should ignore unknown keys where safe.
+
+---
+
+## Related
+
+- [`PATIENT-MPX-PLAN.md`](PATIENT-MPX-PLAN.md) — product goals and implementation order
+- [`ISSUE-NUTRITIONIST-WEB.md`](../../ISSUE-NUTRITIONIST-WEB.md) — issue registry

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -38,6 +38,8 @@ import com.nutriconsultas.dieta.DietaService;
 import com.nutriconsultas.paciente.calculation.BmrCalculationService;
 import com.nutriconsultas.subscription.SubscriptionErrorResponses;
 import com.nutriconsultas.subscription.SubscriptionLimitExceededException;
+import com.nutriconsultas.paciente.mpx.MpxExportResult;
+import com.nutriconsultas.paciente.mpx.PacienteMpxExportService;
 import com.nutriconsultas.util.LogRedaction;
 
 import org.springframework.http.HttpHeaders;
@@ -99,6 +101,9 @@ public class PacienteController extends AbstractAuthorizedController {
 
 	@Autowired
 	private Auth0UserLookup auth0UserLookup;
+
+	@Autowired
+	private PacienteMpxExportService pacienteMpxExportService;
 
 	/**
 	 * Gets the user ID from the OAuth2 principal.
@@ -914,6 +919,35 @@ public class PacienteController extends AbstractAuthorizedController {
 		log.debug("Cancelando asignación de dieta {}", id);
 		pacienteDietaService.cancelAssignment(id);
 		return String.format("redirect:/admin/pacientes/%d/dietas", pacienteId);
+	}
+
+	/**
+	 * Exports patient registration profile to a portable {@code .mpx} YAML file (#221).
+	 * Clinical history and tenant identifiers are excluded from the payload.
+	 * @param id the patient ID
+	 * @param principal the authenticated nutritionist
+	 * @return YAML attachment or 404 when the patient is not owned by the user
+	 */
+	@GetMapping(path = "/admin/pacientes/{id}/export.mpx")
+	public ResponseEntity<byte[]> exportPacienteMpx(@PathVariable("id") @NonNull final Long id,
+			@AuthenticationPrincipal final OidcUser principal) {
+		log.debug("Exporting MPX registration for paciente {}", id);
+		final String userId = getUserId(principal);
+		if (userId == null) {
+			return ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();
+		}
+		try {
+			final MpxExportResult export = pacienteMpxExportService.exportRegistration(id, userId);
+			return ResponseEntity.ok()
+				.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + export.filename() + "\"")
+				.contentType(MediaType.parseMediaType("application/x-yaml"))
+				.contentLength(export.content().length)
+				.body(export.content());
+		}
+		catch (final IllegalArgumentException ex) {
+			log.warn("MPX export denied for paciente {}: {}", id, ex.getMessage());
+			return ResponseEntity.notFound().build();
+		}
 	}
 
 	/**

--- a/src/main/java/com/nutriconsultas/paciente/mpx/MpxBodySnapshot.java
+++ b/src/main/java/com/nutriconsultas/paciente/mpx/MpxBodySnapshot.java
@@ -1,0 +1,33 @@
+package com.nutriconsultas.paciente.mpx;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Cached body metrics mirrored from {@code PacienteBodySnapshot} (#221).
+ */
+@Getter
+@Setter
+public class MpxBodySnapshot {
+
+	private Double peso;
+
+	private Double estatura;
+
+	private Double imc;
+
+	private Double bmr;
+
+	private Double getKcal;
+
+	private String nivelPeso;
+
+	private Double tefKcal;
+
+	private Double totalAdjustedKcal;
+
+	private Double stressKcal;
+
+	private Double finalTotalKcal;
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/mpx/MpxConstants.java
+++ b/src/main/java/com/nutriconsultas/paciente/mpx/MpxConstants.java
@@ -1,0 +1,15 @@
+package com.nutriconsultas.paciente.mpx;
+
+/**
+ * MPX v1 format constants (#221).
+ */
+public final class MpxConstants {
+
+	public static final int MPX_VERSION = 1;
+
+	public static final String SOURCE_APP = "nutriconsultas";
+
+	private MpxConstants() {
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/mpx/MpxDocument.java
+++ b/src/main/java/com/nutriconsultas/paciente/mpx/MpxDocument.java
@@ -1,0 +1,21 @@
+package com.nutriconsultas.paciente.mpx;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Root MPX v1 document envelope (#221).
+ */
+@Getter
+@Setter
+public class MpxDocument {
+
+	private int mpxVersion;
+
+	private String exportedAt;
+
+	private String sourceApp;
+
+	private MpxPatientRegistration patient;
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/mpx/MpxEnergyPreferences.java
+++ b/src/main/java/com/nutriconsultas/paciente/mpx/MpxEnergyPreferences.java
@@ -1,0 +1,59 @@
+package com.nutriconsultas.paciente.mpx;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Energy-expenditure preferences for MPX v1 (#221).
+ */
+@Getter
+@Setter
+public class MpxEnergyPreferences {
+
+	private String activityFactorScale;
+
+	private String preferredBmrFormula;
+
+	private String physicalActivityLevel;
+
+	private Double activityFactor;
+
+	private Double customFactorSedentary;
+
+	private Double customFactorLight;
+
+	private Double customFactorModerate;
+
+	private Double customFactorIntense;
+
+	private Double customFactorVeryIntense;
+
+	private Boolean physiologicalStressActive;
+
+	private String physiologicalStressType;
+
+	private String stressFormulaTable;
+
+	private String stressIncrementMode;
+
+	private Double stressFactorValue;
+
+	private String stressValidFrom;
+
+	private String stressValidUntil;
+
+	private Double stressFeverTemperature;
+
+	private String tefMethod;
+
+	private String tefBase;
+
+	private Double tefFixedPercent;
+
+	private Double tefMacroProteinPercent;
+
+	private Double tefMacroCarbsPercent;
+
+	private Double tefMacroFatPercent;
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/mpx/MpxExportResult.java
+++ b/src/main/java/com/nutriconsultas/paciente/mpx/MpxExportResult.java
@@ -1,0 +1,8 @@
+package com.nutriconsultas.paciente.mpx;
+
+/**
+ * Binary MPX export payload and suggested download filename (#221).
+ */
+public record MpxExportResult(byte[] content, String filename) {
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/mpx/MpxMedicalHistory.java
+++ b/src/main/java/com/nutriconsultas/paciente/mpx/MpxMedicalHistory.java
@@ -1,0 +1,47 @@
+package com.nutriconsultas.paciente.mpx;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Medical history and pathology flags for MPX v1 (#221).
+ */
+@Getter
+@Setter
+public class MpxMedicalHistory {
+
+	private String antecedentesPrenatales;
+
+	private String antecedentesNatales;
+
+	private String antecedentesPatologicosPersonales;
+
+	private String antecedentesPatologicosFamiliares;
+
+	private String complicaciones;
+
+	private String tipoSanguineo;
+
+	private String historialAlimenticio;
+
+	private String desarrolloPsicomotor;
+
+	private String alergias;
+
+	private Boolean hipertension;
+
+	private Boolean diabetes;
+
+	private Boolean hipotiroidismo;
+
+	private Boolean obesidad;
+
+	private Boolean anemia;
+
+	private Boolean bulimia;
+
+	private Boolean anorexia;
+
+	private Boolean enfermedadesHepaticas;
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/mpx/MpxPatientRegistration.java
+++ b/src/main/java/com/nutriconsultas/paciente/mpx/MpxPatientRegistration.java
@@ -1,0 +1,35 @@
+package com.nutriconsultas.paciente.mpx;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Registration-only patient payload for MPX v1 (#221).
+ */
+@Getter
+@Setter
+public class MpxPatientRegistration {
+
+	private String name;
+
+	private String dob;
+
+	private String email;
+
+	private String phone;
+
+	private String gender;
+
+	private String responsibleName;
+
+	private String parentesco;
+
+	private Boolean pregnancy;
+
+	private MpxBodySnapshot bodySnapshot;
+
+	private MpxEnergyPreferences energyPreferences;
+
+	private MpxMedicalHistory medicalHistory;
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/mpx/PacienteMpxExportService.java
+++ b/src/main/java/com/nutriconsultas/paciente/mpx/PacienteMpxExportService.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,13 +34,10 @@ public class PacienteMpxExportService {
 
 	private final Clock clock;
 
-	public PacienteMpxExportService(final PacienteRepository pacienteRepository) {
-		this(pacienteRepository, Clock.systemUTC());
-	}
-
-	PacienteMpxExportService(final PacienteRepository pacienteRepository, final Clock clock) {
+	public PacienteMpxExportService(final PacienteRepository pacienteRepository,
+			@Autowired(required = false) final Clock clock) {
 		this.pacienteRepository = pacienteRepository;
-		this.clock = clock;
+		this.clock = clock != null ? clock : Clock.systemUTC();
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/nutriconsultas/paciente/mpx/PacienteMpxExportService.java
+++ b/src/main/java/com/nutriconsultas/paciente/mpx/PacienteMpxExportService.java
@@ -1,0 +1,97 @@
+package com.nutriconsultas.paciente.mpx;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Builds MPX v1 YAML exports for patient registration profiles (#221).
+ */
+@Service
+@Slf4j
+public class PacienteMpxExportService {
+
+	private static final DateTimeFormatter FILENAME_TIMESTAMP = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
+		.withZone(ZoneOffset.UTC);
+
+	private final PacienteRepository pacienteRepository;
+
+	private final Clock clock;
+
+	public PacienteMpxExportService(final PacienteRepository pacienteRepository) {
+		this(pacienteRepository, Clock.systemUTC());
+	}
+
+	PacienteMpxExportService(final PacienteRepository pacienteRepository, final Clock clock) {
+		this.pacienteRepository = pacienteRepository;
+		this.clock = clock;
+	}
+
+	@Transactional(readOnly = true)
+	public MpxExportResult exportRegistration(@NonNull final Long pacienteId, @NonNull final String userId) {
+		final Paciente paciente = pacienteRepository.findByIdAndUserId(pacienteId, userId)
+			.orElseThrow(() -> new IllegalArgumentException("Paciente no encontrado"));
+		initializeSatellites(paciente);
+		final Instant exportedAt = clock.instant();
+		final MpxDocument document = PacienteMpxMapper.toDocument(paciente, exportedAt);
+		final byte[] content = serialize(document);
+		final String filename = buildFilename(paciente, exportedAt);
+		log.info("Exported MPX registration for paciente id {}", pacienteId);
+		return new MpxExportResult(content, filename);
+	}
+
+	private void initializeSatellites(final Paciente paciente) {
+		paciente.getBodySnapshot();
+		paciente.getEnergyPreferences();
+		paciente.getMedicalHistory();
+	}
+
+	private byte[] serialize(final MpxDocument document) {
+		final DumperOptions options = new DumperOptions();
+		options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+		options.setPrettyFlow(true);
+		final Representer representer = new Representer(options);
+		representer.addClassTag(MpxDocument.class, Tag.MAP);
+		representer.addClassTag(MpxPatientRegistration.class, Tag.MAP);
+		representer.addClassTag(MpxBodySnapshot.class, Tag.MAP);
+		representer.addClassTag(MpxEnergyPreferences.class, Tag.MAP);
+		representer.addClassTag(MpxMedicalHistory.class, Tag.MAP);
+		final Yaml yaml = new Yaml(representer, options);
+		return yaml.dump(document).getBytes(StandardCharsets.UTF_8);
+	}
+
+	private String buildFilename(final Paciente paciente, final Instant exportedAt) {
+		final String slugSource = paciente.getAssignedId() != null && !paciente.getAssignedId().isBlank()
+				? paciente.getAssignedId() : paciente.getName();
+		final String slug = sanitizeFilename(slugSource);
+		final String timestamp = FILENAME_TIMESTAMP.format(exportedAt);
+		return slug + "-" + timestamp + ".mpx";
+	}
+
+	private String sanitizeFilename(final String value) {
+		if (value == null || value.isBlank()) {
+			return "paciente";
+		}
+		final String sanitized = value.trim().toLowerCase().replaceAll("[^a-z0-9]+", "-").replaceAll("^-+|-+$", "");
+		if (sanitized.isBlank()) {
+			return "paciente";
+		}
+		return sanitized.length() > 60 ? sanitized.substring(0, 60) : sanitized;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/mpx/PacienteMpxMapper.java
+++ b/src/main/java/com/nutriconsultas/paciente/mpx/PacienteMpxMapper.java
@@ -1,6 +1,7 @@
 package com.nutriconsultas.paciente.mpx;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
@@ -125,7 +126,14 @@ public final class PacienteMpxMapper {
 		if (date == null) {
 			return null;
 		}
-		return ISO_DATE.format(date.toInstant().atZone(ZoneOffset.UTC).toLocalDate());
+		return ISO_DATE.format(toLocalDate(date));
+	}
+
+	private static LocalDate toLocalDate(final Date date) {
+		if (date instanceof java.sql.Date sqlDate) {
+			return sqlDate.toLocalDate();
+		}
+		return date.toInstant().atZone(ZoneOffset.UTC).toLocalDate();
 	}
 
 	private static String formatEnum(final Enum<?> value) {

--- a/src/main/java/com/nutriconsultas/paciente/mpx/PacienteMpxMapper.java
+++ b/src/main/java/com/nutriconsultas/paciente/mpx/PacienteMpxMapper.java
@@ -1,0 +1,135 @@
+package com.nutriconsultas.paciente.mpx;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.embeddable.PacienteBodySnapshot;
+import com.nutriconsultas.paciente.satellite.PacienteEnergyPreferences;
+import com.nutriconsultas.paciente.satellite.PacienteMedicalHistory;
+
+/**
+ * Maps owned {@link Paciente} entities to MPX v1 DTOs (#221).
+ */
+public final class PacienteMpxMapper {
+
+	private static final DateTimeFormatter ISO_DATE = DateTimeFormatter.ISO_LOCAL_DATE;
+
+	private static final DateTimeFormatter ISO_INSTANT = DateTimeFormatter.ISO_INSTANT;
+
+	private PacienteMpxMapper() {
+	}
+
+	public static MpxDocument toDocument(final Paciente paciente, final Instant exportedAt) {
+		final MpxDocument document = new MpxDocument();
+		document.setMpxVersion(MpxConstants.MPX_VERSION);
+		document.setExportedAt(ISO_INSTANT.format(exportedAt.atOffset(ZoneOffset.UTC)));
+		document.setSourceApp(MpxConstants.SOURCE_APP);
+		document.setPatient(toPatientRegistration(paciente));
+		return document;
+	}
+
+	private static MpxPatientRegistration toPatientRegistration(final Paciente paciente) {
+		final MpxPatientRegistration registration = new MpxPatientRegistration();
+		registration.setName(paciente.getName());
+		registration.setDob(formatDate(paciente.getDob()));
+		registration.setEmail(paciente.getEmail());
+		registration.setPhone(paciente.getPhone());
+		registration.setGender(paciente.getGender());
+		registration.setResponsibleName(paciente.getResponsibleName());
+		registration.setParentesco(paciente.getParentesco());
+		registration.setPregnancy(paciente.getPregnancy());
+		registration.setBodySnapshot(toBodySnapshot(paciente.getBodySnapshot()));
+		registration.setEnergyPreferences(toEnergyPreferences(paciente.getEnergyPreferences()));
+		registration.setMedicalHistory(toMedicalHistory(paciente.getMedicalHistory()));
+		return registration;
+	}
+
+	private static MpxBodySnapshot toBodySnapshot(final PacienteBodySnapshot snapshot) {
+		if (snapshot == null) {
+			return null;
+		}
+		final MpxBodySnapshot body = new MpxBodySnapshot();
+		body.setPeso(snapshot.getPeso());
+		body.setEstatura(snapshot.getEstatura());
+		body.setImc(snapshot.getImc());
+		body.setBmr(snapshot.getBmr());
+		body.setGetKcal(snapshot.getGetKcal());
+		body.setNivelPeso(formatEnum(snapshot.getNivelPeso()));
+		body.setTefKcal(snapshot.getTefKcal());
+		body.setTotalAdjustedKcal(snapshot.getTotalAdjustedKcal());
+		body.setStressKcal(snapshot.getStressKcal());
+		body.setFinalTotalKcal(snapshot.getFinalTotalKcal());
+		return body;
+	}
+
+	private static MpxEnergyPreferences toEnergyPreferences(final PacienteEnergyPreferences preferences) {
+		if (preferences == null) {
+			return null;
+		}
+		final MpxEnergyPreferences energy = new MpxEnergyPreferences();
+		energy.setActivityFactorScale(formatEnum(preferences.getActivityFactorScale()));
+		energy.setPreferredBmrFormula(formatEnum(preferences.getPreferredBmrFormula()));
+		energy.setPhysicalActivityLevel(formatEnum(preferences.getPhysicalActivityLevel()));
+		energy.setActivityFactor(preferences.getActivityFactor());
+		energy.setCustomFactorSedentary(preferences.getCustomFactorSedentary());
+		energy.setCustomFactorLight(preferences.getCustomFactorLight());
+		energy.setCustomFactorModerate(preferences.getCustomFactorModerate());
+		energy.setCustomFactorIntense(preferences.getCustomFactorIntense());
+		energy.setCustomFactorVeryIntense(preferences.getCustomFactorVeryIntense());
+		energy.setPhysiologicalStressActive(preferences.getPhysiologicalStressActive());
+		energy.setPhysiologicalStressType(formatEnum(preferences.getPhysiologicalStressType()));
+		energy.setStressFormulaTable(formatEnum(preferences.getStressFormulaTable()));
+		energy.setStressIncrementMode(formatEnum(preferences.getStressIncrementMode()));
+		energy.setStressFactorValue(preferences.getStressFactorValue());
+		energy.setStressValidFrom(formatDate(preferences.getStressValidFrom()));
+		energy.setStressValidUntil(formatDate(preferences.getStressValidUntil()));
+		energy.setStressFeverTemperature(preferences.getStressFeverTemperature());
+		energy.setTefMethod(formatEnum(preferences.getTefMethod()));
+		energy.setTefBase(formatEnum(preferences.getTefBase()));
+		energy.setTefFixedPercent(preferences.getTefFixedPercent());
+		energy.setTefMacroProteinPercent(preferences.getTefMacroProteinPercent());
+		energy.setTefMacroCarbsPercent(preferences.getTefMacroCarbsPercent());
+		energy.setTefMacroFatPercent(preferences.getTefMacroFatPercent());
+		return energy;
+	}
+
+	private static MpxMedicalHistory toMedicalHistory(final PacienteMedicalHistory history) {
+		if (history == null) {
+			return null;
+		}
+		final MpxMedicalHistory medical = new MpxMedicalHistory();
+		medical.setAntecedentesPrenatales(history.getAntecedentesPrenatales());
+		medical.setAntecedentesNatales(history.getAntecedentesNatales());
+		medical.setAntecedentesPatologicosPersonales(history.getAntecedentesPatologicosPersonales());
+		medical.setAntecedentesPatologicosFamiliares(history.getAntecedentesPatologicosFamiliares());
+		medical.setComplicaciones(history.getComplicaciones());
+		medical.setTipoSanguineo(history.getTipoSanguineo());
+		medical.setHistorialAlimenticio(history.getHistorialAlimenticio());
+		medical.setDesarrolloPsicomotor(history.getDesarrolloPsicomotor());
+		medical.setAlergias(history.getAlergias());
+		medical.setHipertension(history.getHipertension());
+		medical.setDiabetes(history.getDiabetes());
+		medical.setHipotiroidismo(history.getHipotiroidismo());
+		medical.setObesidad(history.getObesidad());
+		medical.setAnemia(history.getAnemia());
+		medical.setBulimia(history.getBulimia());
+		medical.setAnorexia(history.getAnorexia());
+		medical.setEnfermedadesHepaticas(history.getEnfermedadesHepaticas());
+		return medical;
+	}
+
+	private static String formatDate(final Date date) {
+		if (date == null) {
+			return null;
+		}
+		return ISO_DATE.format(date.toInstant().atZone(ZoneOffset.UTC).toLocalDate());
+	}
+
+	private static String formatEnum(final Enum<?> value) {
+		return value != null ? value.name() : null;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/mpx/PacienteMpxExportControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/mpx/PacienteMpxExportControllerTest.java
@@ -1,0 +1,78 @@
+package com.nutriconsultas.paciente.mpx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.nutriconsultas.paciente.PacienteController;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ActiveProfiles("test")
+@SuppressWarnings("null")
+class PacienteMpxExportControllerTest {
+
+	private static final String USER_ID = "nutritionist-owner";
+
+	@InjectMocks
+	private PacienteController controller;
+
+	@Mock
+	private PacienteMpxExportService pacienteMpxExportService;
+
+	@Mock
+	private OidcUser principal;
+
+	@BeforeEach
+	void setUp() {
+		ReflectionTestUtils.setField(controller, "pacienteMpxExportService", pacienteMpxExportService);
+		when(principal.getSubject()).thenReturn(USER_ID);
+	}
+
+	@Test
+	void exportPacienteMpx_returnsAttachmentWhenOwned() {
+		final byte[] yaml = "mpxVersion: 1\n".getBytes(StandardCharsets.UTF_8);
+		when(pacienteMpxExportService.exportRegistration(7L, USER_ID))
+			.thenReturn(new MpxExportResult(yaml, "juan-20260618-120000.mpx"));
+
+		final ResponseEntity<byte[]> response = controller.exportPacienteMpx(7L, principal);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getHeaders().getFirst("Content-Disposition"))
+			.isEqualTo("attachment; filename=\"juan-20260618-120000.mpx\"");
+		assertThat(response.getBody()).isEqualTo(yaml);
+	}
+
+	@Test
+	void exportPacienteMpx_returnsNotFoundWhenPatientMissing() {
+		when(pacienteMpxExportService.exportRegistration(7L, USER_ID))
+			.thenThrow(new IllegalArgumentException("Paciente no encontrado"));
+
+		final ResponseEntity<byte[]> response = controller.exportPacienteMpx(7L, principal);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	void exportPacienteMpx_returnsUnauthorizedWhenPrincipalMissing() {
+		final ResponseEntity<byte[]> response = controller.exportPacienteMpx(7L, null);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/mpx/PacienteMpxExportServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/mpx/PacienteMpxExportServiceTest.java
@@ -1,0 +1,152 @@
+package com.nutriconsultas.paciente.mpx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.nutriconsultas.paciente.NivelPeso;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.calculation.ActivityFactorScale;
+import com.nutriconsultas.paciente.calculation.BmrFormulaType;
+import com.nutriconsultas.paciente.calculation.PhysicalActivityLevel;
+import com.nutriconsultas.paciente.calculation.TefMethod;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+@SuppressWarnings("null")
+class PacienteMpxExportServiceTest {
+
+	private static final String OWNER_USER_ID = "nutritionist-owner";
+
+	private static final String OTHER_USER_ID = "nutritionist-other";
+
+	private static final Instant FIXED_INSTANT = Instant.parse("2026-06-18T12:00:00Z");
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	private PacienteMpxExportService service;
+
+	private Paciente paciente;
+
+	@BeforeEach
+	void setUp() {
+		service = new PacienteMpxExportService(pacienteRepository, Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC));
+		paciente = buildSamplePaciente();
+	}
+
+	@Test
+	void exportRegistration_containsExpectedRegistrationFields() {
+		when(pacienteRepository.findByIdAndUserId(42L, OWNER_USER_ID)).thenReturn(Optional.of(paciente));
+
+		final MpxExportResult result = service.exportRegistration(42L, OWNER_USER_ID);
+		final String yaml = new String(result.content(), StandardCharsets.UTF_8);
+
+		assertThat(result.filename()).endsWith(".mpx");
+		assertThat(result.filename()).startsWith("mp-001-");
+		assertThat(yaml).contains("mpxVersion: 1");
+		assertThat(yaml).contains("sourceApp: nutriconsultas");
+		assertThat(yaml).contains("exportedAt:");
+		assertThat(yaml).contains("2026-06-18T12:00:00Z");
+		assertThat(yaml).contains("name: Juan Perez");
+		assertThat(yaml).contains("dob:");
+		assertThat(yaml).contains("1990-01-15");
+		assertThat(yaml).contains("gender: M");
+		assertThat(yaml).contains("tipoSanguineo: O+");
+		assertThat(yaml).contains("preferredBmrFormula: PROMEDIO");
+		assertThat(yaml).contains("nivelPeso: NORMAL");
+		assertThat(yaml).contains("pregnancy: false");
+	}
+
+	@Test
+	void exportRegistration_excludesTenantAndHistoryIdentifiers() {
+		when(pacienteRepository.findByIdAndUserId(42L, OWNER_USER_ID)).thenReturn(Optional.of(paciente));
+
+		final MpxExportResult result = service.exportRegistration(42L, OWNER_USER_ID);
+		final String yaml = new String(result.content(), StandardCharsets.UTF_8);
+
+		assertThat(yaml).doesNotContain("userId:");
+		assertThat(yaml).doesNotContain("patientAuthSub:");
+		assertThat(yaml).doesNotContain("registro:");
+		assertThat(yaml).doesNotContain("assignedId:");
+		assertThat(yaml).doesNotContain("status:");
+		assertThat(yaml).doesNotContain("id:");
+	}
+
+	@Test
+	void exportRegistration_throwsWhenPatientNotFoundForOwner() {
+		when(pacienteRepository.findByIdAndUserId(99L, OWNER_USER_ID)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.exportRegistration(99L, OWNER_USER_ID))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("Paciente no encontrado");
+	}
+
+	@Test
+	void exportRegistration_throwsWhenPatientOwnedByAnotherNutritionist() {
+		when(pacienteRepository.findByIdAndUserId(42L, OTHER_USER_ID)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.exportRegistration(42L, OTHER_USER_ID))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("Paciente no encontrado");
+	}
+
+	private static Paciente buildSamplePaciente() {
+		final Paciente entity = new Paciente();
+		entity.setId(42L);
+		entity.setUserId(OWNER_USER_ID);
+		entity.setPatientAuthSub("auth0|patient-sub");
+		entity.setAssignedId("MP-001");
+		entity.setName("Juan Perez");
+		entity.setEmail("juan@example.com");
+		entity.setPhone("5551234");
+		entity.setGender("M");
+		entity.setResponsibleName("Maria Perez");
+		entity.setParentesco("Madre");
+		entity.setPregnancy(false);
+		entity.setDob(Date.from(LocalDate.of(1990, 1, 15).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		entity.setRegistro(Date.from(Instant.parse("2025-01-01T10:00:00Z")));
+
+		entity.setPeso(72.5);
+		entity.setEstatura(1.75);
+		entity.setImc(23.7);
+		entity.setBmr(1650.0);
+		entity.setGetKcal(2275.0);
+		entity.setNivelPeso(NivelPeso.NORMAL);
+		entity.setTefKcal(182.0);
+		entity.setTotalAdjustedKcal(2457.0);
+		entity.setStressKcal(0.0);
+		entity.setFinalTotalKcal(2457.0);
+
+		entity.getEnergyPreferences().setActivityFactorScale(ActivityFactorScale.HARRIS_BENEDICT);
+		entity.getEnergyPreferences().setPreferredBmrFormula(BmrFormulaType.PROMEDIO);
+		entity.getEnergyPreferences().setPhysicalActivityLevel(PhysicalActivityLevel.MODERATE);
+		entity.getEnergyPreferences().setActivityFactor(1.55);
+		entity.getEnergyPreferences().setTefMethod(TefMethod.FIXED);
+
+		entity.getMedicalHistory().setTipoSanguineo("O+");
+		entity.getMedicalHistory().setAntecedentesPatologicosPersonales("Ninguno");
+		entity.getMedicalHistory().setHipertension(false);
+		entity.getMedicalHistory().setDiabetes(false);
+
+		return entity;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/mpx/PacienteMpxExportServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/mpx/PacienteMpxExportServiceTest.java
@@ -91,6 +91,17 @@ class PacienteMpxExportServiceTest {
 	}
 
 	@Test
+	void exportRegistration_handlesSqlDateFromDatabase() {
+		paciente.setDob(java.sql.Date.valueOf(LocalDate.of(1985, 3, 20)));
+		when(pacienteRepository.findByIdAndUserId(42L, OWNER_USER_ID)).thenReturn(Optional.of(paciente));
+
+		final MpxExportResult result = service.exportRegistration(42L, OWNER_USER_ID);
+		final String yaml = new String(result.content(), StandardCharsets.UTF_8);
+
+		assertThat(yaml).contains("1985-03-20");
+	}
+
+	@Test
 	void exportRegistration_throwsWhenPatientNotFoundForOwner() {
 		when(pacienteRepository.findByIdAndUserId(99L, OWNER_USER_ID)).thenReturn(Optional.empty());
 


### PR DESCRIPTION
## Summary
- Add `PacienteMpxExportService` to serialize owned patient registration data (demographics, body snapshot, energy preferences, medical history) into MPX v1 YAML
- Expose `GET /admin/pacientes/{id}/export.mpx` for authenticated nutritionist download with attachment headers
- Document the format in `docs/paciente/MPX-FORMAT.md` and add unit/controller tests

## Test plan
- [x] `mvn test -Dtest=PacienteMpxExportServiceTest,PacienteMpxExportControllerTest`
- [ ] Manual: export an owned patient while logged in and verify `.mpx` download contents
- [ ] Manual: confirm 404 for another nutritionist's patient id

Closes #221


Made with [Cursor](https://cursor.com)