### PR TITLE
Fix platillo image upload size limit and show Spanish oversize error (#275)

### DIFF
--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-20 — ~~#236~~ **done** (PR [#274](https://github.com/diego-torres/nutriconsultas/pull/274)). Epic **#271–#272** registered (platform admin **create** system catalog platillos/diets). ~~#259~~ **done** (PR [#270](https://github.com/diego-torres/nutriconsultas/pull/270)). Platillo ownership **#257–#259 complete**. **NEXT:** [#237 PDF logo sizing](https://github.com/diego-torres/nutriconsultas/issues/237). Epics **#237–#242**, **#271–#272** registered.
+**Last updated:** 2026-06-20 — Bug **#275** in progress (platillo upload size + user error). ~~#236~~ **done** (PR [#274](https://github.com/diego-torres/nutriconsultas/pull/274)). Epic **#271–#272** registered (platform admin **create** system catalog platillos/diets). ~~#259~~ **done** (PR [#270](https://github.com/diego-torres/nutriconsultas/pull/270)). Platillo ownership **#257–#259 complete**. **NEXT:** [#237 PDF logo sizing](https://github.com/diego-torres/nutriconsultas/issues/237). Epics **#237–#242**, **#271–#272** registered.
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -127,14 +127,16 @@ Platform admins can **edit** seeded system rows (#232 diets, #257 platillos) but
 | Diet macro table below caloric distribution | #238 |
 | Add-ingredient dialog: recalc weight from portion qty | #239 |
 | Round fractions to ½, ¼, ⅓ in platillo table & PDFs | #240 |
+| Platillo image upload size limit + user-facing oversize error | #275 |
 
-**Suggested order:** #238 independent; #239 → #240.
+**Suggested order:** #238 independent; #239 → #240. **#275** (production 413) can ship independently.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | 238 | Diet detail — macronutrients table below caloric distribution | https://github.com/diego-torres/nutriconsultas/issues/238 | open | — | Match platillo macro table style |
 | 239 | Add-ingredient dialog — recalculate weight from portion quantity | https://github.com/diego-torres/nutriconsultas/issues/239 | open | — | Platillo + dietas modals |
 | 240 | Round ingredient fractions to ½, ¼, or ⅓ in UI and meal-plan PDFs | https://github.com/diego-torres/nutriconsultas/issues/240 | open | — | Extend `AbstractFraccionable` |
+| **275** | Platillo image upload — raise size limit and show user-facing error | https://github.com/diego-torres/nutriconsultas/issues/275 | open | — | `MaxUploadSizeExceededException`; align with nginx 50M |
 
 ---
 
@@ -159,10 +161,15 @@ Platform admins can **edit** seeded system rows (#232 diets, #257 platillos) but
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | **250** | Diet ingesta platillo link uses `PlatilloIngesta.id` instead of catalog `Platillo.id` | https://github.com/diego-torres/nutriconsultas/issues/250 | **done** | #46 | PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256); `sourcePlatilloId` + Liquibase backfill |
+| **275** | Platillo image upload — raise size limit and show user-facing error | https://github.com/diego-torres/nutriconsultas/issues/275 | open | — | Production 413 / `MaxUploadSizeExceededException`; see also Diet & platillo UX epic |
 
-**Repro:** Menú vegetal 02 → Cena → "Frijoles con tortilla" links to `/admin/platillos/32` (wrong catalog row) instead of `/admin/platillos/97`. Name displays correctly; portion REST APIs unaffected.
+**Repro (#250):** Menú vegetal 02 → Cena → "Frijoles con tortilla" links to `/admin/platillos/32` (wrong catalog row) instead of `/admin/platillos/97`. Name displays correctly; portion REST APIs unaffected.
 
-**Fix sketch:** persist `sourcePlatilloId` on `PlatilloIngesta` in `PlatilloIngestaMapping`; template uses catalog id for `/admin/platillos/{id}` only.
+**Fix sketch (#250):** persist `sourcePlatilloId` on `PlatilloIngesta` in `PlatilloIngestaMapping`; template uses catalog id for `/admin/platillos/{id}` only.
+
+**Repro (#275):** Upload a platillo photo > ~1 MB on `/admin/platillos/{id}` → HTTP 413, blank page, no `errorMessage`; app log: `MaxUploadSizeExceededException`. Small files upload OK.
+
+**Fix sketch (#275):** `spring.servlet.multipart.max-file-size` (e.g. 10MB); `@ControllerAdvice` Spanish oversize message on platillo form.
 
 ---
 

--- a/src/main/java/com/nutriconsultas/controller/AdminMultipartExceptionHandler.java
+++ b/src/main/java/com/nutriconsultas/controller/AdminMultipartExceptionHandler.java
@@ -1,0 +1,66 @@
+package com.nutriconsultas.controller;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@ControllerAdvice
+@Slf4j
+public class AdminMultipartExceptionHandler {
+
+	private static final Pattern PLATILLO_PICTURE_URI = Pattern.compile("^/admin/platillos/(\\d+)/picture$");
+
+	private final DataSize maxFileSize;
+
+	public AdminMultipartExceptionHandler(
+			@Value("${spring.servlet.multipart.max-file-size:1MB}") final DataSize maxFileSize) {
+		this.maxFileSize = maxFileSize;
+	}
+
+	@ExceptionHandler(MaxUploadSizeExceededException.class)
+	public String handleMaxUploadSizeExceeded(final MaxUploadSizeExceededException exception,
+			final HttpServletRequest request, final RedirectAttributes redirectAttributes) {
+		log.warn("Multipart upload exceeded size limit for uri={}", request.getRequestURI());
+		redirectAttributes.addFlashAttribute("errorMessage", buildOversizeMessage(request.getRequestURI()));
+		return resolveRedirect(request.getRequestURI());
+	}
+
+	private String buildOversizeMessage(final String requestUri) {
+		final String sizeLabel = formatMaxFileSize();
+		if ("/admin/perfil/logo".equals(requestUri)) {
+			return "El archivo supera el tamaño máximo permitido (" + sizeLabel + ").";
+		}
+		return "La imagen supera el tamaño máximo permitido (" + sizeLabel + ").";
+	}
+
+	private String formatMaxFileSize() {
+		final long megabytes = maxFileSize.toMegabytes();
+		if (megabytes > 0) {
+			return megabytes + " MB";
+		}
+		return maxFileSize.toString();
+	}
+
+	private String resolveRedirect(final String requestUri) {
+		final Matcher platilloMatcher = PLATILLO_PICTURE_URI.matcher(requestUri);
+		if (platilloMatcher.matches()) {
+			return "redirect:/admin/platillos/" + platilloMatcher.group(1);
+		}
+		if ("/admin/perfil/logo".equals(requestUri)) {
+			return "redirect:/admin/perfil";
+		}
+		return "redirect:/admin";
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloTemplateValidator.java
@@ -46,6 +46,7 @@ public class PlatilloTemplateValidator extends BaseTemplateValidator {
 		variables.put("isOwner", true);
 		variables.put("canCopy", false);
 		variables.put("isSystemCatalog", false);
+		variables.put("errorMessage", null);
 
 		return variables;
 	}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,8 @@
 server.port=3000
 server.error.include-stacktrace=always
+# Platillo/profile image uploads (#275); nginx allows up to 50M
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=50MB
 # Trust X-Forwarded-* from nginx (HTTP + HTTPS termination, OAuth redirect URLs).
 server.forward-headers-strategy=framework
 

--- a/src/main/resources/templates/sbadmin/platillos/formulario.html
+++ b/src/main/resources/templates/sbadmin/platillos/formulario.html
@@ -388,6 +388,13 @@
               </div>
             </div>
 
+            <div th:if="${errorMessage}" class="alert alert-danger alert-dismissible fade show mb-4" role="alert">
+              <span th:text="${errorMessage}">Error</span>
+              <button type="button" class="close" data-dismiss="alert" aria-label="Cerrar">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+
             <div th:if="${platillo != null && platillo.id != null && platillo.id != 0 && isSystemCatalog != null && isSystemCatalog && isOwner != null && !isOwner}"
                  class="alert alert-info mb-4" role="alert">
               <i class="fas fa-info-circle"></i>

--- a/src/test/java/com/nutriconsultas/controller/AdminMultipartExceptionHandlerTest.java
+++ b/src/test/java/com/nutriconsultas/controller/AdminMultipartExceptionHandlerTest.java
@@ -1,0 +1,41 @@
+package com.nutriconsultas.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+class AdminMultipartExceptionHandlerTest {
+
+	@Test
+	void handleMaxUploadSizeExceededRedirectsToPlatilloFormWithSpanishMessage() {
+		final AdminMultipartExceptionHandler handler = new AdminMultipartExceptionHandler(DataSize.ofMegabytes(10));
+		final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/admin/platillos/42/picture");
+		final RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
+
+		final String view = handler.handleMaxUploadSizeExceeded(new MaxUploadSizeExceededException(1024L), request,
+				redirectAttributes);
+
+		assertThat(view).isEqualTo("redirect:/admin/platillos/42");
+		assertThat(redirectAttributes.getFlashAttributes().get("errorMessage"))
+			.isEqualTo("La imagen supera el tamaño máximo permitido (10 MB).");
+	}
+
+	@Test
+	void handleMaxUploadSizeExceededRedirectsToProfileFormWithSpanishMessage() {
+		final AdminMultipartExceptionHandler handler = new AdminMultipartExceptionHandler(DataSize.ofMegabytes(10));
+		final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/admin/perfil/logo");
+		final RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
+
+		final String view = handler.handleMaxUploadSizeExceeded(new MaxUploadSizeExceededException(1024L), request,
+				redirectAttributes);
+
+		assertThat(view).isEqualTo("redirect:/admin/perfil");
+		assertThat(redirectAttributes.getFlashAttributes().get("errorMessage"))
+			.isEqualTo("El archivo supera el tamaño máximo permitido (10 MB).");
+	}
+
+}


### PR DESCRIPTION
## Summary
- Raise Spring multipart limits to **10 MB** per file / **50 MB** per request (aligned with nginx).
- Add `AdminMultipartExceptionHandler` to redirect oversize platillo picture and profile logo uploads with a Spanish flash `errorMessage`.
- Show the error alert on the platillo edit form (profile form already had one).

Fixes #275

## Test plan
- [x] `AdminMultipartExceptionHandlerTest` — platillo and profile redirect + Spanish message
- [x] `PlatilloControllerTest` — existing picture upload paths
- [x] `ThymeleafTemplateValidationTest` — platillo form template
- [ ] Manual: upload a platillo photo > 1 MB and confirm redirect with Spanish error on `/admin/platillos/{id}`
- [ ] Manual: upload a photo > 10 MB and confirm oversize message


Made with [Cursor](https://cursor.com)