### PR TITLE
docs: mark nutritionist web #221 done, NEXT #222

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -42,7 +42,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (subscription):** [#207 — Stripe payment provider](https://github.com/diego-torres/nutriconsultas/issues/207). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#211~~ merged PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230).
 
-**Current next issue (nutritionist web):** [#221 — Export patient registration to .mpx](https://github.com/diego-torres/nutriconsultas/issues/221) → #222 → #223. Bug [#250](https://github.com/diego-torres/nutriconsultas/issues/250) (diet platillo link) when touching diet UX. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+**Current next issue (nutritionist web):** [#222 — Import patient registration from .mpx](https://github.com/diego-torres/nutriconsultas/issues/222) → #223. ~~#221~~ done (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). Bug [#250](https://github.com/diego-torres/nutriconsultas/issues/250) (diet platillo link) when touching diet UX. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
 ---
 
@@ -432,7 +432,7 @@ gh pr create ...
 
 **Subscription track (parallel):** see [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#180–#185~~, ~~#187~~ (PR #218), ~~#190~~ (PR #216), ~~#210~~ (PR #224), ~~#211~~ (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)) on `main`. **NEXT:** #207 (+ #208 Stripe ops, email #209, retention #220).
 
-**Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) — MPX epic **#221–#223** registered; **NEXT:** #221 export.
+**Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) — MPX epic **#221–#223**; ~~#221~~ done (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)); **NEXT:** #222 import.
 
 **Production (2026-06-18):** ~~#226~~ invitation base URL fix (PR #227) — `APP_BASE_URL` / host remediation on EC2.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -598,7 +598,7 @@ Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow
 
 Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md).
 
-**Epic #221–#223** (2026-06-18): export/import patient **registration** to `.mpx` (YAML, no history) + export/delete UI. **NEXT:** [#221 export](https://github.com/diego-torres/nutriconsultas/issues/221) → #222 → #223. Complements #190 patient caps; available all tiers.
+**Epic #221–#223** (2026-06-18): export/import patient **registration** to `.mpx` (YAML, no history) + export/delete UI. ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). **NEXT:** [#222 import](https://github.com/diego-torres/nutriconsultas/issues/222) → #223. Complements #190 patient caps; available all tiers.
 
 **Epics #232–#242** (2026-06-19): diet catalog (#232–#235), branding (#236–#237), diet/platillo UX (#238–#240), patient UX (#241–#242). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-19 — #221 MPX export in progress; bug **#250** (diet platillo link); epics **#232–#242** registered.
+**Last updated:** 2026-06-19 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). **NEXT:** [#222 import](https://github.com/diego-torres/nutriconsultas/issues/222). Bug **#250** (diet platillo link); epics **#232–#242** registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -36,8 +36,8 @@ Help nutritionists **rotate patient slots** (especially **plan básico** cap via
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| **221** | Export patient registration to .mpx (YAML, no history) | https://github.com/diego-torres/nutriconsultas/issues/221 | **in-progress** | #156, #190 (context) | `PacienteMpxExportService`; `docs/paciente/MPX-FORMAT.md` |
-| 222 | Import patient registration from .mpx file | https://github.com/diego-torres/nutriconsultas/issues/222 | **NEXT** | **221**, #190 | New `Paciente`; no history restore |
+| **221** | Export patient registration to .mpx (YAML, no history) | https://github.com/diego-torres/nutriconsultas/issues/221 | **done** | #156, #190 (context) | PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254); `GET /admin/pacientes/{id}/export.mpx` |
+| **222** | Import patient registration from .mpx file | https://github.com/diego-torres/nutriconsultas/issues/222 | **NEXT** | **221**, #190 | New `Paciente`; no history restore |
 | 223 | Patient export and delete actions with pre-delete backup | https://github.com/diego-torres/nutriconsultas/issues/223 | open | **221**, **222**, #190 | SweetAlert; historial loss copy |
 
 **All tiers:** export/import/delete UI is **not** entitlement-gated; basic plan is the primary use case.


### PR DESCRIPTION
## Summary
- Mark #221 **done** in `ISSUE-NUTRITIONIST-WEB.md` (PR #254, deployed EC2)
- Advance **NEXT** to #222 import in the nutritionist web registry
- Sync sprint pointers in `AGENTS.md` and `AGENT-WORKFLOW.md`

## Test plan
- [x] Docs-only change; verify registry table and NEXT pointers are consistent


Made with [Cursor](https://cursor.com)