### PR TITLE
[Nutritionist Web] Diet list grid — edit action (#233)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -42,7 +42,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (subscription):** [#207 — Stripe payment provider](https://github.com/diego-torres/nutriconsultas/issues/207). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#211~~ merged PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230).
 
-**Current next issue (nutritionist web):** [#233 — Diet list grid edit action](https://github.com/diego-torres/nutriconsultas/issues/233). ~~#232~~ done (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)). ~~#223~~ done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). ~~#222~~ done (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#221~~ done (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). ~~#250~~ done (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+**Current next issue (nutritionist web):** [#234 — Diet list grid delete action](https://github.com/diego-torres/nutriconsultas/issues/234). ~~#233~~ done (PR [#264](https://github.com/diego-torres/nutriconsultas/pull/264)). ~~#232~~ done (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)). ~~#223~~ done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). ~~#222~~ done (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#221~~ done (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). ~~#250~~ done (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
 ---
 
@@ -432,7 +432,7 @@ gh pr create ...
 
 **Subscription track (parallel):** see [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#180–#185~~, ~~#187~~ (PR #218), ~~#190~~ (PR #216), ~~#210~~ (PR #224), ~~#211~~ (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)) on `main`. **NEXT:** #207 (+ #208 Stripe ops, email #209, retention #220).
 
-**Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) — MPX epic ~~#221–#223~~ done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)); ~~#232~~ done (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)); **NEXT:** #233 diet grid edit.
+**Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) — MPX epic ~~#221–#223~~ done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)); ~~#232~~ done (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)); ~~#233~~ done (PR [#264](https://github.com/diego-torres/nutriconsultas/pull/264)); **NEXT:** #234 diet grid delete.
 
 **Production (2026-06-18):** ~~#226~~ invitation base URL fix (PR #227) — `APP_BASE_URL` / host remediation on EC2.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -600,7 +600,7 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 **Epic #221–#223** (2026-06-20): export/import patient **registration** to `.mpx` (YAML, no history) + export/delete UI. ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#223~~ **done** (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). Complements #190 patient caps; available all tiers.
 
-**Epics #232–#242** (2026-06-19): diet catalog (#232–#235), branding (#236–#237), diet/platillo UX (#238–#240), patient UX (#241–#242). ~~#232~~ **done** (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)). **NEXT:** [#233 diet grid edit](https://github.com/diego-torres/nutriconsultas/issues/233). **Epic #257–#259** (2026-06-19): platillo catalog ownership (lock system rows, creator edit, copy). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+**Epics #232–#242** (2026-06-19): diet catalog (#232–#235), branding (#236–#237), diet/platillo UX (#238–#240), patient UX (#241–#242). ~~#232~~ **done** (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)). ~~#233~~ **done** (PR [#264](https://github.com/diego-torres/nutriconsultas/pull/264)). **NEXT:** [#234 diet grid delete](https://github.com/diego-torres/nutriconsultas/issues/234). **Epic #257–#259** (2026-06-19): platillo catalog ownership (lock system rows, creator edit, copy). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
 **Bug ~~#250~~** (2026-06-19): diet ingesta platillo name links to wrong catalog platillo — **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)).
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-20 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). ~~#223~~ **done** (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). ~~#232~~ **done** (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)). **#233** **in-progress** (diet grid edit action). **NEXT (after #233):** [#234 diet grid delete](https://github.com/diego-torres/nutriconsultas/issues/234). Epics **#232–#242**, **#257–#259** (platillo ownership) registered.
+**Last updated:** 2026-06-20 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). ~~#223~~ **done** (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). ~~#232~~ **done** (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)). ~~#233~~ **done** (PR [#264](https://github.com/diego-torres/nutriconsultas/pull/264)). **NEXT:** [#234 diet grid delete](https://github.com/diego-torres/nutriconsultas/issues/234). Epics **#232–#242**, **#257–#259** (platillo ownership) registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -60,8 +60,8 @@ System template diets (`userId = system:template-dietas`), grid actions, and own
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | **232** | Platform admins can edit system template diets | https://github.com/diego-torres/nutriconsultas/issues/232 | **done** | #183 | PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263); `DietaAuthorization` |
-| **233** | Diet list grid — edit action | https://github.com/diego-torres/nutriconsultas/issues/233 | **in-progress** | — | Link to `/admin/dietas/{id}`; `DietaAuthorization.canModify` |
-| 234 | Diet list grid — delete action with patient-usage guard | https://github.com/diego-torres/nutriconsultas/issues/234 | open | — | Block if `PacienteDieta` exists; SweetAlert |
+| **233** | Diet list grid — edit action | https://github.com/diego-torres/nutriconsultas/issues/233 | **done** | — | PR [#264](https://github.com/diego-torres/nutriconsultas/pull/264); `DietaAuthorization.canModify` |
+| 234 | Diet list grid — delete action with patient-usage guard | https://github.com/diego-torres/nutriconsultas/issues/234 | **NEXT** | — | Block if `PacienteDieta` exists; SweetAlert |
 | 235 | Diet list grid — filter all, system, or own diets | https://github.com/diego-torres/nutriconsultas/issues/235 | open | — | Server-side filter on `/rest/dietas` grid |
 
 ---

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-20 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). ~~#223~~ **done** (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). ~~#232~~ **done** (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)). **NEXT:** [#233 diet grid edit action](https://github.com/diego-torres/nutriconsultas/issues/233). Epics **#232–#242**, **#257–#259** (platillo ownership) registered.
+**Last updated:** 2026-06-20 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). ~~#223~~ **done** (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). ~~#232~~ **done** (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)). **#233** **in-progress** (diet grid edit action). **NEXT (after #233):** [#234 diet grid delete](https://github.com/diego-torres/nutriconsultas/issues/234). Epics **#232–#242**, **#257–#259** (platillo ownership) registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -60,7 +60,7 @@ System template diets (`userId = system:template-dietas`), grid actions, and own
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | **232** | Platform admins can edit system template diets | https://github.com/diego-torres/nutriconsultas/issues/232 | **done** | #183 | PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263); `DietaAuthorization` |
-| **233** | Diet list grid — edit action | https://github.com/diego-torres/nutriconsultas/issues/233 | **NEXT** | — | Link to `/admin/dietas/{id}` |
+| **233** | Diet list grid — edit action | https://github.com/diego-torres/nutriconsultas/issues/233 | **in-progress** | — | Link to `/admin/dietas/{id}`; `DietaAuthorization.canModify` |
 | 234 | Diet list grid — delete action with patient-usage guard | https://github.com/diego-torres/nutriconsultas/issues/234 | open | — | Block if `PacienteDieta` exists; SweetAlert |
 | 235 | Diet list grid — filter all, system, or own diets | https://github.com/diego-torres/nutriconsultas/issues/235 | open | — | Server-side filter on `/rest/dietas` grid |
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-20):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web **NEXT:** #233; ~~#232~~ done (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)); ~~#223~~ done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)); epics #232–#242; platillo ownership #257–#259; ~~#250~~ done (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). Public booking #245–#248 (deferred).
+**On `main` (2026-06-20):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web **NEXT:** #234; ~~#233~~ done (PR [#264](https://github.com/diego-torres/nutriconsultas/pull/264)); ~~#232~~ done (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)); ~~#223~~ done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)); epics #232–#242; platillo ownership #257–#259; ~~#250~~ done (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). Public booking #245–#248 (deferred).
 
 ## AWS (production infrastructure)
 

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -38,7 +38,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`../../ISSUE-NUTRITIONIST-WEB.md`](../../ISSUE-NUTRITIONIST-WEB.md) | Patient MPX epic (#221–#223) |
 | [`../paciente/PATIENT-MPX-PLAN.md`](../paciente/PATIENT-MPX-PLAN.md) | Export/import plan |
 
-**Nutritionist web NEXT:** [#233](https://github.com/diego-torres/nutriconsultas/issues/233) diet grid edit action. ~~#232~~ done (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)); ~~#221–#223~~ MPX epic done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)).
+**Nutritionist web NEXT:** [#234](https://github.com/diego-torres/nutriconsultas/issues/234) diet grid delete action. ~~#233~~ done (PR [#264](https://github.com/diego-torres/nutriconsultas/pull/264)); ~~#232~~ done (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)); ~~#221–#223~~ MPX epic done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)).
 
 **Subscription NEXT:** [#207](https://github.com/diego-torres/nutriconsultas/issues/207) Stripe payment provider (~~#211~~ PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230), ~~#210~~ PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224), ~~#187~~ PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218), ~~#190~~ PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) on `main`).
 

--- a/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
@@ -304,22 +304,16 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 	}
 
 	private String buildActionsColumn(final Dieta row, final OidcUser principal) {
-		final StringBuilder actions = new StringBuilder();
-		if (principal != null && dietaAuthorization.canModify(row, principal.getSubject(), principal)) {
-			actions.append("<a href='/admin/dietas/")
-				.append(row.getId())
-				.append("' class='btn btn-sm btn-warning' title='Editar Dieta'>")
-				.append("<i class='fas fa-edit'></i></a> ");
-		}
-		actions.append("<a href='/admin/dietas/")
-			.append(row.getId())
-			.append("/print' class='btn btn-sm btn-primary' target='_blank' title='Imprimir PDF'>")
-			.append("<i class='fas fa-file-pdf'></i></a> ");
-		actions.append("<button onclick='duplicateDieta(")
-			.append(row.getId())
-			.append(")' class='btn btn-sm btn-info' title='Duplicar Dieta'>")
-			.append("<i class='fas fa-copy'></i></button>");
-		return actions.toString();
+		final String editButton = principal != null && dietaAuthorization
+			.canModify(row, principal.getSubject(), principal)
+					? "<a href='/admin/dietas/" + row.getId()
+							+ "' class='btn btn-sm btn-warning' title='Editar Dieta'><i class='fas fa-edit'></i></a> "
+					: "";
+		final String printButton = "<a href='/admin/dietas/" + row.getId()
+				+ "/print' class='btn btn-sm btn-primary' target='_blank' title='Imprimir PDF'><i class='fas fa-file-pdf'></i></a> ";
+		final String duplicateButton = "<button onclick='duplicateDieta(" + row.getId()
+				+ ")' class='btn btn-sm btn-info' title='Duplicar Dieta'><i class='fas fa-copy'></i></button>";
+		return editButton + printButton + duplicateButton;
 	}
 
 	private String getIngestas(final Dieta row) {

--- a/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
@@ -10,7 +10,9 @@ import java.util.stream.Stream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.NonNull;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,6 +27,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.nutriconsultas.controller.AbstractGridController;
 import com.nutriconsultas.dataTables.paging.Column;
 import com.nutriconsultas.dataTables.paging.Direction;
+import com.nutriconsultas.dataTables.paging.PageArray;
+import com.nutriconsultas.dataTables.paging.PagingRequest;
 import com.nutriconsultas.model.ApiResponse;
 
 import lombok.extern.slf4j.Slf4j;
@@ -254,6 +258,32 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 	}
 
 	@Override
+	@PostMapping("data-table")
+	public PageArray getPageArray(@RequestBody final PagingRequest pagingRequest) {
+		log.info("starting getPageArray with pagingRequest: {}", pagingRequest);
+		final OidcUser principal = resolveGridPrincipal();
+		pagingRequest.setColumns(getColumns());
+		final com.nutriconsultas.dataTables.paging.Page<Dieta> page = getRows(pagingRequest);
+		log.debug("page with records: {}", page.getRecordsTotal());
+		final PageArray pageArray = new PageArray();
+		pageArray
+			.setData(page.getData().stream().map(row -> toStringList(row, principal)).collect(Collectors.toList()));
+		pageArray.setDraw(page.getDraw());
+		pageArray.setRecordsFiltered(page.getRecordsFiltered());
+		pageArray.setRecordsTotal(page.getRecordsTotal());
+		log.info("returning data at getPageArray: {}", pageArray.getRecordsTotal());
+		return pageArray;
+	}
+
+	private OidcUser resolveGridPrincipal() {
+		final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication != null && authentication.getPrincipal() instanceof OidcUser oidcUser) {
+			return oidcUser;
+		}
+		return null;
+	}
+
+	@Override
 	protected List<Column> getColumns() {
 		return Stream.of("acciones", "dieta", "ingestas", "dist", "kcal", "prot", "lip", "hc")
 			.map(Column::new)
@@ -262,16 +292,34 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 
 	@Override
 	protected List<String> toStringList(final Dieta row) {
+		return toStringList(row, null);
+	}
+
+	private List<String> toStringList(final Dieta row, final OidcUser principal) {
 		log.debug("converting Dieta row {} to string list.", row);
-		final String printButton = "<a href='/admin/dietas/" + row.getId()
-				+ "/print' class='btn btn-sm btn-primary' target='_blank' title='Imprimir PDF'><i class='fas fa-file-pdf'></i></a>";
-		final String duplicateButton = "<button onclick='duplicateDieta(" + row.getId()
-				+ ")' class='btn btn-sm btn-info' title='Duplicar Dieta'><i class='fas fa-copy'></i></button>";
-		// Note: Ownership indicator will be added in the template if needed
-		return Arrays.asList(printButton + " " + duplicateButton,
+		return Arrays.asList(buildActionsColumn(row, principal),
 				"<a href='/admin/dietas/" + row.getId() + "'>" + row.getNombre() + "</a>", getIngestas(row),
 				getDist(row), String.format("%.1f", getKCal(row)), String.format("%.1f", getTotalProteina(row)),
 				String.format("%.1f", getTotalLipidos(row)), String.format("%.1f", getTotalHidratosDeCarbono(row)));
+	}
+
+	private String buildActionsColumn(final Dieta row, final OidcUser principal) {
+		final StringBuilder actions = new StringBuilder();
+		if (principal != null && dietaAuthorization.canModify(row, principal.getSubject(), principal)) {
+			actions.append("<a href='/admin/dietas/")
+				.append(row.getId())
+				.append("' class='btn btn-sm btn-warning' title='Editar Dieta'>")
+				.append("<i class='fas fa-edit'></i></a> ");
+		}
+		actions.append("<a href='/admin/dietas/")
+			.append(row.getId())
+			.append("/print' class='btn btn-sm btn-primary' target='_blank' title='Imprimir PDF'>")
+			.append("<i class='fas fa-file-pdf'></i></a> ");
+		actions.append("<button onclick='duplicateDieta(")
+			.append(row.getId())
+			.append(")' class='btn btn-sm btn-info' title='Duplicar Dieta'>")
+			.append("<i class='fas fa-copy'></i></button>");
+		return actions.toString();
 	}
 
 	private String getIngestas(final Dieta row) {

--- a/src/test/java/com/nutriconsultas/dieta/DietasRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietasRestControllerTest.java
@@ -20,6 +20,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -1350,6 +1353,95 @@ public class DietasRestControllerTest {
 
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
 		verify(dietaService, never()).saveDieta(any(Dieta.class));
+	}
+
+	@Test
+	public void testBuildActionsColumnIncludesEditButtonForOwnedDiet() throws Exception {
+		dietaVacia.setUserId(TEST_USER_ID);
+		final OidcUser principal = createMockOidcUser(TEST_USER_ID);
+
+		final Method buildActionsMethod = DietasRestController.class.getDeclaredMethod("buildActionsColumn",
+				Dieta.class, OidcUser.class);
+		buildActionsMethod.setAccessible(true);
+		final String actions = (String) buildActionsMethod.invoke(dietasRestController, dietaVacia, principal);
+
+		assertThat(actions).contains("href='/admin/dietas/1'");
+		assertThat(actions).contains("class='btn btn-sm btn-warning'");
+		assertThat(actions).contains("title='Editar Dieta'");
+		assertThat(actions).contains("fa-edit");
+		assertThat(actions).contains("fa-file-pdf");
+		assertThat(actions).contains("duplicateDieta(1)");
+	}
+
+	@Test
+	public void testBuildActionsColumnOmitsEditButtonForSystemDietWhenNotAdmin() throws Exception {
+		final Dieta systemDieta = new Dieta();
+		systemDieta.setId(8L);
+		systemDieta.setNombre("Plantilla sistema");
+		systemDieta.setUserId(DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID);
+		when(platformAdminService.isPlatformAdmin(org.mockito.ArgumentMatchers.any(OidcUser.class))).thenReturn(false);
+
+		final OidcUser principal = createMockOidcUser(TEST_USER_ID);
+		final Method buildActionsMethod = DietasRestController.class.getDeclaredMethod("buildActionsColumn",
+				Dieta.class, OidcUser.class);
+		buildActionsMethod.setAccessible(true);
+		final String actions = (String) buildActionsMethod.invoke(dietasRestController, systemDieta, principal);
+
+		assertThat(actions).doesNotContain("fa-edit");
+		assertThat(actions).doesNotContain("title='Editar Dieta'");
+		assertThat(actions).contains("fa-file-pdf");
+		assertThat(actions).contains("duplicateDieta(8)");
+	}
+
+	@Test
+	public void testBuildActionsColumnIncludesEditButtonForSystemDietWhenPlatformAdmin() throws Exception {
+		final Dieta systemDieta = new Dieta();
+		systemDieta.setId(8L);
+		systemDieta.setNombre("Plantilla sistema");
+		systemDieta.setUserId(DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID);
+		when(platformAdminService.isPlatformAdmin(org.mockito.ArgumentMatchers.any(OidcUser.class))).thenReturn(true);
+
+		final OidcUser principal = createMockOidcUser(PLATFORM_ADMIN_USER_ID);
+		final Method buildActionsMethod = DietasRestController.class.getDeclaredMethod("buildActionsColumn",
+				Dieta.class, OidcUser.class);
+		buildActionsMethod.setAccessible(true);
+		final String actions = (String) buildActionsMethod.invoke(dietasRestController, systemDieta, principal);
+
+		assertThat(actions).contains("href='/admin/dietas/8'");
+		assertThat(actions).contains("fa-edit");
+		assertThat(actions).contains("title='Editar Dieta'");
+	}
+
+	@Test
+	public void testGetPageArrayIncludesEditButtonForOwnedDiet() {
+		dietaVacia.setUserId(TEST_USER_ID);
+		when(dietaService.getDietas()).thenReturn(Arrays.asList(dietaVacia));
+
+		final OidcUser principal = createMockOidcUser(TEST_USER_ID);
+		final Authentication authentication = org.mockito.Mockito.mock(Authentication.class);
+		org.mockito.Mockito.when(authentication.getPrincipal()).thenReturn(principal);
+		final SecurityContext securityContext = org.mockito.Mockito.mock(SecurityContext.class);
+		org.mockito.Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
+		SecurityContextHolder.setContext(securityContext);
+
+		try {
+			final PagingRequest pagingRequest = new PagingRequest();
+			pagingRequest.setStart(0);
+			pagingRequest.setLength(10);
+			pagingRequest.setDraw(1);
+			pagingRequest.setOrder(Arrays.asList(new Order(1, Direction.asc)));
+			pagingRequest.setSearch(new Search("", "false"));
+
+			final PageArray result = dietasRestController.getPageArray(pagingRequest);
+
+			assertThat(result.getData()).isNotEmpty();
+			final List<String> firstRow = (List<String>) result.getData().get(0);
+			assertThat(firstRow.get(0)).contains("fa-edit");
+			assertThat(firstRow.get(0)).contains("href='/admin/dietas/1'");
+		}
+		finally {
+			SecurityContextHolder.clearContext();
+		}
 	}
 
 }


### PR DESCRIPTION
## Summary
- Add an **Editar** action button to the diet list DataGrid (`/admin/dietas`) linking to `/admin/dietas/{id}`
- Button is shown only when `DietaAuthorization.canModify` allows it (owned diets for nutritionists; system template diets for platform admins)
- PDF print and duplicate actions unchanged

## Test plan
- [x] `DietasRestControllerTest` — edit shown for owned diets, hidden for system diets (non-admin), shown for platform admin on system diets
- [x] `mvn checkstyle:check` and `mvn pmd:check` pass locally
- [ ] Manual: open `/admin/dietas`, confirm Editar appears on owned rows and opens the diet form
- [ ] Manual: system template row shows no Editar for regular nutritionist; platform admin sees Editar

Closes #233


Made with [Cursor](https://cursor.com)