### PR TITLE
[Nutritionist Web] Platform admin create system catalog platillo (#271)

### DIFF
--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-21 — ~~#285~~ **done** (`issue-285-platillo-inline-cantidad`, 340a318). **NEXT:** #271–#272. ~~#281~~ **done** (`issue-281-ingesta-platillo-ingredient-edit`). ~~#280~~ **done** (PR [#284](https://github.com/diego-torres/nutriconsultas/pull/284)).
+**Last updated:** 2026-06-21 — ~~#271~~ **in-progress** (`issue-271-system-platillo-create`). **NEXT:** #272 after #271. ~~#285~~ **done** (`issue-285-platillo-inline-cantidad`, 340a318). ~~#281~~ **done** (`issue-281-ingesta-platillo-ingredient-edit`). ~~#280~~ **done** (PR [#284](https://github.com/diego-torres/nutriconsultas/pull/284)).
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -99,7 +99,7 @@ Platform admins can **edit** seeded system rows (#232 diets, #257 platillos) but
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| **271** | Platform admin — create system catalog platillo | https://github.com/diego-torres/nutriconsultas/issues/271 | open | #183, **257** | `PlatilloController` / REST add → `system:catalog-platillos` |
+| **271** | Platform admin — create system catalog platillo | https://github.com/diego-torres/nutriconsultas/issues/271 | **in-progress** | #183, **257** | `PlatilloController` / REST add → `system:catalog-platillos` |
 | **272** | Platform admin — create system template diet | https://github.com/diego-torres/nutriconsultas/issues/272 | open | #183, **232** | `POST /rest/dietas/add` → `system:template-dietas` |
 
 ---

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloAuthorization.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloAuthorization.java
@@ -84,4 +84,17 @@ public class PlatilloAuthorization {
 		platformAdminAuditService.recordAction(actorUserId, action + ":platilloId=" + platillo.getId());
 	}
 
+	/**
+	 * Resolves the owner {@code userId} for a newly created platillo. Platform admins
+	 * create system catalog rows; all other users create owned rows. Client-supplied
+	 * {@code userId} values are ignored — callers must use this method instead of
+	 * trusting request data.
+	 */
+	public String resolveCreateUserId(final OidcUser principal, @NonNull final String oauthUserId) {
+		if (platformAdminService.isPlatformAdmin(principal)) {
+			return PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID;
+		}
+		return oauthUserId;
+	}
+
 }

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloController.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloController.java
@@ -70,7 +70,7 @@ public class PlatilloController extends AbstractAuthorizedController {
 	}
 
 	@GetMapping(path = "/admin/platillos/nuevo")
-	public String nuevo(final Model model) {
+	public String nuevo(final Model model, @AuthenticationPrincipal final OidcUser principal) {
 		log.debug("Starting nuevo");
 		model.addAttribute("activeMenu", "platillos");
 		final Platillo platillo = new Platillo();
@@ -78,7 +78,10 @@ public class PlatilloController extends AbstractAuthorizedController {
 		model.addAttribute("platillo", platillo);
 		model.addAttribute("isOwner", true);
 		model.addAttribute("canCopy", false);
-		model.addAttribute("isSystemCatalog", false);
+		final String userId = getUserId(principal);
+		final boolean createsAsSystemCatalog = userId != null && PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID
+			.equals(platilloAuthorization.resolveCreateUserId(principal, userId));
+		model.addAttribute("isSystemCatalog", createsAsSystemCatalog);
 		log.debug("Finishing nuevo platillo con valores predeterminados: {}", platillo);
 		return "sbadmin/platillos/formulario";
 	}
@@ -128,8 +131,9 @@ public class PlatilloController extends AbstractAuthorizedController {
 			if (userId == null) {
 				throw new IllegalArgumentException("No se pudo identificar al usuario");
 			}
-			platillo.setUserId(userId);
+			platillo.setUserId(platilloAuthorization.resolveCreateUserId(principal, userId));
 			service.save(platillo);
+			platilloAuthorization.auditSystemPlatilloMutationIfNeeded(principal, platillo, "platillos.create");
 			log.debug("Finishing save with new platillo {}", platillo);
 			result = "redirect:/admin/platillos/" + platillo.getId();
 		}

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloRestController.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloRestController.java
@@ -221,8 +221,9 @@ public class PlatilloRestController extends AbstractGridController<Platillo> {
 		if (userId == null) {
 			throw new IllegalArgumentException("No se pudo identificar al usuario");
 		}
-		platillo.setUserId(userId);
+		platillo.setUserId(platilloAuthorization.resolveCreateUserId(principal, userId));
 		final Platillo saved = service.save(platillo);
+		platilloAuthorization.auditSystemPlatilloMutationIfNeeded(principal, saved, "platillos.create");
 		log.info("finish add with platillo {}.", saved);
 		return saved;
 	}

--- a/src/main/resources/templates/sbadmin/platillos/formulario.html
+++ b/src/main/resources/templates/sbadmin/platillos/formulario.html
@@ -395,6 +395,12 @@
               </button>
             </div>
 
+            <div th:if="${platillo != null && platillo.id != null && platillo.id == 0 && isSystemCatalog != null && isSystemCatalog}"
+                 class="alert alert-info mb-4" role="alert">
+              <i class="fas fa-info-circle"></i>
+              <strong>Catálogo del sistema:</strong> Este platillo se agregará al catálogo compartido visible para todos los nutricionistas.
+            </div>
+
             <div th:if="${platillo != null && platillo.id != null && platillo.id != 0 && isSystemCatalog != null && isSystemCatalog && isOwner != null && !isOwner}"
                  class="alert alert-info mb-4" role="alert">
               <i class="fas fa-info-circle"></i>

--- a/src/main/resources/templates/sbadmin/platillos/listado.html
+++ b/src/main/resources/templates/sbadmin/platillos/listado.html
@@ -45,6 +45,9 @@
               </button>
             </div>
             <div class="modal-body">
+              <div th:if="${platformAdmin}" class="alert alert-info py-2 mb-3" role="alert">
+                <small><i class="fas fa-info-circle"></i> Se agregará al catálogo del sistema (visible para todos los nutricionistas).</small>
+              </div>
               <div class="form-group row">
                 <label for="nombrePlatillo" class="col-sm-3 col-form-label">Nombre</label>
                 <div class="col-sm-9">

--- a/src/test/java/com/nutriconsultas/platillos/PlatilloAuthorizationTest.java
+++ b/src/test/java/com/nutriconsultas/platillos/PlatilloAuthorizationTest.java
@@ -181,6 +181,24 @@ class PlatilloAuthorizationTest {
 				org.mockito.ArgumentMatchers.anyString());
 	}
 
+	@Test
+	void resolveCreateUserId_returnsSystemCatalogUserIdForPlatformAdmin() {
+		platilloAuthorization = new PlatilloAuthorization(platformAdminService, platformAdminAuditService);
+		when(platformAdminService.isPlatformAdmin(platformAdminPrincipal)).thenReturn(true);
+
+		assertThat(platilloAuthorization.resolveCreateUserId(platformAdminPrincipal, PLATFORM_ADMIN_USER_ID))
+			.isEqualTo(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID);
+	}
+
+	@Test
+	void resolveCreateUserId_returnsOAuthUserIdForNutritionist() {
+		platilloAuthorization = new PlatilloAuthorization(platformAdminService, platformAdminAuditService);
+		when(platformAdminService.isPlatformAdmin(nutritionistPrincipal)).thenReturn(false);
+
+		assertThat(platilloAuthorization.resolveCreateUserId(nutritionistPrincipal, NUTRITIONIST_USER_ID))
+			.isEqualTo(NUTRITIONIST_USER_ID);
+	}
+
 	private static Platillo ownedPlatillo(final Long id, final String userId) {
 		final Platillo platillo = new Platillo();
 		platillo.setId(id);

--- a/src/test/java/com/nutriconsultas/platillos/PlatilloControllerTest.java
+++ b/src/test/java/com/nutriconsultas/platillos/PlatilloControllerTest.java
@@ -402,6 +402,63 @@ public class PlatilloControllerTest {
 
 	@Test
 	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testSaveNewPlatilloAsPlatformAdminSetsSystemUserId() throws Exception {
+		when(platilloService
+			.save(argThat(saved -> PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID.equals(saved.getUserId()))))
+			.thenAnswer(invocation -> {
+				final Platillo saved = invocation.getArgument(0);
+				saved.setId(100L);
+				return saved;
+			});
+
+		mockMvc
+			.perform(MockMvcRequestBuilders.post("/admin/platillos/save")
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("id", "0")
+				.param("name", "System Catalog Platillo")
+				.param("description", "Shared catalog entry")
+				.with(oidcLogin(PLATFORM_ADMIN_USER_ID))
+				.with(SecurityMockMvcRequestPostProcessors.csrf()))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(MockMvcResultMatchers.redirectedUrl("/admin/platillos/100"));
+
+		verify(platilloService).save(any(Platillo.class));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testSaveNewPlatilloIgnoresClientSuppliedSystemUserId() throws Exception {
+		when(platilloService.save(argThat(saved -> TEST_USER_ID.equals(saved.getUserId())))).thenAnswer(invocation -> {
+			final Platillo saved = invocation.getArgument(0);
+			saved.setId(43L);
+			return saved;
+		});
+
+		mockMvc
+			.perform(MockMvcRequestBuilders.post("/admin/platillos/save")
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("id", "0")
+				.param("name", "Spoofed Platillo")
+				.param("userId", PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID)
+				.with(oidcLogin(TEST_USER_ID))
+				.with(SecurityMockMvcRequestPostProcessors.csrf()))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(MockMvcResultMatchers.redirectedUrl("/admin/platillos/43"));
+
+		verify(platilloService).save(any(Platillo.class));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testNuevoAsPlatformAdminShowsSystemCatalog() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.get("/admin/platillos/nuevo").with(oidcLogin(PLATFORM_ADMIN_USER_ID)))
+			.andExpect(status().isOk())
+			.andExpect(MockMvcResultMatchers.model().attribute("isSystemCatalog", true))
+			.andExpect(MockMvcResultMatchers.model().attribute("isOwner", true));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
 	public void testSaveRejectsNonOwnerOnOwnedPlatillo() throws Exception {
 		final Platillo otherPlatillo = new Platillo();
 		otherPlatillo.setId(8L);

--- a/src/test/java/com/nutriconsultas/platillos/PlatilloRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/platillos/PlatilloRestControllerTest.java
@@ -95,6 +95,8 @@ public class PlatilloRestControllerTest {
 			.thenAnswer(invocation -> platilloService.findById(invocation.getArgument(0)));
 		doNothing().when(platilloAuthorization).verifyCanModify(any(), any(), any());
 		doNothing().when(platilloAuthorization).auditSystemPlatilloMutationIfNeeded(any(), any(), anyString());
+		when(platilloAuthorization.resolveCreateUserId(any(), any()))
+			.thenAnswer(invocation -> invocation.getArgument(1));
 		// Read CSV file from classpath and convert to list of Platillo
 		try (Reader reader = new InputStreamReader(getClass().getResourceAsStream("/platillos.csv"))) {
 			log.debug("reading platillos from csv file");
@@ -135,6 +137,57 @@ public class PlatilloRestControllerTest {
 		assertThat(result).isNotNull();
 		assertThat(result.getName()).isEqualTo(newPlatillo.getName());
 		assertThat(result.getUserId()).isEqualTo(TEST_USER_ID);
+		verify(platilloAuthorization).resolveCreateUserId(principal, TEST_USER_ID);
+	}
+
+	@Test
+	public void testAddIgnoresClientSuppliedSystemUserId() {
+		final Platillo newPlatillo = new Platillo();
+		newPlatillo.setName("Spoofed platillo");
+		newPlatillo.setUserId(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID);
+
+		when(platilloAuthorization.resolveCreateUserId(any(), eq(TEST_USER_ID))).thenReturn(TEST_USER_ID);
+		when(platilloService.save(any(Platillo.class))).thenAnswer(invocation -> {
+			final Platillo saved = invocation.getArgument(0);
+			saved.setId(43L);
+			return saved;
+		});
+
+		final OidcUser principal = (OidcUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+		final Platillo result = platilloRestController.add(newPlatillo, principal);
+
+		assertThat(result.getUserId()).isEqualTo(TEST_USER_ID);
+		verify(platilloAuthorization).resolveCreateUserId(principal, TEST_USER_ID);
+	}
+
+	@Test
+	public void testAddAsPlatformAdminSetsSystemUserId() {
+		final String adminUserId = "auth0|platform-admin-test";
+		final OidcIdToken adminToken = OidcIdToken.withTokenValue("admin-token")
+			.subject(adminUserId)
+			.claim("name", "Platform Admin")
+			.issuedAt(Instant.now())
+			.expiresAt(Instant.now().plusSeconds(3600))
+			.build();
+		final DefaultOidcUser adminPrincipal = new DefaultOidcUser(Collections.emptyList(), adminToken);
+		SecurityContextHolder.getContext().setAuthentication(new TestingAuthenticationToken(adminPrincipal, null));
+
+		final Platillo newPlatillo = new Platillo();
+		newPlatillo.setName("System platillo");
+
+		when(platilloAuthorization.resolveCreateUserId(adminPrincipal, adminUserId))
+			.thenReturn(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID);
+		when(platilloService.save(any(Platillo.class))).thenAnswer(invocation -> {
+			final Platillo saved = invocation.getArgument(0);
+			assertThat(saved.getUserId()).isEqualTo(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID);
+			saved.setId(99L);
+			return saved;
+		});
+
+		final Platillo result = platilloRestController.add(newPlatillo, adminPrincipal);
+
+		assertThat(result.getUserId()).isEqualTo(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID);
+		verify(platilloAuthorization).auditSystemPlatilloMutationIfNeeded(adminPrincipal, result, "platillos.create");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Platform admins creating platillos via `/admin/platillos/save` or `POST /rest/platillos/add` now get `userId = system:catalog-platillos` instead of their OAuth `sub`.
- Nutritionists continue creating owned platillos; client-supplied `userId` is ignored server-side.
- System catalog creation is audit-logged; admin UI shows an info banner on the list modal and new-platillo form.

Fixes #271

## Test plan
- [x] `PlatilloAuthorizationTest` — admin vs nutritionist create userId resolution
- [x] `PlatilloControllerTest` — admin create, nutritionist spoof blocked, nuevo model flag
- [x] `PlatilloRestControllerTest` — REST add paths + audit on admin create
- [x] Thymeleaf template validation
- [ ] Manual: log in as platform admin → Agregar Platillo → verify new row appears under sistema filter and is editable by admin only
- [ ] Manual: log in as nutritionist → Agregar Platillo → verify owned `userId` and no system-scope UI


Made with [Cursor](https://cursor.com)