### PR TITLE
[Nutritionist Web] Nutritionist-owned platillos — creator edit and delete (#258)

### DIFF
--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-20 — ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254), deployed EC2). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#250~~ **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)). ~~#223~~ **done** (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). ~~#232~~ **done** (PR [#263](https://github.com/diego-torres/nutriconsultas/pull/263)). ~~#233~~ **done** (PR [#264](https://github.com/diego-torres/nutriconsultas/pull/264)). ~~#234~~ **done** (PR [#265](https://github.com/diego-torres/nutriconsultas/pull/265)). ~~#235~~ **done** (PR [#267](https://github.com/diego-torres/nutriconsultas/pull/267)). ~~#257~~ **done** (PR [#268](https://github.com/diego-torres/nutriconsultas/pull/268)). **NEXT:** [#258 nutritionist-owned platillos](https://github.com/diego-torres/nutriconsultas/issues/258). Epics **#236–#242**, **#258–#259** registered.
+**Last updated:** 2026-06-20 — ~~#257~~ **done** (PR [#268](https://github.com/diego-torres/nutriconsultas/pull/268)). **NEXT:** [#258 nutritionist-owned platillos](https://github.com/diego-torres/nutriconsultas/issues/258) **in-progress** on `feature/258-nutritionist-owned-platillos`. Epics **#236–#242**, **#258–#259** registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -81,7 +81,7 @@ Lock **system** catalog platillos for nutritionists; **owned** platillos editabl
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | **257** | Lock system catalog platillos for non-admin users | https://github.com/diego-torres/nutriconsultas/issues/257 | **done** | #183, #46 | PR [#268](https://github.com/diego-torres/nutriconsultas/pull/268); `PlatilloAuthorization`; `user_id` backfill; UI read-only |
-| 258 | Nutritionist-owned platillos — creator can edit and delete | https://github.com/diego-torres/nutriconsultas/issues/258 | open | **257**, #46 | Multi-tenant like `Dieta.userId`; grid filter own + system |
+| **258** | Nutritionist-owned platillos — creator can edit and delete | https://github.com/diego-torres/nutriconsultas/issues/258 | **in-progress** | **257**, #46 | Branch `feature/258-nutritionist-owned-platillos`; ownership + catalog filter + delete guard |
 | 259 | Copy platillo — duplicate into nutritionist-owned catalog row | https://github.com/diego-torres/nutriconsultas/issues/259 | open | **257**, **258** | SweetAlert optional; clone ingredients; complements #250 `sourcePlatilloId` |
 
 ---

--- a/src/main/java/com/nutriconsultas/dieta/PlatilloIngestaRepository.java
+++ b/src/main/java/com/nutriconsultas/dieta/PlatilloIngestaRepository.java
@@ -1,0 +1,18 @@
+package com.nutriconsultas.dieta;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlatilloIngestaRepository extends JpaRepository<PlatilloIngesta, Long> {
+
+	@Query("SELECT COUNT(pi) FROM PlatilloIngesta pi WHERE pi.sourcePlatilloId = :platilloId")
+	long countBySourcePlatilloId(@Param("platilloId") Long platilloId);
+
+	@Query("SELECT COUNT(pi) FROM PlatilloIngesta pi JOIN pi.ingesta i JOIN i.dieta d "
+			+ "WHERE pi.sourcePlatilloId = :platilloId AND d.userId = :userId")
+	long countBySourcePlatilloIdAndDietaUserId(@Param("platilloId") Long platilloId, @Param("userId") String userId);
+
+}

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloAuthorization.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloAuthorization.java
@@ -1,5 +1,7 @@
 package com.nutriconsultas.platillos;
 
+import java.util.Objects;
+
 import org.springframework.lang.NonNull;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Component;
