### PR TITLE
feat(paciente): import patient registration from .mpx file (#222)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -42,7 +42,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (subscription):** [#207 — Stripe payment provider](https://github.com/diego-torres/nutriconsultas/issues/207). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#211~~ merged PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230).
 
-**Current next issue (nutritionist web):** [#222 — Import patient registration from .mpx](https://github.com/diego-torres/nutriconsultas/issues/222) → #223. ~~#221~~ done (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). ~~#250~~ done (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+**Current next issue (nutritionist web):** [#223 — Patient export and delete actions](https://github.com/diego-torres/nutriconsultas/issues/223). ~~#222~~ done (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#221~~ done (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). ~~#250~~ done (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
 ---
 
@@ -432,7 +432,7 @@ gh pr create ...
 
 **Subscription track (parallel):** see [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#180–#185~~, ~~#187~~ (PR #218), ~~#190~~ (PR #216), ~~#210~~ (PR #224), ~~#211~~ (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)) on `main`. **NEXT:** #207 (+ #208 Stripe ops, email #209, retention #220).
 
-**Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) — MPX epic **#221–#223**; ~~#221~~ done (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)); **NEXT:** #222 import.
+**Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) — MPX epic **#221–#223**; ~~#221~~ done (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)); ~~#222~~ done (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)); **NEXT:** #223 export/delete UI.
 
 **Production (2026-06-18):** ~~#226~~ invitation base URL fix (PR #227) — `APP_BASE_URL` / host remediation on EC2.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -598,7 +598,7 @@ Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow
 
 Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md).
 
-**Epic #221–#223** (2026-06-18): export/import patient **registration** to `.mpx` (YAML, no history) + export/delete UI. ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). **NEXT:** [#222 import](https://github.com/diego-torres/nutriconsultas/issues/222) → #223. Complements #190 patient caps; available all tiers.
+**Epic #221–#223** (2026-06-18): export/import patient **registration** to `.mpx` (YAML, no history) + export/delete UI. ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). **NEXT:** [#223 export/delete UI](https://github.com/diego-torres/nutriconsultas/issues/223). Complements #190 patient caps; available all tiers.
 
 **Epics #232–#242** (2026-06-19): diet catalog (#232–#235), branding (#236–#237), diet/platillo UX (#238–#240), patient UX (#241–#242). **Epic #257–#259** (2026-06-19): platillo catalog ownership (lock system rows, creator edit, copy). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-19 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). **NEXT:** [#222 import](https://github.com/diego-torres/nutriconsultas/issues/222). Epics **#232–#242**, **#257–#259** (platillo ownership) registered.
