### PR TITLE
[Nutritionist Web] Platform admins can edit system template diets (#232)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -42,7 +42,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (subscription):** [#207 — Stripe payment provider](https://github.com/diego-torres/nutriconsultas/issues/207). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#211~~ merged PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230).
 
-**Current next issue (nutritionist web):** [#232 — Platform admins can edit system template diets](https://github.com/diego-torres/nutriconsultas/issues/232). ~~#223~~ done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). ~~#222~~ done (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#221~~ done (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). ~~#250~~ done (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+**Current next issue (nutritionist web):** [#233 — Diet list grid edit action](https://github.com/diego-torres/nutriconsultas/issues/233). ~~#232~~ done (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)). ~~#223~~ done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). ~~#222~~ done (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#221~~ done (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). ~~#250~~ done (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
 ---
 
@@ -432,7 +432,7 @@ gh pr create ...
 
 **Subscription track (parallel):** see [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#180–#185~~, ~~#187~~ (PR #218), ~~#190~~ (PR #216), ~~#210~~ (PR #224), ~~#211~~ (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)) on `main`. **NEXT:** #207 (+ #208 Stripe ops, email #209, retention #220).
 
-**Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) — MPX epic ~~#221–#223~~ done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)); **NEXT:** #232 diet catalog.
+**Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) — MPX epic ~~#221–#223~~ done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)); ~~#232~~ done (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)); **NEXT:** #233 diet grid edit.
 
 **Production (2026-06-18):** ~~#226~~ invitation base URL fix (PR #227) — `APP_BASE_URL` / host remediation on EC2.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -598,9 +598,9 @@ Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow
 
 Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md).
 
-**Epic #221–#223** (2026-06-20): export/import patient **registration** to `.mpx` (YAML, no history) + export/delete UI. ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#223~~ **done** (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). **NEXT:** [#232 diet catalog](https://github.com/diego-torres/nutriconsultas/issues/232). Complements #190 patient caps; available all tiers.
+**Epic #221–#223** (2026-06-20): export/import patient **registration** to `.mpx` (YAML, no history) + export/delete UI. ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#223~~ **done** (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). Complements #190 patient caps; available all tiers.
 
-**Epics #232–#242** (2026-06-19): diet catalog (#232–#235), branding (#236–#237), diet/platillo UX (#238–#240), patient UX (#241–#242). **Epic #257–#259** (2026-06-19): platillo catalog ownership (lock system rows, creator edit, copy). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+**Epics #232–#242** (2026-06-19): diet catalog (#232–#235), branding (#236–#237), diet/platillo UX (#238–#240), patient UX (#241–#242). ~~#232~~ **done** (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)). **NEXT:** [#233 diet grid edit](https://github.com/diego-torres/nutriconsultas/issues/233). **Epic #257–#259** (2026-06-19): platillo catalog ownership (lock system rows, creator edit, copy). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
 **Bug ~~#250~~** (2026-06-19): diet ingesta platillo name links to wrong catalog platillo — **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)).
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-20 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). ~~#223~~ **done** (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). **NEXT:** [#233 diet grid edit action](https://github.com/diego-torres/nutriconsultas/issues/233) (after #232 PR merges). #232 **in-progress** on `issue-232-platform-admin-edit-system-diets`. Epics **#232–#242**, **#257–#259** (platillo ownership) registered.
+**Last updated:** 2026-06-20 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). ~~#223~~ **done** (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). ~~#232~~ **done** (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)). **NEXT:** [#233 diet grid edit action](https://github.com/diego-torres/nutriconsultas/issues/233). Epics **#232–#242**, **#257–#259** (platillo ownership) registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -59,8 +59,8 @@ System template diets (`userId = system:template-dietas`), grid actions, and own
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| **232** | Platform admins can edit system template diets | https://github.com/diego-torres/nutriconsultas/issues/232 | **in-progress** | #183 | `DietaAuthorization`; bypass ownership for `system:template-dietas` |
-| 233 | Diet list grid — edit action | https://github.com/diego-torres/nutriconsultas/issues/233 | open | — | Link to `/admin/dietas/{id}` |
+| **232** | Platform admins can edit system template diets | https://github.com/diego-torres/nutriconsultas/issues/232 | **done** | #183 | PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263); `DietaAuthorization` |
+| **233** | Diet list grid — edit action | https://github.com/diego-torres/nutriconsultas/issues/233 | **NEXT** | — | Link to `/admin/dietas/{id}` |
 | 234 | Diet list grid — delete action with patient-usage guard | https://github.com/diego-torres/nutriconsultas/issues/234 | open | — | Block if `PacienteDieta` exists; SweetAlert |
 | 235 | Diet list grid — filter all, system, or own diets | https://github.com/diego-torres/nutriconsultas/issues/235 | open | — | Server-side filter on `/rest/dietas` grid |
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-20 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). ~~#223~~ **done** (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). **NEXT:** [#232 diet catalog — platform admin edit system diets](https://github.com/diego-torres/nutriconsultas/issues/232). Epics **#232–#242**, **#257–#259** (platillo ownership) registered.
+**Last updated:** 2026-06-20 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). ~~#223~~ **done** (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). **NEXT:** [#233 diet grid edit action](https://github.com/diego-torres/nutriconsultas/issues/233) (after #232 PR merges). #232 **in-progress** on `issue-232-platform-admin-edit-system-diets`. Epics **#232–#242**, **#257–#259** (platillo ownership) registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -59,7 +59,7 @@ System template diets (`userId = system:template-dietas`), grid actions, and own
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| 232 | Platform admins can edit system template diets | https://github.com/diego-torres/nutriconsultas/issues/232 | open | #183 | Bypass `verifyDietOwnership` for `system:template-dietas` |
+| **232** | Platform admins can edit system template diets | https://github.com/diego-torres/nutriconsultas/issues/232 | **in-progress** | #183 | `DietaAuthorization`; bypass ownership for `system:template-dietas` |
 | 233 | Diet list grid — edit action | https://github.com/diego-torres/nutriconsultas/issues/233 | open | — | Link to `/admin/dietas/{id}` |
 | 234 | Diet list grid — delete action with patient-usage guard | https://github.com/diego-torres/nutriconsultas/issues/234 | open | — | Block if `PacienteDieta` exists; SweetAlert |
 | 235 | Diet list grid — filter all, system, or own diets | https://github.com/diego-torres/nutriconsultas/issues/235 | open | — | Server-side filter on `/rest/dietas` grid |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-20):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web **NEXT:** #232; ~~#223~~ done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)); epics #232–#242; platillo ownership #257–#259; ~~#250~~ done (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). Public booking #245–#248 (deferred).
