### PR TITLE
[Nutritionist Web] Platform admin create system template diet (#272)

### DIFF
--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-21 — ~~#271~~ **in-progress** (`issue-271-system-platillo-create`). **NEXT:** #272 after #271. ~~#285~~ **done** (`issue-285-platillo-inline-cantidad`, 340a318). ~~#281~~ **done** (`issue-281-ingesta-platillo-ingredient-edit`). ~~#280~~ **done** (PR [#284](https://github.com/diego-torres/nutriconsultas/pull/284)).
+**Last updated:** 2026-06-21 — ~~#272~~ **in-progress** (`issue-272-system-diet-create`). ~~#271~~ **done** (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)). ~~#285~~ **done** (`issue-285-platillo-inline-cantidad`, 340a318). ~~#281~~ **done** (`issue-281-ingesta-platillo-ingredient-edit`). ~~#280~~ **done** (PR [#284](https://github.com/diego-torres/nutriconsultas/pull/284)).
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -99,8 +99,8 @@ Platform admins can **edit** seeded system rows (#232 diets, #257 platillos) but
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| **271** | Platform admin — create system catalog platillo | https://github.com/diego-torres/nutriconsultas/issues/271 | **in-progress** | #183, **257** | `PlatilloController` / REST add → `system:catalog-platillos` |
-| **272** | Platform admin — create system template diet | https://github.com/diego-torres/nutriconsultas/issues/272 | open | #183, **232** | `POST /rest/dietas/add` → `system:template-dietas` |
+| **271** | Platform admin — create system catalog platillo | https://github.com/diego-torres/nutriconsultas/issues/271 | **done** | #183, **257** | PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288); `system:catalog-platillos` on create |
+| **272** | Platform admin — create system template diet | https://github.com/diego-torres/nutriconsultas/issues/272 | **in-progress** | #183, **232** | `POST /rest/dietas/add` → `system:template-dietas` |
 
 ---
 

--- a/src/main/java/com/nutriconsultas/dieta/DietaAuthorization.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaAuthorization.java
@@ -75,4 +75,17 @@ public class DietaAuthorization {
 		platformAdminAuditService.recordAction(actorUserId, action + ":dietaId=" + dieta.getId());
 	}
 
+	/**
+	 * Resolves the owner {@code userId} for a newly created diet. Platform admins create
+	 * system template rows; all other users create owned rows. Client-supplied
+	 * {@code userId} values are ignored — callers must use this method instead of
+	 * trusting request data.
+	 */
+	public String resolveCreateUserId(final OidcUser principal, @NonNull final String oauthUserId) {
+		if (platformAdminService.isPlatformAdmin(principal)) {
+			return DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID;
+		}
+		return oauthUserId;
+	}
+
 }

--- a/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
@@ -79,14 +79,15 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 			throw new IllegalArgumentException("No se pudo identificar al usuario");
 		}
 		final String userId = principal.getSubject();
-		dieta.setUserId(userId);
+		dieta.setUserId(dietaAuthorization.resolveCreateUserId(principal, userId));
 		final List<Ingesta> ingestas = Stream.of("Desayuno", "Comida", "Cena")
 			.map(Ingesta::new)
 			.collect(Collectors.toList());
 		ingestas.forEach(i -> i.setDieta(dieta));
 		dieta.setIngestas(ingestas);
 		final Dieta savedDieta = dietaService.saveDieta(dieta);
-		log.info("finish addDieta with dieta {}.", dieta);
+		dietaAuthorization.auditSystemDietMutationIfNeeded(principal, savedDieta, "dietas.create");
+		log.info("finish addDieta with dieta {}.", savedDieta);
 		return savedDieta;
 	}
 

--- a/src/main/resources/templates/sbadmin/dietas/listado.html
+++ b/src/main/resources/templates/sbadmin/dietas/listado.html
@@ -45,6 +45,9 @@
               </button>
             </div>
             <div class="modal-body">
+              <div th:if="${platformAdmin}" class="alert alert-info py-2 mb-3" role="alert">
+                <small><i class="fas fa-info-circle"></i> Se agregará como plantilla del sistema (visible para todos los nutricionistas).</small>
+              </div>
               <div class="form-group">
                 <label for="nombreDieta">Nombre</label>
                 <input type="text" class="form-control" id="nombreDieta" name="nombreDieta" placeholder="Nombre de la dieta" required />

--- a/src/test/java/com/nutriconsultas/dieta/DietaAuthorizationTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaAuthorizationTest.java
@@ -147,6 +147,24 @@ class DietaAuthorizationTest {
 				org.mockito.ArgumentMatchers.anyString());
 	}
 