+**Last updated:** 2026-06-19 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). **NEXT:** [#223 export/delete UI](https://github.com/diego-torres/nutriconsultas/issues/223). ~~#222~~ **in-progress** (import). Epics **#232–#242**, **#257–#259** (platillo ownership) registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -37,8 +37,8 @@ Help nutritionists **rotate patient slots** (especially **plan básico** cap via
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | **221** | Export patient registration to .mpx (YAML, no history) | https://github.com/diego-torres/nutriconsultas/issues/221 | **done** | #156, #190 (context) | PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254); `GET /admin/pacientes/{id}/export.mpx` |
-| **222** | Import patient registration from .mpx file | https://github.com/diego-torres/nutriconsultas/issues/222 | **NEXT** | **221**, #190 | New `Paciente`; no history restore |
-| 223 | Patient export and delete actions with pre-delete backup | https://github.com/diego-torres/nutriconsultas/issues/223 | open | **221**, **222**, #190 | SweetAlert; historial loss copy |
+| **222** | Import patient registration from .mpx file | https://github.com/diego-torres/nutriconsultas/issues/222 | **in-progress** | **221**, #190 | `POST /admin/pacientes/importar.mpx`; listado upload form |
+| 223 | Patient export and delete actions with pre-delete backup | https://github.com/diego-torres/nutriconsultas/issues/223 | **NEXT** | **221**, **222**, #190 | SweetAlert; historial loss copy |
 
 **All tiers:** export/import/delete UI is **not** entitlement-gated; basic plan is the primary use case.
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-19 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). **NEXT:** [#223 export/delete UI](https://github.com/diego-torres/nutriconsultas/issues/223). ~~#222~~ **in-progress** (import). Epics **#232–#242**, **#257–#259** (platillo ownership) registered.
+**Last updated:** 2026-06-19 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). **NEXT:** [#223 export/delete UI](https://github.com/diego-torres/nutriconsultas/issues/223). Epics **#232–#242**, **#257–#259** (platillo ownership) registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -37,8 +37,8 @@ Help nutritionists **rotate patient slots** (especially **plan básico** cap via
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | **221** | Export patient registration to .mpx (YAML, no history) | https://github.com/diego-torres/nutriconsultas/issues/221 | **done** | #156, #190 (context) | PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254); `GET /admin/pacientes/{id}/export.mpx` |
-| **222** | Import patient registration from .mpx file | https://github.com/diego-torres/nutriconsultas/issues/222 | **in-progress** | **221**, #190 | `POST /admin/pacientes/importar.mpx`; listado upload form |
-| 223 | Patient export and delete actions with pre-delete backup | https://github.com/diego-torres/nutriconsultas/issues/223 | **NEXT** | **221**, **222**, #190 | SweetAlert; historial loss copy |
+| **222** | Import patient registration from .mpx file | https://github.com/diego-torres/nutriconsultas/issues/222 | **done** | **221**, #190 | PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261); `POST /admin/pacientes/importar.mpx` |
+| **223** | Patient export and delete actions with pre-delete backup | https://github.com/diego-torres/nutriconsultas/issues/223 | **NEXT** | **221**, **222**, #190 | SweetAlert; historial loss copy |
 
 **All tiers:** export/import/delete UI is **not** entitlement-gated; basic plan is the primary use case.
 

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -38,7 +38,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`../../ISSUE-NUTRITIONIST-WEB.md`](../../ISSUE-NUTRITIONIST-WEB.md) | Patient MPX epic (#221–#223) |
 | [`../paciente/PATIENT-MPX-PLAN.md`](../paciente/PATIENT-MPX-PLAN.md) | Export/import plan |
 
-**Nutritionist web NEXT:** [#221](https://github.com/diego-torres/nutriconsultas/issues/221) export → #222 import → #223 UI.
+**Nutritionist web NEXT:** [#223](https://github.com/diego-torres/nutriconsultas/issues/223) export/delete UI. ~~#221~~ export · ~~#222~~ import done (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)).
 
 **Subscription NEXT:** [#207](https://github.com/diego-torres/nutriconsultas/issues/207) Stripe payment provider (~~#211~~ PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230), ~~#210~~ PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224), ~~#187~~ PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218), ~~#190~~ PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) on `main`).
 

--- a/docs/paciente/MPX-FORMAT.md
+++ b/docs/paciente/MPX-FORMAT.md
@@ -143,6 +143,26 @@ patient:
 
 ---
 
+## Import rules (#222)
+
+| Topic | Rule |
+|-------|------|
+| Endpoint | `POST /admin/pacientes/importar.mpx` (multipart field `mpxFile`) |
+| Extension | Must end with `.mpx` |
+| Version | Reject `mpxVersion` other than `1` with Spanish error |
+| Tenant | Always set `userId` from authenticated nutritionist — never from file |
+| New row | Always creates a **new** `Paciente`; never merges into an existing record |
+| Status | Set `PacienteStatus.ACTIVE` |
+| `registro` | Set to server time at import (not restored from file) |
+| Excluded on import | `id`, `userId`, `patientAuthSub`, `assignedId`, `displayName`, `emailHint`, all history entities |
+| Plan cap | `SubscriptionEntitlementService.assertCanCreatePatient(userId)` before save (#190) |
+| Validation | Same Jakarta constraints as manual alta (`@NotBlank` name/gender, `@NotNull` dob, `@ValidPregnancy`) |
+| Duplicate hint | Soft warning (SweetAlert) when same `name` + `dob` already exists for the nutritionist; import still proceeds |
+| Success UX | Redirect to `/admin/pacientes/{id}` with success SweetAlert; duplicate warning shown after success |
+| Errors | Spanish messages; invalid file/version/validation shown via SweetAlert on listado |
+
+---
+
 ## Related
 
 - [`PATIENT-MPX-PLAN.md`](PATIENT-MPX-PLAN.md) — product goals and implementation order

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -21,6 +21,9 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.nutriconsultas.calendar.CalendarEvent;
 import com.nutriconsultas.calendar.CalendarEventService;
@@ -39,7 +42,10 @@ import com.nutriconsultas.paciente.calculation.BmrCalculationService;
 import com.nutriconsultas.subscription.SubscriptionErrorResponses;
 import com.nutriconsultas.subscription.SubscriptionLimitExceededException;
 import com.nutriconsultas.paciente.mpx.MpxExportResult;
+import com.nutriconsultas.paciente.mpx.MpxImportException;
+import com.nutriconsultas.paciente.mpx.MpxImportResult;
 import com.nutriconsultas.paciente.mpx.PacienteMpxExportService;
+import com.nutriconsultas.paciente.mpx.PacienteMpxImportService;
 import com.nutriconsultas.util.LogRedaction;
 
 import org.springframework.http.HttpHeaders;
@@ -105,6 +111,9 @@ public class PacienteController extends AbstractAuthorizedController {
 	@Autowired
 	private PacienteMpxExportService pacienteMpxExportService;
 
+	@Autowired
+	private PacienteMpxImportService pacienteMpxImportService;
+
 	/**
 	 * Gets the user ID from the OAuth2 principal.
 	 * @param principal the OAuth2 principal
@@ -158,6 +167,40 @@ public class PacienteController extends AbstractAuthorizedController {
 		log.debug("Listado de pacientes");
 		model.addAttribute("activeMenu", "pacientes");
 		return "sbadmin/pacientes/listado";
+	}
+
+	/**
+	 * Imports a patient registration profile from an uploaded {@code .mpx} file (#222).
+	 * Creates a new patient for the authenticated nutritionist; clinical history is not
+	 * restored.
+	 */
+	@PostMapping(path = "/admin/pacientes/importar.mpx", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public String importPacienteMpx(@RequestParam("mpxFile") final MultipartFile mpxFile,
+			@AuthenticationPrincipal final OidcUser principal, final RedirectAttributes redirectAttributes) {
+		log.debug("Importing MPX registration");
+		final String userId = getUserId(principal);
+		if (userId == null) {
+			redirectAttributes.addFlashAttribute("importError", "No se pudo identificar al usuario");
+			return "redirect:/admin/pacientes";
+		}
+		try {
+			final MpxImportResult result = pacienteMpxImportService.importRegistration(mpxFile, userId);
+			redirectAttributes.addFlashAttribute("importSuccess", "Paciente importado correctamente");
+			if (result.duplicateWarning()) {
+				redirectAttributes.addFlashAttribute("importDuplicateWarning",
+						"Ya existe un paciente con el mismo nombre y fecha de nacimiento en su lista");
+			}
+			return "redirect:/admin/pacientes/" + result.pacienteId();
+		}
+		catch (final MpxImportException ex) {
+			log.warn("MPX import rejected: {}", ex.getMessage());
+			redirectAttributes.addFlashAttribute("importError", ex.getMessage());
+			return "redirect:/admin/pacientes";
+		}
+		catch (final SubscriptionLimitExceededException ex) {
+			redirectAttributes.addFlashAttribute("importError", subscriptionErrorResponses.resolve(ex));
+			return "redirect:/admin/pacientes";
+		}
 	}
 
 	@PostMapping(path = "/admin/pacientes/nuevo")

--- a/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
@@ -1,6 +1,7 @@
 package com.nutriconsultas.paciente;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -73,5 +74,7 @@ public interface PacienteRepository extends JpaRepository<Paciente, Long> {
 
 	@Query("SELECT COUNT(p) FROM Paciente p WHERE p.userId IN :userIds")
 	long countByUserIdIn(@Param("userIds") Collection<String> userIds);
+
+	boolean existsByUserIdAndNameIgnoreCaseAndDob(String userId, String name, Date dob);
 
 }

--- a/src/main/java/com/nutriconsultas/paciente/mpx/MpxImportException.java
+++ b/src/main/java/com/nutriconsultas/paciente/mpx/MpxImportException.java
@@ -1,0 +1,18 @@
+package com.nutriconsultas.paciente.mpx;
+
+/**
+ * User-facing MPX import failure (#222). Message is safe to show in the admin UI.
+ */
+public class MpxImportException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public MpxImportException(final String message) {
+		super(message);
+	}
+
+	public MpxImportException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/mpx/MpxImportResult.java
+++ b/src/main/java/com/nutriconsultas/paciente/mpx/MpxImportResult.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.paciente.mpx;
+
+/**
+ * Result of a successful MPX import (#222).
+ *
+ * @param pacienteId saved patient primary key
+ * @param duplicateWarning {@code true} when another patient with the same name and date
+ * of birth already exists for the nutritionist
+ */
+public record MpxImportResult(Long pacienteId, boolean duplicateWarning) {
+}

--- a/src/main/java/com/nutriconsultas/paciente/mpx/PacienteMpxImportService.java
+++ b/src/main/java/com/nutriconsultas/paciente/mpx/PacienteMpxImportService.java
@@ -1,0 +1,107 @@
+package com.nutriconsultas.paciente.mpx;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.error.YAMLException;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteService;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Imports patient registration profiles from MPX v1 YAML files (#222).
+ */
+@Service
+@Slf4j
+public class PacienteMpxImportService {
+
+	private final PacienteRepository pacienteRepository;
+
+	private final PacienteService pacienteService;
+
+	private final Validator validator;
+
+	public PacienteMpxImportService(final PacienteRepository pacienteRepository, final PacienteService pacienteService,
+			final Validator validator) {
+		this.pacienteRepository = pacienteRepository;
+		this.pacienteService = pacienteService;
+		this.validator = validator;
+	}
+
+	@Transactional
+	public MpxImportResult importRegistration(@NonNull final MultipartFile file, @NonNull final String userId) {
+		validateFile(file);
+		final MpxDocument document = parseDocument(readContent(file));
+		final Paciente paciente = PacienteMpxMapper.toPaciente(document, userId);
+		validatePaciente(paciente);
+		final boolean duplicateWarning = detectDuplicateWarning(userId, paciente);
+		final Paciente saved = pacienteService.save(paciente);
+		log.info("Imported MPX registration as new paciente id {}", saved.getId());
+		return new MpxImportResult(saved.getId(), duplicateWarning);
+	}
+
+	private void validateFile(final MultipartFile file) {
+		final String filename = file.getOriginalFilename();
+		if (filename == null || !filename.toLowerCase().endsWith(".mpx")) {
+			throw new MpxImportException("El archivo debe tener extensión .mpx");
+		}
+		if (file.isEmpty()) {
+			throw new MpxImportException("El archivo está vacío");
+		}
+	}
+
+	private byte[] readContent(final MultipartFile file) {
+		try {
+			return file.getBytes();
+		}
+		catch (final IOException ex) {
+			throw new MpxImportException("No se pudo leer el archivo MPX", ex);
+		}
+	}
+
+	private MpxDocument parseDocument(final byte[] content) {
+		try {
+			final Constructor constructor = new Constructor(MpxDocument.class, new LoaderOptions());
+			final Yaml yaml = new Yaml(constructor);
+			final Object loaded = yaml.load(new String(content, StandardCharsets.UTF_8));
+			if (!(loaded instanceof MpxDocument document)) {
+				throw new MpxImportException("El archivo no es un MPX válido");
+			}
+			return document;
+		}
+		catch (final YAMLException ex) {
+			throw new MpxImportException("El archivo no es un MPX válido", ex);
+		}
+	}
+
+	private void validatePaciente(final Paciente paciente) {
+		final String validationMessage = validator.validate(paciente)
+			.stream()
+			.map(ConstraintViolation::getMessage)
+			.collect(Collectors.joining("; "));
+		if (!validationMessage.isBlank()) {
+			throw new MpxImportException("Datos de paciente inválidos: " + validationMessage);
+		}
+	}
+
+	private boolean detectDuplicateWarning(final String userId, final Paciente paciente) {
+		if (paciente.getName() == null || paciente.getDob() == null) {
+			return false;
+		}
+		return pacienteRepository.existsByUserIdAndNameIgnoreCaseAndDob(userId, paciente.getName(), paciente.getDob());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/mpx/PacienteMpxMapper.java
+++ b/src/main/java/com/nutriconsultas/paciente/mpx/PacienteMpxMapper.java
@@ -4,9 +4,20 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 
+import com.nutriconsultas.paciente.NivelPeso;
 import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.calculation.ActivityFactorScale;
+import com.nutriconsultas.paciente.calculation.BmrFormulaType;
+import com.nutriconsultas.paciente.calculation.PhysicalActivityLevel;
+import com.nutriconsultas.paciente.calculation.PhysiologicalStressType;
+import com.nutriconsultas.paciente.calculation.StressFormulaTable;
+import com.nutriconsultas.paciente.calculation.StressIncrementMode;
+import com.nutriconsultas.paciente.calculation.TefBase;
+import com.nutriconsultas.paciente.calculation.TefMethod;
 import com.nutriconsultas.paciente.embeddable.PacienteBodySnapshot;
 import com.nutriconsultas.paciente.satellite.PacienteEnergyPreferences;
 import com.nutriconsultas.paciente.satellite.PacienteMedicalHistory;
@@ -30,6 +41,141 @@ public final class PacienteMpxMapper {
 		document.setSourceApp(MpxConstants.SOURCE_APP);
 		document.setPatient(toPatientRegistration(paciente));
 		return document;
+	}
+
+	public static Paciente toPaciente(final MpxDocument document, final String userId) {
+		if (document == null || document.getPatient() == null) {
+			throw new MpxImportException("El archivo MPX no contiene datos de paciente");
+		}
+		if (document.getMpxVersion() != MpxConstants.MPX_VERSION) {
+			throw new MpxImportException("Versión MPX no compatible. Solo se admite la versión 1.");
+		}
+		if (document.getSourceApp() != null && !MpxConstants.SOURCE_APP.equals(document.getSourceApp())) {
+			throw new MpxImportException("El archivo MPX no proviene de Minutriporción");
+		}
+		final Paciente paciente = fromPatientRegistration(document.getPatient());
+		paciente.setUserId(userId);
+		paciente.setStatus(PacienteStatus.ACTIVE);
+		paciente.setRegistro(new Date());
+		return paciente;
+	}
+
+	private static Paciente fromPatientRegistration(final MpxPatientRegistration registration) {
+		final Paciente paciente = new Paciente();
+		paciente.setName(registration.getName());
+		paciente.setDob(parseDate(registration.getDob(), "fecha de nacimiento"));
+		paciente.setEmail(registration.getEmail());
+		paciente.setPhone(registration.getPhone());
+		paciente.setGender(registration.getGender());
+		paciente.setResponsibleName(registration.getResponsibleName());
+		paciente.setParentesco(registration.getParentesco());
+		paciente.setPregnancy(registration.getPregnancy() != null ? registration.getPregnancy() : false);
+		applyBodySnapshot(paciente, registration.getBodySnapshot());
+		applyEnergyPreferences(paciente, registration.getEnergyPreferences());
+		applyMedicalHistory(paciente, registration.getMedicalHistory());
+		return paciente;
+	}
+
+	private static void applyBodySnapshot(final Paciente paciente, final MpxBodySnapshot snapshot) {
+		if (snapshot == null) {
+			return;
+		}
+		paciente.setPeso(snapshot.getPeso());
+		paciente.setEstatura(snapshot.getEstatura());
+		paciente.setImc(snapshot.getImc());
+		paciente.setBmr(snapshot.getBmr());
+		paciente.setGetKcal(snapshot.getGetKcal());
+		paciente.setNivelPeso(parseEnum(snapshot.getNivelPeso(), NivelPeso.class, "nivel de peso"));
+		paciente.setTefKcal(snapshot.getTefKcal());
+		paciente.setTotalAdjustedKcal(snapshot.getTotalAdjustedKcal());
+		paciente.setStressKcal(snapshot.getStressKcal());
+		paciente.setFinalTotalKcal(snapshot.getFinalTotalKcal());
+	}
+
+	private static void applyEnergyPreferences(final Paciente paciente, final MpxEnergyPreferences energy) {
+		if (energy == null) {
+			return;
+		}
+		final PacienteEnergyPreferences preferences = paciente.getEnergyPreferences();
+		preferences.setActivityFactorScale(
+				parseEnum(energy.getActivityFactorScale(), ActivityFactorScale.class, "escala de factor de actividad"));
+		preferences.setPreferredBmrFormula(
+				parseEnum(energy.getPreferredBmrFormula(), BmrFormulaType.class, "fórmula de TMB preferida"));
+		preferences.setPhysicalActivityLevel(
+				parseEnum(energy.getPhysicalActivityLevel(), PhysicalActivityLevel.class, "nivel de actividad física"));
+		preferences.setActivityFactor(energy.getActivityFactor());
+		preferences.setCustomFactorSedentary(energy.getCustomFactorSedentary());
+		preferences.setCustomFactorLight(energy.getCustomFactorLight());
+		preferences.setCustomFactorModerate(energy.getCustomFactorModerate());
+		preferences.setCustomFactorIntense(energy.getCustomFactorIntense());
+		preferences.setCustomFactorVeryIntense(energy.getCustomFactorVeryIntense());
+		preferences.setPhysiologicalStressActive(energy.getPhysiologicalStressActive());
+		preferences.setPhysiologicalStressType(parseEnum(energy.getPhysiologicalStressType(),
+				PhysiologicalStressType.class, "tipo de estrés fisiológico"));
+		preferences.setStressFormulaTable(
+				parseEnum(energy.getStressFormulaTable(), StressFormulaTable.class, "tabla de estrés"));
+		preferences.setStressIncrementMode(
+				parseEnum(energy.getStressIncrementMode(), StressIncrementMode.class, "modo de incremento de estrés"));
+		preferences.setStressFactorValue(energy.getStressFactorValue());
+		preferences.setStressValidFrom(parseDate(energy.getStressValidFrom(), "inicio de vigencia de estrés"));
+		preferences.setStressValidUntil(parseDate(energy.getStressValidUntil(), "fin de vigencia de estrés"));
+		preferences.setStressFeverTemperature(energy.getStressFeverTemperature());
+		preferences.setTefMethod(parseEnum(energy.getTefMethod(), TefMethod.class, "método de TEF"));
+		preferences.setTefBase(parseEnum(energy.getTefBase(), TefBase.class, "base de TEF"));
+		preferences.setTefFixedPercent(energy.getTefFixedPercent());
+		preferences.setTefMacroProteinPercent(energy.getTefMacroProteinPercent());
+		preferences.setTefMacroCarbsPercent(energy.getTefMacroCarbsPercent());
+		preferences.setTefMacroFatPercent(energy.getTefMacroFatPercent());
+	}
+
+	private static void applyMedicalHistory(final Paciente paciente, final MpxMedicalHistory history) {
+		if (history == null) {
+			return;
+		}
+		final PacienteMedicalHistory medical = paciente.getMedicalHistory();
+		medical.setAntecedentesPrenatales(history.getAntecedentesPrenatales());
+		medical.setAntecedentesNatales(history.getAntecedentesNatales());
+		medical.setAntecedentesPatologicosPersonales(history.getAntecedentesPatologicosPersonales());
+		medical.setAntecedentesPatologicosFamiliares(history.getAntecedentesPatologicosFamiliares());
+		medical.setComplicaciones(history.getComplicaciones());
+		medical.setTipoSanguineo(history.getTipoSanguineo());
+		medical.setHistorialAlimenticio(history.getHistorialAlimenticio());
+		medical.setDesarrolloPsicomotor(history.getDesarrolloPsicomotor());
+		medical.setAlergias(history.getAlergias());
+		medical.setHipertension(history.getHipertension());
+		medical.setDiabetes(history.getDiabetes());
+		medical.setHipotiroidismo(history.getHipotiroidismo());
+		medical.setObesidad(history.getObesidad());
+		medical.setAnemia(history.getAnemia());
+		medical.setBulimia(history.getBulimia());
+		medical.setAnorexia(history.getAnorexia());
+		medical.setEnfermedadesHepaticas(history.getEnfermedadesHepaticas());
+	}
+
+	private static Date parseDate(final String value, final String fieldLabel) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		try {
+			final LocalDate localDate = LocalDate.parse(value, ISO_DATE);
+			return Date.from(localDate.atStartOfDay(ZoneOffset.UTC).toInstant());
+		}
+		catch (final DateTimeParseException ex) {
+			throw new MpxImportException("Fecha inválida en " + fieldLabel + ": " + value, ex);
+		}
+	}
+
+	private static <E extends Enum<E>> E parseEnum(final String value, final Class<E> enumType,
+			final String fieldLabel) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		try {
+			return Enum.valueOf(enumType, value);
+		}
+		catch (final IllegalArgumentException ex) {
+			throw new MpxImportException("Valor inválido en " + fieldLabel + ": " + value, ex);
+		}
 	}
 
 	private static MpxPatientRegistration toPatientRegistration(final Paciente paciente) {

--- a/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/subscription/invitation/NutritionistInvitationServiceImpl.java
@@ -218,7 +218,8 @@ public class NutritionistInvitationServiceImpl implements NutritionistInvitation
 		}
 		catch (PaymentProviderException ex) {
 			throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
-					"El pago en línea no está configurado. Solicite una invitación exenta de pago al administrador.", ex);
+					"El pago en línea no está configurado. Solicite una invitación exenta de pago al administrador.",
+					ex);
 		}
 	}
 

--- a/src/main/resources/templates/sbadmin/pacientes/listado.html
+++ b/src/main/resources/templates/sbadmin/pacientes/listado.html
@@ -23,6 +23,7 @@
 
   <!-- Custom styles for this template-->
   <link th:href="@{/sbadmin/css/sb-admin-2.min.css}" rel="stylesheet">
+  <link th:href="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.css}" rel="stylesheet">
 </head>
 
 <body id="page-top">
@@ -42,9 +43,36 @@
           <!-- Page Heading -->
           <div class="d-sm-flex align-items-center justify-content-between mb-4">
             <h1 class="h3 mb-0 text-gray-800">Listado de Pacientes</h1>
-            <a th:href="@{/admin/pacientes/nuevo}" class="d-none d-sm-inline-block btn btn-sm btn-primary shadow-sm">
-              <i class="fas fa-user-plus fa-sm text-white-50"></i> Nuevo Paciente
-            </a>
+            <div>
+              <a th:href="@{/admin/pacientes/nuevo}" class="d-none d-sm-inline-block btn btn-sm btn-primary shadow-sm mr-2">
+                <i class="fas fa-user-plus fa-sm text-white-50"></i> Nuevo Paciente
+              </a>
+            </div>
+          </div>
+
+          <div class="row mb-4">
+            <div class="col-12">
+              <div class="card shadow">
+                <div class="card-body">
+                  <h6 class="font-weight-bold text-primary mb-3">
+                    <i class="fas fa-file-import"></i> Importar paciente desde archivo .mpx
+                  </h6>
+                  <form th:action="@{/admin/pacientes/importar.mpx}" method="post" enctype="multipart/form-data"
+                    class="form-inline flex-wrap">
+                    <div class="form-group mr-2 mb-2">
+                      <input type="file" name="mpxFile" class="form-control-file" accept=".mpx" required
+                        aria-label="Archivo MPX">
+                    </div>
+                    <button type="submit" class="btn btn-sm btn-outline-primary mb-2">
+                      <i class="fas fa-upload"></i> Importar
+                    </button>
+                  </form>
+                  <small class="form-text text-muted">
+                    Restaura el perfil de registro exportado previamente. No incluye historial clínico.
+                  </small>
+                </div>
+              </div>
+            </div>
           </div>
 
           <!-- Content Row -->
@@ -94,6 +122,7 @@
 
     <!-- Custom scripts for all pages-->
     <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
+    <script th:src="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.js}"></script>
     <script lang="javascript">
       'use strict';
       (function ($) {
@@ -127,6 +156,16 @@
             }
           },
         });
+
+        var importError = /*[[${importError}]]*/ null;
+        if (importError && typeof swal !== 'undefined') {
+          swal({
+            title: 'No se pudo importar',
+            text: importError,
+            type: 'error',
+            timer: 5000
+          });
+        }
 
       })(jQuery);
     </script>

--- a/src/main/resources/templates/sbadmin/pacientes/perfil.html
+++ b/src/main/resources/templates/sbadmin/pacientes/perfil.html
@@ -22,6 +22,7 @@
 
   <!-- Custom styles for this template-->
   <link th:href="@{/sbadmin/css/sb-admin-2.css}" rel="stylesheet">
+  <link th:href="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.css}" rel="stylesheet">
   <div th:insert="~{sbadmin/pacientes/imc-gauge :: imcGaugeStyles}"></div>
 
 </head>
@@ -464,6 +465,34 @@
         });
     }
 
