### PR TITLE
[Public Booking] Nutritionist profile working hours and availability (#246)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -32,11 +32,14 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | `[Nutritionist Web]` issues (#221–#223 MPX; #232–#242 epics; #257–#259 platillo ownership; #271–#272 system catalog create; #280–#281 diet nutrients & ingesta platillo edit; ~~#285~~ platillo inline cantidad; ~~#241~~ ~~#242~~ patient UX; ~~#250~~), states, dependencies |
 | [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md) | Patient registration export/import plan |
 
-**Parallel track (public booking — future; depends on #246+):**
+**Parallel track (public booking — active; #246 done on branch):**
 
 | File | Purpose |
 |------|---------|
 | [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) | `[Public Booking]` epic #245–#248 |
+| [`docs/public-booking/AVAILABILITY.md`](docs/public-booking/AVAILABILITY.md) | Working hours model, timezone, REST (#246) |
+
+**Current next issue (public booking):** [#247 — calendar unavailable days and absence windows](https://github.com/diego-torres/nutriconsultas/issues/247). ~~#246~~ done (branch `issue-246-working-hours`). See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
 **Current next issue (mobile):** [#134 — POST /rest/mobile/invitations](https://github.com/diego-torres/nutriconsultas/issues/134). ~~#133~~ done (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -606,7 +606,7 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 ## Public booking (tracking)
 
-Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. **NEXT (when active):** [#246 working hours](https://github.com/diego-torres/nutriconsultas/issues/246) → #247 → #248.
+Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done** (branch `issue-246-working-hours`). **NEXT:** [#247 calendar blocks](https://github.com/diego-torres/nutriconsultas/issues/247) → #248.
 
 ## Resources
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -221,7 +221,7 @@ Inline **cantidad** editing on the catalog platillo form (`/admin/platillos/{id}
 | #280 / #281 Diet nutrients | Full nutrient modal (#280); in-row platillo edit on ingesta grid (#281) — refresh dieta rollup |
 | ~~#285~~ Platillo form | Inline cantidad edit on catalog `#ingredientesGrid` + diet ingesta grid — branch `issue-285-platillo-inline-cantidad` |
 | #243 / #244 Subscription | reCAPTCHA + Solicitar acceso pre-fill — public funnel, not admin UI |
-| #245–#248 Public booking | Nutritionist hours in profile (#246) — separate track |
+| #245–#248 Public booking | ~~#246~~ done (branch `issue-246-working-hours`); nutritionist hours in profile — separate track |
 
 ---
 

--- a/ISSUE-PUBLIC-BOOKING.md
+++ b/ISSUE-PUBLIC-BOOKING.md
@@ -3,7 +3,7 @@
 Living index of GitHub issues for **public appointment scheduling** — shareable links, nutritionist availability, and patient self-booking. Update when status changes (commit on the PR that closes work).
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
-**Last updated:** 2026-06-19 — Epic **#245** with child issues **#246–#248** registered.
+**Last updated:** 2026-06-21 — ~~#246~~ **done** (branch `issue-246-working-hours`). **NEXT:** #247. Epic **#245** with child issues **#246–#248** registered.
 
 > **Scope.** Public routes (`/consultas/{id}/agendar-cita` or equivalent), availability configuration, and calendar blocks. Nutritionist admin UI pieces may live in `/admin/**` but this track owns the **public booking product**. Mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Nutritionist web (non-booking): [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
@@ -39,8 +39,8 @@ Shareable URL for patients to book into a nutritionist's real availability:
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | **245** | Epic — public appointment scheduling link per nutritionist | https://github.com/diego-torres/nutriconsultas/issues/245 | open | — | New track; Liquibase for availability + public slug |
-| **246** | Nutritionist profile — configure working hours and availability | https://github.com/diego-torres/nutriconsultas/issues/246 | **NEXT** | **245** | Weekly schedule; slot duration |
-| 247 | Calendar — unavailable days and absence windows | https://github.com/diego-torres/nutriconsultas/issues/247 | open | **246** | Blocks subtract from public slots |
+| **246** | Nutritionist profile — configure working hours and availability | https://github.com/diego-torres/nutriconsultas/issues/246 | **done** | **245** | Branch `issue-246-working-hours`; `GET/PUT /rest/profile/availability`; Liquibase `014` |
+| **247** | Calendar — unavailable days and absence windows | https://github.com/diego-torres/nutriconsultas/issues/247 | **NEXT** | **246** | Blocks subtract from public slots |
 | 248 | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | open | **246**, **247**, #243 | reCAPTCHA recommended; opaque public id |
 
 ---

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-21):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web **NEXT:** #271–#272; ~~#285~~ done (`issue-285-platillo-inline-cantidad`, 340a318); ~~#281~~ done (`issue-281-ingesta-platillo-ingredient-edit`); ~~#280~~ done (PR [#284](https://github.com/diego-torres/nutriconsultas/pull/284)); ~~#240~~ done (PR [#283](https://github.com/diego-torres/nutriconsultas/pull/283)); ~~#239~~ done (`issue-239-ingredient-weight-recalc`, bd07fb4); ~~#238~~ done (PR [#279](https://github.com/diego-torres/nutriconsultas/pull/279)); ~~#237~~ done (PR [#278](https://github.com/diego-torres/nutriconsultas/pull/278)); ~~#236~~ done (PR [#274](https://github.com/diego-torres/nutriconsultas/pull/274)); platillo ownership ~~#257–#259~~ done; diet nutrients ~~#280–#281~~ done; diet catalog ~~#232–#235~~ done; diet/platillo UX ~~#238–#240~~ done. Public booking #245–#248 (deferred).
+**On `main` (2026-06-21):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: all registered epics **complete** (#221–#242, #271–#272). Public booking **NEXT:** [#247](https://github.com/diego-torres/nutriconsultas/issues/247); ~~#246~~ done (branch `issue-246-working-hours`).
 
 ## AWS (production infrastructure)
 

--- a/docs/public-booking/AVAILABILITY.md
+++ b/docs/public-booking/AVAILABILITY.md
@@ -1,0 +1,25 @@
+# Nutritionist availability (#246)
+
+Working hours and slot duration configured at **`/admin/perfil`** feed future public booking slot generation (#248).
+
+## Timezone
+
+All availability windows are interpreted in **`America/Mexico_City`** (CST/CDT). The REST API persists this value on `nutritionist_availability_settings.timezone`; the profile UI displays it read-only until multi-timezone support is added.
+
+Public slot APIs (#248) must convert `LocalDate` + slot start `LocalTime` using the nutritionist's stored zone, not the JVM default or the visitor's browser zone.
+
+## Data model
+
+| Table | Purpose |
+|-------|---------|
+| `nutritionist_availability_settings` | One row per OAuth `user_id`: `slot_duration_minutes` (15–120), `timezone` |
+| `nutritionist_working_hours_interval` | Zero or more rows per user: ISO weekday (1=Monday … 7=Sunday), `start_time`, `end_time` |
+
+## REST API (authenticated)
+
+- `GET /rest/profile/availability` — load schedule for `principal.sub`
+- `PUT /rest/profile/availability` — replace intervals + settings; validates overlaps and slot duration
+
+## Slot generation
+
+`BookingSlotGenerator.generateSlotStarts(intervals, slotDurationMinutes)` produces sorted slot start times that fit entirely within configured intervals. Used by unit tests now; public booking (#248) will subtract calendar events and absence blocks (#247).

--- a/src/main/java/com/nutriconsultas/booking/AvailabilityScheduleDto.java
+++ b/src/main/java/com/nutriconsultas/booking/AvailabilityScheduleDto.java
@@ -1,0 +1,31 @@
+package com.nutriconsultas.booking;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AvailabilityScheduleDto {
+
+	@Min(BookingAvailabilityConstants.MIN_SLOT_DURATION_MINUTES)
+	@Max(BookingAvailabilityConstants.MAX_SLOT_DURATION_MINUTES)
+	private int slotDurationMinutes = BookingAvailabilityConstants.DEFAULT_SLOT_DURATION_MINUTES;
+
+	@NotBlank
+	private String timezone = BookingAvailabilityConstants.DEFAULT_TIMEZONE_ID;
+
+	@NotNull
+	@Valid
+	private List<WorkingHoursIntervalDto> intervals = new ArrayList<>();
+
+}

--- a/src/main/java/com/nutriconsultas/booking/BookingAvailabilityConstants.java
+++ b/src/main/java/com/nutriconsultas/booking/BookingAvailabilityConstants.java
@@ -1,0 +1,23 @@
+package com.nutriconsultas.booking;
+
+import java.time.ZoneId;
+
+/**
+ * Defaults and bounds for nutritionist public-booking availability (#246).
+ */
+public final class BookingAvailabilityConstants {
+
+	public static final ZoneId DEFAULT_TIMEZONE = ZoneId.of("America/Mexico_City");
+
+	public static final String DEFAULT_TIMEZONE_ID = DEFAULT_TIMEZONE.getId();
+
+	public static final int DEFAULT_SLOT_DURATION_MINUTES = 60;
+
+	public static final int MIN_SLOT_DURATION_MINUTES = 15;
+
+	public static final int MAX_SLOT_DURATION_MINUTES = 120;
+
+	private BookingAvailabilityConstants() {
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/BookingSlotGenerator.java
+++ b/src/main/java/com/nutriconsultas/booking/BookingSlotGenerator.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Generates bookable slot start times within configured working hours (#246).
+ */
+public final class BookingSlotGenerator {
+
+	private BookingSlotGenerator() {
+	}
+
+	/**
+	 * @param intervals working windows for the target weekday (may span multiple rows)
+	 * @param slotDurationMinutes appointment length in minutes
+	 * @return sorted slot start times that fit entirely inside an interval
+	 */
+	public static List<LocalTime> generateSlotStarts(final List<WorkingHoursIntervalDto> intervals,
+			final int slotDurationMinutes) {
+		WorkingHoursValidator.validateSlotDuration(slotDurationMinutes);
+		if (intervals == null || intervals.isEmpty()) {
+			return List.of();
+		}
+		final List<LocalTime> slotStarts = new ArrayList<>();
+		final List<WorkingHoursIntervalDto> sorted = new ArrayList<>(intervals);
+		sorted.sort(Comparator.comparing(WorkingHoursIntervalDto::getStartTime));
+		for (final WorkingHoursIntervalDto interval : sorted) {
+			if (interval.getStartTime() == null || interval.getEndTime() == null) {
+				continue;
+			}
+			LocalTime candidate = interval.getStartTime();
+			while (!candidate.plusMinutes(slotDurationMinutes).isAfter(interval.getEndTime())) {
+				slotStarts.add(candidate);
+				candidate = candidate.plusMinutes(slotDurationMinutes);
+			}
+		}
+		slotStarts.sort(LocalTime::compareTo);
+		return List.copyOf(slotStarts);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityRestController.java
+++ b/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityRestController.java
@@ -1,0 +1,65 @@
+package com.nutriconsultas.booking;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/profile/availability")
+@Slf4j
+public class NutritionistAvailabilityRestController {
+
+	private final NutritionistAvailabilityService availabilityService;
+
+	public NutritionistAvailabilityRestController(final NutritionistAvailabilityService availabilityService) {
+		this.availabilityService = availabilityService;
+	}
+
+	@GetMapping
+	public ResponseEntity<AvailabilityScheduleDto> getSchedule(@AuthenticationPrincipal final OidcUser principal) {
+		if (principal == null || principal.getSubject() == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
+		return ResponseEntity.ok(availabilityService.getSchedule(principal.getSubject()));
+	}
+
+	@PutMapping
+	public ResponseEntity<?> saveSchedule(@AuthenticationPrincipal final OidcUser principal,
+			@Valid @RequestBody final AvailabilityScheduleDto schedule, final BindingResult bindingResult) {
+		if (principal == null || principal.getSubject() == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
+		if (bindingResult.hasErrors()) {
+			return validationErrorResponse("Datos de horario no válidos");
+		}
+		try {
+			final AvailabilityScheduleDto saved = availabilityService.saveSchedule(principal.getSubject(), schedule);
+			return ResponseEntity.ok(saved);
+		}
+		catch (final IllegalArgumentException ex) {
+			log.debug("Availability validation failed for user request");
+			return validationErrorResponse(ex.getMessage());
+		}
+	}
+
+	private static ResponseEntity<Map<String, Object>> validationErrorResponse(final String message) {
+		final Map<String, Object> body = new HashMap<>();
+		body.put("success", false);
+		body.put("error", message);
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityService.java
+++ b/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityService.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.booking;
+
+import org.springframework.lang.NonNull;
+
+public interface NutritionistAvailabilityService {
+
+	AvailabilityScheduleDto getSchedule(@NonNull String userId);
+
+	AvailabilityScheduleDto saveSchedule(@NonNull String userId, @NonNull AvailabilityScheduleDto schedule);
+
+}

--- a/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityServiceImpl.java
@@ -1,0 +1,88 @@
+package com.nutriconsultas.booking;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class NutritionistAvailabilityServiceImpl implements NutritionistAvailabilityService {
+
+	private final NutritionistAvailabilitySettingsRepository settingsRepository;
+
+	private final NutritionistWorkingHoursIntervalRepository intervalRepository;
+
+	public NutritionistAvailabilityServiceImpl(final NutritionistAvailabilitySettingsRepository settingsRepository,
+			final NutritionistWorkingHoursIntervalRepository intervalRepository) {
+		this.settingsRepository = settingsRepository;
+		this.intervalRepository = intervalRepository;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public AvailabilityScheduleDto getSchedule(@NonNull final String userId) {
+		final NutritionistAvailabilitySettings settings = settingsRepository.findByUserId(userId)
+			.orElse(defaultSettings(userId));
+		final List<NutritionistWorkingHoursInterval> stored = intervalRepository
+			.findByUserIdOrderByDayOfWeekAscStartTimeAsc(userId);
+		return toDto(settings, stored);
+	}
+
+	@Override
+	@Transactional
+	public AvailabilityScheduleDto saveSchedule(@NonNull final String userId,
+			@NonNull final AvailabilityScheduleDto schedule) {
+		WorkingHoursValidator.validateSchedule(schedule);
+		final NutritionistAvailabilitySettings settings = settingsRepository.findByUserId(userId)
+			.orElseGet(() -> defaultSettings(userId));
+		settings.setSlotDurationMinutes(schedule.getSlotDurationMinutes());
+		settings.setTimezone(schedule.getTimezone().trim());
+		settingsRepository.save(settings);
+
+		intervalRepository.deleteByUserId(userId);
+		final List<NutritionistWorkingHoursInterval> savedIntervals = new ArrayList<>();
+		for (final WorkingHoursIntervalDto intervalDto : schedule.getIntervals()) {
+			final NutritionistWorkingHoursInterval row = new NutritionistWorkingHoursInterval();
+			row.setUserId(userId);
+			row.setDayOfWeek(intervalDto.getDayOfWeek());
+			row.setStartTime(intervalDto.getStartTime());
+			row.setEndTime(intervalDto.getEndTime());
+			savedIntervals.add(intervalRepository.save(row));
+		}
+		if (log.isInfoEnabled()) {
+			log.info("Saved availability for user {} with {} intervals", LogRedaction.redactUserId(userId),
+					savedIntervals.size());
+		}
+		return toDto(settings, savedIntervals);
+	}
+
+	private static NutritionistAvailabilitySettings defaultSettings(final String userId) {
+		final NutritionistAvailabilitySettings settings = new NutritionistAvailabilitySettings();
+		settings.setUserId(userId);
+		settings.setSlotDurationMinutes(BookingAvailabilityConstants.DEFAULT_SLOT_DURATION_MINUTES);
+		settings.setTimezone(BookingAvailabilityConstants.DEFAULT_TIMEZONE_ID);
+		return settings;
+	}
+
+	private static AvailabilityScheduleDto toDto(final NutritionistAvailabilitySettings settings,
+			final List<NutritionistWorkingHoursInterval> intervals) {
+		final AvailabilityScheduleDto dto = new AvailabilityScheduleDto();
+		dto.setSlotDurationMinutes(settings.getSlotDurationMinutes());
+		dto.setTimezone(settings.getTimezone());
+		final List<WorkingHoursIntervalDto> intervalDtos = new ArrayList<>();
+		for (final NutritionistWorkingHoursInterval interval : intervals) {
+			intervalDtos.add(new WorkingHoursIntervalDto(interval.getDayOfWeek(), interval.getStartTime(),
+					interval.getEndTime()));
+		}
+		dto.setIntervals(intervalDtos);
+		return dto;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilitySettings.java
+++ b/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilitySettings.java
@@ -1,0 +1,36 @@
+package com.nutriconsultas.booking;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Per-nutritionist booking preferences: slot length and timezone (#246).
+ */
+@Entity
+@Table(name = "nutritionist_availability_settings")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NutritionistAvailabilitySettings {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "user_id", nullable = false, unique = true, length = 255)
+	private String userId;
+
+	@Column(name = "slot_duration_minutes", nullable = false)
+	private Integer slotDurationMinutes = BookingAvailabilityConstants.DEFAULT_SLOT_DURATION_MINUTES;
+
+	@Column(nullable = false, length = 64)
+	private String timezone = BookingAvailabilityConstants.DEFAULT_TIMEZONE_ID;
+
+}

--- a/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilitySettingsRepository.java
+++ b/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilitySettingsRepository.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.booking;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NutritionistAvailabilitySettingsRepository
+		extends JpaRepository<NutritionistAvailabilitySettings, Long> {
+
+	Optional<NutritionistAvailabilitySettings> findByUserId(String userId);
+
+}

--- a/src/main/java/com/nutriconsultas/booking/NutritionistWorkingHoursInterval.java
+++ b/src/main/java/com/nutriconsultas/booking/NutritionistWorkingHoursInterval.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * One contiguous working-hours window for a weekday (ISO-8601 day 1=Monday … 7=Sunday).
+ */
+@Entity
+@Table(name = "nutritionist_working_hours_interval")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NutritionistWorkingHoursInterval {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "user_id", nullable = false, length = 255)
+	private String userId;
+
+	/**
+	 * {@link java.time.DayOfWeek#getValue()} — 1 (Monday) through 7 (Sunday).
+	 */
+	@Column(name = "day_of_week", nullable = false)
+	private Integer dayOfWeek;
+
+	@Column(name = "start_time", nullable = false)
+	private LocalTime startTime;
+
+	@Column(name = "end_time", nullable = false)
+	private LocalTime endTime;
+
+}

--- a/src/main/java/com/nutriconsultas/booking/NutritionistWorkingHoursIntervalRepository.java
+++ b/src/main/java/com/nutriconsultas/booking/NutritionistWorkingHoursIntervalRepository.java
@@ -1,0 +1,16 @@
+package com.nutriconsultas.booking;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NutritionistWorkingHoursIntervalRepository
+		extends JpaRepository<NutritionistWorkingHoursInterval, Long> {
+
+	List<NutritionistWorkingHoursInterval> findByUserIdOrderByDayOfWeekAscStartTimeAsc(String userId);
+
+	void deleteByUserId(String userId);
+
+}

--- a/src/main/java/com/nutriconsultas/booking/WorkingHoursIntervalDto.java
+++ b/src/main/java/com/nutriconsultas/booking/WorkingHoursIntervalDto.java
@@ -1,0 +1,32 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkingHoursIntervalDto {
+
+	@NotNull
+	@Min(1)
+	@Max(7)
+	private Integer dayOfWeek;
+
+	@NotNull
+	@JsonFormat(pattern = "HH:mm")
+	private LocalTime startTime;
+
+	@NotNull
+	@JsonFormat(pattern = "HH:mm")
+	private LocalTime endTime;
+
+}

--- a/src/main/java/com/nutriconsultas/booking/WorkingHoursValidator.java
+++ b/src/main/java/com/nutriconsultas/booking/WorkingHoursValidator.java
@@ -1,0 +1,85 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Validates working-hours intervals and slot duration (#246).
+ */
+public final class WorkingHoursValidator {
+
+	private WorkingHoursValidator() {
+	}
+
+	public static void validateSchedule(final AvailabilityScheduleDto schedule) {
+		if (schedule == null) {
+			throw new IllegalArgumentException("Horario no válido");
+		}
+		validateSlotDuration(schedule.getSlotDurationMinutes());
+		validateTimezone(schedule.getTimezone());
+		if (schedule.getIntervals() == null) {
+			return;
+		}
+		for (final WorkingHoursIntervalDto interval : schedule.getIntervals()) {
+			validateInterval(interval);
+		}
+		validateNoOverlaps(schedule.getIntervals());
+	}
+
+	public static void validateSlotDuration(final int slotDurationMinutes) {
+		if (slotDurationMinutes < BookingAvailabilityConstants.MIN_SLOT_DURATION_MINUTES
+				|| slotDurationMinutes > BookingAvailabilityConstants.MAX_SLOT_DURATION_MINUTES) {
+			throw new IllegalArgumentException(
+					"La duración de cita debe estar entre " + BookingAvailabilityConstants.MIN_SLOT_DURATION_MINUTES
+							+ " y " + BookingAvailabilityConstants.MAX_SLOT_DURATION_MINUTES + " minutos");
+		}
+	}
+
+	public static void validateTimezone(final String timezoneId) {
+		if (timezoneId == null || timezoneId.isBlank()) {
+			throw new IllegalArgumentException("La zona horaria es requerida");
+		}
+		try {
+			java.time.ZoneId.of(timezoneId.trim());
+		}
+		catch (final java.time.DateTimeException ex) {
+			throw new IllegalArgumentException("Zona horaria no válida: " + timezoneId, ex);
+		}
+	}
+
+	private static void validateInterval(final WorkingHoursIntervalDto interval) {
+		if (interval == null) {
+			throw new IllegalArgumentException("Intervalo de horario no válido");
+		}
+		if (interval.getDayOfWeek() == null || interval.getDayOfWeek() < 1 || interval.getDayOfWeek() > 7) {
+			throw new IllegalArgumentException("Día de la semana no válido");
+		}
+		final LocalTime start = interval.getStartTime();
+		final LocalTime end = interval.getEndTime();
+		if (start == null || end == null) {
+			throw new IllegalArgumentException("Hora de inicio y fin son requeridas");
+		}
+		if (!start.isBefore(end)) {
+			throw new IllegalArgumentException("La hora de inicio debe ser anterior a la hora de fin");
+		}
+	}
+
+	private static void validateNoOverlaps(final List<WorkingHoursIntervalDto> intervals) {
+		final List<WorkingHoursIntervalDto> sorted = new ArrayList<>(intervals);
+		sorted.sort(Comparator.comparing(WorkingHoursIntervalDto::getDayOfWeek)
+			.thenComparing(WorkingHoursIntervalDto::getStartTime));
+		for (int i = 1; i < sorted.size(); i++) {
+			final WorkingHoursIntervalDto previous = sorted.get(i - 1);
+			final WorkingHoursIntervalDto current = sorted.get(i);
+			if (!previous.getDayOfWeek().equals(current.getDayOfWeek())) {
+				continue;
+			}
+			if (current.getStartTime().isBefore(previous.getEndTime())) {
+				throw new IllegalArgumentException("Los horarios se traslapan el mismo día");
+			}
+		}
+	}
+
+}

--- a/src/main/resources/db/changelog/changes/014-nutritionist-availability.yaml
+++ b/src/main/resources/db/changelog/changes/014-nutritionist-availability.yaml
@@ -1,0 +1,83 @@
+databaseChangeLog:
+  - changeSet:
+      id: 014-nutritionist-availability-settings
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            tableExists:
+              tableName: nutritionist_availability_settings
+      changes:
+        - createTable:
+            tableName: nutritionist_availability_settings
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
+                  name: slot_duration_minutes
+                  type: INT
+                  defaultValueNumeric: 60
+                  constraints:
+                    nullable: false
+              - column:
+                  name: timezone
+                  type: VARCHAR(64)
+                  defaultValue: America/Mexico_City
+                  constraints:
+                    nullable: false
+  - changeSet:
+      id: 014-nutritionist-working-hours-interval
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            tableExists:
+              tableName: nutritionist_working_hours_interval
+      changes:
+        - createTable:
+            tableName: nutritionist_working_hours_interval
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: day_of_week
+                  type: SMALLINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: start_time
+                  type: TIME
+                  constraints:
+                    nullable: false
+              - column:
+                  name: end_time
+                  type: TIME
+                  constraints:
+                    nullable: false
+        - createIndex:
+            indexName: idx_nwhi_user_id
+            tableName: nutritionist_working_hours_interval
+            columns:
+              - column:
+                  name: user_id

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -38,3 +38,6 @@ databaseChangeLog:
   - include:
       file: changes/013-anthropometric-updated-at.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/014-nutritionist-availability.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -35,3 +35,6 @@ databaseChangeLog:
   - include:
       file: changes/013-anthropometric-updated-at.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/014-nutritionist-availability.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/templates/sbadmin/profile/formulario.html
+++ b/src/main/resources/templates/sbadmin/profile/formulario.html
@@ -17,6 +17,7 @@
     <link href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i" rel="stylesheet" />
 
     <!-- Custom styles -->
+    <link th:href="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.css}" rel="stylesheet" />
     <link th:href="@{/sbadmin/css/sb-admin-2.css}" rel="stylesheet" />
   </head>
 
@@ -210,6 +211,63 @@
                 </div>
               </div>
 
+              <!-- Public booking: working hours (#246) -->
+              <div class="col-12">
+                <div class="card shadow mb-4">
+                  <div class="card-header py-3 d-flex align-items-center justify-content-between">
+                    <h6 class="m-0 font-weight-bold text-primary">
+                      <i class="fas fa-calendar-check"></i> Horario para citas en línea
+                    </h6>
+                    <small class="text-muted">Zona horaria: America/Mexico_City</small>
+                  </div>
+                  <div class="card-body">
+                    <p class="text-muted small">
+                      Define tu horario habitual de consulta. Se usará para generar espacios disponibles
+                      en tu enlace público de agendamiento.
+                    </p>
+                    <div id="availabilityAlert" class="alert d-none" role="alert"></div>
+                    <div class="form-row mb-3">
+                      <div class="form-group col-md-4">
+                        <label for="slotDurationMinutes">Duración de cada cita</label>
+                        <select id="slotDurationMinutes" class="form-control">
+                          <option value="15">15 minutos</option>
+                          <option value="30">30 minutos</option>
+                          <option value="45">45 minutos</option>
+                          <option value="60" selected>60 minutos</option>
+                          <option value="90">90 minutos</option>
+                          <option value="120">120 minutos</option>
+                        </select>
+                      </div>
+                    </div>
+                    <div class="table-responsive">
+                      <table class="table table-sm table-bordered mb-0" id="workingHoursTable">
+                        <thead class="thead-light">
+                          <tr>
+                            <th style="width: 8rem;">Día</th>
+                            <th style="width: 6rem;" class="text-center">Activo</th>
+                            <th style="width: 10rem;">Inicio</th>
+                            <th style="width: 10rem;">Fin</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr data-day="1"><td>Lunes</td><td class="text-center"><input type="checkbox" class="day-enabled" checked /></td><td><input type="time" class="form-control form-control-sm day-start" value="09:00" /></td><td><input type="time" class="form-control form-control-sm day-end" value="17:00" /></td></tr>
+                          <tr data-day="2"><td>Martes</td><td class="text-center"><input type="checkbox" class="day-enabled" checked /></td><td><input type="time" class="form-control form-control-sm day-start" value="09:00" /></td><td><input type="time" class="form-control form-control-sm day-end" value="17:00" /></td></tr>
+                          <tr data-day="3"><td>Miércoles</td><td class="text-center"><input type="checkbox" class="day-enabled" checked /></td><td><input type="time" class="form-control form-control-sm day-start" value="09:00" /></td><td><input type="time" class="form-control form-control-sm day-end" value="17:00" /></td></tr>
+                          <tr data-day="4"><td>Jueves</td><td class="text-center"><input type="checkbox" class="day-enabled" checked /></td><td><input type="time" class="form-control form-control-sm day-start" value="09:00" /></td><td><input type="time" class="form-control form-control-sm day-end" value="17:00" /></td></tr>
+                          <tr data-day="5"><td>Viernes</td><td class="text-center"><input type="checkbox" class="day-enabled" checked /></td><td><input type="time" class="form-control form-control-sm day-start" value="09:00" /></td><td><input type="time" class="form-control form-control-sm day-end" value="17:00" /></td></tr>
+                          <tr data-day="6"><td>Sábado</td><td class="text-center"><input type="checkbox" class="day-enabled" /></td><td><input type="time" class="form-control form-control-sm day-start" value="09:00" disabled /></td><td><input type="time" class="form-control form-control-sm day-end" value="13:00" disabled /></td></tr>
+                          <tr data-day="7"><td>Domingo</td><td class="text-center"><input type="checkbox" class="day-enabled" /></td><td><input type="time" class="form-control form-control-sm day-start" value="09:00" disabled /></td><td><input type="time" class="form-control form-control-sm day-end" value="13:00" disabled /></td></tr>
+                        </tbody>
+                      </table>
+                    </div>
+                    <hr />
+                    <button type="button" id="btnSaveAvailability" class="btn btn-primary">
+                      <i class="fas fa-save"></i> Guardar horario
+                    </button>
+                  </div>
+                </div>
+              </div>
+
             </div>
             <!-- /.row -->
 
@@ -229,6 +287,111 @@
     <script th:src="@{/sbadmin/vendor/bootstrap/js/bootstrap.bundle.min.js}"></script>
     <script th:src="@{/sbadmin/vendor/jquery-easing/jquery.easing.min.js}"></script>
     <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
+    <script th:src="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.js}"></script>
+    <script lang="javascript">
+      'use strict';
+      (function ($) {
+        var DEFAULT_TIMEZONE = 'America/Mexico_City';
+
+        function showAvailabilityAlert(type, message) {
+          var $alert = $('#availabilityAlert');
+          $alert.removeClass('d-none alert-success alert-danger alert-warning')
+            .addClass('alert-' + type)
+            .text(message);
+        }
+
+        function toggleDayRow($row, enabled) {
+          $row.find('.day-start, .day-end').prop('disabled', !enabled);
+        }
+
+        function normalizeTime(value) {
+          if (!value) {
+            return '';
+          }
+          return value.length >= 5 ? value.substring(0, 5) : value;
+        }
+
+        function applyScheduleToTable(schedule) {
+          $('#slotDurationMinutes').val(String(schedule.slotDurationMinutes || 60));
+          var intervalsByDay = {};
+          (schedule.intervals || []).forEach(function (interval) {
+            intervalsByDay[interval.dayOfWeek] = interval;
+          });
+          $('#workingHoursTable tbody tr').each(function () {
+            var $row = $(this);
+            var day = parseInt($row.data('day'), 10);
+            var interval = intervalsByDay[day];
+            var enabled = !!interval;
+            $row.find('.day-enabled').prop('checked', enabled);
+            if (interval) {
+              $row.find('.day-start').val(normalizeTime(interval.startTime));
+              $row.find('.day-end').val(normalizeTime(interval.endTime));
+            }
+            toggleDayRow($row, enabled);
+          });
+        }
+
+        function collectSchedulePayload() {
+          var intervals = [];
+          $('#workingHoursTable tbody tr').each(function () {
+            var $row = $(this);
+            if (!$row.find('.day-enabled').is(':checked')) {
+              return;
+            }
+            intervals.push({
+              dayOfWeek: parseInt($row.data('day'), 10),
+              startTime: $row.find('.day-start').val(),
+              endTime: $row.find('.day-end').val()
+            });
+          });
+          return {
+            slotDurationMinutes: parseInt($('#slotDurationMinutes').val(), 10),
+            timezone: DEFAULT_TIMEZONE,
+            intervals: intervals
+          };
+        }
+
+        function loadAvailability() {
+          $.getJSON('/rest/profile/availability')
+            .done(function (schedule) {
+              applyScheduleToTable(schedule);
+            })
+            .fail(function () {
+              showAvailabilityAlert('warning', 'No se pudo cargar tu horario guardado.');
+            });
+        }
+
+        $('#workingHoursTable').on('change', '.day-enabled', function () {
+          var $row = $(this).closest('tr');
+          toggleDayRow($row, $(this).is(':checked'));
+        });
+
+        $('#btnSaveAvailability').on('click', function () {
+          var payload = collectSchedulePayload();
+          $.ajax({
+            url: '/rest/profile/availability',
+            method: 'PUT',
+            contentType: 'application/json',
+            data: JSON.stringify(payload)
+          }).done(function () {
+            swal({
+              title: 'Horario guardado',
+              text: 'Tu disponibilidad para citas en línea se actualizó correctamente.',
+              type: 'success',
+              timer: 2000
+            });
+          }).fail(function (xhr) {
+            var message = 'No se pudo guardar el horario.';
+            if (xhr.responseJSON && xhr.responseJSON.error) {
+              message = xhr.responseJSON.error;
+            }
+            swal({ title: 'Error', text: message, type: 'error', timer: 5000 });
+          });
+        });
+
+        loadAvailability();
+      })(jQuery);
+    </script>
     <script lang="javascript">
       'use strict';
       (function ($) {

--- a/src/test/java/com/nutriconsultas/booking/BookingSlotGeneratorTest.java
+++ b/src/test/java/com/nutriconsultas/booking/BookingSlotGeneratorTest.java
@@ -1,0 +1,57 @@
+package com.nutriconsultas.booking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class BookingSlotGeneratorTest {
+
+	@Test
+	void generateSlotStartsWithinSingleInterval() {
+		final List<WorkingHoursIntervalDto> intervals = List
+			.of(new WorkingHoursIntervalDto(1, LocalTime.of(9, 0), LocalTime.of(12, 0)));
+
+		final List<LocalTime> slots = BookingSlotGenerator.generateSlotStarts(intervals, 60);
+
+		assertThat(slots).containsExactly(LocalTime.of(9, 0), LocalTime.of(10, 0), LocalTime.of(11, 0));
+	}
+
+	@Test
+	void generateSlotStartsRespectsSlotDurationBoundary() {
+		final List<WorkingHoursIntervalDto> intervals = List
+			.of(new WorkingHoursIntervalDto(2, LocalTime.of(9, 0), LocalTime.of(10, 30)));
+
+		final List<LocalTime> slots = BookingSlotGenerator.generateSlotStarts(intervals, 60);
+
+		assertThat(slots).containsExactly(LocalTime.of(9, 0));
+	}
+
+	@Test
+	void generateSlotStartsAcrossMultipleIntervalsSameDay() {
+		final List<WorkingHoursIntervalDto> intervals = List.of(
+				new WorkingHoursIntervalDto(3, LocalTime.of(9, 0), LocalTime.of(11, 0)),
+				new WorkingHoursIntervalDto(3, LocalTime.of(14, 0), LocalTime.of(16, 0)));
+
+		final List<LocalTime> slots = BookingSlotGenerator.generateSlotStarts(intervals, 30);
+
+		assertThat(slots).containsExactly(LocalTime.of(9, 0), LocalTime.of(9, 30), LocalTime.of(10, 0),
+				LocalTime.of(10, 30), LocalTime.of(14, 0), LocalTime.of(14, 30), LocalTime.of(15, 0),
+				LocalTime.of(15, 30));
+	}
+
+	@Test
+	void generateSlotStartsReturnsEmptyWhenNoIntervals() {
+		assertThat(BookingSlotGenerator.generateSlotStarts(List.of(), 30)).isEmpty();
+	}
+
+	@Test
+	void generateSlotStartsRejectsInvalidDuration() {
+		assertThatThrownBy(() -> BookingSlotGenerator.generateSlotStarts(List.of(), 5))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/booking/NutritionistAvailabilityRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/booking/NutritionistAvailabilityRestControllerTest.java
@@ -1,0 +1,78 @@
+package com.nutriconsultas.booking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class NutritionistAvailabilityRestControllerTest {
+
+	@InjectMocks
+	private NutritionistAvailabilityRestController controller;
+
+	@Mock
+	private NutritionistAvailabilityService availabilityService;
+
+	@Mock
+	private OidcUser principal;
+
+	private AvailabilityScheduleDto schedule;
+
+	@BeforeEach
+	void setup() {
+		schedule = new AvailabilityScheduleDto();
+		schedule.setSlotDurationMinutes(60);
+		schedule.setTimezone(BookingAvailabilityConstants.DEFAULT_TIMEZONE_ID);
+		schedule.setIntervals(List.of(new WorkingHoursIntervalDto(1, LocalTime.of(9, 0), LocalTime.of(17, 0))));
+		when(principal.getSubject()).thenReturn("auth0|user1");
+	}
+
+	@Test
+	void getScheduleReturnsSavedData() {
+		when(availabilityService.getSchedule("auth0|user1")).thenReturn(schedule);
+
+		final ResponseEntity<AvailabilityScheduleDto> response = controller.getSchedule(principal);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().getIntervals()).hasSize(1);
+	}
+
+	@Test
+	void getScheduleRequiresAuthentication() {
+		final ResponseEntity<AvailabilityScheduleDto> response = controller.getSchedule(null);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+	}
+
+	@Test
+	void saveScheduleReturnsValidationError() {
+		when(availabilityService.saveSchedule("auth0|user1", schedule))
+			.thenThrow(new IllegalArgumentException("Los horarios se traslapan el mismo día"));
+
+		final ResponseEntity<?> response = controller.saveSchedule(principal, schedule,
+				new org.springframework.validation.BeanPropertyBindingResult(schedule, "schedule"));
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> body = (Map<String, Object>) response.getBody();
+		assertThat(body).containsEntry("success", false);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/booking/NutritionistAvailabilityRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/booking/NutritionistAvailabilityRestControllerTest.java
@@ -15,7 +15,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -40,11 +39,11 @@ class NutritionistAvailabilityRestControllerTest {
 		schedule.setSlotDurationMinutes(60);
 		schedule.setTimezone(BookingAvailabilityConstants.DEFAULT_TIMEZONE_ID);
 		schedule.setIntervals(List.of(new WorkingHoursIntervalDto(1, LocalTime.of(9, 0), LocalTime.of(17, 0))));
-		when(principal.getSubject()).thenReturn("auth0|user1");
 	}
 
 	@Test
 	void getScheduleReturnsSavedData() {
+		when(principal.getSubject()).thenReturn("auth0|user1");
 		when(availabilityService.getSchedule("auth0|user1")).thenReturn(schedule);
 
 		final ResponseEntity<AvailabilityScheduleDto> response = controller.getSchedule(principal);
@@ -63,6 +62,7 @@ class NutritionistAvailabilityRestControllerTest {
 
 	@Test
 	void saveScheduleReturnsValidationError() {
+		when(principal.getSubject()).thenReturn("auth0|user1");
 		when(availabilityService.saveSchedule("auth0|user1", schedule))
 			.thenThrow(new IllegalArgumentException("Los horarios se traslapan el mismo día"));
 

--- a/src/test/java/com/nutriconsultas/booking/NutritionistAvailabilityServiceTest.java
+++ b/src/test/java/com/nutriconsultas/booking/NutritionistAvailabilityServiceTest.java
@@ -1,0 +1,75 @@
+package com.nutriconsultas.booking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class NutritionistAvailabilityServiceTest {
+
+	private static final String USER_ID = "auth0|nutritionist1";
+
+	@InjectMocks
+	private NutritionistAvailabilityServiceImpl service;
+
+	@Mock
+	private NutritionistAvailabilitySettingsRepository settingsRepository;
+
+	@Mock
+	private NutritionistWorkingHoursIntervalRepository intervalRepository;
+
+	@BeforeEach
+	void setup() {
+		when(settingsRepository.findByUserId(USER_ID)).thenReturn(Optional.empty());
+		when(intervalRepository.findByUserIdOrderByDayOfWeekAscStartTimeAsc(USER_ID)).thenReturn(List.of());
+	}
+
+	@Test
+	void getScheduleReturnsDefaultsWhenMissing() {
+		final AvailabilityScheduleDto schedule = service.getSchedule(USER_ID);
+
+		assertThat(schedule.getSlotDurationMinutes()).isEqualTo(60);
+		assertThat(schedule.getTimezone()).isEqualTo(BookingAvailabilityConstants.DEFAULT_TIMEZONE_ID);
+		assertThat(schedule.getIntervals()).isEmpty();
+	}
+
+	@Test
+	void saveSchedulePersistsSettingsAndIntervals() {
+		when(settingsRepository.findByUserId(USER_ID)).thenReturn(Optional.empty());
+		when(settingsRepository.save(any(NutritionistAvailabilitySettings.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+		when(intervalRepository.save(any(NutritionistWorkingHoursInterval.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		final AvailabilityScheduleDto request = new AvailabilityScheduleDto();
+		request.setSlotDurationMinutes(30);
+		request.setTimezone(BookingAvailabilityConstants.DEFAULT_TIMEZONE_ID);
+		request.setIntervals(List.of(new WorkingHoursIntervalDto(1, LocalTime.of(8, 0), LocalTime.of(16, 0))));
+
+		final AvailabilityScheduleDto saved = service.saveSchedule(USER_ID, request);
+
+		assertThat(saved.getSlotDurationMinutes()).isEqualTo(30);
+		assertThat(saved.getIntervals()).hasSize(1);
+		verify(intervalRepository).deleteByUserId(USER_ID);
+		final ArgumentCaptor<NutritionistWorkingHoursInterval> captor = ArgumentCaptor
+			.forClass(NutritionistWorkingHoursInterval.class);
+		verify(intervalRepository).save(captor.capture());
+		assertThat(captor.getValue().getDayOfWeek()).isEqualTo(1);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/booking/NutritionistAvailabilityServiceTest.java
+++ b/src/test/java/com/nutriconsultas/booking/NutritionistAvailabilityServiceTest.java
@@ -9,7 +9,6 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -33,14 +32,11 @@ class NutritionistAvailabilityServiceTest {
 	@Mock
 	private NutritionistWorkingHoursIntervalRepository intervalRepository;
 
-	@BeforeEach
-	void setup() {
-		when(settingsRepository.findByUserId(USER_ID)).thenReturn(Optional.empty());
-		when(intervalRepository.findByUserIdOrderByDayOfWeekAscStartTimeAsc(USER_ID)).thenReturn(List.of());
-	}
-
 	@Test
 	void getScheduleReturnsDefaultsWhenMissing() {
+		when(settingsRepository.findByUserId(USER_ID)).thenReturn(Optional.empty());
+		when(intervalRepository.findByUserIdOrderByDayOfWeekAscStartTimeAsc(USER_ID)).thenReturn(List.of());
+
 		final AvailabilityScheduleDto schedule = service.getSchedule(USER_ID);
 
 		assertThat(schedule.getSlotDurationMinutes()).isEqualTo(60);

--- a/src/test/java/com/nutriconsultas/booking/WorkingHoursValidatorTest.java
+++ b/src/test/java/com/nutriconsultas/booking/WorkingHoursValidatorTest.java
@@ -1,0 +1,67 @@
+package com.nutriconsultas.booking;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class WorkingHoursValidatorTest {
+
+	@Test
+	void acceptsNonOverlappingIntervals() {
+		final AvailabilityScheduleDto schedule = validSchedule();
+		schedule.setIntervals(List.of(new WorkingHoursIntervalDto(1, LocalTime.of(9, 0), LocalTime.of(12, 0)),
+				new WorkingHoursIntervalDto(1, LocalTime.of(14, 0), LocalTime.of(17, 0))));
+
+		WorkingHoursValidator.validateSchedule(schedule);
+	}
+
+	@Test
+	void rejectsOverlappingIntervalsSameDay() {
+		final AvailabilityScheduleDto schedule = validSchedule();
+		schedule.setIntervals(List.of(new WorkingHoursIntervalDto(1, LocalTime.of(9, 0), LocalTime.of(12, 0)),
+				new WorkingHoursIntervalDto(1, LocalTime.of(11, 0), LocalTime.of(13, 0))));
+
+		assertThatThrownBy(() -> WorkingHoursValidator.validateSchedule(schedule))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("traslap");
+	}
+
+	@Test
+	void rejectsEndBeforeStart() {
+		final AvailabilityScheduleDto schedule = validSchedule();
+		schedule.setIntervals(List.of(new WorkingHoursIntervalDto(2, LocalTime.of(17, 0), LocalTime.of(9, 0))));
+
+		assertThatThrownBy(() -> WorkingHoursValidator.validateSchedule(schedule))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void rejectsSlotDurationOutsideBounds() {
+		final AvailabilityScheduleDto schedule = validSchedule();
+		schedule.setSlotDurationMinutes(10);
+
+		assertThatThrownBy(() -> WorkingHoursValidator.validateSchedule(schedule))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void rejectsInvalidTimezone() {
+		final AvailabilityScheduleDto schedule = validSchedule();
+		schedule.setTimezone("Not/AZone");
+
+		assertThatThrownBy(() -> WorkingHoursValidator.validateSchedule(schedule))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	private static AvailabilityScheduleDto validSchedule() {
+		final AvailabilityScheduleDto schedule = new AvailabilityScheduleDto();
+		schedule.setSlotDurationMinutes(60);
+		schedule.setTimezone(BookingAvailabilityConstants.DEFAULT_TIMEZONE_ID);
+		schedule.setIntervals(List.of(new WorkingHoursIntervalDto(1, LocalTime.of(9, 0), LocalTime.of(17, 0))));
+		return schedule;
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixes #246

- Adds **Horario para citas en línea** card on `/admin/perfil`: weekly schedule (Spanish), slot duration (15–120 min), timezone display (`America/Mexico_City`)
- Persists `nutritionist_availability_settings` + `nutritionist_working_hours_interval` via Liquibase `014`
- Authenticated REST: `GET/PUT /rest/profile/availability` scoped to `principal.sub`
- `WorkingHoursValidator` (overlap + bounds) and `BookingSlotGenerator` for future public slot APIs (#248)
- Docs: [`docs/public-booking/AVAILABILITY.md`](docs/public-booking/AVAILABILITY.md)
- Tracking: #246 **done**, **NEXT** #247 in registry files

## Test plan

### Automated
- [x] `mvn test` — `BookingSlotGeneratorTest`, `WorkingHoursValidatorTest`, `NutritionistAvailabilityServiceTest`, `NutritionistAvailabilityRestControllerTest`
- [x] `./lint.sh` and `mvn pmd:check -Pci` pass
- [x] Thymeleaf validation — `sbadmin/profile/formulario.html`

### Manual UI (executed locally, `http://localhost:3000/admin/perfil`)

| # | Scenario | Result |
|---|----------|--------|
| 1 | Page loads **Horario para citas en línea** card with timezone label | Pass |
| 2 | Empty schedule loads from API (all weekdays disabled) | Pass |
| 3 | Enable Mon–Fri; set Mon **08:00–16:00**; slot duration **30 min** | Pass |
| 4 | **Guardar horario** → SweetAlert **Horario guardado** | Pass |
| 5 | Server persists 5 intervals (app log) | Pass |
| 6 | Full page reload → **30 min**, Mon–Fri restored, Mon **08:00–16:00** | Pass |
| 7 | Invalid Mon end before start → SweetAlert error *La hora de inicio debe ser anterior a la hora de fin* | Pass |
| 8 | Liquibase `014` applied on dev boot (both tables created) | Pass |


Made with [Cursor](https://cursor.com)