### PR TITLE
[Nutritionist Web] Diet list grid delete with patient-usage guard (#234)

### DIFF
--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-20 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). ~~#223~~ **done** (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). ~~#232~~ **done** (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)). ~~#233~~ **done** (PR [#264](https://github.com/diego-torres/nutriconsultas/pull/264)). **NEXT:** [#234 diet grid delete](https://github.com/diego-torres/nutriconsultas/issues/234). Epics **#232–#242**, **#257–#259** (platillo ownership) registered.
+**Last updated:** 2026-06-20 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). ~~#223~~ **done** (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). ~~#232~~ **done** (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)). ~~#233~~ **done** (PR [#264](https://github.com/diego-torres/nutriconsultas/pull/264)). **NEXT:** [#235 diet grid filter](https://github.com/diego-torres/nutriconsultas/issues/235). **#234** in-progress. Epics **#232–#242**, **#257–#259** (platillo ownership) registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -61,7 +61,7 @@ System template diets (`userId = system:template-dietas`), grid actions, and own
 |---|-------|-----|-------|-----------|-------|
 | **232** | Platform admins can edit system template diets | https://github.com/diego-torres/nutriconsultas/issues/232 | **done** | #183 | PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263); `DietaAuthorization` |
 | **233** | Diet list grid — edit action | https://github.com/diego-torres/nutriconsultas/issues/233 | **done** | — | PR [#264](https://github.com/diego-torres/nutriconsultas/pull/264); `DietaAuthorization.canModify` |
-| 234 | Diet list grid — delete action with patient-usage guard | https://github.com/diego-torres/nutriconsultas/issues/234 | **NEXT** | — | Block if `PacienteDieta` exists; SweetAlert |
+| 234 | Diet list grid — delete action with patient-usage guard | https://github.com/diego-torres/nutriconsultas/issues/234 | **in-progress** | — | Block if `PacienteDieta` exists; SweetAlert |
 | 235 | Diet list grid — filter all, system, or own diets | https://github.com/diego-torres/nutriconsultas/issues/235 | open | — | Server-side filter on `/rest/dietas` grid |
 
 ---