+  </script>
+  <script th:src="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.js}"></script>
+  <script th:inline="javascript">
+    'use strict';
+    (function () {
+      var importSuccess = /*[[${importSuccess}]]*/ null;
+      var importDuplicateWarning = /*[[${importDuplicateWarning}]]*/ null;
+      if (typeof swal === 'undefined') {
+        return;
+      }
+      if (importSuccess) {
+        swal({
+          title: 'Importación exitosa',
+          text: importSuccess,
+          type: 'success',
+          timer: 2500
+        });
+      }
+      if (importDuplicateWarning) {
+        setTimeout(function () {
+          swal({
+            title: 'Posible duplicado',
+            text: importDuplicateWarning,
+            type: 'warning'
+          });
+        }, importSuccess ? 2600 : 0);
+      }
+    })();
   </script>
 
 </body>

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationHumanCodeTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationHumanCodeTest.java
@@ -32,7 +32,8 @@ class PatientInvitationHumanCodeTest {
 		final String code = PatientInvitationHumanCode.format(secret, "NUTRI");
 
 		assertThat(PatientInvitationHumanCode.matchesSecret(secret, "NUTRI", code)).isTrue();
-		assertThat(PatientInvitationHumanCode.matchesSecret(secret, "NUTRI", code.substring(0, code.length() - 1) + "Z"))
+		assertThat(
+				PatientInvitationHumanCode.matchesSecret(secret, "NUTRI", code.substring(0, code.length() - 1) + "Z"))
 			.isFalse();
 	}
 