+	@Test
+	void resolveCreateUserId_returnsSystemTemplateUserIdForPlatformAdmin() {
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		when(platformAdminService.isPlatformAdmin(platformAdminPrincipal)).thenReturn(true);
+
+		assertThat(dietaAuthorization.resolveCreateUserId(platformAdminPrincipal, PLATFORM_ADMIN_USER_ID))
+			.isEqualTo(DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID);
+	}
+
+	@Test
+	void resolveCreateUserId_returnsOAuthUserIdForNutritionist() {
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		when(platformAdminService.isPlatformAdmin(nutritionistPrincipal)).thenReturn(false);
+
+		assertThat(dietaAuthorization.resolveCreateUserId(nutritionistPrincipal, NUTRITIONIST_USER_ID))
+			.isEqualTo(NUTRITIONIST_USER_ID);
+	}
+
 	private static Dieta ownedDiet(final Long id, final String userId) {
 		final Dieta dieta = new Dieta();
 		dieta.setId(id);

--- a/src/test/java/com/nutriconsultas/dieta/DietasRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietasRestControllerTest.java
@@ -1159,12 +1159,6 @@ public class DietasRestControllerTest {
 		newDieta.setNombre("Nueva Dieta");
 		newDieta.setIngestas(new ArrayList<>());
 
-		Dieta savedDieta = new Dieta();
-		savedDieta.setId(1L);
-		savedDieta.setNombre("Nueva Dieta");
-		savedDieta.setUserId(TEST_USER_ID);
-		savedDieta.setIngestas(new ArrayList<>());
-
 		when(dietaService.saveDieta(any(Dieta.class))).thenAnswer(invocation -> {
 			Dieta dieta = invocation.getArgument(0);
 			dieta.setId(1L);
@@ -1174,6 +1168,7 @@ public class DietasRestControllerTest {
 		// Create mock OidcUser
 		OidcUser principal = org.mockito.Mockito.mock(OidcUser.class);
 		org.mockito.Mockito.when(principal.getSubject()).thenReturn(TEST_USER_ID);
+		when(platformAdminService.isPlatformAdmin(principal)).thenReturn(false);
 
 		// Act
 		Dieta result = dietasRestController.addDieta(newDieta, principal);
@@ -1185,6 +1180,50 @@ public class DietasRestControllerTest {
 		verify(dietaService).saveDieta(dietaCaptor.capture());
 		assertThat(dietaCaptor.getValue().getUserId()).isEqualTo(TEST_USER_ID);
 		log.info("Finishing testAddDietaSetsUserId");
+	}
+
+	@Test
+	public void testAddDietaAsPlatformAdminSetsSystemUserId() {
+		Dieta newDieta = new Dieta();
+		newDieta.setNombre("Plantilla: Menú nuevo");
+		newDieta.setIngestas(new ArrayList<>());
+
+		when(platformAdminService.isPlatformAdmin(org.mockito.ArgumentMatchers.any(OidcUser.class))).thenReturn(true);
+		when(platformAdminService.resolveActorUserId(org.mockito.ArgumentMatchers.any(OidcUser.class)))
+			.thenReturn(PLATFORM_ADMIN_USER_ID);
+		when(dietaService.saveDieta(any(Dieta.class))).thenAnswer(invocation -> {
+			Dieta dieta = invocation.getArgument(0);
+			dieta.setId(99L);
+			return dieta;
+		});
+
+		final OidcUser principal = createMockOidcUser(PLATFORM_ADMIN_USER_ID);
+		final Dieta result = dietasRestController.addDieta(newDieta, principal);
+
+		assertThat(result.getUserId()).isEqualTo(DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID);
+		verify(platformAdminAuditService).recordAction(PLATFORM_ADMIN_USER_ID, "dietas.create:dietaId=99");
+	}
+
+	@Test
+	public void testAddDietaIgnoresClientSuppliedSystemUserId() {
+		Dieta newDieta = new Dieta();
+		newDieta.setNombre("Spoofed Dieta");
+		newDieta.setUserId(DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID);
+		newDieta.setIngestas(new ArrayList<>());
+
+		when(platformAdminService.isPlatformAdmin(org.mockito.ArgumentMatchers.any(OidcUser.class))).thenReturn(false);
+		when(dietaService.saveDieta(any(Dieta.class))).thenAnswer(invocation -> {
+			Dieta dieta = invocation.getArgument(0);
+			dieta.setId(43L);
+			return dieta;
+		});
+
+		final OidcUser principal = createMockOidcUser(TEST_USER_ID);
+		final Dieta result = dietasRestController.addDieta(newDieta, principal);
+
+		assertThat(result.getUserId()).isEqualTo(TEST_USER_ID);
+		verify(platformAdminAuditService, never()).recordAction(org.mockito.ArgumentMatchers.anyString(),
+				org.mockito.ArgumentMatchers.anyString());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Platform admins creating diets via `POST /rest/dietas/add` now get `userId = system:template-dietas` instead of their OAuth `sub`.
- Nutritionists continue creating owned diets; client-supplied `userId` is ignored server-side.
- System template creation is audit-logged; admin UI shows an info banner in the Agregar Dieta modal.

Fixes #272

## Test plan
- [x] `DietaAuthorizationTest` — admin vs nutritionist create userId resolution
- [x] `DietasRestControllerTest` — admin create, nutritionist spoof blocked, audit on admin create
- [ ] Manual: log in as platform admin → Agregar Dieta → verify new row appears under sistema filter and is editable by admin only
- [ ] Manual: log in as nutritionist → Agregar Dieta → verify owned `userId`


Made with [Cursor](https://cursor.com)