--- a/src/main/java/com/nutriconsultas/dieta/DietaDeleteResult.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaDeleteResult.java
@@ -1,0 +1,39 @@
+package com.nutriconsultas.dieta;
+
+import lombok.Getter;
+
+@Getter
+public final class DietaDeleteResult {
+
+	public enum Outcome {
+
+		DELETED, NOT_FOUND, FORBIDDEN, IN_USE
+
+	}
+
+	private final Outcome outcome;
+
+	private final long assignedPatientCount;
+
+	private DietaDeleteResult(final Outcome outcome, final long assignedPatientCount) {
+		this.outcome = outcome;
+		this.assignedPatientCount = assignedPatientCount;
+	}
+
+	public static DietaDeleteResult deleted() {
+		return new DietaDeleteResult(Outcome.DELETED, 0L);
+	}
+
+	public static DietaDeleteResult notFound() {
+		return new DietaDeleteResult(Outcome.NOT_FOUND, 0L);
+	}
+
+	public static DietaDeleteResult forbidden() {
+		return new DietaDeleteResult(Outcome.FORBIDDEN, 0L);
+	}
+
+	public static DietaDeleteResult inUse(final long assignedPatientCount) {
+		return new DietaDeleteResult(Outcome.IN_USE, assignedPatientCount);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/dieta/DietaDeletionService.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaDeletionService.java
@@ -1,0 +1,12 @@
+package com.nutriconsultas.dieta;
+
+import org.springframework.lang.NonNull;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+public interface DietaDeletionService {
+
+	DietaDeleteResult deleteDieta(@NonNull Long dietaId, @NonNull String userId, OidcUser principal);
+
+	long countPatientAssignments(@NonNull Dieta dieta, @NonNull String userId);
+
+}

--- a/src/main/java/com/nutriconsultas/dieta/DietaDeletionServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaDeletionServiceImpl.java
@@ -1,0 +1,74 @@
+package com.nutriconsultas.dieta;
+
+import org.springframework.lang.NonNull;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nutriconsultas.paciente.PacienteDietaRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Deletes diets when authorized. Owned diets require no {@code PacienteDieta} rows for
+ * the nutritionist's patients. System template diets may be deleted by platform admins
+ * only and are blocked when any patient assignment exists platform-wide.
+ */
+@Service
+@Slf4j
+public class DietaDeletionServiceImpl implements DietaDeletionService {
+
+	private final DietaService dietaService;
+
+	private final DietaAuthorization dietaAuthorization;
+
+	private final PacienteDietaRepository pacienteDietaRepository;
+
+	public DietaDeletionServiceImpl(final DietaService dietaService, final DietaAuthorization dietaAuthorization,
+			final PacienteDietaRepository pacienteDietaRepository) {
+		this.dietaService = dietaService;
+		this.dietaAuthorization = dietaAuthorization;
+		this.pacienteDietaRepository = pacienteDietaRepository;
+	}
+
+	@Override
+	@Transactional
+	public DietaDeleteResult deleteDieta(@NonNull final Long dietaId, @NonNull final String userId,
+			final OidcUser principal) {
+		final Dieta dieta = dietaAuthorization.resolveForMutation(dietaId, userId, principal, dietaService);
+		if (dieta == null) {
+			if (dietaService.getDieta(dietaId) == null) {
+				return DietaDeleteResult.notFound();
+			}
+			return DietaDeleteResult.forbidden();
+		}
+		if (!dietaAuthorization.canModify(dieta, userId, principal)) {
+			return DietaDeleteResult.forbidden();
+		}
+
+		final long assignedCount = countPatientAssignments(dieta, userId);
+		if (assignedCount > 0) {
+			if (log.isInfoEnabled()) {
+				log.info("Blocked delete of diet {}: assigned to {} patient(s)", dietaId, assignedCount);
+			}
+			return DietaDeleteResult.inUse(assignedCount);
+		}
+
+		dietaAuthorization.auditSystemDietMutationIfNeeded(principal, dieta, "dietas.delete");
+		dietaService.deleteDieta(dietaId);
+		if (log.isInfoEnabled()) {
+			log.info("Deleted diet {}", dietaId);
+		}
+		return DietaDeleteResult.deleted();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public long countPatientAssignments(@NonNull final Dieta dieta, @NonNull final String userId) {
+		if (DietaCatalogConstants.isSystemTemplate(dieta)) {
+			return pacienteDietaRepository.countByDietaId(dieta.getId());
+		}
+		return pacienteDietaRepository.countByDietaIdAndPacienteUserId(dieta.getId(), userId);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
@@ -273,31 +273,28 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 		}
 
 		final DietaDeleteResult result = dietaDeletionService.deleteDieta(dietaId, userId, principal);
-		final ResponseEntity<ApiResponse<Void>> response;
-		switch (result.getOutcome()) {
+		return switch (result.getOutcome()) {
 			case DELETED -> {
 				log.info("finish deleteDieta with dietaId {}.", dietaId);
-				response = ResponseEntity.ok(new ApiResponse<>(null));
+				yield ResponseEntity.ok(new ApiResponse<>(null));
 			}
 			case NOT_FOUND -> {
 				log.warn("Dieta with id {} not found for deletion", dietaId);
-				response = ResponseEntity.notFound().build();
+				yield ResponseEntity.notFound().build();
 			}
 			case FORBIDDEN -> {
 				log.warn("User {} forbidden to delete diet {}", userId, dietaId);
-				response = ResponseEntity.status(org.springframework.http.HttpStatus.FORBIDDEN)
+				yield ResponseEntity.status(org.springframework.http.HttpStatus.FORBIDDEN)
 					.body(buildDeleteErrorResponse(org.springframework.http.HttpStatus.FORBIDDEN.value(),
 							"No tiene permiso para eliminar esta dieta"));
 			}
 			case IN_USE -> {
 				final String message = buildInUseMessage(result.getAssignedPatientCount());
 				log.info("Delete blocked for diet {}: {}", dietaId, message);
-				response = ResponseEntity.status(org.springframework.http.HttpStatus.CONFLICT)
+				yield ResponseEntity.status(org.springframework.http.HttpStatus.CONFLICT)
 					.body(buildDeleteErrorResponse(org.springframework.http.HttpStatus.CONFLICT.value(), message));
 			}
-			default -> response = ResponseEntity.internalServerError().build();
-		}
-		return response;
+		};
 	}
 
 	private ApiResponse<Void> buildDeleteErrorResponse(final int status, final String message) {

--- a/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
@@ -44,6 +44,9 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 	@Autowired
 	private DietaAuthorization dietaAuthorization;
 
+	@Autowired
+	private DietaDeletionService dietaDeletionService;
+
 	private Dieta loadDietaForMutation(@NonNull final Long dietaId, final OidcUser principal) {
 		if (principal == null) {
 			return null;
@@ -257,6 +260,59 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 		return ResponseEntity.ok(new ApiResponse<Dieta>(duplicatedDieta));
 	}
 
+	@DeleteMapping("{dietaId}")
+	public ResponseEntity<ApiResponse<Void>> deleteDieta(@PathVariable @NonNull final Long dietaId,
+			@AuthenticationPrincipal final OidcUser principal) {
+		log.info("starting deleteDieta with dietaId {}.", dietaId);
+		if (principal == null) {
+			return ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();
+		}
+		final String userId = principal.getSubject();
+		if (userId == null) {
+			return ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();
+		}
+
+		final DietaDeleteResult result = dietaDeletionService.deleteDieta(dietaId, userId, principal);
+		final ResponseEntity<ApiResponse<Void>> response;
+		switch (result.getOutcome()) {
+			case DELETED -> {
+				log.info("finish deleteDieta with dietaId {}.", dietaId);
+				response = ResponseEntity.ok(new ApiResponse<>(null));
+			}
+			case NOT_FOUND -> {
+				log.warn("Dieta with id {} not found for deletion", dietaId);
+				response = ResponseEntity.notFound().build();
+			}
+			case FORBIDDEN -> {
+				log.warn("User {} forbidden to delete diet {}", userId, dietaId);
+				response = ResponseEntity.status(org.springframework.http.HttpStatus.FORBIDDEN)
+					.body(buildDeleteErrorResponse(org.springframework.http.HttpStatus.FORBIDDEN.value(),
+							"No tiene permiso para eliminar esta dieta"));
+			}
+			case IN_USE -> {
+				final String message = buildInUseMessage(result.getAssignedPatientCount());
+				log.info("Delete blocked for diet {}: {}", dietaId, message);
+				response = ResponseEntity.status(org.springframework.http.HttpStatus.CONFLICT)
+					.body(buildDeleteErrorResponse(org.springframework.http.HttpStatus.CONFLICT.value(), message));
+			}
+			default -> response = ResponseEntity.internalServerError().build();
+		}
+		return response;
+	}
+
+	private ApiResponse<Void> buildDeleteErrorResponse(final int status, final String message) {
+		final ApiResponse<Void> apiResponse = new ApiResponse<>();
+		apiResponse.setStatus(status);
+		apiResponse.setMessage(message);
+		apiResponse.setData(null);
+		return apiResponse;
+	}
+
+	private String buildInUseMessage(final long assignedPatientCount) {
+		return "Esta dieta está asignada a " + assignedPatientCount + (assignedPatientCount == 1
+				? " paciente y no puede eliminarse" : " paciente(s) y no puede eliminarse");
+	}
+
 	@Override
 	@PostMapping("data-table")
 	public PageArray getPageArray(@RequestBody final PagingRequest pagingRequest) {
@@ -309,11 +365,15 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 					? "<a href='/admin/dietas/" + row.getId()
 							+ "' class='btn btn-sm btn-warning' title='Editar Dieta'><i class='fas fa-edit'></i></a> "
 					: "";
+		final String deleteButton = principal != null && dietaAuthorization
+			.canModify(row, principal.getSubject(), principal) ? "<button onclick='deleteDieta(" + row.getId()
+					+ ")' class='btn btn-sm btn-danger' title='Eliminar Dieta'><i class='fas fa-trash'></i></button> "
+					: "";
 		final String printButton = "<a href='/admin/dietas/" + row.getId()
 				+ "/print' class='btn btn-sm btn-primary' target='_blank' title='Imprimir PDF'><i class='fas fa-file-pdf'></i></a> ";
 		final String duplicateButton = "<button onclick='duplicateDieta(" + row.getId()
 				+ ")' class='btn btn-sm btn-info' title='Duplicar Dieta'><i class='fas fa-copy'></i></button>";
-		return editButton + printButton + duplicateButton;
+		return editButton + deleteButton + printButton + duplicateButton;
 	}
 
 	private String getIngestas(final Dieta row) {

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaRepository.java
@@ -37,6 +37,12 @@ public interface PacienteDietaRepository extends JpaRepository<PacienteDieta, Lo
 	@Query("SELECT COUNT(pd) FROM PacienteDieta pd WHERE pd.paciente.userId = :userId AND pd.status = :status")
 	long countByUserIdAndStatus(@Param("userId") String userId, @Param("status") PacienteDietaStatus status);
 
+	@Query("SELECT COUNT(pd) FROM PacienteDieta pd WHERE pd.dieta.id = :dietaId")
+	long countByDietaId(@Param("dietaId") Long dietaId);
+
+	@Query("SELECT COUNT(pd) FROM PacienteDieta pd WHERE pd.dieta.id = :dietaId AND pd.paciente.userId = :userId")
+	long countByDietaIdAndPacienteUserId(@Param("dietaId") Long dietaId, @Param("userId") String userId);
+
 	@Query("SELECT pd FROM PacienteDieta pd WHERE pd.paciente.userId = :userId "
 			+ "AND pd.startDate >= :startDate AND pd.startDate <= :endDate")
 	List<PacienteDieta> findByUserIdAndDateRange(@Param("userId") String userId, @Param("startDate") Date startDate,

--- a/src/main/resources/templates/sbadmin/dietas/listado.html
+++ b/src/main/resources/templates/sbadmin/dietas/listado.html
@@ -231,6 +231,51 @@
               }
             });
           };
+
+          window.deleteDieta = function (dietaId) {
+            swal({
+              title: 'Eliminar Dieta',
+              text: '¿Está seguro que desea eliminar esta dieta? Esta acción no se puede deshacer.',
+              type: 'warning',
+              showCancelButton: true,
+              confirmButtonColor: '#d33',
+              cancelButtonColor: '#3085d6',
+              confirmButtonText: 'Sí, eliminar',
+              cancelButtonText: 'Cancelar',
+              closeOnConfirm: false,
+              showLoaderOnConfirm: true
+            }, function (isConfirm) {
+              if (isConfirm) {
+                $.ajax({
+                  url: '/rest/dietas/' + dietaId,
+                  type: 'DELETE',
+                  success: function () {
+                    swal({
+                      title: '¡Eliminada!',
+                      text: 'La dieta ha sido eliminada correctamente',
+                      type: 'success',
+                      timer: 2000,
+                      showConfirmButton: true
+                    }, function () {
+                      $('#mainGrid').DataTable().ajax.reload(null, false);
+                    });
+                  },
+                  error: function (xhr) {
+                    var message = 'Error al eliminar la dieta';
+                    if (xhr.responseJSON && xhr.responseJSON.message) {
+                      message = xhr.responseJSON.message;
+                    }
+                    swal({
+                      title: xhr.status === 409 ? 'No se puede eliminar' : 'Error',
+                      text: message,
+                      type: xhr.status === 409 ? 'warning' : 'error',
+                      timer: xhr.status === 409 ? null : 5000
+                    });
+                  }
+                });
+              }
+            });
+          };
         });
       }
       