+**On `main` (2026-06-20):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web **NEXT:** #233; ~~#232~~ done (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)); ~~#223~~ done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)); epics #232–#242; platillo ownership #257–#259; ~~#250~~ done (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). Public booking #245–#248 (deferred).
 
 ## AWS (production infrastructure)
 

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -38,7 +38,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`../../ISSUE-NUTRITIONIST-WEB.md`](../../ISSUE-NUTRITIONIST-WEB.md) | Patient MPX epic (#221–#223) |
 | [`../paciente/PATIENT-MPX-PLAN.md`](../paciente/PATIENT-MPX-PLAN.md) | Export/import plan |
 
-**Nutritionist web NEXT:** [#232](https://github.com/diego-torres/nutriconsultas/issues/232) diet catalog (system diet edit). ~~#221–#223~~ MPX epic done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)).
+**Nutritionist web NEXT:** [#233](https://github.com/diego-torres/nutriconsultas/issues/233) diet grid edit action. ~~#232~~ done (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)); ~~#221–#223~~ MPX epic done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)).
 
 **Subscription NEXT:** [#207](https://github.com/diego-torres/nutriconsultas/issues/207) Stripe payment provider (~~#211~~ PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230), ~~#210~~ PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224), ~~#187~~ PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218), ~~#190~~ PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) on `main`).
 

--- a/src/main/java/com/nutriconsultas/dieta/DietaAuthorization.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaAuthorization.java
@@ -1,0 +1,80 @@
+package com.nutriconsultas.dieta;
+
+import java.util.Objects;
+
+import org.springframework.lang.NonNull;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Component;
+
+import com.nutriconsultas.platform.PlatformAdminAuditService;
+import com.nutriconsultas.platform.PlatformAdminService;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Diet mutation access: nutritionists may edit their own diets; platform admins may also
+ * edit system template diets ({@link DietaCatalogConstants#SYSTEM_TEMPLATE_USER_ID}).
+ */
+@Component
+@Slf4j
+public class DietaAuthorization {
+
+	private final PlatformAdminService platformAdminService;
+
+	private final PlatformAdminAuditService platformAdminAuditService;
+
+	public DietaAuthorization(final PlatformAdminService platformAdminService,
+			final PlatformAdminAuditService platformAdminAuditService) {
+		this.platformAdminService = platformAdminService;
+		this.platformAdminAuditService = platformAdminAuditService;
+	}
+
+	public boolean canModify(final Dieta dieta, final String userId, final OidcUser principal) {
+		if (dieta == null || userId == null) {
+			return false;
+		}
+		if (Objects.equals(userId, dieta.getUserId())) {
+			return true;
+		}
+		return platformAdminService.isPlatformAdmin(principal) && DietaCatalogConstants.isSystemTemplate(dieta);
+	}
+
+	public void verifyCanModify(final Dieta dieta, final String userId, final OidcUser principal) {
+		if (dieta == null) {
+			throw new IllegalArgumentException("Dieta no encontrada");
+		}
+		if (!canModify(dieta, userId, principal)) {
+			if (log.isWarnEnabled()) {
+				log.warn("User {} attempted to modify diet {} owned by {}", userId, dieta.getId(), dieta.getUserId());
+			}
+			throw new IllegalArgumentException("No tiene permiso para modificar esta dieta");
+		}
+	}
+
+	public Dieta resolveForMutation(@NonNull final Long id, @NonNull final String userId, final OidcUser principal,
+			final DietaService dietaService) {
+		final Dieta owned = dietaService.getDietaByIdAndUserId(id, userId);
+		if (owned != null) {
+			return owned;
+		}
+		if (!platformAdminService.isPlatformAdmin(principal)) {
+			return null;
+		}
+		final Dieta dieta = dietaService.getDieta(id);
+		if (dieta != null && DietaCatalogConstants.isSystemTemplate(dieta)) {
+			return dieta;
+		}
+		return null;
+	}
+
+	public void auditSystemDietMutationIfNeeded(final OidcUser principal, final Dieta dieta,
+			@NonNull final String action) {
+		if (dieta == null || !DietaCatalogConstants.isSystemTemplate(dieta)
+				|| !platformAdminService.isPlatformAdmin(principal)) {
+			return;
+		}
+		final String actorUserId = platformAdminService.resolveActorUserId(principal);
+		platformAdminAuditService.recordAction(actorUserId, action + ":dietaId=" + dieta.getId());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/dieta/DietaAuthorization.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaAuthorization.java
@@ -33,10 +33,8 @@ public class DietaAuthorization {
 		if (dieta == null || userId == null) {
 			return false;
 		}
-		if (Objects.equals(userId, dieta.getUserId())) {
-			return true;
-		}
-		return platformAdminService.isPlatformAdmin(principal) && DietaCatalogConstants.isSystemTemplate(dieta);
+		return Objects.equals(userId, dieta.getUserId())
+				|| (platformAdminService.isPlatformAdmin(principal) && DietaCatalogConstants.isSystemTemplate(dieta));
 	}
 
 	public void verifyCanModify(final Dieta dieta, final String userId, final OidcUser principal) {

--- a/src/main/java/com/nutriconsultas/dieta/DietaCatalogConstants.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaCatalogConstants.java
@@ -1,0 +1,17 @@
+package com.nutriconsultas.dieta;
+
+/**
+ * Ownership sentinel values for the shared diet catalog.
+ */
+public final class DietaCatalogConstants {
+
+	public static final String SYSTEM_TEMPLATE_USER_ID = "system:template-dietas";
+
+	private DietaCatalogConstants() {
+	}
+
+	public static boolean isSystemTemplate(final Dieta dieta) {
+		return dieta != null && SYSTEM_TEMPLATE_USER_ID.equals(dieta.getUserId());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/dieta/DietaController.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaController.java
@@ -47,6 +47,9 @@ public class DietaController extends AbstractAuthorizedController {
 	@Autowired
 	private DietaPdfService dietaPdfService;
 
+	@Autowired
+	private DietaAuthorization dietaAuthorization;
+
 	/**
 	 * Gets the user ID from the OAuth2 principal.
 	 * @param principal the OAuth2 principal
@@ -62,20 +65,17 @@ public class DietaController extends AbstractAuthorizedController {
 		return userId;
 	}
 
-	/**
-	 * Verifies that a diet belongs to the current user.
-	 * @param dieta the diet to verify
-	 * @param userId the current user's ID
-	 * @throws IllegalArgumentException if the diet does not belong to the user
-	 */
-	private void verifyDietOwnership(final Dieta dieta, final String userId) {
+	private Dieta loadDietaForMutation(@NonNull final Long id, @AuthenticationPrincipal final OidcUser principal) {
+		final String userId = getUserId(principal);
+		if (userId == null) {
+			throw new IllegalArgumentException("No se pudo identificar al usuario");
+		}
+		final Dieta dieta = dietaAuthorization.resolveForMutation(id, userId, principal, dietaService);
 		if (dieta == null) {
-			throw new IllegalArgumentException("Dieta no encontrada");
+			throw new IllegalArgumentException("Dieta no encontrada o no tiene permiso para modificarla");
 		}
-		if (dieta.getUserId() == null || !dieta.getUserId().equals(userId)) {
-			LOGGER.warn("User {} attempted to modify diet {} owned by {}", userId, dieta.getId(), dieta.getUserId());
-			throw new IllegalArgumentException("No tiene permiso para modificar esta dieta");
-		}
+		dietaAuthorization.verifyCanModify(dieta, userId, principal);
+		return dieta;
 	}
 
 	@GetMapping(path = "/admin/dietas")
@@ -89,17 +89,10 @@ public class DietaController extends AbstractAuthorizedController {
 	public String saveDieta(@RequestParam @NonNull final Long id, @RequestParam @NonNull final String nombre,
 			final Model model, @AuthenticationPrincipal final OidcUser principal) {
 		LOGGER.debug("Guardar dieta with id {}, {}", id, nombre);
-		final String userId = getUserId(principal);
-		if (userId == null) {
-			throw new IllegalArgumentException("No se pudo identificar al usuario");
-		}
-		final Dieta dieta = dietaService.getDietaByIdAndUserId(id, userId);
-		if (dieta == null) {
-			throw new IllegalArgumentException("Dieta no encontrada o no tiene permiso para modificarla");
-		}
-		verifyDietOwnership(dieta, userId);
+		final Dieta dieta = loadDietaForMutation(id, principal);
 		dieta.setNombre(nombre);
 		dietaService.saveDieta(dieta);
+		dietaAuthorization.auditSystemDietMutationIfNeeded(principal, dieta, "dietas.save");
 		return "redirect:/admin/dietas/" + id;
 	}
 
@@ -116,9 +109,9 @@ public class DietaController extends AbstractAuthorizedController {
 		LOGGER.debug("Dieta encontrada: {}", dieta);
 		model.addAttribute("dieta", dieta);
 
-		// Check ownership and pass to model
+		// Check edit permission and pass to model
 		final String userId = getUserId(principal);
-		final boolean isOwner = Objects.equals(userId, dieta.getUserId());
+		final boolean isOwner = dietaAuthorization.canModify(dieta, userId, principal);
 		model.addAttribute("isOwner", isOwner);
 
 		// Sort the ingestas list by id
@@ -188,20 +181,13 @@ public class DietaController extends AbstractAuthorizedController {
 		LOGGER.debug("Agregar ingesta {} a dieta con id {}", ingesta, id);
 		model.addAttribute("activeMenu", "dietas");
 
-		final String userId = getUserId(principal);
-		if (userId == null) {
-			throw new IllegalArgumentException("No se pudo identificar al usuario");
-		}
-		final Dieta dieta = dietaService.getDietaByIdAndUserId(id, userId);
-		if (dieta == null) {
-			throw new IllegalArgumentException("Dieta no encontrada o no tiene permiso para modificarla");
-		}
-		verifyDietOwnership(dieta, userId);
+		final Dieta dieta = loadDietaForMutation(id, principal);
 
 		String result;
 		if (ingesta.getIngestaId() == 0) {
 			LOGGER.debug("nueva ingesta en dieta, agregar");
 			dietaService.addIngesta(id, ingesta.getIngesta());
+			dietaAuthorization.auditSystemDietMutationIfNeeded(principal, dieta, "dietas.ingestas.save");
 			result = "redirect:/admin/dietas/" + id;
 		}
 		else {
@@ -213,6 +199,7 @@ public class DietaController extends AbstractAuthorizedController {
 			}
 			else {
 				dietaService.renameIngesta(id, ingestaId, ingesta.getIngesta());
+				dietaAuthorization.auditSystemDietMutationIfNeeded(principal, dieta, "dietas.ingestas.save");
 				result = "redirect:/admin/dietas/" + id;
 			}
 		}
@@ -224,17 +211,10 @@ public class DietaController extends AbstractAuthorizedController {
 			@ModelAttribute final IngestaFormModel ingestaModel, final Model model,
 			@AuthenticationPrincipal final OidcUser principal) {
 		LOGGER.debug("Eliminar ingesta con id {} de dieta con id {}", ingestaModel, id);
-		final String userId = getUserId(principal);
-		if (userId == null) {
-			throw new IllegalArgumentException("No se pudo identificar al usuario");
-		}
-		final Dieta dieta = dietaService.getDietaByIdAndUserId(id, userId);
-		if (dieta == null) {
-			throw new IllegalArgumentException("Dieta no encontrada o no tiene permiso para modificarla");
-		}
-		verifyDietOwnership(dieta, userId);
+		final Dieta dieta = loadDietaForMutation(id, principal);
 		dieta.getIngestas().removeIf(ingesta -> ingesta.getId().equals(ingestaModel.getIngestaId()));
 		dietaService.saveDieta(dieta);
+		dietaAuthorization.auditSystemDietMutationIfNeeded(principal, dieta, "dietas.ingestas.delete");
 		return "redirect:/admin/dietas/" + id;
 	}
 
@@ -242,15 +222,7 @@ public class DietaController extends AbstractAuthorizedController {
 	public String savePlatillo(@PathVariable @NonNull Long id, @ModelAttribute PlatilloFormModel platilloModel,
 			Model model, @AuthenticationPrincipal final OidcUser principal) {
 		LOGGER.debug("Agregar platillo {} a ingesta con id {}", platilloModel, id);
-		final String userId = getUserId(principal);
-		if (userId == null) {
-			throw new IllegalArgumentException("No se pudo identificar al usuario");
-		}
-		Dieta dieta = dietaService.getDietaByIdAndUserId(id, userId);
-		if (dieta == null) {
-			throw new IllegalArgumentException("Dieta no encontrada o no tiene permiso para modificarla");
-		}
-		verifyDietOwnership(dieta, userId);
+		final Dieta dieta = loadDietaForMutation(id, principal);
 		Ingesta ingesta = dieta.getIngestas()
 			.stream()
 			.filter(i -> i.getId().equals(platilloModel.getIngestaPlatillo()))
@@ -278,6 +250,7 @@ public class DietaController extends AbstractAuthorizedController {
 
 				ingesta.getPlatillos().add(platilloIngesta);
 				dietaService.saveDieta(dieta);
+				dietaAuthorization.auditSystemDietMutationIfNeeded(principal, dieta, "dietas.platillos.save");
 			}
 		}
 		return "redirect:/admin/dietas/" + id;
@@ -287,15 +260,7 @@ public class DietaController extends AbstractAuthorizedController {
 	public String saveAlimento(@PathVariable @NonNull Long id, @ModelAttribute AlimentoFormModel alimentoModel,
 			Model model, @AuthenticationPrincipal final OidcUser principal) {
 		LOGGER.debug("Agregar alimento {} a ingesta con id {}", alimentoModel, id);
-		final String userId = getUserId(principal);
-		if (userId == null) {
-			throw new IllegalArgumentException("No se pudo identificar al usuario");
-		}
-		Dieta dieta = dietaService.getDietaByIdAndUserId(id, userId);
-		if (dieta == null) {
-			throw new IllegalArgumentException("Dieta no encontrada o no tiene permiso para modificarla");
-		}
-		verifyDietOwnership(dieta, userId);
+		final Dieta dieta = loadDietaForMutation(id, principal);
 		Ingesta ingesta = dieta.getIngestas()
 			.stream()
 			.filter(i -> i.getId().equals(alimentoModel.getIngestaAlimento()))
@@ -312,6 +277,7 @@ public class DietaController extends AbstractAuthorizedController {
 
 				ingesta.getAlimentos().add(alimentoIngesta);
 				dietaService.saveDieta(dieta);
+				dietaAuthorization.auditSystemDietMutationIfNeeded(principal, dieta, "dietas.alimentos.save");
 			}
 		}
 		return "redirect:/admin/dietas/" + id;
@@ -321,55 +287,45 @@ public class DietaController extends AbstractAuthorizedController {
 	public String updatePlatilloIngesta(@PathVariable @NonNull Long id, @PathVariable @NonNull Long platilloIngestaId,
 			@RequestParam @NonNull Integer porciones, @AuthenticationPrincipal final OidcUser principal) {
 		LOGGER.debug("Actualizar platillo ingesta {} con {} porciones en dieta {}", platilloIngestaId, porciones, id);
-		final String userId = getUserId(principal);
-		if (userId == null) {
-			throw new IllegalArgumentException("No se pudo identificar al usuario");
-		}
-		Dieta dieta = dietaService.getDietaByIdAndUserId(id, userId);
-		if (dieta == null) {
-			throw new IllegalArgumentException("Dieta no encontrada o no tiene permiso para modificarla");
-		}
-		verifyDietOwnership(dieta, userId);
-		if (dieta != null) {
-			dieta.getIngestas()
-				.stream()
-				.flatMap(ingesta -> ingesta.getPlatillos().stream())
-				.filter(platillo -> platillo.getId().equals(platilloIngestaId))
-				.findFirst()
-				.ifPresent(platilloIngesta -> {
-					Integer oldPortions = platilloIngesta.getPortions() != null ? platilloIngesta.getPortions() : 1;
-					Integer newPortions = porciones != null ? porciones : 1;
-					double ratio = newPortions.doubleValue() / oldPortions.doubleValue();
+		final Dieta dieta = loadDietaForMutation(id, principal);
+		dieta.getIngestas()
+			.stream()
+			.flatMap(ingesta -> ingesta.getPlatillos().stream())
+			.filter(platillo -> platillo.getId().equals(platilloIngestaId))
+			.findFirst()
+			.ifPresent(platilloIngesta -> {
+				Integer oldPortions = platilloIngesta.getPortions() != null ? platilloIngesta.getPortions() : 1;
+				Integer newPortions = porciones != null ? porciones : 1;
+				double ratio = newPortions.doubleValue() / oldPortions.doubleValue();
 
-					// Update portions
-					platilloIngesta.setPortions(newPortions);
+				// Update portions
+				platilloIngesta.setPortions(newPortions);
 
-					// Recalculate nutritional values based on portion ratio
-					if (platilloIngesta.getEnergia() != null) {
-						platilloIngesta.setEnergia((int) (platilloIngesta.getEnergia() * ratio));
-					}
-					if (platilloIngesta.getProteina() != null) {
-						platilloIngesta.setProteina(platilloIngesta.getProteina() * ratio);
-					}
-					if (platilloIngesta.getLipidos() != null) {
-						platilloIngesta.setLipidos(platilloIngesta.getLipidos() * ratio);
-					}
-					if (platilloIngesta.getHidratosDeCarbono() != null) {
-						platilloIngesta.setHidratosDeCarbono(platilloIngesta.getHidratosDeCarbono() * ratio);
-					}
-					if (platilloIngesta.getPesoBrutoRedondeado() != null) {
-						platilloIngesta
-							.setPesoBrutoRedondeado((int) (platilloIngesta.getPesoBrutoRedondeado() * ratio));
-					}
-					if (platilloIngesta.getPesoNeto() != null) {
-						platilloIngesta.setPesoNeto((int) (platilloIngesta.getPesoNeto() * ratio));
-					}
-					// Update other nutritional values similarly
-					updatePlatilloIngestaNutritionalValues(platilloIngesta, ratio);
+				// Recalculate nutritional values based on portion ratio
+				if (platilloIngesta.getEnergia() != null) {
+					platilloIngesta.setEnergia((int) (platilloIngesta.getEnergia() * ratio));
+				}
+				if (platilloIngesta.getProteina() != null) {
+					platilloIngesta.setProteina(platilloIngesta.getProteina() * ratio);
+				}
+				if (platilloIngesta.getLipidos() != null) {
+					platilloIngesta.setLipidos(platilloIngesta.getLipidos() * ratio);
+				}
+				if (platilloIngesta.getHidratosDeCarbono() != null) {
+					platilloIngesta.setHidratosDeCarbono(platilloIngesta.getHidratosDeCarbono() * ratio);
+				}
+				if (platilloIngesta.getPesoBrutoRedondeado() != null) {
+					platilloIngesta.setPesoBrutoRedondeado((int) (platilloIngesta.getPesoBrutoRedondeado() * ratio));
+				}
+				if (platilloIngesta.getPesoNeto() != null) {
+					platilloIngesta.setPesoNeto((int) (platilloIngesta.getPesoNeto() * ratio));
+				}
+				// Update other nutritional values similarly
+				updatePlatilloIngestaNutritionalValues(platilloIngesta, ratio);
 
-					dietaService.saveDieta(dieta);
-				});
-		}
+				dietaService.saveDieta(dieta);
+				dietaAuthorization.auditSystemDietMutationIfNeeded(principal, dieta, "dietas.platillos.update");
+			});
 		return "redirect:/admin/dietas/" + id;
 	}
 
@@ -377,54 +333,45 @@ public class DietaController extends AbstractAuthorizedController {
 	public String updateAlimentoIngesta(@PathVariable @NonNull Long id, @PathVariable @NonNull Long alimentoIngestaId,
 			@RequestParam @NonNull Integer porciones, @AuthenticationPrincipal final OidcUser principal) {
 		LOGGER.debug("Actualizar alimento ingesta {} con {} porciones en dieta {}", alimentoIngestaId, porciones, id);
-		final String userId = getUserId(principal);
-		if (userId == null) {
-			throw new IllegalArgumentException("No se pudo identificar al usuario");
-		}
-		Dieta dieta = dietaService.getDietaByIdAndUserId(id, userId);
-		if (dieta == null) {
-			throw new IllegalArgumentException("Dieta no encontrada o no tiene permiso para modificarla");
-		}
-		verifyDietOwnership(dieta, userId);
-		if (dieta != null) {
-			dieta.getIngestas()
-				.stream()
-				.flatMap(ingesta -> ingesta.getAlimentos().stream())
-				.filter(alimento -> alimento.getId().equals(alimentoIngestaId))
-				.findFirst()
-				.ifPresent(alimentoIngesta -> {
-					if (alimentoIngesta.getAlimento() != null) {
-						// Recalculate from original alimento
-						Alimento alimento = alimentoIngesta.getAlimento();
-						Integer newPortions = porciones != null ? porciones : 1;
-						alimentoIngesta.setPortions(newPortions);
+		final Dieta dieta = loadDietaForMutation(id, principal);
+		dieta.getIngestas()
+			.stream()
+			.flatMap(ingesta -> ingesta.getAlimentos().stream())
+			.filter(alimento -> alimento.getId().equals(alimentoIngestaId))
+			.findFirst()
+			.ifPresent(alimentoIngesta -> {
+				if (alimentoIngesta.getAlimento() != null) {
+					// Recalculate from original alimento
+					Alimento alimento = alimentoIngesta.getAlimento();
+					Integer newPortions = porciones != null ? porciones : 1;
+					alimentoIngesta.setPortions(newPortions);
 
-						// Recalculate nutritional values from original alimento
-						if (alimento.getEnergia() != null) {
-							alimentoIngesta.setEnergia((int) (alimento.getEnergia() * newPortions));
-						}
-						if (alimento.getProteina() != null) {
-							alimentoIngesta.setProteina(alimento.getProteina() * newPortions);
-						}
-						if (alimento.getLipidos() != null) {
-							alimentoIngesta.setLipidos(alimento.getLipidos() * newPortions);
-						}
-						if (alimento.getHidratosDeCarbono() != null) {
-							alimentoIngesta.setHidratosDeCarbono(alimento.getHidratosDeCarbono() * newPortions);
-						}
-						if (alimento.getPesoBrutoRedondeado() != null) {
-							alimentoIngesta.setPesoBrutoRedondeado(alimento.getPesoBrutoRedondeado() * newPortions);
-						}
-						if (alimento.getPesoNeto() != null) {
-							alimentoIngesta.setPesoNeto(alimento.getPesoNeto() * newPortions);
-						}
-						// Update other nutritional values
-						updateAlimentoIngestaNutritionalValues(alimentoIngesta, alimento, newPortions);
-
-						dietaService.saveDieta(dieta);
+					// Recalculate nutritional values from original alimento
+					if (alimento.getEnergia() != null) {
+						alimentoIngesta.setEnergia((int) (alimento.getEnergia() * newPortions));
 					}
-				});
-		}
+					if (alimento.getProteina() != null) {
+						alimentoIngesta.setProteina(alimento.getProteina() * newPortions);
+					}
+					if (alimento.getLipidos() != null) {
+						alimentoIngesta.setLipidos(alimento.getLipidos() * newPortions);
+					}
+					if (alimento.getHidratosDeCarbono() != null) {
+						alimentoIngesta.setHidratosDeCarbono(alimento.getHidratosDeCarbono() * newPortions);
+					}
+					if (alimento.getPesoBrutoRedondeado() != null) {
+						alimentoIngesta.setPesoBrutoRedondeado(alimento.getPesoBrutoRedondeado() * newPortions);
+					}
+					if (alimento.getPesoNeto() != null) {
+						alimentoIngesta.setPesoNeto(alimento.getPesoNeto() * newPortions);
+					}
+					// Update other nutritional values
+					updateAlimentoIngestaNutritionalValues(alimentoIngesta, alimento, newPortions);
+
+					dietaService.saveDieta(dieta);
+					dietaAuthorization.auditSystemDietMutationIfNeeded(principal, dieta, "dietas.alimentos.update");
+				}
+			});
 		return "redirect:/admin/dietas/" + id;
 	}
 

--- a/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
@@ -37,6 +37,25 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 	@Autowired
 	private DietaService dietaService;
 
+	@Autowired
+	private DietaAuthorization dietaAuthorization;
+
+	private Dieta loadDietaForMutation(@NonNull final Long dietaId, final OidcUser principal) {
+		if (principal == null) {
+			return null;
+		}
+		final String userId = principal.getSubject();
+		if (userId == null) {
+			return null;
+		}
+		final Dieta dieta = dietaAuthorization.resolveForMutation(dietaId, userId, principal, dietaService);
+		if (dieta == null) {
+			return null;
+		}
+		dietaAuthorization.verifyCanModify(dieta, userId, principal);
+		return dieta;
+	}
+
 	@GetMapping("picker")
 	public DietaPickerPageDto getPickerPage(@RequestParam(required = false) final String q,
 			@RequestParam(defaultValue = "0") final int page, @RequestParam(defaultValue = "20") final int size,
@@ -72,11 +91,7 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 		if (principal == null) {
 			return ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();
 		}
-		final String userId = principal.getSubject();
-		if (userId == null) {
-			return ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();
-		}
-		final Dieta dieta = dietaService.getDietaByIdAndUserId(dietaId, userId);
+		final Dieta dieta = loadDietaForMutation(dietaId, principal);
 		ResponseEntity<ApiResponse<Dieta>> result;
 		if (dieta != null) {
 			dieta.getIngestas()
@@ -86,12 +101,13 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 				.ifPresent(ingesta -> ingesta.getPlatillos()
 					.removeIf(platillo -> platillo.getId().equals(platilloIngestaId)));
 			final Dieta saved = dietaService.saveDieta(dieta);
+			dietaAuthorization.auditSystemDietMutationIfNeeded(principal, saved, "dietas.platillos.delete");
 			log.info("finish deletePlatilloIngesta with dietaId {}, ingestaId {}, platilloIngestaId {}.", dietaId,
 					ingestaId, platilloIngestaId);
 			result = ResponseEntity.ok(new ApiResponse<Dieta>(saved));
 		}
 		else {
-			log.warn("Dieta with id {} not found or user {} does not have permission", dietaId, userId);
+			log.warn("Dieta with id {} not found or user does not have permission", dietaId);
 			result = ResponseEntity.notFound().build();
 		}
 		return result;
@@ -106,11 +122,7 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 		if (principal == null) {
 			return ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();
 		}
-		final String userId = principal.getSubject();
-		if (userId == null) {
-			return ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();
-		}
-		final Dieta dieta = dietaService.getDietaByIdAndUserId(dietaId, userId);
+		final Dieta dieta = loadDietaForMutation(dietaId, principal);
 		ResponseEntity<ApiResponse<Dieta>> result;
 		if (dieta != null) {
 			dieta.getIngestas()
@@ -120,12 +132,13 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 				.ifPresent(ingesta -> ingesta.getAlimentos()
 					.removeIf(alimento -> alimento.getId().equals(alimentoIngestaId)));
 			final Dieta saved = dietaService.saveDieta(dieta);
+			dietaAuthorization.auditSystemDietMutationIfNeeded(principal, saved, "dietas.alimentos.delete");
 			log.info("finish deleteAlimentoIngesta with dietaId {}, ingestaId {}, alimentoIngestaId {}.", dietaId,
 					ingestaId, alimentoIngestaId);
 			result = ResponseEntity.ok(new ApiResponse<Dieta>(saved));
 		}
 		else {
-			log.warn("Dieta with id {} not found or user {} does not have permission", dietaId, userId);
+			log.warn("Dieta with id {} not found or user does not have permission", dietaId);
 			result = ResponseEntity.notFound().build();
 		}
 		return result;
@@ -145,11 +158,7 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 		if (principal == null) {
 			return ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();
 		}
-		final String userId = principal.getSubject();
-		if (userId == null) {
-			return ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();
-		}
-		final Dieta dieta = dietaService.getDietaByIdAndUserId(dietaId, userId);
+		final Dieta dieta = loadDietaForMutation(dietaId, principal);
 		if (dieta == null) {
 			log.warn("Dieta with id {} not found when trying to update platilloIngesta portions", dietaId);
 			return ResponseEntity.notFound().build();
@@ -170,6 +179,7 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 		}
 		dietaService.recalculatePlatilloIngestaNutrients(platilloIngesta, portions);
 		final Dieta saved = dietaService.saveDieta(dieta);
+		dietaAuthorization.auditSystemDietMutationIfNeeded(principal, saved, "dietas.platillos.update");
 		log.info("finish updatePlatilloIngestaPortions with dietaId {}, ingestaId {}, "
 				+ "platilloIngestaId {}, portions {}.", dietaId, ingestaId, platilloIngestaId, portions);
 		return ResponseEntity.ok(new ApiResponse<Dieta>(saved));
@@ -189,11 +199,7 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 		if (principal == null) {
 			return ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();
 		}
-		final String userId = principal.getSubject();
-		if (userId == null) {
-			return ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();
-		}
-		final Dieta dieta = dietaService.getDietaByIdAndUserId(dietaId, userId);
+		final Dieta dieta = loadDietaForMutation(dietaId, principal);
 		if (dieta == null) {
 			log.warn("Dieta with id {} not found when trying to update alimentoIngesta portions", dietaId);
 			return ResponseEntity.notFound().build();
@@ -214,6 +220,7 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 		}
 		dietaService.recalculateAlimentoIngestaNutrients(alimentoIngesta, portions);
 		final Dieta saved = dietaService.saveDieta(dieta);
+		dietaAuthorization.auditSystemDietMutationIfNeeded(principal, saved, "dietas.alimentos.update");
 		log.info("finish updateAlimentoIngestaPortions with dietaId {}, ingestaId {}, "
 				+ "alimentoIngestaId {}, portions {}.", dietaId, ingestaId, alimentoIngestaId, portions);
 		return ResponseEntity.ok(new ApiResponse<Dieta>(saved));

--- a/src/test/java/com/nutriconsultas/dieta/DietaAuthorizationTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaAuthorizationTest.java
@@ -1,0 +1,166 @@
+package com.nutriconsultas.dieta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import com.nutriconsultas.platform.PlatformAdminAuditService;
+import com.nutriconsultas.platform.PlatformAdminService;
+
+@ExtendWith(MockitoExtension.class)
+class DietaAuthorizationTest {
+
+	private static final String NUTRITIONIST_USER_ID = "auth0|nutritionist-one";
+
+	private static final String PLATFORM_ADMIN_USER_ID = "auth0|platform-admin-test";
+
+	@Mock
+	private PlatformAdminService platformAdminService;
+
+	@Mock
+	private PlatformAdminAuditService platformAdminAuditService;
+
+	@Mock
+	private DietaService dietaService;
+
+	@Mock
+	private OidcUser nutritionistPrincipal;
+
+	@Mock
+	private OidcUser platformAdminPrincipal;
+
+	private DietaAuthorization dietaAuthorization;
+
+	@Test
+	void canModify_returnsTrueForOwnedDiet() {
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		final Dieta dieta = ownedDiet(10L, NUTRITIONIST_USER_ID);
+
+		assertThat(dietaAuthorization.canModify(dieta, NUTRITIONIST_USER_ID, nutritionistPrincipal)).isTrue();
+	}
+
+	@Test
+	void canModify_returnsTrueForPlatformAdminOnSystemTemplate() {
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		final Dieta dieta = systemDiet(8L);
+		when(platformAdminService.isPlatformAdmin(platformAdminPrincipal)).thenReturn(true);
+
+		assertThat(dietaAuthorization.canModify(dieta, PLATFORM_ADMIN_USER_ID, platformAdminPrincipal)).isTrue();
+	}
+
+	@Test
+	void canModify_returnsFalseForNutritionistOnSystemTemplate() {
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		final Dieta dieta = systemDiet(8L);
+		when(platformAdminService.isPlatformAdmin(nutritionistPrincipal)).thenReturn(false);
+
+		assertThat(dietaAuthorization.canModify(dieta, NUTRITIONIST_USER_ID, nutritionistPrincipal)).isFalse();
+	}
+
+	@Test
+	void canModify_returnsFalseForPlatformAdminOnOtherUserDiet() {
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		final Dieta dieta = ownedDiet(11L, "auth0|other-user");
+		when(platformAdminService.isPlatformAdmin(platformAdminPrincipal)).thenReturn(true);
+
+		assertThat(dietaAuthorization.canModify(dieta, PLATFORM_ADMIN_USER_ID, platformAdminPrincipal)).isFalse();
+	}
+
+	@Test
+	void verifyCanModify_throwsForUnauthorizedUser() {
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		final Dieta dieta = systemDiet(8L);
+		when(platformAdminService.isPlatformAdmin(nutritionistPrincipal)).thenReturn(false);
+
+		assertThatThrownBy(() -> dietaAuthorization.verifyCanModify(dieta, NUTRITIONIST_USER_ID, nutritionistPrincipal))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("No tiene permiso para modificar esta dieta");
+	}
+
+	@Test
+	void resolveForMutation_returnsOwnedDietWithoutAdminCheck() {
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		final Dieta owned = ownedDiet(5L, NUTRITIONIST_USER_ID);
+		when(dietaService.getDietaByIdAndUserId(5L, NUTRITIONIST_USER_ID)).thenReturn(owned);
+
+		final Dieta result = dietaAuthorization.resolveForMutation(5L, NUTRITIONIST_USER_ID, nutritionistPrincipal,
+				dietaService);
+
+		assertThat(result).isSameAs(owned);
+		verify(platformAdminService, never()).isPlatformAdmin(nutritionistPrincipal);
+	}
+
+	@Test
+	void resolveForMutation_returnsSystemDietForPlatformAdmin() {
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		final Dieta system = systemDiet(8L);
+		when(dietaService.getDietaByIdAndUserId(8L, PLATFORM_ADMIN_USER_ID)).thenReturn(null);
+		when(platformAdminService.isPlatformAdmin(platformAdminPrincipal)).thenReturn(true);
+		when(dietaService.getDieta(8L)).thenReturn(system);
+
+		final Dieta result = dietaAuthorization.resolveForMutation(8L, PLATFORM_ADMIN_USER_ID, platformAdminPrincipal,
+				dietaService);
+
+		assertThat(result).isSameAs(system);
+	}
+
+	@Test
+	void resolveForMutation_returnsNullForNutritionistOnSystemDiet() {
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		when(dietaService.getDietaByIdAndUserId(8L, NUTRITIONIST_USER_ID)).thenReturn(null);
+		when(platformAdminService.isPlatformAdmin(nutritionistPrincipal)).thenReturn(false);
+
+		final Dieta result = dietaAuthorization.resolveForMutation(8L, NUTRITIONIST_USER_ID, nutritionistPrincipal,
+				dietaService);
+
+		assertThat(result).isNull();
+	}
+
+	@Test
+	void auditSystemDietMutationIfNeeded_recordsPlatformAdminAction() {
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		final Dieta system = systemDiet(8L);
+		when(platformAdminService.isPlatformAdmin(platformAdminPrincipal)).thenReturn(true);
+		when(platformAdminService.resolveActorUserId(platformAdminPrincipal)).thenReturn(PLATFORM_ADMIN_USER_ID);
+
+		dietaAuthorization.auditSystemDietMutationIfNeeded(platformAdminPrincipal, system, "dietas.save");
+
+		verify(platformAdminAuditService).recordAction(PLATFORM_ADMIN_USER_ID, "dietas.save:dietaId=8");
+	}
+
+	@Test
+	void auditSystemDietMutationIfNeeded_skipsNonSystemDiet() {
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		final Dieta owned = ownedDiet(5L, NUTRITIONIST_USER_ID);
+
+		dietaAuthorization.auditSystemDietMutationIfNeeded(platformAdminPrincipal, owned, "dietas.save");
+
+		verify(platformAdminAuditService, never()).recordAction(org.mockito.ArgumentMatchers.anyString(),
+				org.mockito.ArgumentMatchers.anyString());
+	}
+
+	private static Dieta ownedDiet(final Long id, final String userId) {
+		final Dieta dieta = new Dieta();
+		dieta.setId(id);
+		dieta.setNombre("Dieta propia");
+		dieta.setUserId(userId);
+		return dieta;
+	}
+
+	private static Dieta systemDiet(final Long id) {
+		final Dieta dieta = new Dieta();
+		dieta.setId(id);
+		dieta.setNombre("Plantilla: Menú vegetal 02");
+		dieta.setUserId(DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID);
+		return dieta;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/dieta/DietaControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaControllerTest.java
@@ -72,6 +72,8 @@ public class DietaControllerTest {
 
 	private static final String OTHER_USER_ID = "other-user-id-456";
 
+	private static final String PLATFORM_ADMIN_USER_ID = "auth0|platform-admin-test";
+
 	@BeforeEach
 	public void setup() {
 		// Create test data
@@ -912,6 +914,98 @@ public class DietaControllerTest {
 		verify(dietaService, never()).saveDieta(any(Dieta.class));
 
 		log.info("Finishing testSavePlatilloRejectsOtherUserDiet");
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testSaveDietaAllowsPlatformAdminOnSystemTemplate() throws Exception {
+		final Dieta systemDieta = new Dieta();
+		systemDieta.setId(8L);
+		systemDieta.setNombre("Plantilla: Menú vegetal 02");
+		systemDieta.setUserId(DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID);
+		systemDieta.setIngestas(new ArrayList<>());
+
+		when(dietaService.getDietaByIdAndUserId(8L, PLATFORM_ADMIN_USER_ID)).thenReturn(null);
+		when(dietaService.getDieta(8L)).thenReturn(systemDieta);
+		when(dietaService.saveDieta(any(Dieta.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		mockMvc
+			.perform(MockMvcRequestBuilders.post("/admin/dietas/save")
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("id", "8")
+				.param("nombre", "Plantilla actualizada")
+				.with(oidcLogin(PLATFORM_ADMIN_USER_ID))
+				.with(SecurityMockMvcRequestPostProcessors.csrf()))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(MockMvcResultMatchers.redirectedUrl("/admin/dietas/8"));
+
+		verify(dietaService).getDietaByIdAndUserId(8L, PLATFORM_ADMIN_USER_ID);
+		verify(dietaService).getDieta(8L);
+		verify(dietaService).saveDieta(any(Dieta.class));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testSaveDietaRejectsNutritionistOnSystemTemplate() throws Exception {
+		final Dieta systemDieta = new Dieta();
+		systemDieta.setId(8L);
+		systemDieta.setNombre("Plantilla: Menú vegetal 02");
+		systemDieta.setUserId(DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID);
+		systemDieta.setIngestas(new ArrayList<>());
+
+		when(dietaService.getDietaByIdAndUserId(8L, TEST_USER_ID)).thenReturn(null);
+		when(dietaService.getDieta(8L)).thenReturn(systemDieta);
+
+		try {
+			mockMvc
+				.perform(MockMvcRequestBuilders.post("/admin/dietas/save")
+					.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+					.param("id", "8")
+					.param("nombre", "Intento no autorizado")
+					.with(oidcLogin(TEST_USER_ID))
+					.with(SecurityMockMvcRequestPostProcessors.csrf()))
+				.andExpect(status().is5xxServerError());
+		}
+		catch (Exception e) {
+			assertThat(e).hasRootCauseInstanceOf(IllegalArgumentException.class);
+		}
+
+		verify(dietaService).getDietaByIdAndUserId(8L, TEST_USER_ID);
+		verify(dietaService, never()).saveDieta(any(Dieta.class));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testEditarSystemTemplateShowsEditableForPlatformAdmin() throws Exception {
+		final Dieta systemDieta = new Dieta();
+		systemDieta.setId(8L);
+		systemDieta.setNombre("Plantilla: Menú vegetal 02");
+		systemDieta.setUserId(DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID);
+		systemDieta.setIngestas(new ArrayList<>());
+
+		when(dietaService.getDieta(8L)).thenReturn(systemDieta);
+		when(platilloService.findAll()).thenReturn(List.of(platillo));
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/8").with(oidcLogin(PLATFORM_ADMIN_USER_ID)))
+			.andExpect(status().isOk())
+			.andExpect(MockMvcResultMatchers.model().attribute("isOwner", true));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testEditarSystemTemplateShowsReadOnlyForNutritionist() throws Exception {
+		final Dieta systemDieta = new Dieta();
+		systemDieta.setId(8L);
+		systemDieta.setNombre("Plantilla: Menú vegetal 02");
+		systemDieta.setUserId(DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID);
+		systemDieta.setIngestas(new ArrayList<>());
+
+		when(dietaService.getDieta(8L)).thenReturn(systemDieta);
+		when(platilloService.findAll()).thenReturn(List.of(platillo));
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/8").with(oidcLogin(TEST_USER_ID)))
+			.andExpect(status().isOk())
+			.andExpect(MockMvcResultMatchers.model().attribute("isOwner", false));
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/dieta/DietasRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietasRestControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.nutriconsultas.dataTables.paging.Direction;
 import com.nutriconsultas.dataTables.paging.Order;
@@ -29,6 +30,8 @@ import com.nutriconsultas.dataTables.paging.PageArray;
 import com.nutriconsultas.dataTables.paging.PagingRequest;
 import com.nutriconsultas.dataTables.paging.Search;
 import com.nutriconsultas.model.ApiResponse;
+import com.nutriconsultas.platform.PlatformAdminAuditService;
+import com.nutriconsultas.platform.PlatformAdminService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -44,6 +47,14 @@ public class DietasRestControllerTest {
 	@Mock
 	private DietaService dietaService;
 
+	@Mock
+	private PlatformAdminService platformAdminService;
+
+	@Mock
+	private PlatformAdminAuditService platformAdminAuditService;
+
+	private DietaAuthorization dietaAuthorization;
+
 	private Dieta dietaVacia;
 
 	private Dieta dietaConPlatillos;
@@ -58,6 +69,8 @@ public class DietasRestControllerTest {
 
 	private static final String OTHER_USER_ID = "other-user-id-456";
 
+	private static final String PLATFORM_ADMIN_USER_ID = "auth0|platform-admin-test";
+
 	/**
 	 * Creates a mock OidcUser for testing.
 	 * @param userId the user ID (subject)
@@ -71,6 +84,9 @@ public class DietasRestControllerTest {
 
 	@BeforeEach
 	public void setup() {
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		ReflectionTestUtils.setField(dietasRestController, "dietaAuthorization", dietaAuthorization);
+
 		// Create empty diet
 		dietaVacia = new Dieta();
 		dietaVacia.setId(1L);
@@ -1283,6 +1299,57 @@ public class DietasRestControllerTest {
 		verify(dietaService).duplicateDieta(1L, TEST_USER_ID);
 		verify(dietaService, never()).saveDieta(any(Dieta.class));
 		log.info("Finishing testDuplicateDietaSetsUserIdToCopyingUser");
+	}
+
+	@Test
+	public void testDeletePlatilloIngestaAllowsPlatformAdminOnSystemTemplate() {
+		final Dieta systemDieta = new Dieta();
+		systemDieta.setId(8L);
+		systemDieta.setNombre("Plantilla: Menú vegetal 02");
+		systemDieta.setUserId(DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID);
+		systemDieta.setIngestas(new ArrayList<>());
+
+		final Ingesta ingesta = new Ingesta();
+		ingesta.setId(10L);
+		ingesta.setNombre("Desayuno");
+		ingesta.setDieta(systemDieta);
+		ingesta.setPlatillos(new ArrayList<>());
+
+		final PlatilloIngesta platillo = new PlatilloIngesta();
+		platillo.setId(20L);
+		platillo.setName("Platillo sistema");
+		platillo.setIngesta(ingesta);
+		ingesta.getPlatillos().add(platillo);
+		systemDieta.getIngestas().add(ingesta);
+
+		when(dietaService.getDietaByIdAndUserId(8L, PLATFORM_ADMIN_USER_ID)).thenReturn(null);
+		when(platformAdminService.isPlatformAdmin(org.mockito.ArgumentMatchers.any(OidcUser.class))).thenReturn(true);
+		when(dietaService.getDieta(8L)).thenReturn(systemDieta);
+		when(dietaService.saveDieta(any(Dieta.class))).thenReturn(systemDieta);
+		when(platformAdminService.resolveActorUserId(org.mockito.ArgumentMatchers.any(OidcUser.class)))
+			.thenReturn(PLATFORM_ADMIN_USER_ID);
+
+		final OidcUser principal = createMockOidcUser(PLATFORM_ADMIN_USER_ID);
+		final ResponseEntity<ApiResponse<Dieta>> response = dietasRestController.deletePlatilloIngesta(8L, 10L, 20L,
+				principal);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		verify(dietaService).getDieta(8L);
+		verify(dietaService).saveDieta(any(Dieta.class));
+		verify(platformAdminAuditService).recordAction(PLATFORM_ADMIN_USER_ID, "dietas.platillos.delete:dietaId=8");
+	}
+
+	@Test
+	public void testDeletePlatilloIngestaRejectsNutritionistOnSystemTemplate() {
+		when(dietaService.getDietaByIdAndUserId(8L, TEST_USER_ID)).thenReturn(null);
+		when(platformAdminService.isPlatformAdmin(org.mockito.ArgumentMatchers.any(OidcUser.class))).thenReturn(false);
+
+		final OidcUser principal = createMockOidcUser(TEST_USER_ID);
+		final ResponseEntity<ApiResponse<Dieta>> response = dietasRestController.deletePlatilloIngesta(8L, 10L, 20L,
+				principal);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+		verify(dietaService, never()).saveDieta(any(Dieta.class));
 	}
 
 }


### PR DESCRIPTION
## Summary
- Add `DietaAuthorization` so platform admins can mutate system template diets (`system:template-dietas`) from the nutritionist web UI and REST APIs.
- Nutritionists keep read-only access to system templates; own-diet ownership rules are unchanged.
- Record platform-admin audit entries on system diet mutations (actor user id + diet id only).

## Test plan
- [x] `DietaAuthorizationTest` — ownership and audit rules
- [x] `DietaControllerTest` — admin can save system diet; nutritionist blocked; `isOwner` flags
- [x] `DietasRestControllerTest` — admin REST delete on system template; nutritionist blocked
- [x] `mvn checkstyle:check pmd:check spotbugs:check test`

Closes #232


Made with [Cursor](https://cursor.com)