### PR TITLE
Register epic #271–#272: platform admin create system catalog

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -29,7 +29,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 | File | Purpose |
 |------|---------|
-| [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX; #232–#242 epics; #257–#259 platillo ownership; ~~#250~~), states, dependencies |
+| [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX; #232–#242 epics; #257–#259 platillo ownership; #271–#272 system catalog create; ~~#250~~), states, dependencies |
 | [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md) | Patient registration export/import plan |
 
 **Parallel track (public booking — future; depends on #246+):**
@@ -432,7 +432,7 @@ gh pr create ...
 
 **Subscription track (parallel):** see [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#180–#185~~, ~~#187~~ (PR #218), ~~#190~~ (PR #216), ~~#210~~ (PR #224), ~~#211~~ (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)) on `main`. **NEXT:** #207 (+ #208 Stripe ops, email #209, retention #220).
 
-**Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) — platillo ownership ~~#257–#259~~ done (#259 PR [#270](https://github.com/diego-torres/nutriconsultas/pull/270), `Fixes #259`); **NEXT:** #236 branding logo on profile.
+**Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) — platillo ownership ~~#257–#259~~ done (#259 PR [#270](https://github.com/diego-torres/nutriconsultas/pull/270)); system catalog create #271–#272 registered; **NEXT:** #236 branding logo on profile.
 
 **Production (2026-06-18):** ~~#226~~ invitation base URL fix (PR #227) — `APP_BASE_URL` / host remediation on EC2.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -600,7 +600,7 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 **Epic #221–#223** (2026-06-20): export/import patient **registration** to `.mpx` (YAML, no history) + export/delete UI. ~~#221~~ **done** (PR [#254](https://github.com/diego-torres/nutriconsultas/pull/254)). ~~#222~~ **done** (PR [#261](https://github.com/diego-torres/nutriconsultas/pull/261)). ~~#223~~ **done** (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). Complements #190 patient caps; available all tiers.
 
-**Epics #232–#242** (2026-06-19): diet catalog (#232–#235) **complete**, branding (#236–#237), diet/platillo UX (#238–#240), patient UX (#241–#242). Platillo ownership ~~#257–#259~~ done (#259 PR [#270](https://github.com/diego-torres/nutriconsultas/pull/270), `Fixes #259`). **NEXT:** [#236 show logo on profile](https://github.com/diego-torres/nutriconsultas/issues/236). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+**Epics #232–#242** (2026-06-19): diet catalog (#232–#235) **complete**, branding (#236–#237), diet/platillo UX (#238–#240), patient UX (#241–#242). Platillo ownership ~~#257–#259~~ done (#259 PR [#270](https://github.com/diego-torres/nutriconsultas/pull/270)). **Epic #271–#272** (2026-06-20): platform admin **create** system catalog platillos/diets (edit exists via #232/#257; create gap). **NEXT:** [#236 show logo on profile](https://github.com/diego-torres/nutriconsultas/issues/236). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
 **Bug ~~#250~~** (2026-06-19): diet ingesta platillo name links to wrong catalog platillo — **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)).
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-20 — ~~#259~~ **done** (PR [#270](https://github.com/diego-torres/nutriconsultas/pull/270), `Fixes #259` — closes on merge). Platillo ownership epic **#257–#259 complete**. **NEXT:** [#236 show logo on profile](https://github.com/diego-torres/nutriconsultas/issues/236). Epics **#236–#242** registered.
+**Last updated:** 2026-06-20 — Epic **#271–#272** registered (platform admin **create** system catalog platillos/diets). ~~#259~~ **done** (PR [#270](https://github.com/diego-torres/nutriconsultas/pull/270)). Platillo ownership **#257–#259 complete**. **NEXT:** [#236 show logo on profile](https://github.com/diego-torres/nutriconsultas/issues/236). Epics **#236–#242**, **#271–#272** registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -86,6 +86,24 @@ Lock **system** catalog platillos for nutritionists; **owned** platillos editabl
 
 ---
 
+## Epic — System catalog authoring (platform admin create)
+
+Platform admins can **edit** seeded system rows (#232 diets, #257 platillos) but **create** paths still assign the OAuth `sub` as owner. New issues cover admin-only creation of shared catalog entries without Liquibase deploys.
+
+| Requirement | Issues |
+|-------------|--------|
+| Platform admin create system catalog platillo | #271 |
+| Platform admin create system template diet | #272 |
+
+**Suggested order:** #271 + #272 parallel (after #257 and #232 respectively).
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| **271** | Platform admin — create system catalog platillo | https://github.com/diego-torres/nutriconsultas/issues/271 | open | #183, **257** | `PlatilloController` / REST add → `system:catalog-platillos` |
+| **272** | Platform admin — create system template diet | https://github.com/diego-torres/nutriconsultas/issues/272 | open | #183, **232** | `POST /rest/dietas/add` → `system:template-dietas` |
+
+---
+
 ## Epic — Nutritionist branding (profile & PDF)
 
 | Requirement | Issues |
@@ -156,9 +174,9 @@ Lock **system** catalog platillos for nutritionists; **owned** platillos editabl
 | #109 Mobile linkage | Delete clears `patientAuthSub`; not stored in `.mpx` |
 | #220 Retention purge | Platform admin purge of **revoked** nutritionists — orthogonal to nutritionist-initiated patient delete |
 | #132 Patient invitations | Onboarding `Paciente.status` — import creates `ACTIVE` patient unless product specifies otherwise |
-| #183 Platform admin | System diet edit (#232); ~~system platillo edit (#257)~~ |
+| #183 Platform admin | System diet edit (#232), create (#272); system platillo edit (#257), create (#271) |
 | #187 Branded PDF | Logo profile (#236) and PDF sizing (#237) |
-| #198 Diet templates | System diets seeded; editable by admin via #232 |
+| #198 Diet templates | System diets seeded; editable (#232) and creatable (#272) by admin |
 | #243 / #244 Subscription | reCAPTCHA + Solicitar acceso pre-fill — public funnel, not admin UI |
 | #245–#248 Public booking | Nutritionist hours in profile (#246) — separate track |
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-20):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web **NEXT:** #236; platillo ownership ~~#257–#259~~ done (#259 PR [#270](https://github.com/diego-torres/nutriconsultas/pull/270), `Fixes #259`); diet catalog ~~#232–#235~~ done; epics #236–#242. Public booking #245–#248 (deferred).
+**On `main` (2026-06-20):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web **NEXT:** #236; platillo ownership ~~#257–#259~~ done; system catalog create #271–#272 registered; diet catalog ~~#232–#235~~ done; epics #236–#242. Public booking #245–#248 (deferred).
 
 ## AWS (production infrastructure)
 

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -38,7 +38,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`../../ISSUE-NUTRITIONIST-WEB.md`](../../ISSUE-NUTRITIONIST-WEB.md) | Patient MPX epic (#221–#223) |
 | [`../paciente/PATIENT-MPX-PLAN.md`](../paciente/PATIENT-MPX-PLAN.md) | Export/import plan |
 
-**Nutritionist web NEXT:** [#236](https://github.com/diego-torres/nutriconsultas/issues/236) show logo on profile. ~~#259~~ done (PR [#270](https://github.com/diego-torres/nutriconsultas/pull/270), `Fixes #259`); platillo ownership ~~#257–#258~~ done; diet catalog ~~#232–#235~~ done (PR [#267](https://github.com/diego-torres/nutriconsultas/pull/267)); ~~#221–#223~~ MPX epic done (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)).
+**Nutritionist web NEXT:** [#236](https://github.com/diego-torres/nutriconsultas/issues/236) show logo on profile. System catalog create [#271](https://github.com/diego-torres/nutriconsultas/issues/271)–[#272](https://github.com/diego-torres/nutriconsultas/issues/272) registered. ~~#259~~ done (PR [#270](https://github.com/diego-torres/nutriconsultas/pull/270)); platillo ownership ~~#257–#258~~ done; diet catalog ~~#232–#235~~ done; ~~#221–#223~~ MPX epic done.
 
 **Subscription NEXT:** [#207](https://github.com/diego-torres/nutriconsultas/issues/207) Stripe payment provider (~~#211~~ PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230), ~~#210~~ PR [#224](https://github.com/diego-torres/nutriconsultas/pull/224), ~~#187~~ PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218), ~~#190~~ PR [#216](https://github.com/diego-torres/nutriconsultas/pull/216) on `main`).
 


### PR DESCRIPTION
## Summary
- Registers GitHub issues [#271](https://github.com/diego-torres/nutriconsultas/issues/271) (create system catalog platillo) and [#272](https://github.com/diego-torres/nutriconsultas/issues/272) (create system template diet)
- Adds **Epic — System catalog authoring** to `ISSUE-NUTRITIONIST-WEB.md` with dependencies on #257/#232 and #183
- Updates `AGENT-WORKFLOW.md`, `AGENTS.md`, `README.md`, and `docs/mobile-api/README.md`

**Context:** Platform admins can edit seeded system rows (#232, #257) but create flows assign OAuth `sub` as owner — no UI/API path for new system-level catalog entries without Liquibase.

## Test plan
- [x] Docs-only change; no code or tests required
- [x] Issue URLs resolve on GitHub

Made with [Cursor](https://cursor.com)