--- a/src/test/java/com/nutriconsultas/dieta/DietaDeletionServiceTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaDeletionServiceTest.java
@@ -1,0 +1,176 @@
+package com.nutriconsultas.dieta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.nutriconsultas.paciente.PacienteDietaRepository;
+import com.nutriconsultas.platform.PlatformAdminAuditService;
+import com.nutriconsultas.platform.PlatformAdminService;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+@SuppressWarnings("null")
+class DietaDeletionServiceTest {
+
+	private static final String NUTRITIONIST_USER_ID = "auth0|nutritionist";
+
+	private static final String OTHER_USER_ID = "auth0|other-user";
+
+	private static final String PLATFORM_ADMIN_USER_ID = "auth0|platform-admin";
+
+	@Mock
+	private DietaService dietaService;
+
+	@Mock
+	private PacienteDietaRepository pacienteDietaRepository;
+
+	@Mock
+	private PlatformAdminService platformAdminService;
+
+	@Mock
+	private PlatformAdminAuditService platformAdminAuditService;
+
+	@Mock
+	private OidcUser nutritionistPrincipal;
+
+	@Mock
+	private OidcUser platformAdminPrincipal;
+
+	private DietaDeletionServiceImpl service;
+
+	@BeforeEach
+	void setUp() {
+		final DietaAuthorization dietaAuthorization = new DietaAuthorization(platformAdminService,
+				platformAdminAuditService);
+		service = new DietaDeletionServiceImpl(dietaService, dietaAuthorization, pacienteDietaRepository);
+	}
+
+	@Test
+	void deleteDieta_deletesOwnedDietWhenNotAssigned() {
+		final Dieta dieta = ownedDiet(5L);
+		when(dietaService.getDietaByIdAndUserId(5L, NUTRITIONIST_USER_ID)).thenReturn(dieta);
+		when(pacienteDietaRepository.countByDietaIdAndPacienteUserId(5L, NUTRITIONIST_USER_ID)).thenReturn(0L);
+
+		final DietaDeleteResult result = service.deleteDieta(5L, NUTRITIONIST_USER_ID, nutritionistPrincipal);
+
+		assertThat(result.getOutcome()).isEqualTo(DietaDeleteResult.Outcome.DELETED);
+		verify(dietaService).deleteDieta(5L);
+	}
+
+	@Test
+	void deleteDieta_blocksWhenOwnedDietAssignedToPatients() {
+		final Dieta dieta = ownedDiet(6L);
+		when(dietaService.getDietaByIdAndUserId(6L, NUTRITIONIST_USER_ID)).thenReturn(dieta);
+		when(pacienteDietaRepository.countByDietaIdAndPacienteUserId(6L, NUTRITIONIST_USER_ID)).thenReturn(2L);
+
+		final DietaDeleteResult result = service.deleteDieta(6L, NUTRITIONIST_USER_ID, nutritionistPrincipal);
+
+		assertThat(result.getOutcome()).isEqualTo(DietaDeleteResult.Outcome.IN_USE);
+		assertThat(result.getAssignedPatientCount()).isEqualTo(2L);
+		verify(dietaService, never()).deleteDieta(6L);
+	}
+
+	@Test
+	void deleteDieta_returnsForbiddenForOtherTenantDiet() {
+		when(dietaService.getDietaByIdAndUserId(7L, NUTRITIONIST_USER_ID)).thenReturn(null);
+		when(platformAdminService.isPlatformAdmin(nutritionistPrincipal)).thenReturn(false);
+		final Dieta otherDiet = ownedDiet(7L);
+		otherDiet.setUserId(OTHER_USER_ID);
+		when(dietaService.getDieta(7L)).thenReturn(otherDiet);
+
+		final DietaDeleteResult result = service.deleteDieta(7L, NUTRITIONIST_USER_ID, nutritionistPrincipal);
+
+		assertThat(result.getOutcome()).isEqualTo(DietaDeleteResult.Outcome.FORBIDDEN);
+		verify(dietaService, never()).deleteDieta(7L);
+	}
+
+	@Test
+	void deleteDieta_returnsNotFoundWhenDietMissing() {
+		when(dietaService.getDietaByIdAndUserId(99L, NUTRITIONIST_USER_ID)).thenReturn(null);
+		when(platformAdminService.isPlatformAdmin(nutritionistPrincipal)).thenReturn(false);
+		when(dietaService.getDieta(99L)).thenReturn(null);
+
+		final DietaDeleteResult result = service.deleteDieta(99L, NUTRITIONIST_USER_ID, nutritionistPrincipal);
+
+		assertThat(result.getOutcome()).isEqualTo(DietaDeleteResult.Outcome.NOT_FOUND);
+		verify(dietaService, never()).deleteDieta(99L);
+	}
+
+	@Test
+	void deleteDieta_allowsPlatformAdminToDeleteUnusedSystemTemplate() {
+		final Dieta systemDieta = systemDiet(8L);
+		when(dietaService.getDietaByIdAndUserId(8L, PLATFORM_ADMIN_USER_ID)).thenReturn(null);
+		when(platformAdminService.isPlatformAdmin(platformAdminPrincipal)).thenReturn(true);
+		when(platformAdminService.resolveActorUserId(platformAdminPrincipal)).thenReturn(PLATFORM_ADMIN_USER_ID);
+		when(dietaService.getDieta(8L)).thenReturn(systemDieta);
+		when(pacienteDietaRepository.countByDietaId(8L)).thenReturn(0L);
+
+		final DietaDeleteResult result = service.deleteDieta(8L, PLATFORM_ADMIN_USER_ID, platformAdminPrincipal);
+
+		assertThat(result.getOutcome()).isEqualTo(DietaDeleteResult.Outcome.DELETED);
+		verify(dietaService).deleteDieta(8L);
+		verify(platformAdminAuditService).recordAction(PLATFORM_ADMIN_USER_ID, "dietas.delete:dietaId=8");
+	}
+
+	@Test
+	void deleteDieta_blocksPlatformAdminWhenSystemTemplateAssignedGlobally() {
+		final Dieta systemDieta = systemDiet(9L);
+		when(dietaService.getDietaByIdAndUserId(9L, PLATFORM_ADMIN_USER_ID)).thenReturn(null);
+		when(platformAdminService.isPlatformAdmin(platformAdminPrincipal)).thenReturn(true);
+		when(dietaService.getDieta(9L)).thenReturn(systemDieta);
+		when(pacienteDietaRepository.countByDietaId(9L)).thenReturn(4L);
+
+		final DietaDeleteResult result = service.deleteDieta(9L, PLATFORM_ADMIN_USER_ID, platformAdminPrincipal);
+
+		assertThat(result.getOutcome()).isEqualTo(DietaDeleteResult.Outcome.IN_USE);
+		assertThat(result.getAssignedPatientCount()).isEqualTo(4L);
+		verify(dietaService, never()).deleteDieta(9L);
+	}
+
+	@Test
+	void countPatientAssignments_usesNutritionistScopeForOwnedDiet() {
+		final Dieta dieta = ownedDiet(10L);
+
+		service.countPatientAssignments(dieta, NUTRITIONIST_USER_ID);
+
+		verify(pacienteDietaRepository).countByDietaIdAndPacienteUserId(10L, NUTRITIONIST_USER_ID);
+		verify(pacienteDietaRepository, never()).countByDietaId(10L);
+	}
+
+	@Test
+	void countPatientAssignments_usesGlobalScopeForSystemTemplate() {
+		final Dieta systemDieta = systemDiet(11L);
+
+		service.countPatientAssignments(systemDieta, PLATFORM_ADMIN_USER_ID);
+
+		verify(pacienteDietaRepository).countByDietaId(11L);
+		verify(pacienteDietaRepository, never()).countByDietaIdAndPacienteUserId(11L, PLATFORM_ADMIN_USER_ID);
+	}
+
+	private Dieta ownedDiet(final Long id) {
+		final Dieta dieta = new Dieta();
+		dieta.setId(id);
+		dieta.setNombre("Dieta propia");
+		dieta.setUserId(NUTRITIONIST_USER_ID);
+		return dieta;
+	}
+
+	private Dieta systemDiet(final Long id) {
+		final Dieta dieta = new Dieta();
+		dieta.setId(id);
+		dieta.setNombre("Plantilla sistema");
+		dieta.setUserId(DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID);
+		return dieta;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/dieta/DietasRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietasRestControllerTest.java
@@ -56,6 +56,9 @@ public class DietasRestControllerTest {
 	@Mock
 	private PlatformAdminAuditService platformAdminAuditService;
 
+	@Mock
+	private DietaDeletionService dietaDeletionService;
+
 	private DietaAuthorization dietaAuthorization;
 
 	private Dieta dietaVacia;
@@ -1369,6 +1372,9 @@ public class DietasRestControllerTest {
 		assertThat(actions).contains("class='btn btn-sm btn-warning'");
 		assertThat(actions).contains("title='Editar Dieta'");
 		assertThat(actions).contains("fa-edit");
+		assertThat(actions).contains("deleteDieta(1)");
+		assertThat(actions).contains("title='Eliminar Dieta'");
+		assertThat(actions).contains("fa-trash");
 		assertThat(actions).contains("fa-file-pdf");
 		assertThat(actions).contains("duplicateDieta(1)");
 	}
@@ -1389,6 +1395,8 @@ public class DietasRestControllerTest {
 
 		assertThat(actions).doesNotContain("fa-edit");
 		assertThat(actions).doesNotContain("title='Editar Dieta'");
+		assertThat(actions).doesNotContain("deleteDieta(8)");
+		assertThat(actions).doesNotContain("fa-trash");
 		assertThat(actions).contains("fa-file-pdf");
 		assertThat(actions).contains("duplicateDieta(8)");
 	}
@@ -1410,6 +1418,62 @@ public class DietasRestControllerTest {
 		assertThat(actions).contains("href='/admin/dietas/8'");
 		assertThat(actions).contains("fa-edit");
 		assertThat(actions).contains("title='Editar Dieta'");
+		assertThat(actions).contains("deleteDieta(8)");
+	}
+
+	@Test
+	public void testDeleteDietaReturnsOkWhenDeleted() {
+		final OidcUser principal = createMockOidcUser(TEST_USER_ID);
+		when(dietaDeletionService.deleteDieta(1L, TEST_USER_ID, principal)).thenReturn(DietaDeleteResult.deleted());
+
+		final ResponseEntity<ApiResponse<Void>> response = dietasRestController.deleteDieta(1L, principal);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		verify(dietaDeletionService).deleteDieta(1L, TEST_USER_ID, principal);
+	}
+
+	@Test
+	public void testDeleteDietaReturnsConflictWhenAssignedToPatients() {
+		final OidcUser principal = createMockOidcUser(TEST_USER_ID);
+		when(dietaDeletionService.deleteDieta(1L, TEST_USER_ID, principal)).thenReturn(DietaDeleteResult.inUse(3L));
+
+		final ResponseEntity<ApiResponse<Void>> response = dietasRestController.deleteDieta(1L, principal);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().getMessage())
+			.isEqualTo("Esta dieta está asignada a 3 paciente(s) y no puede eliminarse");
+	}
+
+	@Test
+	public void testDeleteDietaReturnsForbiddenForOtherTenant() {
+		final OidcUser principal = createMockOidcUser(TEST_USER_ID);
+		when(dietaDeletionService.deleteDieta(1L, TEST_USER_ID, principal)).thenReturn(DietaDeleteResult.forbidden());
+
+		final ResponseEntity<ApiResponse<Void>> response = dietasRestController.deleteDieta(1L, principal);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().getMessage()).isEqualTo("No tiene permiso para eliminar esta dieta");
+	}
+
+	@Test
+	public void testDeleteDietaReturnsNotFoundWhenMissing() {
+		final OidcUser principal = createMockOidcUser(TEST_USER_ID);
+		when(dietaDeletionService.deleteDieta(99L, TEST_USER_ID, principal)).thenReturn(DietaDeleteResult.notFound());
+
+		final ResponseEntity<ApiResponse<Void>> response = dietasRestController.deleteDieta(99L, principal);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	public void testDeleteDietaReturnsUnauthorizedWhenPrincipalMissing() {
+		final ResponseEntity<ApiResponse<Void>> response = dietasRestController.deleteDieta(1L, null);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+		verify(dietaDeletionService, never()).deleteDieta(org.mockito.ArgumentMatchers.anyLong(),
+				org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Add `DELETE /rest/dietas/{id}` with `DietaAuthorization` ownership checks and a `PacienteDieta` assignment guard before deletion.
- Show an **Eliminar** button in the diet grid (when `canModify`) with SweetAlert confirm; blocked deletes return HTTP 409 with a Spanish count-only message.
- System template diets are deletable only by platform admins; assignment guard is platform-wide for those rows.

## Product decision
System template diets (`system:template-dietas`) follow the same rule as #232 edit access: nutritionists cannot delete them; platform admins can, but only when no patient assignment exists anywhere in the catalog.

## Test plan
- [x] `mvn test -Dtest=DietaDeletionServiceTest,DietasRestControllerTest`
- [x] `mvn checkstyle:check pmd:check`
- [ ] Manual: delete an unused owned diet from `/admin/dietas` grid
- [ ] Manual: attempt delete on a diet assigned to a patient → SweetAlert warning with count
- [ ] Manual: nutritionist cannot delete system template row (no button); platform admin can when unassigned

Closes #234

Made with [Cursor](https://cursor.com)