### PR TITLE
docs: register platillo ownership issues #257–#259

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -29,7 +29,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 | File | Purpose |
 |------|---------|
-| [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX; #232–#242 epics; ~~#250~~), states, dependencies |
+| [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX; #232–#242 epics; #257–#259 platillo ownership; ~~#250~~), states, dependencies |
 | [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md) | Patient registration export/import plan |
 
 **Parallel track (public booking — future; depends on #246+):**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -600,7 +600,7 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 **Epic #221–#223** (2026-06-18): export/import patient **registration** to `.mpx` (YAML, no history) + export/delete UI. ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). **NEXT:** [#222 import](https://github.com/diego-torres/nutriconsultas/issues/222) → #223. Complements #190 patient caps; available all tiers.
 
-**Epics #232–#242** (2026-06-19): diet catalog (#232–#235), branding (#236–#237), diet/platillo UX (#238–#240), patient UX (#241–#242). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+**Epics #232–#242** (2026-06-19): diet catalog (#232–#235), branding (#236–#237), diet/platillo UX (#238–#240), patient UX (#241–#242). **Epic #257–#259** (2026-06-19): platillo catalog ownership (lock system rows, creator edit, copy). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
 **Bug ~~#250~~** (2026-06-19): diet ingesta platillo name links to wrong catalog platillo — **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)).
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-19 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). **NEXT:** [#222 import](https://github.com/diego-torres/nutriconsultas/issues/222). Epics **#232–#242** registered.
+**Last updated:** 2026-06-19 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). **NEXT:** [#222 import](https://github.com/diego-torres/nutriconsultas/issues/222). Epics **#232–#242**, **#257–#259** (platillo ownership) registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -63,6 +63,26 @@ System template diets (`userId = system:template-dietas`), grid actions, and own
 | 233 | Diet list grid — edit action | https://github.com/diego-torres/nutriconsultas/issues/233 | open | — | Link to `/admin/dietas/{id}` |
 | 234 | Diet list grid — delete action with patient-usage guard | https://github.com/diego-torres/nutriconsultas/issues/234 | open | — | Block if `PacienteDieta` exists; SweetAlert |
 | 235 | Diet list grid — filter all, system, or own diets | https://github.com/diego-torres/nutriconsultas/issues/235 | open | — | Server-side filter on `/rest/dietas` grid |
+
+---
+
+## Epic — Platillo catalog ownership
+
+Lock **system** catalog platillos for nutritionists; **owned** platillos editable by creator; **copy** to fork without mutating shared rows.
+
+| Requirement | Issues |
+|-------------|--------|
+| System platillos read-only for non-admin | #257 |
+| Creator can edit/delete own platillos | #258 |
+| Copy platillo into owned catalog row | #259 |
+
+**Suggested order:** #257 → #258 → #259 (ownership schema before copy).
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| 257 | Lock system catalog platillos for non-admin users | https://github.com/diego-torres/nutriconsultas/issues/257 | open | #183, #46 | `userId` / system sentinel; UI read-only; server guards |
+| 258 | Nutritionist-owned platillos — creator can edit and delete | https://github.com/diego-torres/nutriconsultas/issues/258 | open | **257**, #46 | Multi-tenant like `Dieta.userId`; grid filter own + system |
+| 259 | Copy platillo — duplicate into nutritionist-owned catalog row | https://github.com/diego-torres/nutriconsultas/issues/259 | open | **257**, **258** | SweetAlert optional; clone ingredients; complements #250 `sourcePlatilloId` |
 
 ---
 
@@ -136,7 +156,7 @@ System template diets (`userId = system:template-dietas`), grid actions, and own
 | #109 Mobile linkage | Delete clears `patientAuthSub`; not stored in `.mpx` |
 | #220 Retention purge | Platform admin purge of **revoked** nutritionists — orthogonal to nutritionist-initiated patient delete |
 | #132 Patient invitations | Onboarding `Paciente.status` — import creates `ACTIVE` patient unless product specifies otherwise |
-| #183 Platform admin | System diet edit (#232) |
+| #183 Platform admin | System diet edit (#232); system platillo edit (#257) |
 | #187 Branded PDF | Logo profile (#236) and PDF sizing (#237) |
 | #198 Diet templates | System diets seeded; editable by admin via #232 |
 | #243 / #244 Subscription | reCAPTCHA + Solicitar acceso pre-fill — public funnel, not admin UI |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-19):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: MPX #221–#223; epics #232–#242; ~~#250~~ done (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). Public booking #245–#248 (deferred).
+**On `main` (2026-06-19):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: MPX #221–#223; epics #232–#242; platillo ownership #257–#259; ~~#250~~ done (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). Public booking #245–#248 (deferred).
 
 ## AWS (production infrastructure)
 


### PR DESCRIPTION
## Summary
- Register three `[Nutritionist Web]` GitHub issues for platillo catalog ownership
- Add **Epic — Platillo catalog ownership** to `ISSUE-NUTRITIONIST-WEB.md`
- Cross-reference in `AGENTS.md`, `AGENT-WORKFLOW.md`, and `README.md`

## Issues
| # | Title |
|---|--------|
| [#257](https://github.com/diego-torres/nutriconsultas/issues/257) | Lock system catalog platillos for non-admin users |
| [#258](https://github.com/diego-torres/nutriconsultas/issues/258) | Nutritionist-owned platillos — creator can edit and delete |
| [#259](https://github.com/diego-torres/nutriconsultas/issues/259) | Copy platillo — duplicate into nutritionist-owned catalog row |

**Suggested order:** #257 → #258 → #259

## Test plan
- [ ] Review epic table and dependency links in `ISSUE-NUTRITIONIST-WEB.md`
- [ ] Confirm GitHub issue URLs #257–#259 resolve
- [ ] Spot-check AGENTS / AGENT-WORKFLOW / README pointers


Made with [Cursor](https://cursor.com)