@@ -10,8 +12,8 @@ import com.nutriconsultas.platform.PlatformAdminService;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Platillo mutation access: non-system platillos remain editable until nutritionist
- * ownership (#258); platform admins may edit system catalog rows
+ * Platillo mutation access: nutritionists may edit their own platillos; platform admins
+ * may also edit system catalog rows
  * ({@link PlatilloCatalogConstants#SYSTEM_CATALOG_USER_ID}).
  */
 @Component
@@ -29,11 +31,11 @@ public class PlatilloAuthorization {
 	}
 
 	public boolean canModify(final Platillo platillo, final String userId, final OidcUser principal) {
-		if (platillo == null) {
+		if (platillo == null || userId == null) {
 			return false;
 		}
-		return !PlatilloCatalogConstants.isSystemCatalog(platillo)
-				|| platformAdminService.isPlatformAdmin(principal);
+		return Objects.equals(userId, platillo.getUserId()) || (platformAdminService.isPlatformAdmin(principal)
+				&& PlatilloCatalogConstants.isSystemCatalog(platillo));
 	}
 
 	public void verifyCanModify(final Platillo platillo, final String userId, final OidcUser principal) {
@@ -42,19 +44,24 @@ public class PlatilloAuthorization {
 		}
 		if (!canModify(platillo, userId, principal)) {
 			if (log.isWarnEnabled()) {
-				log.warn("User {} attempted to modify system platillo {}", userId, platillo.getId());
+				log.warn("User {} attempted to modify platillo {} owned by {}", userId, platillo.getId(),
+						platillo.getUserId());
 			}
 			throw new IllegalArgumentException("No tiene permiso para modificar este platillo");
 		}
 	}
 
-	public Platillo resolveForMutation(@NonNull final Long id, final String userId, final OidcUser principal,
+	public Platillo resolveForMutation(@NonNull final Long id, @NonNull final String userId, final OidcUser principal,
 			final PlatilloService platilloService) {
-		final Platillo platillo = platilloService.findById(id);
-		if (platillo == null) {
+		final Platillo owned = platilloService.findByIdAndUserId(id, userId);
+		if (owned != null) {
+			return owned;
+		}
+		if (!platformAdminService.isPlatformAdmin(principal)) {
 			return null;
 		}
-		if (canModify(platillo, userId, principal)) {
+		final Platillo platillo = platilloService.findById(id);
+		if (platillo != null && PlatilloCatalogConstants.isSystemCatalog(platillo)) {
 			return platillo;
 		}
 		return null;

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloCatalogFilter.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloCatalogFilter.java
@@ -1,0 +1,24 @@
+package com.nutriconsultas.platillos;
+
+/**
+ * Ownership filter for the platillo catalog grid.
+ */
+public enum PlatilloCatalogFilter {
+
+	TODAS, SISTEMA, PROPIAS;
+
+	public static PlatilloCatalogFilter fromRequestValue(final String value) {
+		if (value == null || value.isBlank()) {
+			return TODAS;
+		}
+		final String normalized = value.trim().toLowerCase();
+		if ("sistema".equals(normalized)) {
+			return SISTEMA;
+		}
+		if ("propias".equals(normalized) || "mis".equals(normalized)) {
+			return PROPIAS;
+		}
+		return TODAS;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloComparators.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloComparators.java
@@ -43,9 +43,10 @@ public final class PlatilloComparators {
 				Comparator.comparingDouble(Platillo::getHidratosDeCarbono).reversed());
 	}
 
-	public static Comparator<Platillo> getComparator(String name, Direction dir) {
+	public static Comparator<Platillo> getComparator(final String name, final Direction dir) {
 		log.debug("comparator request name: {}, dir: {}", name, dir);
-		return MAP.get(new ComparatorKey(name, dir));
+		final Comparator<Platillo> comparator = MAP.get(new ComparatorKey(name, dir));
+		return comparator != null ? comparator : (o1, o2) -> 0;
 	}
 
 	private PlatilloComparators() {

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloController.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloController.java
@@ -122,6 +122,11 @@ public class PlatilloController extends AbstractAuthorizedController {
 			result = "redirect:/admin/platillos";
 		}
 		else if (platilloId == 0L) {
+			final String userId = getUserId(principal);
+			if (userId == null) {
+				throw new IllegalArgumentException("No se pudo identificar al usuario");
+			}
+			platillo.setUserId(userId);
 			service.save(platillo);
 			log.debug("Finishing save with new platillo {}", platillo);
 			result = "redirect:/admin/platillos/" + platillo.getId();

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloDeleteResult.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloDeleteResult.java
@@ -1,0 +1,39 @@
+package com.nutriconsultas.platillos;
+
+import lombok.Getter;
+
+@Getter
+public final class PlatilloDeleteResult {
+
+	public enum Outcome {
+
+		DELETED, NOT_FOUND, FORBIDDEN, IN_USE
+
+	}
+
+	private final Outcome outcome;
+
+	private final long dietReferenceCount;
+
+	private PlatilloDeleteResult(final Outcome outcome, final long dietReferenceCount) {
+		this.outcome = outcome;
+		this.dietReferenceCount = dietReferenceCount;
+	}
+
+	public static PlatilloDeleteResult deleted() {
+		return new PlatilloDeleteResult(Outcome.DELETED, 0L);
+	}
+
+	public static PlatilloDeleteResult notFound() {
+		return new PlatilloDeleteResult(Outcome.NOT_FOUND, 0L);
+	}
+
+	public static PlatilloDeleteResult forbidden() {
+		return new PlatilloDeleteResult(Outcome.FORBIDDEN, 0L);
+	}
+
+	public static PlatilloDeleteResult inUse(final long dietReferenceCount) {
+		return new PlatilloDeleteResult(Outcome.IN_USE, dietReferenceCount);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloDeletionService.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloDeletionService.java
@@ -1,0 +1,12 @@
+package com.nutriconsultas.platillos;
+
+import org.springframework.lang.NonNull;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+public interface PlatilloDeletionService {
+
+	PlatilloDeleteResult deletePlatillo(@NonNull Long platilloId, @NonNull String userId, OidcUser principal);
+
+	long countDietReferences(@NonNull Platillo platillo, @NonNull String userId);
+
+}

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloDeletionServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloDeletionServiceImpl.java
@@ -1,0 +1,77 @@
+package com.nutriconsultas.platillos;
+
+import org.springframework.lang.NonNull;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nutriconsultas.dieta.PlatilloIngestaRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Deletes platillos when authorized. Owned platillos are blocked when referenced in the
+ * nutritionist's diet templates. System catalog platillos may be deleted by platform
+ * admins only and are blocked when referenced in any diet template.
+ */
+@Service
+@Slf4j
+public class PlatilloDeletionServiceImpl implements PlatilloDeletionService {
+
+	private final PlatilloService platilloService;
+
+	private final PlatilloAuthorization platilloAuthorization;
+
+	private final PlatilloIngestaRepository platilloIngestaRepository;
+
+	public PlatilloDeletionServiceImpl(final PlatilloService platilloService,
+			final PlatilloAuthorization platilloAuthorization,
+			final PlatilloIngestaRepository platilloIngestaRepository) {
+		this.platilloService = platilloService;
+		this.platilloAuthorization = platilloAuthorization;
+		this.platilloIngestaRepository = platilloIngestaRepository;
+	}
+
+	@Override
+	@Transactional
+	public PlatilloDeleteResult deletePlatillo(@NonNull final Long platilloId, @NonNull final String userId,
+			final OidcUser principal) {
+		final Platillo platillo = platilloAuthorization.resolveForMutation(platilloId, userId, principal,
+				platilloService);
+		if (platillo == null) {
+			if (platilloService.findById(platilloId) == null) {
+				return PlatilloDeleteResult.notFound();
+			}
+			return PlatilloDeleteResult.forbidden();
+		}
+		if (!platilloAuthorization.canModify(platillo, userId, principal)) {
+			return PlatilloDeleteResult.forbidden();
+		}
+
+		final long referenceCount = countDietReferences(platillo, userId);
+		if (referenceCount > 0) {
+			if (log.isInfoEnabled()) {
+				log.info("Blocked delete of platillo {}: referenced in {} diet template(s)", platilloId,
+						referenceCount);
+			}
+			return PlatilloDeleteResult.inUse(referenceCount);
+		}
+
+		platilloAuthorization.auditSystemPlatilloMutationIfNeeded(principal, platillo, "platillos.delete");
+		platilloService.deletePlatillo(platilloId);
+		if (log.isInfoEnabled()) {
+			log.info("Deleted platillo {}", platilloId);
+		}
+		return PlatilloDeleteResult.deleted();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public long countDietReferences(@NonNull final Platillo platillo, @NonNull final String userId) {
+		if (PlatilloCatalogConstants.isSystemCatalog(platillo)) {
+			return platilloIngestaRepository.countBySourcePlatilloId(platillo.getId());
+		}
+		return platilloIngestaRepository.countBySourcePlatilloIdAndDietaUserId(platillo.getId(), userId);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloRepository.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloRepository.java
@@ -1,5 +1,6 @@
 package com.nutriconsultas.platillos;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,6 +18,12 @@ import jakarta.transaction.Transactional;
 public interface PlatilloRepository extends JpaRepository<Platillo, Long> {
 
 	Optional<Platillo> findFirstByNameIgnoreCaseOrderByIdAsc(String name);
+
+	Optional<Platillo> findByIdAndUserId(Long id, String userId);
+
+	List<Platillo> findByUserId(String userId);
+
+	List<Platillo> findByUserIdIn(Collection<String> userIds);
 
 	@Modifying
 	@Transactional

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloRestController.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloRestController.java
@@ -25,7 +25,6 @@ import org.springframework.web.server.ResponseStatusException;
 
 import com.nutriconsultas.controller.AbstractGridController;
 import com.nutriconsultas.dataTables.paging.Column;
-import com.nutriconsultas.dataTables.paging.Direction;
 import com.nutriconsultas.dataTables.paging.Page;
 import com.nutriconsultas.dataTables.paging.PageArray;
 import com.nutriconsultas.dataTables.paging.PagingRequest;

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloRestController.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloRestController.java
@@ -2,21 +2,17 @@ package com.nutriconsultas.platillos;
 
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.NonNull;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -30,7 +26,7 @@ import org.springframework.web.server.ResponseStatusException;
 import com.nutriconsultas.controller.AbstractGridController;
 import com.nutriconsultas.dataTables.paging.Column;
 import com.nutriconsultas.dataTables.paging.Direction;
-import com.nutriconsultas.dataTables.paging.Order;
+import com.nutriconsultas.dataTables.paging.Page;
 import com.nutriconsultas.dataTables.paging.PageArray;
 import com.nutriconsultas.dataTables.paging.PagingRequest;
 import com.nutriconsultas.model.ApiResponse;
@@ -47,6 +43,9 @@ public class PlatilloRestController extends AbstractGridController<Platillo> {
 
 	@Autowired
 	private PlatilloAuthorization platilloAuthorization;
+
+	@Autowired
+	private PlatilloDeletionService platilloDeletionService;
 
 	private String getUserId(final OidcUser principal) {
 		if (principal == null) {
@@ -80,57 +79,17 @@ public class PlatilloRestController extends AbstractGridController<Platillo> {
 		return platillo;
 	}
 
-	private static final Map<String, String> COLUMN_TO_FIELD_MAP = new HashMap<>();
-
-	static {
-		COLUMN_TO_FIELD_MAP.put("platillo", "name");
-		COLUMN_TO_FIELD_MAP.put("ingestas", "ingestasSugeridas");
-		COLUMN_TO_FIELD_MAP.put("kcal", "energia");
-		COLUMN_TO_FIELD_MAP.put("prot", "proteina");
-		COLUMN_TO_FIELD_MAP.put("lip", "lipidos");
-		COLUMN_TO_FIELD_MAP.put("hc", "hidratosDeCarbono");
-	}
-
-	/**
-	 * Converts a PagingRequest to Spring Data Pageable.
-	 * @param pagingRequest the paging request
-	 * @return Spring Data Pageable
-	 */
-	@NonNull
-	private Pageable toPageable(final PagingRequest pagingRequest) {
-		final int length = pagingRequest.getLength() > 0 ? pagingRequest.getLength() : 10;
-		final int page = pagingRequest.getStart() / length;
-		final int size = length;
-
-		Sort sort = Sort.unsorted();
-		if (pagingRequest.getOrder() != null && !pagingRequest.getOrder().isEmpty()) {
-			final Order order = pagingRequest.getOrder().get(0);
-			if (order.getColumn() != null && order.getColumn() < pagingRequest.getColumns().size()) {
-				final String columnName = pagingRequest.getColumns().get(order.getColumn()).getData();
-				final String fieldName = COLUMN_TO_FIELD_MAP.getOrDefault(columnName, columnName);
-				final Sort.Direction direction = order.getDir() == Direction.asc ? Sort.Direction.ASC
-						: Sort.Direction.DESC;
-				sort = Sort.by(direction, fieldName);
-			}
-		}
-
-		return PageRequest.of(page, size, sort);
-	}
-
-	/**
-	 * Overrides base class method to use server-side pagination.
-	 * @param pagingRequest the paging request
-	 * @return paginated platillo data
-	 */
 	@Override
 	@PostMapping("data-table")
 	public PageArray getPageArray(@RequestBody final PagingRequest pagingRequest) {
 		log.info("starting getPageArray with pagingRequest: {}", pagingRequest);
+		final OidcUser principal = resolveGridPrincipal();
 		pagingRequest.setColumns(getColumns());
-		final com.nutriconsultas.dataTables.paging.Page<Platillo> page = getRows(pagingRequest);
+		final Page<Platillo> page = getRows(pagingRequest, principal);
 		log.debug("page with records: {}", page.getRecordsTotal());
 		final PageArray pageArray = new PageArray();
-		pageArray.setData(page.getData().stream().map(this::toStringList).collect(Collectors.toList()));
+		pageArray
+			.setData(page.getData().stream().map(row -> toStringList(row, principal)).collect(Collectors.toList()));
 		pageArray.setDraw(page.getDraw());
 		pageArray.setRecordsFiltered(page.getRecordsFiltered());
 		pageArray.setRecordsTotal(page.getRecordsTotal());
@@ -138,41 +97,21 @@ public class PlatilloRestController extends AbstractGridController<Platillo> {
 		return pageArray;
 	}
 
-	/**
-	 * Gets rows using server-side pagination.
-	 * @param pagingRequest the paging request
-	 * @return the page of platillos
-	 */
-	@Override
-	protected com.nutriconsultas.dataTables.paging.Page<Platillo> getRows(final PagingRequest pagingRequest) {
+	protected Page<Platillo> getRows(final PagingRequest pagingRequest, final OidcUser principal) {
 		log.debug("starting getRows with pagingRequest: {}", pagingRequest);
-		final Pageable pageable = toPageable(pagingRequest);
-		final String searchValue = pagingRequest.getSearch() != null && pagingRequest.getSearch().getValue() != null
-				? pagingRequest.getSearch().getValue().trim() : null;
+		final PlatilloCatalogFilter catalogFilter = PlatilloCatalogFilter
+			.fromRequestValue(pagingRequest.getOwnershipFilter());
+		final String userId = principal != null ? principal.getSubject() : null;
+		final List<Platillo> data = service.getPlatillosForCatalogFilter(catalogFilter, userId);
+		return getPage(pagingRequest, data);
+	}
 
-		final Page<Platillo> springPage;
-		final long totalCount;
-		final long filteredCount;
-
-		if (searchValue != null && !searchValue.isEmpty()) {
-			springPage = service.findBySearchTerm(searchValue, pageable);
-			filteredCount = service.countBySearchTerm(searchValue);
+	private OidcUser resolveGridPrincipal() {
+		final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication != null && authentication.getPrincipal() instanceof OidcUser oidcUser) {
+			return oidcUser;
 		}
-		else {
-			springPage = service.findAll(pageable);
-			filteredCount = service.count();
-		}
-		totalCount = service.count();
-
-		final com.nutriconsultas.dataTables.paging.Page<Platillo> result = new com.nutriconsultas.dataTables.paging.Page<>(
-				springPage.getContent());
-		result.setRecordsFiltered((int) filteredCount);
-		result.setRecordsTotal((int) totalCount);
-		result.setDraw(pagingRequest.getDraw());
-
-		log.debug("returning data at getRows: recordsTotal={}, recordsFiltered={}", result.getRecordsTotal(),
-				result.getRecordsFiltered());
-		return result;
+		return null;
 	}
 
 	@PostMapping("{id}/ingredientes/add")
@@ -208,7 +147,6 @@ public class PlatilloRestController extends AbstractGridController<Platillo> {
 		final OidcUser principal = currentUser();
 		String ingestas = platillo.getIngestasSugeridas();
 
-		// prevent duplicate ingestas
 		ResponseEntity<ApiResponse<Platillo>> result;
 		if (ingestas != null && ingestas.contains(ingesta.getIngesta())) {
 			log.info("finish addIngesta with id {} and ingesta {} - DUPLICATE requested.", id, ingesta);
@@ -260,7 +198,6 @@ public class PlatilloRestController extends AbstractGridController<Platillo> {
 		return result;
 	}
 
-	// "/rest/platillos/" + $("#id").val() + "/video/add"
 	@PostMapping("{id}/video/add")
 	public ResponseEntity<ApiResponse<Platillo>> addVideo(@PathVariable @NonNull final Long id,
 			@RequestBody @NonNull final VideoFormModel video) {
@@ -275,38 +212,114 @@ public class PlatilloRestController extends AbstractGridController<Platillo> {
 	}
 
 	@PostMapping("add")
-	public Platillo add(@RequestBody @NonNull final Platillo platillo) {
+	public Platillo add(@RequestBody @NonNull final Platillo platillo,
+			@AuthenticationPrincipal final OidcUser principal) {
 		log.info("starting add with platillo {}.", platillo);
+		if (principal == null) {
+			throw new IllegalArgumentException("No se pudo identificar al usuario");
+		}
+		final String userId = principal.getSubject();
+		if (userId == null) {
+			throw new IllegalArgumentException("No se pudo identificar al usuario");
+		}
+		platillo.setUserId(userId);
 		final Platillo saved = service.save(platillo);
 		log.info("finish add with platillo {}.", saved);
 		return saved;
 	}
 
+	@DeleteMapping("{id}")
+	public ResponseEntity<ApiResponse<Void>> deletePlatillo(@PathVariable @NonNull final Long id,
+			@AuthenticationPrincipal final OidcUser principal) {
+		log.info("starting deletePlatillo with id {}.", id);
+		if (principal == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
+		final String userId = principal.getSubject();
+		if (userId == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
+
+		final PlatilloDeleteResult result = platilloDeletionService.deletePlatillo(id, userId, principal);
+		return switch (result.getOutcome()) {
+			case DELETED -> {
+				log.info("finish deletePlatillo with id {}.", id);
+				yield ResponseEntity.ok(new ApiResponse<>(null));
+			}
+			case NOT_FOUND -> {
+				log.warn("Platillo with id {} not found for deletion", id);
+				yield ResponseEntity.notFound().build();
+			}
+			case FORBIDDEN -> {
+				log.warn("User {} forbidden to delete platillo {}", userId, id);
+				yield ResponseEntity.status(HttpStatus.FORBIDDEN)
+					.body(buildDeleteErrorResponse(HttpStatus.FORBIDDEN.value(),
+							"No tiene permiso para eliminar este platillo"));
+			}
+			case IN_USE -> {
+				final String message = buildInUseMessage(result.getDietReferenceCount());
+				log.info("Delete blocked for platillo {}: {}", id, message);
+				yield ResponseEntity.status(HttpStatus.CONFLICT)
+					.body(buildDeleteErrorResponse(HttpStatus.CONFLICT.value(), message));
+			}
+		};
+	}
+
+	private ApiResponse<Void> buildDeleteErrorResponse(final int status, final String message) {
+		final ApiResponse<Void> apiResponse = new ApiResponse<>();
+		apiResponse.setStatus(status);
+		apiResponse.setMessage(message);
+		apiResponse.setData(null);
+		return apiResponse;
+	}
+
+	private String buildInUseMessage(final long dietReferenceCount) {
+		return "Este platillo está referenciado en " + dietReferenceCount
+				+ (dietReferenceCount == 1 ? " dieta y no puede eliminarse" : " dieta(s) y no puede eliminarse");
+	}
+
 	@Override
 	protected List<Column> getColumns() {
 		log.debug("getting Platillo columns.");
-		return Arrays.asList(new Column("platillo"), //
-				new Column("ingestas"), //
-				new Column("kcal"), //
-				new Column("prot"), //
-				new Column("lip"), //
-				new Column("hc"));
+		return Stream.of("acciones", "platillo", "ingestas", "kcal", "prot", "lip", "hc")
+			.map(Column::new)
+			.collect(Collectors.toList());
 	}
 
 	@Override
 	protected List<String> toStringList(final Platillo row) {
+		return toStringList(row, null);
+	}
+
+	private List<String> toStringList(final Platillo row, final OidcUser principal) {
 		log.debug("converting Platillo row {} to string list.", row);
-		return Arrays.asList("<a href='/admin/platillos/" + row.getId() + "'>" + row.getName() + "</a>",
+		return Arrays.asList(buildActionsColumn(row, principal),
+				"<a href='/admin/platillos/" + row.getId() + "'>" + row.getName() + "</a>",
 				row.getIngestasSugeridas() == null ? "" : row.getIngestasSugeridas(),
-				row.getEnergia() == null ? "" : row.getEnergia().toString(), String.format("%.1f", row.getProteina()), //
-				String.format("%.1f", row.getLipidos()), //
-				String.format("%.1f", row.getHidratosDeCarbono()));
+				row.getEnergia() == null ? "" : row.getEnergia().toString(), String.format("%.1f", row.getProteina()),
+				String.format("%.1f", row.getLipidos()), String.format("%.1f", row.getHidratosDeCarbono()));
+	}
+
+	private String buildActionsColumn(final Platillo row, final OidcUser principal) {
+		if (principal == null || !platilloAuthorization.canModify(row, principal.getSubject(), principal)) {
+			return "";
+		}
+		final String editButton = "<a href='/admin/platillos/" + row.getId()
+				+ "' class='btn btn-sm btn-warning' title='Editar Platillo'><i class='fas fa-edit'></i></a> ";
+		final String deleteButton = "<button onclick='deletePlatillo(" + row.getId()
+				+ ")' class='btn btn-sm btn-danger' title='Eliminar Platillo'><i class='fas fa-trash'></i></button>";
+		return editButton + deleteButton;
 	}
 
 	@Override
 	protected List<Platillo> getData() {
 		log.warn("getData() called without pagination. This should not happen in production.");
 		return service.findAll();
+	}
+
+	@Override
+	protected Page<Platillo> getRows(final PagingRequest pagingRequest) {
+		return getRows(pagingRequest, resolveGridPrincipal());
 	}
 
 	@Override

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloService.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloService.java
@@ -21,7 +21,13 @@ public interface PlatilloService {
 
 	Platillo findById(@NonNull Long id);
 
+	Platillo findByIdAndUserId(@NonNull Long id, @NonNull String userId);
+
+	List<Platillo> getPlatillosForCatalogFilter(PlatilloCatalogFilter filter, String userId);
+
 	Platillo save(@NonNull Platillo platillo);
+
+	void deletePlatillo(@NonNull Long id);
 
 	void deleteIngrediente(@NonNull Long id, @NonNull Long ingredienteId);
 

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloServiceImpl.java
@@ -56,6 +56,40 @@ public class PlatilloServiceImpl implements PlatilloService {
 	}
 
 	@Override
+	public Platillo findByIdAndUserId(@NonNull final Long id, @NonNull final String userId) {
+		log.info("Retrieving platillo with id: {} for userId present", id);
+		return platilloRepository.findByIdAndUserId(id, userId).orElse(null);
+	}
+
+	@Override
+	public List<Platillo> getPlatillosForCatalogFilter(final PlatilloCatalogFilter filter, final String userId) {
+		if (filter == null || filter == PlatilloCatalogFilter.TODAS) {
+			if (userId == null || userId.isBlank()) {
+				log.info("Getting system catalog platillos without userId");
+				return platilloRepository.findByUserId(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID);
+			}
+			log.info("Getting system and owned platillos for catalog filter todas");
+			return platilloRepository.findByUserIdIn(List.of(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID, userId));
+		}
+		if (filter == PlatilloCatalogFilter.SISTEMA) {
+			log.info("Getting system catalog platillos for filter sistema");
+			return platilloRepository.findByUserId(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID);
+		}
+		if (userId == null || userId.isBlank()) {
+			log.warn("Cannot resolve propias platillos without userId");
+			return List.of();
+		}
+		log.info("Getting owned platillos for catalog filter propias");
+		return platilloRepository.findByUserId(userId);
+	}
+
+	@Override
+	public void deletePlatillo(@NonNull final Long id) {
+		log.info("Deleting platillo with id: {}", id);
+		platilloRepository.deleteById(id);
+	}
+
+	@Override
 	public Platillo save(@NonNull final Platillo platillo) {
 		log.info("Saving platillo: {}", platillo);
 		return platilloRepository.save(platillo);

--- a/src/main/resources/templates/sbadmin/platillos/listado.html
+++ b/src/main/resources/templates/sbadmin/platillos/listado.html
@@ -17,6 +17,7 @@
   <!-- Custom fonts for this template-->
   <link th:href="@{/sbadmin/vendor/fontawesome-free/css/all.min.css}" rel="stylesheet" type="text/css">
   <link th:href="@{/sbadmin/vendor/datatables/dataTables.bootstrap4.min.css}" rel="stylesheet">
+  <link th:href="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.css}" rel="stylesheet">
   <link
     href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
     rel="stylesheet">
@@ -78,10 +79,20 @@
             <!-- Platillos data table -->
             <div class="col-12">
               <div class="card shadow mb-4">
+                <div class="card-header py-3 d-flex flex-wrap align-items-center justify-content-between">
+                  <h6 class="m-0 font-weight-bold text-primary">Catálogo de platillos</h6>
+                  <div class="btn-group btn-group-sm mt-2 mt-md-0" role="group" aria-label="Filtrar platillos"
+                    id="platilloCatalogFilter">
+                    <button type="button" class="btn btn-primary active" data-filter="todas">Todas</button>
+                    <button type="button" class="btn btn-outline-primary" data-filter="sistema">De sistema</button>
+                    <button type="button" class="btn btn-outline-primary" data-filter="propias">Mis platillos</button>
+                  </div>
+                </div>
                 <table id="mainGrid" class="table table-striped table-bordered dt-responsive nowrap"
                     style="width: 100%;">
                     <thead>
                       <tr>
+                        <th>Acciones</th>
                         <th>Platillo</th>
                         <th>Ingestas</th>
                         <th>Kcal</th>
@@ -119,56 +130,129 @@
 
     <!-- Custom scripts for all pages-->
     <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
+    <script th:src="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.js}"></script>
     <script lang="javascript">
       'use strict';
-      (function ($) {
-        $('#mainGrid').DataTable({
-          "processing": true,
-          "serverSide": true,
-          "scrollX": true,
-          "language": {
-            "emptyTable": "No hay registros",
-            "lengthMenu": "Mostrar _MENU_ registros por página",
-            "zeroRecords": "No se encontraron registros",
-            "info": "Mostrando página _PAGE_ de _PAGES_",
-            "infoEmpty": "No hay registros disponibles",
-            "infoFiltered": "(filtrado de _MAX_ registros totales)",
-            "loadingRecords": "Buscando...",
-            "search": "Buscar:",
-            "paginate": {
-              "first": "Inicio",
-              "last": "Fin",
-              "next": "Siguiente",
-              "previous": "Anterior"
+
+      function waitForDependencies() {
+        if (typeof jQuery === 'undefined' || typeof swal === 'undefined') {
+          setTimeout(waitForDependencies, 50);
+          return;
+        }
+
+        jQuery(document).ready(function ($) {
+          var platilloCatalogFilter = 'todas';
+          var mainGrid = $('#mainGrid').DataTable({
+            "processing": true,
+            "serverSide": true,
+            "scrollX": true,
+            "columnDefs": [
+              { "targets": 0, "orderable": false }
+            ],
+            "language": {
+              "emptyTable": "No hay registros",
+              "lengthMenu": "Mostrar _MENU_ registros por página",
+              "zeroRecords": "No se encontraron registros",
+              "info": "Mostrando página _PAGE_ de _PAGES_",
+              "infoEmpty": "No hay registros disponibles",
+              "infoFiltered": "(filtrado de _MAX_ registros totales)",
+              "loadingRecords": "Buscando...",
+              "search": "Buscar:",
+              "paginate": {
+                "first": "Inicio",
+                "last": "Fin",
+                "next": "Siguiente",
+                "previous": "Anterior"
+              },
             },
-          },
-          "ajax": {
-            "url": '/rest/platillos/data-table',
-            "type": "POST",
-            "dataType": "json",
-            "contentType": "application/json",
-            "data": function (d) {
-              return JSON.stringify(d);
+            "ajax": {
+              "url": '/rest/platillos/data-table',
+              "type": "POST",
+              "dataType": "json",
+              "contentType": "application/json",
+              "data": function (d) {
+                d.ownershipFilter = platilloCatalogFilter;
+                return JSON.stringify(d);
+              }
+            },
+          });
+
+          $('#platilloCatalogFilter button').click(function () {
+            var filter = $(this).data('filter');
+            if (filter === platilloCatalogFilter) {
+              return;
             }
-          },
-        });
-        $('#addPlatilloButton').on('click', function () {
-          if (nombrePlatillo) {
-            $.ajax({
-              url: '/rest/platillos/add',
-              type: 'POST',
-              contentType: 'application/json',
-              data: JSON.stringify({
-                name: $('#nombrePlatillo').val()
-              }),
-              success: function (data) {
-                window.location.href = '/admin/platillos/' + data.id;
+            platilloCatalogFilter = filter;
+            $('#platilloCatalogFilter button').removeClass('active btn-primary').addClass('btn-outline-primary');
+            $(this).removeClass('btn-outline-primary').addClass('active btn-primary');
+            mainGrid.ajax.reload();
+          });
+
+          $('#addPlatilloButton').on('click', function () {
+            var nombre = $('#nombrePlatillo').val();
+            if (nombre) {
+              $.ajax({
+                url: '/rest/platillos/add',
+                type: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify({
+                  name: nombre
+                }),
+                success: function (data) {
+                  window.location.href = '/admin/platillos/' + data.id;
+                }
+              });
+            }
+          });
+
+          window.deletePlatillo = function (platilloId) {
+            swal({
+              title: 'Eliminar Platillo',
+              text: '¿Está seguro que desea eliminar este platillo? Esta acción no se puede deshacer.',
+              type: 'warning',
+              showCancelButton: true,
+              confirmButtonColor: '#d33',
+              cancelButtonColor: '#3085d6',
+              confirmButtonText: 'Sí, eliminar',
+              cancelButtonText: 'Cancelar',
+              closeOnConfirm: false,
+              showLoaderOnConfirm: true
+            }, function (isConfirm) {
+              if (isConfirm) {
+                $.ajax({
+                  url: '/rest/platillos/' + platilloId,
+                  type: 'DELETE',
+                  success: function () {
+                    swal({
+                      title: '¡Eliminado!',
+                      text: 'El platillo ha sido eliminado correctamente',
+                      type: 'success',
+                      timer: 2000,
+                      showConfirmButton: true
+                    }, function () {
+                      mainGrid.ajax.reload(null, false);
+                    });
+                  },
+                  error: function (xhr) {
+                    var message = 'Error al eliminar el platillo';
+                    if (xhr.responseJSON && xhr.responseJSON.message) {
+                      message = xhr.responseJSON.message;
+                    }
+                    swal({
+                      title: xhr.status === 409 ? 'No se puede eliminar' : 'Error',
+                      text: message,
+                      type: xhr.status === 409 ? 'warning' : 'error',
+                      timer: xhr.status === 409 ? null : 5000
+                    });
+                  }
+                });
               }
             });
-          }
+          };
         });
+      }
 
-      })(jQuery);
+      waitForDependencies();
     </script>
 </body>
 

--- a/src/main/resources/templates/sbadmin/platillos/listado.html
+++ b/src/main/resources/templates/sbadmin/platillos/listado.html
@@ -149,6 +149,7 @@
             "columnDefs": [
               { "targets": 0, "orderable": false }
             ],
+            "order": [[1, "asc"]],
             "language": {
               "emptyTable": "No hay registros",
               "lengthMenu": "Mostrar _MENU_ registros por página",

--- a/src/main/resources/templates/sbadmin/platillos/listado.html
+++ b/src/main/resources/templates/sbadmin/platillos/listado.html
@@ -131,7 +131,7 @@
     <!-- Custom scripts for all pages-->
     <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
     <script th:src="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.js}"></script>
-    <script lang="javascript">
+    <script lang="javascript" th:inline="none">
       'use strict';
 
       function waitForDependencies() {

--- a/src/test/java/com/nutriconsultas/platillos/PlatilloAuthorizationTest.java
+++ b/src/test/java/com/nutriconsultas/platillos/PlatilloAuthorizationTest.java
@@ -40,11 +40,19 @@ class PlatilloAuthorizationTest {
 	private PlatilloAuthorization platilloAuthorization;
 
 	@Test
-	void canModify_returnsTrueForNonSystemPlatillo() {
+	void canModify_returnsTrueForOwner() {
 		platilloAuthorization = new PlatilloAuthorization(platformAdminService, platformAdminAuditService);
-		final Platillo platillo = ownedPlatillo(10L, null);
+		final Platillo platillo = ownedPlatillo(10L, NUTRITIONIST_USER_ID);
 
 		assertThat(platilloAuthorization.canModify(platillo, NUTRITIONIST_USER_ID, nutritionistPrincipal)).isTrue();
+	}
+
+	@Test
+	void canModify_returnsFalseForNonOwnerOnOwnedPlatillo() {
+		platilloAuthorization = new PlatilloAuthorization(platformAdminService, platformAdminAuditService);
+		final Platillo platillo = ownedPlatillo(10L, "auth0|other-nutritionist");
+
+		assertThat(platilloAuthorization.canModify(platillo, NUTRITIONIST_USER_ID, nutritionistPrincipal)).isFalse();
 	}
 
 	@Test
@@ -78,9 +86,34 @@ class PlatilloAuthorizationTest {
 	}
 
 	@Test
+	void resolveForMutation_returnsOwnedPlatilloForCreator() {
+		platilloAuthorization = new PlatilloAuthorization(platformAdminService, platformAdminAuditService);
+		final Platillo owned = ownedPlatillo(5L, NUTRITIONIST_USER_ID);
+		when(platilloService.findByIdAndUserId(5L, NUTRITIONIST_USER_ID)).thenReturn(owned);
+
+		final Platillo result = platilloAuthorization.resolveForMutation(5L, NUTRITIONIST_USER_ID,
+				nutritionistPrincipal, platilloService);
+
+		assertThat(result).isSameAs(owned);
+	}
+
+	@Test
+	void resolveForMutation_returnsNullForNonOwnerOnOwnedPlatillo() {
+		platilloAuthorization = new PlatilloAuthorization(platformAdminService, platformAdminAuditService);
+		when(platilloService.findByIdAndUserId(5L, NUTRITIONIST_USER_ID)).thenReturn(null);
+		when(platformAdminService.isPlatformAdmin(nutritionistPrincipal)).thenReturn(false);
+
+		final Platillo result = platilloAuthorization.resolveForMutation(5L, NUTRITIONIST_USER_ID,
+				nutritionistPrincipal, platilloService);
+
+		assertThat(result).isNull();
+	}
+
+	@Test
 	void resolveForMutation_returnsSystemPlatilloForPlatformAdmin() {
 		platilloAuthorization = new PlatilloAuthorization(platformAdminService, platformAdminAuditService);
 		final Platillo system = systemPlatillo(97L);
+		when(platilloService.findByIdAndUserId(97L, PLATFORM_ADMIN_USER_ID)).thenReturn(null);
 		when(platilloService.findById(97L)).thenReturn(system);
 		when(platformAdminService.isPlatformAdmin(platformAdminPrincipal)).thenReturn(true);
 
@@ -93,8 +126,7 @@ class PlatilloAuthorizationTest {
 	@Test
 	void resolveForMutation_returnsNullForNutritionistOnSystemPlatillo() {
 		platilloAuthorization = new PlatilloAuthorization(platformAdminService, platformAdminAuditService);
-		final Platillo system = systemPlatillo(97L);
-		when(platilloService.findById(97L)).thenReturn(system);
+		when(platilloService.findByIdAndUserId(97L, NUTRITIONIST_USER_ID)).thenReturn(null);
 		when(platformAdminService.isPlatformAdmin(nutritionistPrincipal)).thenReturn(false);
 
 		final Platillo result = platilloAuthorization.resolveForMutation(97L, NUTRITIONIST_USER_ID,

--- a/src/test/java/com/nutriconsultas/platillos/PlatilloComparatorsTest.java
+++ b/src/test/java/com/nutriconsultas/platillos/PlatilloComparatorsTest.java
@@ -1,0 +1,20 @@
+package com.nutriconsultas.platillos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Comparator;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.dataTables.paging.Direction;
+
+class PlatilloComparatorsTest {
+
+	@Test
+	void getComparator_returnsNoOpForUnknownColumn() {
+		final Comparator<Platillo> comparator = PlatilloComparators.getComparator("acciones", Direction.asc);
+
+		assertThat(comparator.compare(new Platillo(), new Platillo())).isZero();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/platillos/PlatilloControllerTest.java
+++ b/src/test/java/com/nutriconsultas/platillos/PlatilloControllerTest.java
@@ -1,12 +1,13 @@
 package com.nutriconsultas.platillos;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.ArrayList;
@@ -64,10 +65,14 @@ public class PlatilloControllerTest {
 		platillo.setName("Test Platillo");
 		platillo.setDescription("Test Description");
 		platillo.setIngestasSugeridas("Desayuno,Comida");
+		platillo.setUserId(TEST_USER_ID);
 
 		alimento = new Alimento();
 		alimento.setId(1L);
 		alimento.setNombreAlimento("Test Alimento");
+
+		when(platilloService.findById(1L)).thenReturn(platillo);
+		when(platilloService.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(platillo);
 
 		log.info("finished setting up PlatilloController test");
 	}
@@ -136,33 +141,6 @@ public class PlatilloControllerTest {
 
 	@Test
 	@WithMockUser(username = "admin", roles = { "ADMIN" })
-	public void testSaveNewPlatillo() throws Exception {
-		log.info("Starting testSaveNewPlatillo");
-		Platillo newPlatillo = new Platillo();
-		newPlatillo.setId(0L);
-		newPlatillo.setName("New Platillo");
-		newPlatillo.setDescription("New Description");
-
-		when(platilloService.findById(0L)).thenReturn(null);
-		when(platilloService.save(any(Platillo.class))).thenReturn(newPlatillo);
-
-		mockMvc
-			.perform(MockMvcRequestBuilders.post("/admin/platillos/save")
-				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
-				.param("id", "0")
-				.param("name", "New Platillo")
-				.param("description", "New Description")
-				.with(oidcLogin(TEST_USER_ID))
-				.with(SecurityMockMvcRequestPostProcessors.csrf()))
-			.andExpect(status().is3xxRedirection())
-			.andExpect(MockMvcResultMatchers.redirectedUrl("/admin/platillos/0"));
-
-		verify(platilloService).save(any(Platillo.class));
-		log.info("Finishing testSaveNewPlatillo");
-	}
-
-	@Test
-	@WithMockUser(username = "admin", roles = { "ADMIN" })
 	public void testSaveExistingPlatillo() throws Exception {
 		log.info("Starting testSaveExistingPlatillo");
 		when(platilloService.findById(1L)).thenReturn(platillo);
@@ -179,7 +157,7 @@ public class PlatilloControllerTest {
 			.andExpect(status().is3xxRedirection())
 			.andExpect(MockMvcResultMatchers.redirectedUrl("/admin/platillos/1"));
 
-		verify(platilloService).findById(1L);
+		verify(platilloService).findByIdAndUserId(1L, TEST_USER_ID);
 		verify(platilloService).save(any(Platillo.class));
 		log.info("Finishing testSaveExistingPlatillo");
 	}
@@ -327,6 +305,8 @@ public class PlatilloControllerTest {
 		systemPlatillo.setIngestasSugeridas("Cena");
 
 		when(platilloService.findById(97L)).thenReturn(systemPlatillo);
+		when(platilloService.findByIdAndUserId(97L, TEST_USER_ID)).thenReturn(null);
+		when(platilloService.findByIdAndUserId(97L, PLATFORM_ADMIN_USER_ID)).thenReturn(null);
 		when(alimentoService.findAll()).thenReturn(Arrays.asList(alimento));
 
 		mockMvc.perform(MockMvcRequestBuilders.get("/admin/platillos/97").with(oidcLogin(TEST_USER_ID)))
@@ -345,6 +325,8 @@ public class PlatilloControllerTest {
 		systemPlatillo.setIngestasSugeridas("Cena");
 
 		when(platilloService.findById(97L)).thenReturn(systemPlatillo);
+		when(platilloService.findByIdAndUserId(97L, TEST_USER_ID)).thenReturn(null);
+		when(platilloService.findByIdAndUserId(97L, PLATFORM_ADMIN_USER_ID)).thenReturn(null);
 		when(alimentoService.findAll()).thenReturn(Arrays.asList(alimento));
 
 		mockMvc.perform(MockMvcRequestBuilders.get("/admin/platillos/97").with(oidcLogin(PLATFORM_ADMIN_USER_ID)))
@@ -362,12 +344,78 @@ public class PlatilloControllerTest {
 		systemPlatillo.setUserId(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID);
 
 		when(platilloService.findById(97L)).thenReturn(systemPlatillo);
+		when(platilloService.findByIdAndUserId(97L, TEST_USER_ID)).thenReturn(null);
+		when(platilloService.findByIdAndUserId(97L, PLATFORM_ADMIN_USER_ID)).thenReturn(null);
 
 		try {
 			mockMvc
 				.perform(MockMvcRequestBuilders.post("/admin/platillos/save")
 					.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 					.param("id", "97")
+					.param("name", "Intento no autorizado")
+					.param("description", "Cambio bloqueado")
+					.with(oidcLogin(TEST_USER_ID))
+					.with(SecurityMockMvcRequestPostProcessors.csrf()))
+				.andExpect(status().is5xxServerError());
+		}
+		catch (Exception e) {
+			assertThat(e).hasRootCauseInstanceOf(IllegalArgumentException.class);
+		}
+
+		verify(platilloService, never()).save(any(Platillo.class));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testEditarOwnedPlatilloShowsEditable() throws Exception {
+		when(platilloService.findById(1L)).thenReturn(platillo);
+		when(alimentoService.findAll()).thenReturn(Arrays.asList(alimento));
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/admin/platillos/1").with(oidcLogin(TEST_USER_ID)))
+			.andExpect(status().isOk())
+			.andExpect(MockMvcResultMatchers.model().attribute("isOwner", true))
+			.andExpect(MockMvcResultMatchers.model().attribute("isSystemCatalog", false));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testSaveNewPlatilloSetsUserId() throws Exception {
+		when(platilloService.save(argThat(saved -> TEST_USER_ID.equals(saved.getUserId())))).thenAnswer(invocation -> {
+			final Platillo saved = invocation.getArgument(0);
+			saved.setId(42L);
+			return saved;
+		});
+
+		mockMvc
+			.perform(MockMvcRequestBuilders.post("/admin/platillos/save")
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("id", "0")
+				.param("name", "New Platillo")
+				.param("description", "New Description")
+				.with(oidcLogin(TEST_USER_ID))
+				.with(SecurityMockMvcRequestPostProcessors.csrf()))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(MockMvcResultMatchers.redirectedUrl("/admin/platillos/42"));
+
+		verify(platilloService).save(any(Platillo.class));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testSaveRejectsNonOwnerOnOwnedPlatillo() throws Exception {
+		final Platillo otherPlatillo = new Platillo();
+		otherPlatillo.setId(8L);
+		otherPlatillo.setName("Platillo ajeno");
+		otherPlatillo.setUserId("auth0|other-nutritionist");
+
+		when(platilloService.findById(8L)).thenReturn(otherPlatillo);
+		when(platilloService.findByIdAndUserId(8L, TEST_USER_ID)).thenReturn(null);
+
+		try {
+			mockMvc
+				.perform(MockMvcRequestBuilders.post("/admin/platillos/save")
+					.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+					.param("id", "8")
 					.param("name", "Intento no autorizado")
 					.param("description", "Cambio bloqueado")
 					.with(oidcLogin(TEST_USER_ID))
@@ -390,6 +438,8 @@ public class PlatilloControllerTest {
 		systemPlatillo.setUserId(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID);
 
 		when(platilloService.findById(97L)).thenReturn(systemPlatillo);
+		when(platilloService.findByIdAndUserId(97L, TEST_USER_ID)).thenReturn(null);
+		when(platilloService.findByIdAndUserId(97L, PLATFORM_ADMIN_USER_ID)).thenReturn(null);
 		when(platilloService.save(any(Platillo.class))).thenReturn(systemPlatillo);
 
 		mockMvc

--- a/src/test/java/com/nutriconsultas/platillos/PlatilloDeletionServiceTest.java
+++ b/src/test/java/com/nutriconsultas/platillos/PlatilloDeletionServiceTest.java
@@ -1,0 +1,88 @@
+package com.nutriconsultas.platillos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import com.nutriconsultas.dieta.PlatilloIngestaRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PlatilloDeletionServiceTest {
+
+	private static final String OWNER_USER_ID = "auth0|nutritionist-one";
+
+	private static final String OTHER_USER_ID = "auth0|nutritionist-two";
+
+	@InjectMocks
+	private PlatilloDeletionServiceImpl platilloDeletionService;
+
+	@Mock
+	private PlatilloService platilloService;
+
+	@Mock
+	private PlatilloAuthorization platilloAuthorization;
+
+	@Mock
+	private PlatilloIngestaRepository platilloIngestaRepository;
+
+	@Mock
+	private OidcUser ownerPrincipal;
+
+	@Test
+	void deletePlatillo_deletesOwnedPlatilloWhenNotReferenced() {
+		final Platillo owned = ownedPlatillo(5L, OWNER_USER_ID);
+		when(platilloAuthorization.resolveForMutation(5L, OWNER_USER_ID, ownerPrincipal, platilloService))
+			.thenReturn(owned);
+		when(platilloAuthorization.canModify(owned, OWNER_USER_ID, ownerPrincipal)).thenReturn(true);
+		when(platilloIngestaRepository.countBySourcePlatilloIdAndDietaUserId(5L, OWNER_USER_ID)).thenReturn(0L);
+
+		final PlatilloDeleteResult result = platilloDeletionService.deletePlatillo(5L, OWNER_USER_ID, ownerPrincipal);
+
+		assertThat(result.getOutcome()).isEqualTo(PlatilloDeleteResult.Outcome.DELETED);
+		verify(platilloService).deletePlatillo(5L);
+	}
+
+	@Test
+	void deletePlatillo_forbiddenForNonOwner() {
+		when(platilloAuthorization.resolveForMutation(5L, OTHER_USER_ID, ownerPrincipal, platilloService))
+			.thenReturn(null);
+		when(platilloService.findById(5L)).thenReturn(ownedPlatillo(5L, OWNER_USER_ID));
+
+		final PlatilloDeleteResult result = platilloDeletionService.deletePlatillo(5L, OTHER_USER_ID, ownerPrincipal);
+
+		assertThat(result.getOutcome()).isEqualTo(PlatilloDeleteResult.Outcome.FORBIDDEN);
+		verify(platilloService, never()).deletePlatillo(5L);
+	}
+
+	@Test
+	void deletePlatillo_blockedWhenReferencedInDiets() {
+		final Platillo owned = ownedPlatillo(5L, OWNER_USER_ID);
+		when(platilloAuthorization.resolveForMutation(5L, OWNER_USER_ID, ownerPrincipal, platilloService))
+			.thenReturn(owned);
+		when(platilloAuthorization.canModify(owned, OWNER_USER_ID, ownerPrincipal)).thenReturn(true);
+		when(platilloIngestaRepository.countBySourcePlatilloIdAndDietaUserId(5L, OWNER_USER_ID)).thenReturn(2L);
+
+		final PlatilloDeleteResult result = platilloDeletionService.deletePlatillo(5L, OWNER_USER_ID, ownerPrincipal);
+
+		assertThat(result.getOutcome()).isEqualTo(PlatilloDeleteResult.Outcome.IN_USE);
+		assertThat(result.getDietReferenceCount()).isEqualTo(2L);
+		verify(platilloService, never()).deletePlatillo(5L);
+	}
+
+	private static Platillo ownedPlatillo(final Long id, final String userId) {
+		final Platillo platillo = new Platillo();
+		platillo.setId(id);
+		platillo.setName("Owned platillo");
+		platillo.setUserId(userId);
+		return platillo;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/platillos/PlatilloRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/platillos/PlatilloRestControllerTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -25,10 +24,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.TestingAuthenticationToken;
@@ -69,6 +64,9 @@ public class PlatilloRestControllerTest {
 
 	@Mock
 	private PlatilloAuthorization platilloAuthorization;
+
+	@Mock
+	private PlatilloDeletionService platilloDeletionService;
 
 	private List<Platillo> allPlatillos;
 
@@ -120,34 +118,33 @@ public class PlatilloRestControllerTest {
 	@Test
 	public void testAdd() {
 		log.info("Starting testAdd");
-		// Arrange
-		Platillo platillo = new Platillo();
-		platillo.setName("Test platillo");
-		log.debug("Platillo to add: {}", platillo);
+		final Platillo newPlatillo = new Platillo();
+		newPlatillo.setName("Test platillo");
+		log.debug("Platillo to add: {}", newPlatillo);
 
-		// Mock the save method
-		when(platilloService.save(any(Platillo.class))).thenReturn(platillo);
+		when(platilloService.save(any(Platillo.class))).thenAnswer(invocation -> {
+			final Platillo saved = invocation.getArgument(0);
+			saved.setId(42L);
+			return saved;
+		});
 
-		// Act
-		Platillo result = platilloRestController.add(platillo);
+		final OidcUser principal = (OidcUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+		final Platillo result = platilloRestController.add(newPlatillo, principal);
 
-		// Assert
 		assertThat(result).isNotNull();
-		assertThat(result.getName()).isEqualTo(platillo.getName());
+		assertThat(result.getName()).isEqualTo(newPlatillo.getName());
+		assertThat(result.getUserId()).isEqualTo(TEST_USER_ID);
 	}
 
 	@Test
 	public void testArray() {
 		log.info("starting testArray");
-		// Arrange
-		final Pageable pageable = PageRequest.of(0, 10);
-		final Page<Platillo> springPage = new PageImpl<>(allPlatillos.subList(0, Math.min(10, allPlatillos.size())),
-				pageable, allPlatillos.size());
-		when(platilloService.findAll(any(Pageable.class))).thenReturn(springPage);
-		when(platilloService.count()).thenReturn((long) allPlatillos.size());
+		when(platilloService.getPlatillosForCatalogFilter(PlatilloCatalogFilter.TODAS, TEST_USER_ID))
+			.thenReturn(allPlatillos);
 
 		PagingRequest pagingRequest = new PagingRequest();
 		List<Column> columnList = new ArrayList<>();
+		columnList.add(new Column("acciones", "", true, true, new Search("", "false")));
 		columnList.add(new Column("platillo", "", true, true, new Search("", "false")));
 		columnList.add(new Column("ingestas", "", true, true, new Search("", "false")));
 		columnList.add(new Column("kcal", "", true, true, new Search("", "false")));
@@ -159,43 +156,38 @@ public class PlatilloRestControllerTest {
 		pagingRequest.setStart(0);
 		pagingRequest.setLength(10);
 		pagingRequest.setDraw(1);
-		pagingRequest.setOrder(Arrays.asList(new Order(0, Direction.asc)));
+		pagingRequest.setOrder(Arrays.asList(new Order(1, Direction.asc)));
 		pagingRequest.setSearch(new Search("", "false"));
+		pagingRequest.setOwnershipFilter("todas");
 		log.debug("arrange paging request {}.", pagingRequest);
 
-		// Act
 		PageArray result = platilloRestController.getPageArray(pagingRequest);
 
-		// Assert
 		assertThat(result).isNotNull();
 		assertThat(result.getRecordsTotal()).isEqualTo(allPlatillos.size());
 		assertThat(result.getRecordsFiltered()).isEqualTo(allPlatillos.size());
 		assertThat(result.getDraw()).isEqualTo(1);
 		assertThat(result.getData()).isNotEmpty();
 		assertThat(result.getData().size()).isEqualTo(Math.min(10, allPlatillos.size()));
-		verify(platilloService).findAll(any(Pageable.class));
-		verify(platilloService, times(2)).count();
+		verify(platilloService).getPlatillosForCatalogFilter(PlatilloCatalogFilter.TODAS, TEST_USER_ID);
 		log.info("finished testArray with records {}", result.getRecordsTotal());
 	}
 
 	@Test
 	public void testArrayWithSearch() {
 		log.info("starting testArrayWithSearch");
-		// Arrange - Find platillos matching search term
 		final String searchTerm = "test";
 		final List<Platillo> filteredPlatillos = allPlatillos.stream()
 			.filter(p -> (p.getName() != null && p.getName().toLowerCase().contains(searchTerm))
 					|| (p.getIngestasSugeridas() != null
 							&& p.getIngestasSugeridas().toLowerCase().contains(searchTerm)))
 			.toList();
-		final Pageable pageable = PageRequest.of(0, 10);
-		final Page<Platillo> springPage = new PageImpl<>(filteredPlatillos, pageable, filteredPlatillos.size());
-		when(platilloService.findBySearchTerm(eq(searchTerm), any(Pageable.class))).thenReturn(springPage);
-		when(platilloService.countBySearchTerm(eq(searchTerm))).thenReturn((long) filteredPlatillos.size());
-		when(platilloService.count()).thenReturn((long) allPlatillos.size());
+		when(platilloService.getPlatillosForCatalogFilter(PlatilloCatalogFilter.TODAS, TEST_USER_ID))
+			.thenReturn(allPlatillos);
 
 		PagingRequest pagingRequest = new PagingRequest();
 		List<Column> columnList = new ArrayList<>();
+		columnList.add(new Column("acciones", "", true, true, new Search("", "false")));
 		columnList.add(new Column("platillo", "", true, true, new Search("", "false")));
 		columnList.add(new Column("ingestas", "", true, true, new Search("", "false")));
 		columnList.add(new Column("kcal", "", true, true, new Search("", "false")));
@@ -206,36 +198,30 @@ public class PlatilloRestControllerTest {
 		pagingRequest.setStart(0);
 		pagingRequest.setLength(10);
 		pagingRequest.setDraw(1);
-		pagingRequest.setOrder(Arrays.asList(new Order(0, Direction.asc)));
+		pagingRequest.setOrder(Arrays.asList(new Order(1, Direction.asc)));
 		pagingRequest.setSearch(new Search(searchTerm, "false"));
+		pagingRequest.setOwnershipFilter("todas");
 		log.debug("arrange paging request {}.", pagingRequest);
 
-		// Act
 		PageArray result = platilloRestController.getPageArray(pagingRequest);
 
-		// Assert
 		assertThat(result).isNotNull();
 		assertThat(result.getRecordsTotal()).isEqualTo(allPlatillos.size());
 		assertThat(result.getRecordsFiltered()).isEqualTo(filteredPlatillos.size());
 		assertThat(result.getDraw()).isEqualTo(1);
-		verify(platilloService).findBySearchTerm(eq(searchTerm), any(Pageable.class));
-		verify(platilloService).countBySearchTerm(eq(searchTerm));
-		verify(platilloService).count();
+		verify(platilloService).getPlatillosForCatalogFilter(PlatilloCatalogFilter.TODAS, TEST_USER_ID);
 		log.info("finished testArrayWithSearch with records {}", result.getRecordsTotal());
 	}
 
 	@Test
 	public void testArrayNoOrder() {
 		log.info("starting testArrayNoOrder");
-		// Arrange
-		final Pageable pageable = PageRequest.of(0, 10);
-		final Page<Platillo> springPage = new PageImpl<>(allPlatillos.subList(0, Math.min(10, allPlatillos.size())),
-				pageable, allPlatillos.size());
-		when(platilloService.findAll(any(Pageable.class))).thenReturn(springPage);
-		when(platilloService.count()).thenReturn((long) allPlatillos.size());
+		when(platilloService.getPlatillosForCatalogFilter(PlatilloCatalogFilter.TODAS, TEST_USER_ID))
+			.thenReturn(allPlatillos);
 
 		PagingRequest pagingRequest = new PagingRequest();
 		List<Column> columnList = new ArrayList<>();
+		columnList.add(new Column("acciones", "", true, true, new Search("", "false")));
 		columnList.add(new Column("platillo", "", true, true, new Search("", "false")));
 		columnList.add(new Column("ingestas", "", true, true, new Search("", "false")));
 		columnList.add(new Column("kcal", "", true, true, new Search("", "false")));
@@ -247,11 +233,10 @@ public class PlatilloRestControllerTest {
 		pagingRequest.setLength(10);
 		pagingRequest.setDraw(1);
 		pagingRequest.setSearch(new Search("", "false"));
+		pagingRequest.setOwnershipFilter("todas");
 
-		// Act
 		PageArray result = platilloRestController.getPageArray(pagingRequest);
 
-		// Assert
 		assertThat(result).isNotNull();
 		assertThat(result.getRecordsTotal()).isEqualTo(allPlatillos.size());
 		assertThat(result.getRecordsFiltered()).isEqualTo(allPlatillos.size());

--- a/src/test/java/com/nutriconsultas/platillos/PlatilloServiceTest.java
+++ b/src/test/java/com/nutriconsultas/platillos/PlatilloServiceTest.java
@@ -1,0 +1,102 @@
+package com.nutriconsultas.platillos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class PlatilloServiceTest {
+
+	private static final String TEST_USER_ID = "auth0|nutritionist-one";
+
+	@InjectMocks
+	private PlatilloServiceImpl platilloService;
+
+	@Mock
+	private PlatilloRepository platilloRepository;
+
+	@Test
+	void getPlatillosForCatalogFilter_todas_returnsSystemAndOwned() {
+		final Platillo system = systemPlatillo(1L);
+		final Platillo owned = ownedPlatillo(2L, TEST_USER_ID);
+		when(platilloRepository.findByUserIdIn(List.of(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID, TEST_USER_ID)))
+			.thenReturn(List.of(system, owned));
+
+		final List<Platillo> result = platilloService.getPlatillosForCatalogFilter(PlatilloCatalogFilter.TODAS,
+				TEST_USER_ID);
+
+		assertThat(result).containsExactly(system, owned);
+	}
+
+	@Test
+	void getPlatillosForCatalogFilter_sistema_returnsSystemOnly() {
+		final Platillo system = systemPlatillo(1L);
+		when(platilloRepository.findByUserId(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID))
+			.thenReturn(List.of(system));
+
+		final List<Platillo> result = platilloService.getPlatillosForCatalogFilter(PlatilloCatalogFilter.SISTEMA,
+				TEST_USER_ID);
+
+		assertThat(result).containsExactly(system);
+	}
+
+	@Test
+	void getPlatillosForCatalogFilter_propias_returnsOwnedOnly() {
+		final Platillo owned = ownedPlatillo(2L, TEST_USER_ID);
+		when(platilloRepository.findByUserId(TEST_USER_ID)).thenReturn(List.of(owned));
+
+		final List<Platillo> result = platilloService.getPlatillosForCatalogFilter(PlatilloCatalogFilter.PROPIAS,
+				TEST_USER_ID);
+
+		assertThat(result).containsExactly(owned);
+	}
+
+	@Test
+	void getPlatillosForCatalogFilter_propias_withoutUserId_returnsEmpty() {
+		final List<Platillo> result = platilloService.getPlatillosForCatalogFilter(PlatilloCatalogFilter.PROPIAS, null);
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void findByIdAndUserId_delegatesToRepository() {
+		final Platillo owned = ownedPlatillo(5L, TEST_USER_ID);
+		when(platilloRepository.findByIdAndUserId(5L, TEST_USER_ID)).thenReturn(java.util.Optional.of(owned));
+
+		assertThat(platilloService.findByIdAndUserId(5L, TEST_USER_ID)).isSameAs(owned);
+	}
+
+	@Test
+	void deletePlatillo_delegatesToRepository() {
+		platilloService.deletePlatillo(9L);
+
+		verify(platilloRepository).deleteById(9L);
+	}
+
+	private static Platillo systemPlatillo(final Long id) {
+		final Platillo platillo = new Platillo();
+		platillo.setId(id);
+		platillo.setName("System platillo");
+		platillo.setUserId(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID);
+		return platillo;
+	}
+
+	private static Platillo ownedPlatillo(final Long id, final String userId) {
+		final Platillo platillo = new Platillo();
+		platillo.setId(id);
+		platillo.setName("Owned platillo");
+		platillo.setUserId(userId);
+		return platillo;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Enforce multi-tenant platillo ownership: only the creator (or a platform admin on system catalog rows) may edit or delete.
- Assign `userId` from the OAuth principal when creating platillos via web form or REST.
- Catalog grid filters (Todas / De sistema / Mis platillos) show system + own platillos only; add edit/delete actions with SweetAlert confirmation.
- Block delete when the platillo is referenced in diet templates via `sourcePlatilloId`.

## Test plan
- [ ] Create a new platillo — verify it appears under **Mis platillos** and is editable
- [ ] Open a system platillo as nutritionist — read-only; no edit/delete in grid
- [ ] Filter grid: Todas, De sistema, Mis platillos
- [ ] Delete an owned platillo with no diet references — succeeds
- [ ] Delete an owned platillo referenced in a diet — blocked with warning (409)
- [ ] User A cannot edit/delete User B platillo via REST or form save

Closes #258


Made with [Cursor](https://cursor.com)