### PR TITLE
fix(dieta): link ingesta platillos to catalog id (#250)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -42,7 +42,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (subscription):** [#207 — Stripe payment provider](https://github.com/diego-torres/nutriconsultas/issues/207). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#211~~ merged PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230).
 
-**Current next issue (nutritionist web):** [#222 — Import patient registration from .mpx](https://github.com/diego-torres/nutriconsultas/issues/222) → #223. ~~#221~~ done (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). ~~#250~~ done (catalog platillo link). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+**Current next issue (nutritionist web):** [#222 — Import patient registration from .mpx](https://github.com/diego-torres/nutriconsultas/issues/222) → #223. ~~#221~~ done (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). ~~#250~~ done (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
 ---
 

--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -29,7 +29,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 | File | Purpose |
 |------|---------|
-| [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX; #232–#242 epics; bug #250), states, dependencies |
+| [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX; #232–#242 epics; ~~#250~~), states, dependencies |
 | [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md) | Patient registration export/import plan |
 
 **Parallel track (public booking — future; depends on #246+):**
@@ -42,7 +42,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (subscription):** [#207 — Stripe payment provider](https://github.com/diego-torres/nutriconsultas/issues/207). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#211~~ merged PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230).
 
-**Current next issue (nutritionist web):** [#222 — Import patient registration from .mpx](https://github.com/diego-torres/nutriconsultas/issues/222) → #223. ~~#221~~ done (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). Bug [#250](https://github.com/diego-torres/nutriconsultas/issues/250) (diet platillo link) when touching diet UX. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+**Current next issue (nutritionist web):** [#222 — Import patient registration from .mpx](https://github.com/diego-torres/nutriconsultas/issues/222) → #223. ~~#221~~ done (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). ~~#250~~ done (catalog platillo link). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -602,7 +602,7 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 **Epics #232–#242** (2026-06-19): diet catalog (#232–#235), branding (#236–#237), diet/platillo UX (#238–#240), patient UX (#241–#242). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Bug ~~#250~~** (2026-06-19): diet ingesta platillo name links to wrong catalog platillo — fixed with `sourcePlatilloId` on `PlatilloIngesta`.
+**Bug ~~#250~~** (2026-06-19): diet ingesta platillo name links to wrong catalog platillo — **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)).
 
 ## Public booking (tracking)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -602,7 +602,7 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 **Epics #232–#242** (2026-06-19): diet catalog (#232–#235), branding (#236–#237), diet/platillo UX (#238–#240), patient UX (#241–#242). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Bug #250** (2026-06-19): diet ingesta platillo name links to wrong catalog platillo — `PlatilloIngesta.id` vs `Platillo.id`. **NEXT** when fixing diet UX.
+**Bug ~~#250~~** (2026-06-19): diet ingesta platillo name links to wrong catalog platillo — fixed with `sourcePlatilloId` on `PlatilloIngesta`.
 
 ## Public booking (tracking)
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-19 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). **NEXT:** [#222 import](https://github.com/diego-torres/nutriconsultas/issues/222). Bug **#250** (diet platillo link); epics **#232–#242** registered.
+**Last updated:** 2026-06-19 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#250~~ **done** (catalog platillo link). **NEXT:** [#222 import](https://github.com/diego-torres/nutriconsultas/issues/222). Epics **#232–#242** registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -120,7 +120,7 @@ System template diets (`userId = system:template-dietas`), grid actions, and own
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| **250** | Diet ingesta platillo link uses `PlatilloIngesta.id` instead of catalog `Platillo.id` | https://github.com/diego-torres/nutriconsultas/issues/250 | **NEXT** | #46 | `formulario.html` href; add `sourcePlatilloId` + Liquibase backfill |
+| **250** | Diet ingesta platillo link uses `PlatilloIngesta.id` instead of catalog `Platillo.id` | https://github.com/diego-torres/nutriconsultas/issues/250 | **done** | #46 | `sourcePlatilloId` on `PlatilloIngesta`; Liquibase backfill; template href fix |
 
 **Repro:** Menú vegetal 02 → Cena → "Frijoles con tortilla" links to `/admin/platillos/32` (wrong catalog row) instead of `/admin/platillos/97`. Name displays correctly; portion REST APIs unaffected.
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-19 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#250~~ **done** (catalog platillo link). **NEXT:** [#222 import](https://github.com/diego-torres/nutriconsultas/issues/222). Epics **#232–#242** registered.
+**Last updated:** 2026-06-19 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). **NEXT:** [#222 import](https://github.com/diego-torres/nutriconsultas/issues/222). Epics **#232–#242** registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -120,7 +120,7 @@ System template diets (`userId = system:template-dietas`), grid actions, and own
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| **250** | Diet ingesta platillo link uses `PlatilloIngesta.id` instead of catalog `Platillo.id` | https://github.com/diego-torres/nutriconsultas/issues/250 | **done** | #46 | `sourcePlatilloId` on `PlatilloIngesta`; Liquibase backfill; template href fix |
+| **250** | Diet ingesta platillo link uses `PlatilloIngesta.id` instead of catalog `Platillo.id` | https://github.com/diego-torres/nutriconsultas/issues/250 | **done** | #46 | PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256); `sourcePlatilloId` + Liquibase backfill |
 
 **Repro:** Menú vegetal 02 → Cena → "Frijoles con tortilla" links to `/admin/platillos/32` (wrong catalog row) instead of `/admin/platillos/97`. Name displays correctly; portion REST APIs unaffected.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-19):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: MPX #221–#223; epics #232–#242; bug #250. Public booking #245–#248 (deferred).
+**On `main` (2026-06-19):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: MPX #221–#223; epics #232–#242; ~~#250~~ done. Public booking #245–#248 (deferred).
 
 ## AWS (production infrastructure)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-19):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: MPX #221–#223; epics #232–#242; ~~#250~~ done. Public booking #245–#248 (deferred).
+**On `main` (2026-06-19):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: MPX #221–#223; epics #232–#242; ~~#250~~ done (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). Public booking #245–#248 (deferred).
 
 ## AWS (production infrastructure)
 

--- a/docs/db/LIQUIBASE.md
+++ b/docs/db/LIQUIBASE.md
@@ -14,6 +14,7 @@ Nutriconsultas uses [Liquibase](https://www.liquibase.org/) for schema and catal
 | `changes/005-nutritionist-invitation-payment-exempt.yaml` | `payment_exempt` on `nutritionist_invitation` (#184) |
 | `changes/006-subscription-notification-log.yaml` | Lifecycle notification log (#185, PR #215) |
 | `changes/007-patient-invitation-onboarding.yaml` | `PacienteStatus` columns + `patient_invitation` table (#132, PR #214) |
+| `changes/008-platillo-ingesta-source-platillo-id.yaml` | `source_platillo_id` on `platillo_ingesta` + catalog backfill (#250) |
 | `data/alimentos-seed.sql` | SMAE alimentos catalog (from `alimentos.sql`) |
 | `data/platillos-seed.sql` | Catalog `platillo` + `ingrediente` rows |
 | `data/dieta-templates-seed.sql` | 20 template `dieta` rows (`system:template-dietas`) and child ingestas |

--- a/src/main/java/com/nutriconsultas/dieta/PlatilloIngesta.java
+++ b/src/main/java/com/nutriconsultas/dieta/PlatilloIngesta.java
@@ -34,6 +34,12 @@ public class PlatilloIngesta extends AbstractNutrible {
 
 	private String name;
 
+	/**
+	 * Catalog {@link com.nutriconsultas.platillos.Platillo#id} when copied from the
+	 * platillo catalog.
+	 */
+	private Long sourcePlatilloId;
+
 	private Integer portions = 1;
 
 	private String recommendations;

--- a/src/main/java/com/nutriconsultas/dieta/PlatilloIngestaMapping.java
+++ b/src/main/java/com/nutriconsultas/dieta/PlatilloIngestaMapping.java
@@ -14,6 +14,7 @@ public final class PlatilloIngestaMapping {
 
 	public static PlatilloIngesta mapPlatilloIngesta(final Platillo platillo) {
 		final PlatilloIngesta platilloIngesta = new PlatilloIngesta();
+		platilloIngesta.setSourcePlatilloId(platillo.getId());
 		platilloIngesta.setName(platillo.getName());
 		platilloIngesta.setRecommendations(platillo.getDescription());
 		platilloIngesta.setVideoUrl(platillo.getVideoUrl());

--- a/src/main/resources/db/changelog/changes/008-platillo-ingesta-source-platillo-id.yaml
+++ b/src/main/resources/db/changelog/changes/008-platillo-ingesta-source-platillo-id.yaml
@@ -1,0 +1,37 @@
+databaseChangeLog:
+  - changeSet:
+      id: 008-platillo-ingesta-source-platillo-id-column
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            columnExists:
+              tableName: platillo_ingesta
+              columnName: source_platillo_id
+      changes:
+        - addColumn:
+            tableName: platillo_ingesta
+            columns:
+              - column:
+                  name: source_platillo_id
+                  type: BIGINT
+                  constraints:
+                    nullable: true
+  - changeSet:
+      id: 008-platillo-ingesta-source-platillo-id-backfill-postgresql
+      author: nutriconsultas
+      dbms: postgresql
+      changes:
+        - sqlFile:
+            path: classpath:db/changelog/data/platillo-ingesta-source-backfill.postgresql.sql
+            splitStatements: true
+            stripComments: true
+  - changeSet:
+      id: 008-platillo-ingesta-source-platillo-id-backfill-h2
+      author: nutriconsultas
+      dbms: h2
+      changes:
+        - sqlFile:
+            path: classpath:db/changelog/data/platillo-ingesta-source-backfill.h2.sql
+            splitStatements: true
+            stripComments: true

--- a/src/main/resources/db/changelog/data/platillo-ingesta-source-backfill.h2.sql
+++ b/src/main/resources/db/changelog/data/platillo-ingesta-source-backfill.h2.sql
@@ -1,0 +1,12 @@
+UPDATE platillo_ingesta pi
+SET source_platillo_id = (
+    SELECT p.id
+    FROM platillo p
+    WHERE p.name = pi.name
+      AND p.energia = pi.energia
+      AND p.proteina = pi.proteina
+      AND p.lipidos = pi.lipidos
+      AND p.hidratos_de_carbono = pi.hidratos_de_carbono
+    FETCH FIRST 1 ROW ONLY
+)
+WHERE pi.source_platillo_id IS NULL;

--- a/src/main/resources/db/changelog/data/platillo-ingesta-source-backfill.postgresql.sql
+++ b/src/main/resources/db/changelog/data/platillo-ingesta-source-backfill.postgresql.sql
@@ -1,0 +1,9 @@
+UPDATE platillo_ingesta pi
+SET source_platillo_id = p.id
+FROM platillo p
+WHERE pi.source_platillo_id IS NULL
+  AND pi.name = p.name
+  AND pi.energia = p.energia
+  AND pi.proteina = p.proteina
+  AND pi.lipidos = p.lipidos
+  AND pi.hidratos_de_carbono = p.hidratos_de_carbono;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -20,3 +20,6 @@ databaseChangeLog:
   - include:
       file: changes/007-patient-invitation-onboarding.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/008-platillo-ingesta-source-platillo-id.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -17,3 +17,6 @@ databaseChangeLog:
   - include:
       file: changes/007-patient-invitation-onboarding.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/008-platillo-ingesta-source-platillo-id.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/templates/sbadmin/dietas/formulario.html
+++ b/src/main/resources/templates/sbadmin/dietas/formulario.html
@@ -606,9 +606,11 @@
                                 <tbody>
                                   <tr th:each="platillo : ${ingesta.platillos}">
                                     <td>
-                                      <a th:href="@{/admin/platillos/{id}(id=${platillo.id})}" 
+                                      <a th:if="${platillo.sourcePlatilloId != null}"
+                                         th:href="@{/admin/platillos/{id}(id=${platillo.sourcePlatilloId})}"
                                          th:text="${platillo.name}"
                                          title="Ver detalles del platillo"></a>
+                                      <span th:if="${platillo.sourcePlatilloId == null}" th:text="${platillo.name}"></span>
                                     </td>
                                     <td>
                                       <div class="input-group input-group-sm" style="width: 120px;">

--- a/src/test/java/com/nutriconsultas/db/LiquibaseMigrationTest.java
+++ b/src/test/java/com/nutriconsultas/db/LiquibaseMigrationTest.java
@@ -64,4 +64,19 @@ public class LiquibaseMigrationTest {
 			.isEqualTo(1L);
 	}
 
+	@Test
+	public void testPlatilloIngestaSourcePlatilloIdBackfilled() {
+		assertThat(
+				jdbc.queryForObject(
+						"SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS "
+								+ "WHERE TABLE_NAME = 'PLATILLO_INGESTA' AND COLUMN_NAME = 'SOURCE_PLATILLO_ID'",
+						Long.class))
+			.isEqualTo(1L);
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM platillo_ingesta WHERE source_platillo_id IS NOT NULL",
+				Long.class))
+			.isGreaterThan(0L);
+		assertThat(jdbc.queryForObject("SELECT source_platillo_id FROM platillo_ingesta WHERE id = 32", Long.class))
+			.isEqualTo(97L);
+	}
+
 }

--- a/src/test/java/com/nutriconsultas/dieta/DietaControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaControllerTest.java
@@ -6,6 +6,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.ArrayList;
@@ -362,6 +365,23 @@ public class DietaControllerTest {
 		verify(platilloService, times(1)).findAll();
 
 		log.info("Finishing testEditarDieta");
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testEditarDietaPlatilloLinkUsesCatalogId() throws Exception {
+		final PlatilloIngesta platilloIngesta = new PlatilloIngesta();
+		platilloIngesta.setId(32L);
+		platilloIngesta.setSourcePlatilloId(97L);
+		platilloIngesta.setName("Frijoles con tortilla");
+		ingesta.getPlatillos().add(platilloIngesta);
+
+		when(platilloService.findAll()).thenReturn(List.of(platillo));
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/1"))
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString("/admin/platillos/97")))
+			.andExpect(content().string(not(containsString("/admin/platillos/32"))));
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/dieta/PlatilloIngestaMappingTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/PlatilloIngestaMappingTest.java
@@ -13,6 +13,7 @@ class PlatilloIngestaMappingTest {
 	@Test
 	void mapPlatilloIngestaCopiesMetadata() {
 		final Platillo platillo = new Platillo();
+		platillo.setId(97L);
 		platillo.setName("Test platillo");
 		platillo.setDescription("Desc");
 		platillo.setEnergia(100);
@@ -20,6 +21,7 @@ class PlatilloIngestaMappingTest {
 
 		final PlatilloIngesta ingesta = PlatilloIngestaMapping.mapPlatilloIngesta(platillo);
 
+		assertThat(ingesta.getSourcePlatilloId()).isEqualTo(97L);
 		assertThat(ingesta.getName()).isEqualTo("Test platillo");
 		assertThat(ingesta.getRecommendations()).isEqualTo("Desc");
 		assertThat(ingesta.getEnergia()).isEqualTo(100);


### PR DESCRIPTION
## Summary
- Add `sourcePlatilloId` on `PlatilloIngesta` and set it when copying from the catalog
- Liquibase #008 adds the column and backfills template rows by name + macronutrients
- Diet form links platillo names to `/admin/platillos/{sourcePlatilloId}` instead of the ingesta row id

Fixes #250

## Test plan
- [x] `PlatilloIngestaMappingTest`, `DietaControllerTest#testEditarDietaPlatilloLinkUsesCatalogId`, `LiquibaseMigrationTest#testPlatilloIngestaSourcePlatilloIdBackfilled`
- [x] Checkstyle + PMD passed locally
- [ ] Manual: `/admin/dietas/8` → Cena → **Frijoles con tortilla** opens `/admin/platillos/97` (not 32)
- [ ] Portion edit/delete REST still uses `PlatilloIngesta.id`


Made with [Cursor](https://cursor.com)