--- a/src/test/java/com/nutriconsultas/paciente/mpx/PacienteMpxImportControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/mpx/PacienteMpxImportControllerTest.java
@@ -1,0 +1,125 @@
+package com.nutriconsultas.paciente.mpx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import com.nutriconsultas.paciente.PacienteController;
+import com.nutriconsultas.subscription.SubscriptionErrorResponses;
+import com.nutriconsultas.subscription.SubscriptionLimitExceededException;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ActiveProfiles("test")
+@SuppressWarnings("null")
+class PacienteMpxImportControllerTest {
+
+	private static final String USER_ID = "nutritionist-owner";
+
+	@InjectMocks
+	private PacienteController controller;
+
+	@Mock
+	private PacienteMpxImportService pacienteMpxImportService;
+
+	@Mock
+	private SubscriptionErrorResponses subscriptionErrorResponses;
+
+	@Mock
+	private OidcUser principal;
+
+	private RedirectAttributes redirectAttributes;
+
+	@BeforeEach
+	void setUp() {
+		ReflectionTestUtils.setField(controller, "pacienteMpxImportService", pacienteMpxImportService);
+		ReflectionTestUtils.setField(controller, "subscriptionErrorResponses", subscriptionErrorResponses);
+		when(principal.getSubject()).thenReturn(USER_ID);
+		redirectAttributes = new RedirectAttributesModelMap();
+	}
+
+	@Test
+	void importPacienteMpx_redirectsToProfileOnSuccess() {
+		final MockMultipartFile file = new MockMultipartFile("mpxFile", "juan.mpx", "application/x-yaml",
+				new byte[] { 1 });
+		when(pacienteMpxImportService.importRegistration(eq(file), eq(USER_ID)))
+			.thenReturn(new MpxImportResult(12L, false));
+
+		final String view = controller.importPacienteMpx(file, principal, redirectAttributes);
+
+		assertThat(view).isEqualTo("redirect:/admin/pacientes/12");
+		assertThat(redirectAttributes.getFlashAttributes().get("importSuccess"))
+			.isEqualTo("Paciente importado correctamente");
+	}
+
+	@Test
+	void importPacienteMpx_addsDuplicateWarningFlash() {
+		final MockMultipartFile file = new MockMultipartFile("mpxFile", "juan.mpx", "application/x-yaml",
+				new byte[] { 1 });
+		when(pacienteMpxImportService.importRegistration(eq(file), eq(USER_ID)))
+			.thenReturn(new MpxImportResult(12L, true));
+
+		controller.importPacienteMpx(file, principal, redirectAttributes);
+
+		assertThat(redirectAttributes.getFlashAttributes()).containsKey("importDuplicateWarning");
+	}
+
+	@Test
+	void importPacienteMpx_redirectsWithErrorOnInvalidFile() {
+		final MockMultipartFile file = new MockMultipartFile("mpxFile", "bad.mpx", "application/x-yaml",
+				new byte[] { 1 });
+		when(pacienteMpxImportService.importRegistration(any(), eq(USER_ID)))
+			.thenThrow(new MpxImportException("El archivo no es un MPX válido"));
+
+		final String view = controller.importPacienteMpx(file, principal, redirectAttributes);
+
+		assertThat(view).isEqualTo("redirect:/admin/pacientes");
+		assertThat(redirectAttributes.getFlashAttributes().get("importError"))
+			.isEqualTo("El archivo no es un MPX válido");
+	}
+
+	@Test
+	void importPacienteMpx_redirectsWithSubscriptionErrorWhenCapExceeded() {
+		final MockMultipartFile file = new MockMultipartFile("mpxFile", "juan.mpx", "application/x-yaml",
+				new byte[] { 1 });
+		when(pacienteMpxImportService.importRegistration(any(), eq(USER_ID)))
+			.thenThrow(new SubscriptionLimitExceededException("error.subscription.patient_limit"));
+		when(subscriptionErrorResponses.resolve(any(SubscriptionLimitExceededException.class)))
+			.thenReturn("Ha alcanzado el límite de pacientes de su plan");
+
+		final String view = controller.importPacienteMpx(file, principal, redirectAttributes);
+
+		assertThat(view).isEqualTo("redirect:/admin/pacientes");
+		assertThat(redirectAttributes.getFlashAttributes().get("importError"))
+			.isEqualTo("Ha alcanzado el límite de pacientes de su plan");
+	}
+
+	@Test
+	void importPacienteMpx_redirectsWhenPrincipalMissing() {
+		final MockMultipartFile file = new MockMultipartFile("mpxFile", "juan.mpx", "application/x-yaml",
+				new byte[] { 1 });
+
+		final String view = controller.importPacienteMpx(file, null, redirectAttributes);
+
+		assertThat(view).isEqualTo("redirect:/admin/pacientes");
+		assertThat(redirectAttributes.getFlashAttributes().get("importError"))
+			.isEqualTo("No se pudo identificar al usuario");
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/mpx/PacienteMpxImportServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/mpx/PacienteMpxImportServiceTest.java
@@ -1,0 +1,271 @@
+package com.nutriconsultas.paciente.mpx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.nutriconsultas.paciente.NivelPeso;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteService;
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.calculation.ActivityFactorScale;
+import com.nutriconsultas.paciente.calculation.BmrFormulaType;
+import com.nutriconsultas.paciente.calculation.PhysicalActivityLevel;
+import com.nutriconsultas.paciente.calculation.TefMethod;
+import com.nutriconsultas.subscription.SubscriptionLimitExceededException;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+@SuppressWarnings("null")
+class PacienteMpxImportServiceTest {
+
+	private static final String OWNER_USER_ID = "nutritionist-owner";
+
+	private static final Instant FIXED_INSTANT = Instant.parse("2026-06-18T12:00:00Z");
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Mock
+	private PacienteService pacienteService;
+
+	private PacienteMpxExportService exportService;
+
+	private PacienteMpxImportService importService;
+
+	private Paciente sourcePaciente;
+
+	@BeforeEach
+	void setUp() {
+		final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+		importService = new PacienteMpxImportService(pacienteRepository, pacienteService, validator);
+		exportService = new PacienteMpxExportService(pacienteRepository, Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC));
+		sourcePaciente = buildSamplePaciente();
+	}
+
+	@Test
+	void importRegistration_roundTripFromExport_createsNewPatientForOwner() {
+		when(pacienteRepository.findByIdAndUserId(42L, OWNER_USER_ID))
+			.thenReturn(java.util.Optional.of(sourcePaciente));
+		when(pacienteRepository.existsByUserIdAndNameIgnoreCaseAndDob(eq(OWNER_USER_ID), eq("Juan Perez"),
+				any(Date.class)))
+			.thenReturn(false);
+
+		final MpxExportResult export = exportService.exportRegistration(42L, OWNER_USER_ID);
+		final MockMultipartFile file = new MockMultipartFile("mpxFile", "juan.mpx", "application/x-yaml",
+				export.content());
+
+		final Paciente saved = new Paciente();
+		saved.setId(100L);
+		when(pacienteService.save(any(Paciente.class))).thenAnswer(invocation -> {
+			final Paciente paciente = invocation.getArgument(0);
+			saved.setName(paciente.getName());
+			saved.setUserId(paciente.getUserId());
+			saved.setStatus(paciente.getStatus());
+			return saved;
+		});
+
+		final MpxImportResult result = importService.importRegistration(file, OWNER_USER_ID);
+
+		assertThat(result.pacienteId()).isEqualTo(100L);
+		assertThat(result.duplicateWarning()).isFalse();
+
+		final ArgumentCaptor<Paciente> captor = ArgumentCaptor.forClass(Paciente.class);
+		verify(pacienteService).save(captor.capture());
+		final Paciente imported = captor.getValue();
+		assertThat(imported.getId()).isNull();
+		assertThat(imported.getUserId()).isEqualTo(OWNER_USER_ID);
+		assertThat(imported.getStatus()).isEqualTo(PacienteStatus.ACTIVE);
+		assertThat(imported.getName()).isEqualTo("Juan Perez");
+		assertThat(imported.getPatientAuthSub()).isNull();
+		assertThat(imported.getAssignedId()).isNull();
+		assertThat(imported.getRegistro()).isNotNull();
+		assertThat(imported.getNivelPeso()).isEqualTo(NivelPeso.NORMAL);
+		assertThat(imported.getEnergyPreferences().getPreferredBmrFormula()).isEqualTo(BmrFormulaType.PROMEDIO);
+		assertThat(imported.getMedicalHistory().getTipoSanguineo()).isEqualTo("O+");
+	}
+
+	@Test
+	void importRegistration_setsDuplicateWarningWhenNameAndDobMatch() {
+		final byte[] content = buildMinimalMpxYaml().getBytes(StandardCharsets.UTF_8);
+		final MockMultipartFile file = new MockMultipartFile("mpxFile", "juan.mpx", "application/x-yaml", content);
+		when(pacienteRepository.existsByUserIdAndNameIgnoreCaseAndDob(any(), any(), any())).thenReturn(true);
+		when(pacienteService.save(any(Paciente.class))).thenAnswer(invocation -> {
+			final Paciente paciente = invocation.getArgument(0);
+			paciente.setId(101L);
+			return paciente;
+		});
+
+		final MpxImportResult result = importService.importRegistration(file, OWNER_USER_ID);
+
+		assertThat(result.duplicateWarning()).isTrue();
+	}
+
+	@Test
+	void importRegistration_rejectsUnsupportedMpxVersion() {
+		final String yaml = buildMinimalMpxYaml().replace("mpxVersion: 1", "mpxVersion: 2");
+		final MockMultipartFile file = new MockMultipartFile("mpxFile", "bad.mpx", "application/x-yaml",
+				yaml.getBytes(StandardCharsets.UTF_8));
+
+		assertThatThrownBy(() -> importService.importRegistration(file, OWNER_USER_ID))
+			.isInstanceOf(MpxImportException.class)
+			.hasMessage("Versión MPX no compatible. Solo se admite la versión 1.");
+		verify(pacienteService, never()).save(any(Paciente.class));
+	}
+
+	@Test
+	void importRegistration_rejectsInvalidYaml() {
+		final MockMultipartFile file = new MockMultipartFile("mpxFile", "bad.mpx", "application/x-yaml",
+				"not: [valid: yaml".getBytes(StandardCharsets.UTF_8));
+
+		assertThatThrownBy(() -> importService.importRegistration(file, OWNER_USER_ID))
+			.isInstanceOf(MpxImportException.class)
+			.hasMessage("El archivo no es un MPX válido");
+	}
+
+	@Test
+	void importRegistration_rejectsMissingRequiredFields() {
+		final String yaml = """
+				mpxVersion: 1
+				exportedAt: "2026-06-18T12:00:00Z"
+				sourceApp: nutriconsultas
+				patient:
+				  email: juan@example.com
+				""";
+		final MockMultipartFile file = new MockMultipartFile("mpxFile", "bad.mpx", "application/x-yaml",
+				yaml.getBytes(StandardCharsets.UTF_8));
+
+		assertThatThrownBy(() -> importService.importRegistration(file, OWNER_USER_ID))
+			.isInstanceOf(MpxImportException.class)
+			.hasMessageContaining("Datos de paciente inválidos");
+	}
+
+	@Test
+	void importRegistration_rejectsNonMpxExtension() {
+		final MockMultipartFile file = new MockMultipartFile("mpxFile", "juan.yaml", "application/x-yaml",
+				buildMinimalMpxYaml().getBytes(StandardCharsets.UTF_8));
+
+		assertThatThrownBy(() -> importService.importRegistration(file, OWNER_USER_ID))
+			.isInstanceOf(MpxImportException.class)
+			.hasMessage("El archivo debe tener extensión .mpx");
+	}
+
+	@Test
+	void importRegistration_rejectsEmptyFile() {
+		final MockMultipartFile file = new MockMultipartFile("mpxFile", "empty.mpx", "application/x-yaml", new byte[0]);
+
+		assertThatThrownBy(() -> importService.importRegistration(file, OWNER_USER_ID))
+			.isInstanceOf(MpxImportException.class)
+			.hasMessage("El archivo está vacío");
+	}
+
+	@Test
+	void importRegistration_propagatesSubscriptionLimitExceeded() {
+		final MockMultipartFile file = new MockMultipartFile("mpxFile", "juan.mpx", "application/x-yaml",
+				buildMinimalMpxYaml().getBytes(StandardCharsets.UTF_8));
+		when(pacienteRepository.existsByUserIdAndNameIgnoreCaseAndDob(any(), any(), any())).thenReturn(false);
+		when(pacienteService.save(any(Paciente.class)))
+			.thenThrow(new SubscriptionLimitExceededException("error.subscription.patient_limit"));
+
+		assertThatThrownBy(() -> importService.importRegistration(file, OWNER_USER_ID))
+			.isInstanceOf(SubscriptionLimitExceededException.class);
+	}
+
+	@Test
+	void importRegistration_assignsAuthenticatedUserIdNotExportTenant() {
+		final MockMultipartFile file = new MockMultipartFile("mpxFile", "juan.mpx", "application/x-yaml",
+				buildMinimalMpxYaml().getBytes(StandardCharsets.UTF_8));
+		when(pacienteRepository.existsByUserIdAndNameIgnoreCaseAndDob(any(), any(), any())).thenReturn(false);
+		when(pacienteService.save(any(Paciente.class))).thenAnswer(invocation -> {
+			final Paciente paciente = invocation.getArgument(0);
+			paciente.setId(55L);
+			return paciente;
+		});
+
+		importService.importRegistration(file, "different-nutritionist");
+
+		final ArgumentCaptor<Paciente> captor = ArgumentCaptor.forClass(Paciente.class);
+		verify(pacienteService).save(captor.capture());
+		assertThat(captor.getValue().getUserId()).isEqualTo("different-nutritionist");
+	}
+
+	private static String buildMinimalMpxYaml() {
+		return """
+				mpxVersion: 1
+				exportedAt: "2026-06-18T12:00:00Z"
+				sourceApp: nutriconsultas
+				patient:
+				  name: Juan Perez
+				  dob: "1990-01-15"
+				  gender: M
+				  pregnancy: false
+				""";
+	}
+
+	private static Paciente buildSamplePaciente() {
+		final Paciente entity = new Paciente();
+		entity.setId(42L);
+		entity.setUserId(OWNER_USER_ID);
+		entity.setPatientAuthSub("auth0|patient-sub");
+		entity.setAssignedId("MP-001");
+		entity.setName("Juan Perez");
+		entity.setEmail("juan@example.com");
+		entity.setPhone("5551234");
+		entity.setGender("M");
+		entity.setResponsibleName("Maria Perez");
+		entity.setParentesco("Madre");
+		entity.setPregnancy(false);
+		entity.setDob(Date.from(LocalDate.of(1990, 1, 15).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		entity.setRegistro(Date.from(Instant.parse("2025-01-01T10:00:00Z")));
+
+		entity.setPeso(72.5);
+		entity.setEstatura(1.75);
+		entity.setImc(23.7);
+		entity.setBmr(1650.0);
+		entity.setGetKcal(2275.0);
+		entity.setNivelPeso(NivelPeso.NORMAL);
+		entity.setTefKcal(182.0);
+		entity.setTotalAdjustedKcal(2457.0);
+		entity.setStressKcal(0.0);
+		entity.setFinalTotalKcal(2457.0);
+
+		entity.getEnergyPreferences().setActivityFactorScale(ActivityFactorScale.HARRIS_BENEDICT);
+		entity.getEnergyPreferences().setPreferredBmrFormula(BmrFormulaType.PROMEDIO);
+		entity.getEnergyPreferences().setPhysicalActivityLevel(PhysicalActivityLevel.MODERATE);
+		entity.getEnergyPreferences().setActivityFactor(1.55);
+		entity.getEnergyPreferences().setTefMethod(TefMethod.FIXED);
+
+		entity.getMedicalHistory().setTipoSanguineo("O+");
+		entity.getMedicalHistory().setAntecedentesPatologicosPersonales("Ninguno");
+		entity.getMedicalHistory().setHipertension(false);
+		entity.getMedicalHistory().setDiabetes(false);
+
+		return entity;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/profile/NutritionistProfileControllerTest.java
+++ b/src/test/java/com/nutriconsultas/profile/NutritionistProfileControllerTest.java
@@ -77,13 +77,13 @@ public class NutritionistProfileControllerTest {
 			.thenReturn(Optional.of(subscription));
 
 		final Model model = new ExtendedModelMap();
-		final String view = controller.perfil(org.mockito.Mockito.mock(
-				org.springframework.security.oauth2.core.oidc.user.OidcUser.class, invocation -> {
-					if ("getSubject".equals(invocation.getMethod().getName())) {
-						return "auth0|test123";
-					}
-					return org.mockito.Mockito.RETURNS_DEFAULTS.answer(invocation);
-				}), model);
+		final String view = controller.perfil(org.mockito.Mockito
+			.mock(org.springframework.security.oauth2.core.oidc.user.OidcUser.class, invocation -> {
+				if ("getSubject".equals(invocation.getMethod().getName())) {
+					return "auth0|test123";
+				}
+				return org.mockito.Mockito.RETURNS_DEFAULTS.answer(invocation);
+			}), model);
 
 		assertThat(view).isEqualTo("sbadmin/profile/formulario");
 		assertThat(model.getAttribute("subscriptionPlanLabel")).isEqualTo("Básico");

--- a/src/test/java/com/nutriconsultas/subscription/invitation/SubscriptionProvisioningServiceTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/invitation/SubscriptionProvisioningServiceTest.java
@@ -100,7 +100,8 @@ class SubscriptionProvisioningServiceTest {
 		invitation.setSubscription(active);
 		when(clinicMemberRepository.findByUserIdWithClinicAndSubscription("auth0|user-1"))
 			.thenReturn(Optional.of(member));
-		when(clinicRepository.save(org.mockito.ArgumentMatchers.any())).thenAnswer(invocation -> invocation.getArgument(0));
+		when(clinicRepository.save(org.mockito.ArgumentMatchers.any()))
+			.thenAnswer(invocation -> invocation.getArgument(0));
 		when(auth0RoleSyncClient.isConfigured()).thenReturn(false);
 
 		provisioningService.activatePaidAccess(invitation, active);

--- a/src/test/java/com/nutriconsultas/subscription/lifecycle/SubscriptionAccessServiceTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/lifecycle/SubscriptionAccessServiceTest.java
@@ -46,7 +46,8 @@ class SubscriptionAccessServiceTest {
 		final Subscription cancelled = subscription(2L, PlanTier.PROFESIONAL, SubscriptionStatus.CANCELLED);
 		stubActiveMemberWithSubscription(cancelled);
 		when(invitationRepository.findFirstByRedeemedByUserIdAndStatusOrderByRedeemedAtDesc(USER_ID,
-				InvitationStatus.REDEEMED)).thenReturn(Optional.empty());
+				InvitationStatus.REDEEMED))
+			.thenReturn(Optional.empty());
 
 		assertThat(subscriptionAccessService.isAdminAccessBlocked(USER_ID)).isTrue();
 	}
@@ -57,7 +58,8 @@ class SubscriptionAccessServiceTest {
 		final Subscription activeBasic = subscription(5L, PlanTier.BASICO, SubscriptionStatus.ACTIVE);
 		stubActiveMemberWithSubscription(cancelled);
 		when(invitationRepository.findFirstByRedeemedByUserIdAndStatusOrderByRedeemedAtDesc(USER_ID,
-				InvitationStatus.REDEEMED)).thenReturn(Optional.of(invitation(activeBasic)));
+				InvitationStatus.REDEEMED))
+			.thenReturn(Optional.of(invitation(activeBasic)));
 
 		assertThat(subscriptionAccessService.isAdminAccessBlocked(USER_ID)).isFalse();
 		assertThat(subscriptionAccessService.findGrantingSubscriptionForUser(USER_ID)).contains(activeBasic);
@@ -69,7 +71,8 @@ class SubscriptionAccessServiceTest {
 		final Subscription activeBasic = subscription(5L, PlanTier.BASICO, SubscriptionStatus.ACTIVE);
 		stubActiveMemberWithSubscription(cancelled);
 		when(invitationRepository.findFirstByRedeemedByUserIdAndStatusOrderByRedeemedAtDesc(USER_ID,
-				InvitationStatus.REDEEMED)).thenReturn(Optional.of(invitation(activeBasic)));
+				InvitationStatus.REDEEMED))
+			.thenReturn(Optional.of(invitation(activeBasic)));
 
 		assertThat(subscriptionAccessService.findSubscriptionForUser(USER_ID)).contains(activeBasic);
 	}


### PR DESCRIPTION
## Summary
- Add MPX v1 import: parse/validate YAML, map to a new `Paciente` (registration + satellites), enforce plan cap via `assertCanCreatePatient`, and assign tenant from the authenticated nutritionist.
- Expose `POST /admin/pacientes/importar.mpx` plus listado upload UI and SweetAlert feedback (success, duplicate hint, validation/subscription errors).
- Document import rules in `MPX-FORMAT.md`; update nutritionist-web issue registry (#222 in-progress, #223 next).

## Test plan
- [x] `PacienteMpxImportServiceTest` — round-trip export→import, invalid YAML/version, validation, cap exceeded, duplicate warning, tenant assignment
- [x] `PacienteMpxImportControllerTest` — success redirect, errors, subscription limit
- [x] Checkstyle, PMD, Spring Java Format validate, Thymeleaf validation
- [x] Manual: upload `.mpx` on `/admin/pacientes`, confirm new patient profile + duplicate warning on re-import

Closes #222


Made with [Cursor](https://cursor.com)