### PR TITLE
[Subscription] Production reCAPTCHA for public forms (#243)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,9 @@ POSTGRES_PORT=5432
 JDBC_DATABASE_URL=jdbc:postgresql://localhost:5432/nutriconsultas
 JDBC_DATABASE_USERNAME=nutriconsultas
 JDBC_DATABASE_PASSWORD=nutriconsultas
-RECAPTCHA_SECRET_KEY=secretkey
-# Google reCAPTCHA v2 site key (public; pair with RECAPTCHA_SECRET_KEY)
+RECAPTCHA_SECRET_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+# Google reCAPTCHA v2 site key (public; pair with RECAPTCHA_SECRET_KEY). Register at
+# https://www.google.com/recaptcha/admin for minutriporcion.com
 RECAPTCHA_SITE_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 
 # Optional: Maps API Key (if using maps functionality)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -586,7 +586,7 @@ Issue registry: [`ISSUE.md`](ISSUE.md). Agent workflow: [`AGENT-WORKFLOW.md`](AG
 
 Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow: [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md). Design: [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md).
 
-**Epic #180–#211** (2026-06-19): ~~#46~~ Liquibase done; ~~#180–#185~~, ~~#190~~, ~~#187~~, ~~#210~~, ~~#211~~ on `main` (PRs [#216](https://github.com/diego-torres/nutriconsultas/pull/216), [#218](https://github.com/diego-torres/nutriconsultas/pull/218), [#224](https://github.com/diego-torres/nutriconsultas/pull/224), [#230](https://github.com/diego-torres/nutriconsultas/pull/230)). **NEXT:** #207 (+ #208 Stripe ops). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
+**Epic #180–#211** (2026-06-19): ~~#46~~ Liquibase done; ~~#180–#185~~, ~~#190~~, ~~#187~~, ~~#210~~, ~~#211~~ on `main` (PRs [#216](https://github.com/diego-torres/nutriconsultas/pull/216), [#218](https://github.com/diego-torres/nutriconsultas/pull/218), [#224](https://github.com/diego-torres/nutriconsultas/pull/224), [#230](https://github.com/diego-torres/nutriconsultas/pull/230)). Public funnel: ~~#243~~ reCAPTCHA **done** (branch `issue-243-recaptcha-production`). **NEXT:** #207 (+ #208 Stripe ops). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -220,7 +220,7 @@ Inline **cantidad** editing on the catalog platillo form (`/admin/platillos/{id}
 | #198 Diet templates | System diets seeded; editable (#232) and creatable (#272) by admin |
 | #280 / #281 Diet nutrients | Full nutrient modal (#280); in-row platillo edit on ingesta grid (#281) — refresh dieta rollup |
 | ~~#285~~ Platillo form | Inline cantidad edit on catalog `#ingredientesGrid` + diet ingesta grid — branch `issue-285-platillo-inline-cantidad` |
-| #243 / #244 Subscription | reCAPTCHA + Solicitar acceso pre-fill — public funnel, not admin UI |
+| ~~#243~~ / #244 Subscription | reCAPTCHA **done**; Solicitar acceso pre-fill — public funnel, not admin UI |
 | #245–#248 Public booking | ~~#246~~ done (branch `issue-246-working-hours`); nutritionist hours in profile — separate track |
 
 ---

--- a/ISSUE-PUBLIC-BOOKING.md
+++ b/ISSUE-PUBLIC-BOOKING.md
@@ -41,7 +41,7 @@ Shareable URL for patients to book into a nutritionist's real availability:
 | **245** | Epic — public appointment scheduling link per nutritionist | https://github.com/diego-torres/nutriconsultas/issues/245 | open | — | New track; Liquibase for availability + public slug |
 | **246** | Nutritionist profile — configure working hours and availability | https://github.com/diego-torres/nutriconsultas/issues/246 | **done** | **245** | Branch `issue-246-working-hours`; `GET/PUT /rest/profile/availability`; Liquibase `014` |
 | **247** | Calendar — unavailable days and absence windows | https://github.com/diego-torres/nutriconsultas/issues/247 | **NEXT** | **246** | Blocks subtract from public slots |
-| 248 | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | open | **246**, **247**, #243 | reCAPTCHA recommended; opaque public id |
+| 248 | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | open | **246**, **247**, ~~**243**~~ | reCAPTCHA via `@PublicRecaptchaForm`; opaque public id |
 
 ---
 
@@ -49,7 +49,7 @@ Shareable URL for patients to book into a nutritionist's real availability:
 
 | Track | Interaction |
 |-------|-------------|
-| #243 reCAPTCHA | Bot protection on public booking form |
+| ~~#243~~ reCAPTCHA | **done** — `RecaptchaVerificationService` + production keys; reuse on public booking (#248) |
 | #244 Solicitar acceso | Orthogonal — nutritionist onboarding vs patient booking |
 | `CalendarEvent` | Existing appointments; clarify vs availability blocks |
 | #236 Nutritionist profile | Same profile area for hours (#246) and logo |

--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -117,7 +117,7 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 | 5b. Patient slot rotation (export/import `.mpx`) | ~~#221~~, ~~#222~~, ~~#223~~ — [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)) |
 | 6. Branded / tiered reports | #187 — PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218) ✓ |
 | 7. PDF export by plan | #187 — PR [#218](https://github.com/diego-torres/nutriconsultas/pull/218) ✓ |
-| 8. Production reCAPTCHA on contact form | #243 |
+| 8. Production reCAPTCHA on contact form | ~~#243~~ ✓ |
 | 9. Plan-aware Solicitar acceso CTA | #244 |
 
 ---

--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -5,7 +5,7 @@ Living index of GitHub issues that implement **subscription enforcement**, platf
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Workflow:** [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md)  
 **Design doc:** [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md)  
-**Last updated:** 2026-06-20 — ~~#211~~ **done** (PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230)); **NEXT:** #207 (Stripe provider). Public funnel: #243, #244 registered. Patient MPX ~~#221–#223~~ done ([`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md), PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). Production **#226** fixed (PR [#227](https://github.com/diego-torres/nutriconsultas/pull/227), invitation base URL).
+**Last updated:** 2026-06-21 — ~~#243~~ **done** (production reCAPTCHA keys on EC2 + shared `RecaptchaVerificationService`); **NEXT:** #207 (Stripe provider). Public funnel: ~~#243~~, #244 registered. Patient MPX ~~#221–#223~~ done ([`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md), PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). Production **#226** fixed (PR [#227](https://github.com/diego-torres/nutriconsultas/pull/227), invitation base URL).
 
 > **Scope.** This registry tracks `[Subscription]` issues only. The patient mobile API lives in [`ISSUE.md`](ISSUE.md). Patient invitation onboarding (#132–#141) is orthogonal — do not merge nutritionist and patient invitation entities.
 
@@ -86,10 +86,10 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| 243 | Production reCAPTCHA keys for minutriporcion.com | https://github.com/diego-torres/nutriconsultas/issues/243 | open | — | Remove "testing purposes only" banner |
+| 243 | Production reCAPTCHA keys for minutriporcion.com | https://github.com/diego-torres/nutriconsultas/issues/243 | **done** | — | EC2 `RECAPTCHA_*` + `RecaptchaVerificationService` / `@PublicRecaptchaForm` |
 | 244 | Pre-fill contact form when clicking Solicitar Acceso for a plan | https://github.com/diego-torres/nutriconsultas/issues/244 | open | — | Plan slug on `ContactInquiry`; pairs with #184 |
 
-**Suggested order:** #243 → #244 (or parallel). Blocks public booking form (#248) reCAPTCHA reuse.
+**Suggested order:** ~~#243~~ → #244 (or parallel). Public booking (#248) reuses `@PublicRecaptchaForm` + `RecaptchaVerificationService`.
 
 ---
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -135,6 +135,16 @@ Set `AUTH_*` (including `AUTH_AUDIENCE` for `/rest/mobile/**` JWT validation), `
 
 Webhook URL to configure in the [Stripe Dashboard](https://dashboard.stripe.com/webhooks): `https://<your-domain>/rest/subscription/payment/webhook`. No card data is stored in the application database.
 
+**reCAPTCHA (#243)** — public contact form and future public booking use Google reCAPTCHA v2 (checkbox). Set in gitignored `terraform.tfvars` as `recaptcha_site_key` / `recaptcha_secret_key`, or export `TF_VAR_recaptcha_site_key` / `TF_VAR_recaptcha_secret_key` before `terraform apply` (written to `RECAPTCHA_*` in `app.env` on first boot). On a running app host:
+
+```bash
+export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+export RECAPTCHA_SITE_KEY='6L...' RECAPTCHA_SECRET_KEY='6L...'
+bash infrastructure/scripts/ssm-update-recaptcha-keys.sh
+```
+
+Local dev: copy `.env.example` to `.env` (Google test keys are fine). Production must use keys registered for `minutriporcion.com` at [Google reCAPTCHA admin](https://www.google.com/recaptcha/admin).
+
 Edit `/opt/nutriconsultas/app.env` in an SSM session (or a systemd `EnvironmentFile` drop-in). On instances already running, add missing keys manually and restart the app — `user_data` only runs at first boot. Never commit real secrets to git.
 
 ## Outputs

--- a/infrastructure/scripts/ssm-update-recaptcha-keys.sh
+++ b/infrastructure/scripts/ssm-update-recaptcha-keys.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Update RECAPTCHA_SITE_KEY and RECAPTCHA_SECRET_KEY in /opt/nutriconsultas/app.env on the app EC2, then restart.
+#
+# Usage:
+#   export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+#   export RECAPTCHA_SITE_KEY='6L...' RECAPTCHA_SECRET_KEY='6L...'
+#   ./ssm-update-recaptcha-keys.sh [project]
+#
+# Keys must be Google reCAPTCHA v2 (checkbox) site/secret pair from https://www.google.com/recaptcha/admin
+set -euo pipefail
+
+PROJECT="${1:-nutriconsultas}"
+P="/${PROJECT}/deploy"
+: "${AWS_REGION:-${AWS_DEFAULT_REGION:?Set AWS_DEFAULT_REGION (or use configure)}}"
+: "${RECAPTCHA_SITE_KEY:?Set RECAPTCHA_SITE_KEY (Google reCAPTCHA v2 site key)}"
+: "${RECAPTCHA_SECRET_KEY:?Set RECAPTCHA_SECRET_KEY (Google reCAPTCHA v2 secret key)}"
+
+if [[ "$RECAPTCHA_SITE_KEY" != 6L* ]] || [[ "$RECAPTCHA_SECRET_KEY" != 6L* ]]; then
+  echo "Error: RECAPTCHA_* values must be Google reCAPTCHA keys (typically starting with 6L)." >&2
+  echo "Got site prefix: ${RECAPTCHA_SITE_KEY:0:8}... secret prefix: ${RECAPTCHA_SECRET_KEY:0:8}..." >&2
+  exit 1
+fi
+
+INSTANCE_ID="$(aws ssm get-parameter --name "$P/app_instance_id" --query "Parameter.Value" --output text)"
+
+SITE_B64="$(printf '%s' "$RECAPTCHA_SITE_KEY" | base64 | tr -d '\n')"
+SECRET_B64="$(printf '%s' "$RECAPTCHA_SECRET_KEY" | base64 | tr -d '\n')"
+
+PARAMS="$(jq -n \
+  --arg site "$SITE_B64" \
+  --arg secret "$SECRET_B64" \
+  '{
+     commands: [
+       "set -euo pipefail",
+       "ENV_FILE=/opt/nutriconsultas/app.env",
+       "touch \"$ENV_FILE\"",
+       "grep -v \"^RECAPTCHA_SITE_KEY=\" \"$ENV_FILE\" > \"${ENV_FILE}.tmp\" || true",
+       "grep -v \"^RECAPTCHA_SECRET_KEY=\" \"${ENV_FILE}.tmp\" > \"${ENV_FILE}.new\" || true",
+       "rm -f \"${ENV_FILE}.tmp\"",
+       ("echo -n RECAPTCHA_SITE_KEY= >> \"${ENV_FILE}.new\""),
+       ("printf %s \"" + $site + "\" | base64 -d >> \"${ENV_FILE}.new\""),
+       "echo >> \"${ENV_FILE}.new\"",
+       ("echo -n RECAPTCHA_SECRET_KEY= >> \"${ENV_FILE}.new\""),
+       ("printf %s \"" + $secret + "\" | base64 -d >> \"${ENV_FILE}.new\""),
+       "echo >> \"${ENV_FILE}.new\"",
+       "mv \"${ENV_FILE}.new\" \"$ENV_FILE\"",
+       "chmod 640 \"$ENV_FILE\"",
+       "chown root:nutri \"$ENV_FILE\"",
+       "systemctl restart nutriconsultas",
+       "systemctl is-active --quiet nutriconsultas"
+     ]
+   }')"
+
+COMMAND_ID="$(aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunShellScript" \
+  --timeout-seconds 120 \
+  --parameters "$PARAMS" \
+  --query 'Command.CommandId' \
+  --output text)"
+
+echo "SSM command: $COMMAND_ID (instance $INSTANCE_ID)"
+aws ssm wait command-executed --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID"
+STATUS="$(aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" --query Status --output text)"
+if [ "$STATUS" != "Success" ]; then
+  aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" --query '[Status,StandardErrorContent]' --output text >&2
+  exit 1
+fi
+echo "reCAPTCHA keys updated and nutriconsultas restarted."

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -33,8 +33,8 @@ ebs_root_volume_size_gb = 30
 # aws_key                = "AKIA..."
 # aws_secret             = "..."
 # maps_key               = ""
-# recaptcha_secret_key   = ""
-# recaptcha_site_key     = ""   # reCAPTCHA v2 checkbox (public site key)
+# recaptcha_secret_key   = "6L..."   # Google reCAPTCHA v2 secret
+# recaptcha_site_key     = "6L..."   # Google reCAPTCHA v2 site key (public widget key)
 #
 # Platform admins (OAuth login emails; contact inquiries inbox). Gitignored tfvars only:
 # platform_admin_emails = ["you@example.com", "colleague@example.com"]

--- a/src/main/java/com/nutriconsultas/controller/WebController.java
+++ b/src/main/java/com/nutriconsultas/controller/WebController.java
@@ -1,19 +1,16 @@
 package com.nutriconsultas.controller;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.client.RestClient;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.nutriconsultas.contact.ContactInquiry;
 import com.nutriconsultas.contact.ContactInquiryService;
+import com.nutriconsultas.recaptcha.PublicRecaptchaForm;
+import com.nutriconsultas.recaptcha.RecaptchaVerificationService;
 import com.nutriconsultas.util.LogRedaction;
 
 import jakarta.validation.Valid;
@@ -21,28 +18,17 @@ import lombok.extern.slf4j.Slf4j;
 
 @Controller
 @Slf4j
+@PublicRecaptchaForm
 public class WebController {
-
-	private static final String RECAPTCHA_VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify";
-
-	private final RestClient restClient;
 
 	private final ContactInquiryService contactInquiryService;
 
-	@Value("${recaptcha.secret-key:6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe}")
-	private String recaptchaSecretKey;
+	private final RecaptchaVerificationService recaptchaVerificationService;
 
-	@Value("${recaptcha.site-key:6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI}")
-	private String recaptchaSiteKey;
-
-	public WebController(final ContactInquiryService contactInquiryService) {
-		this.restClient = RestClient.create();
+	public WebController(final ContactInquiryService contactInquiryService,
+			final RecaptchaVerificationService recaptchaVerificationService) {
 		this.contactInquiryService = contactInquiryService;
-	}
-
-	@ModelAttribute
-	public void addPublicPageAttributes(final Model model) {
-		model.addAttribute("recaptchaSiteKey", recaptchaSiteKey);
+		this.recaptchaVerificationService = recaptchaVerificationService;
 	}
 
 	@GetMapping(path = "/")
@@ -72,7 +58,7 @@ public class WebController {
 			return ResponseEntity.badRequest().body("Por favor, completa la verificación reCAPTCHA.");
 		}
 
-		if (!verifyRecaptcha(recaptchaResponse)) {
+		if (!recaptchaVerificationService.verifyToken(recaptchaResponse)) {
 			log.warn("reCAPTCHA verification failed");
 			return ResponseEntity.badRequest().body("La verificación reCAPTCHA falló. Por favor, intenta nuevamente.");
 		}
@@ -81,46 +67,6 @@ public class WebController {
 		log.info("Contact form submitted successfully: {}", LogRedaction.redactContactInquiry(saved.getId()));
 
 		return ResponseEntity.ok("OK");
-	}
-
-	private boolean verifyRecaptcha(final String recaptchaResponse) {
-		try {
-			final RecaptchaResponse response = restClient.post()
-				.uri(RECAPTCHA_VERIFY_URL + "?secret={secret}&response={response}", recaptchaSecretKey,
-						recaptchaResponse)
-				.retrieve()
-				.body(RecaptchaResponse.class);
-
-			if (response != null && Boolean.TRUE.equals(response.getSuccess())) {
-				log.debug("reCAPTCHA verification successful");
-				return true;
-			}
-			log.warn("reCAPTCHA verification failed: {}", response);
-			return false;
-		}
-		catch (Exception e) {
-			log.error("Error verifying reCAPTCHA", e);
-			return false;
-		}
-	}
-
-	/**
-	 * Response DTO for reCAPTCHA verification.
-	 */
-	@JsonIgnoreProperties(ignoreUnknown = true)
-	private static final class RecaptchaResponse {
-
-		private Boolean success;
-
-		public Boolean getSuccess() {
-			return this.success;
-		}
-
-		@SuppressWarnings("unused")
-		public void setSuccess(final Boolean success) {
-			this.success = success;
-		}
-
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/recaptcha/PublicRecaptchaForm.java
+++ b/src/main/java/com/nutriconsultas/recaptcha/PublicRecaptchaForm.java
@@ -1,0 +1,19 @@
+package com.nutriconsultas.recaptcha;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@link org.springframework.stereotype.Controller} that renders public forms
+ * protected by reCAPTCHA v2 (checkbox). Adds {@code recaptchaSiteKey} to the model for
+ * Thymeleaf widgets.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface PublicRecaptchaForm {
+
+}

--- a/src/main/java/com/nutriconsultas/recaptcha/PublicRecaptchaModelAdvice.java
+++ b/src/main/java/com/nutriconsultas/recaptcha/PublicRecaptchaModelAdvice.java
@@ -1,0 +1,22 @@
+package com.nutriconsultas.recaptcha;
+
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@ControllerAdvice(annotations = PublicRecaptchaForm.class)
+public class PublicRecaptchaModelAdvice {
+
+	private final RecaptchaProperties properties;
+
+	public PublicRecaptchaModelAdvice(final RecaptchaProperties properties) {
+		this.properties = properties;
+	}
+
+	@ModelAttribute
+	public void addRecaptchaAttributes(final Model model) {
+		model.addAttribute("recaptchaSiteKey", properties.getSiteKey());
+		model.addAttribute("recaptchaEnabled", properties.isConfigured());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/recaptcha/RecaptchaConfig.java
+++ b/src/main/java/com/nutriconsultas/recaptcha/RecaptchaConfig.java
@@ -1,0 +1,36 @@
+package com.nutriconsultas.recaptcha;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@EnableConfigurationProperties(RecaptchaProperties.class)
+@Slf4j
+public class RecaptchaConfig {
+
+	private final RecaptchaProperties properties;
+
+	public RecaptchaConfig(final RecaptchaProperties properties) {
+		this.properties = properties;
+	}
+
+	@PostConstruct
+	public void logRecaptchaConfiguration() {
+		if (!properties.isConfigured()) {
+			log.warn("reCAPTCHA is not fully configured (RECAPTCHA_SITE_KEY and/or RECAPTCHA_SECRET_KEY missing). "
+					+ "Public forms will reject submissions until production keys are set.");
+			return;
+		}
+		if (properties.isUsingGoogleTestKeys()) {
+			log.warn("reCAPTCHA is using Google's public test keys. Register production keys for minutriporcion.com "
+					+ "to remove the testing banner on public forms.");
+		}
+		else if (log.isInfoEnabled()) {
+			log.info("reCAPTCHA production keys are configured for public forms");
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/recaptcha/RecaptchaProperties.java
+++ b/src/main/java/com/nutriconsultas/recaptcha/RecaptchaProperties.java
@@ -1,0 +1,55 @@
+package com.nutriconsultas.recaptcha;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+@ConfigurationProperties(prefix = "recaptcha")
+public class RecaptchaProperties {
+
+	public static final String GOOGLE_TEST_SITE_KEY = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI";
+
+	public static final String GOOGLE_TEST_SECRET_KEY = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe";
+
+	private String siteKey = GOOGLE_TEST_SITE_KEY;
+
+	private String secretKey = GOOGLE_TEST_SECRET_KEY;
+
+	private boolean verificationEnabled = true;
+
+	public String getSiteKey() {
+		return siteKey;
+	}
+
+	public void setSiteKey(final String siteKey) {
+		if (StringUtils.hasText(siteKey)) {
+			this.siteKey = siteKey.trim();
+		}
+	}
+
+	public String getSecretKey() {
+		return secretKey;
+	}
+
+	public void setSecretKey(final String secretKey) {
+		if (StringUtils.hasText(secretKey)) {
+			this.secretKey = secretKey.trim();
+		}
+	}
+
+	public boolean isVerificationEnabled() {
+		return verificationEnabled;
+	}
+
+	public void setVerificationEnabled(final boolean verificationEnabled) {
+		this.verificationEnabled = verificationEnabled;
+	}
+
+	public boolean isConfigured() {
+		return StringUtils.hasText(siteKey) && StringUtils.hasText(secretKey);
+	}
+
+	public boolean isUsingGoogleTestKeys() {
+		return GOOGLE_TEST_SITE_KEY.equals(siteKey) || GOOGLE_TEST_SECRET_KEY.equals(secretKey);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/recaptcha/RecaptchaVerificationService.java
+++ b/src/main/java/com/nutriconsultas/recaptcha/RecaptchaVerificationService.java
@@ -1,0 +1,75 @@
+package com.nutriconsultas.recaptcha;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class RecaptchaVerificationService {
+
+	private static final String VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify";
+
+	private final RestClient restClient;
+
+	private final RecaptchaProperties properties;
+
+	public RecaptchaVerificationService(final RecaptchaProperties properties) {
+		this.properties = properties;
+		this.restClient = RestClient.create();
+	}
+
+	public boolean verifyToken(final String token) {
+		if (!StringUtils.hasText(token)) {
+			return false;
+		}
+		if (!properties.isVerificationEnabled()) {
+			log.warn("reCAPTCHA verification skipped because recaptcha.verification-enabled=false");
+			return true;
+		}
+		if (!properties.isConfigured()) {
+			log.error("reCAPTCHA verification failed: site key or secret key is not configured");
+			return false;
+		}
+		try {
+			final RecaptchaVerifyResponse response = restClient.post()
+				.uri(VERIFY_URL + "?secret={secret}&response={response}", properties.getSecretKey(), token)
+				.retrieve()
+				.body(RecaptchaVerifyResponse.class);
+
+			if (response != null && Boolean.TRUE.equals(response.getSuccess())) {
+				if (log.isDebugEnabled()) {
+					log.debug("reCAPTCHA verification successful");
+				}
+				return true;
+			}
+			log.warn("reCAPTCHA verification rejected by Google");
+			return false;
+		}
+		catch (Exception e) {
+			log.error("Error verifying reCAPTCHA", e);
+			return false;
+		}
+	}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	private static final class RecaptchaVerifyResponse {
+
+		private Boolean success;
+
+		public Boolean getSuccess() {
+			return success;
+		}
+
+		@SuppressWarnings("unused")
+		public void setSuccess(final Boolean success) {
+			this.success = success;
+		}
+
+	}
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -53,9 +53,12 @@ resilience4j.ratelimiter.instances.patientMessages.timeout-duration=0s
 app.auth0.management.client-id=${AUTH0_MGMT_CLIENT_ID:}
 app.auth0.management.client-secret=${AUTH0_MGMT_CLIENT_SECRET:}
 app.auth0.management.domain=${AUTH0_MGMT_DOMAIN:${AUTH_ISSUER}}
-# reCAPTCHA configuration
+# reCAPTCHA v2 checkbox — public contact form and future public booking (#243, #248)
+# Register keys at https://www.google.com/recaptcha/admin for minutriporcion.com (production).
+# Local dev defaults to Google's public test pair; set RECAPTCHA_* in .env for production-like QA.
 recaptcha.site-key=${RECAPTCHA_SITE_KEY:6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI}
-recaptcha.secret-key=${RECAPTCHA_SECRET_KEY}
+recaptcha.secret-key=${RECAPTCHA_SECRET_KEY:6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe}
+recaptcha.verification-enabled=${RECAPTCHA_VERIFICATION_ENABLED:true}
 # Platform administrators (Auth0 sub claims or OAuth login emails, comma-separated)
 nutriconsultas.platform.admin-user-ids=${PLATFORM_ADMIN_USER_IDS:}
 nutriconsultas.platform.admin-emails=${PLATFORM_ADMIN_EMAILS:}

--- a/src/test/java/com/nutriconsultas/controller/WebControllerTest.java
+++ b/src/test/java/com/nutriconsultas/controller/WebControllerTest.java
@@ -12,6 +12,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -25,6 +27,16 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @ActiveProfiles("test")
 public class WebControllerTest {
+
+	private static final String TEST_SITE_KEY = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI";
+
+	private static final String TEST_SECRET_KEY = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe";
+
+	@DynamicPropertySource
+	static void recaptchaTestKeys(final DynamicPropertyRegistry registry) {
+		registry.add("recaptcha.site-key", () -> TEST_SITE_KEY);
+		registry.add("recaptcha.secret-key", () -> TEST_SECRET_KEY);
+	}
 
 	@Autowired
 	private MockMvc mockMvc;

--- a/src/test/java/com/nutriconsultas/recaptcha/RecaptchaPropertiesTest.java
+++ b/src/test/java/com/nutriconsultas/recaptcha/RecaptchaPropertiesTest.java
@@ -1,0 +1,39 @@
+package com.nutriconsultas.recaptcha;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RecaptchaPropertiesTest {
+
+	@Test
+	void isConfiguredWhenBothKeysPresent() {
+		final RecaptchaProperties properties = new RecaptchaProperties();
+		properties.setSiteKey("6Lprod-site-key");
+		properties.setSecretKey("6Lprod-secret-key");
+
+		assertThat(properties.isConfigured()).isTrue();
+		assertThat(properties.isUsingGoogleTestKeys()).isFalse();
+	}
+
+	@Test
+	void ignoresBlankSiteKeyOverride() {
+		final RecaptchaProperties properties = new RecaptchaProperties();
+		properties.setSiteKey("   ");
+
+		assertThat(properties.getSiteKey()).isEqualTo(RecaptchaProperties.GOOGLE_TEST_SITE_KEY);
+		assertThat(properties.isConfigured()).isTrue();
+	}
+
+	@Test
+	void detectsGoogleTestKeys() {
+		final RecaptchaProperties properties = new RecaptchaProperties();
+
+		assertThat(properties.isUsingGoogleTestKeys()).isTrue();
+		assertThat(properties.isConfigured()).isTrue();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/recaptcha/RecaptchaVerificationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/recaptcha/RecaptchaVerificationServiceTest.java
@@ -1,0 +1,42 @@
+package com.nutriconsultas.recaptcha;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RecaptchaVerificationServiceTest {
+
+	private RecaptchaProperties properties;
+
+	private RecaptchaVerificationService service;
+
+	@BeforeEach
+	void setUp() {
+		properties = new RecaptchaProperties();
+		service = new RecaptchaVerificationService(properties);
+	}
+
+	@Test
+	void verifyTokenRejectsBlankToken() {
+		assertThat(service.verifyToken(null)).isFalse();
+		assertThat(service.verifyToken("")).isFalse();
+		assertThat(service.verifyToken("   ")).isFalse();
+	}
+
+	@Test
+	void verifyTokenRejectsWhenKeysNotConfigured() {
+		properties.setSiteKey("");
+		properties.setSecretKey("secret");
+
+		assertThat(service.verifyToken("token")).isFalse();
+	}
+
+	@Test
+	void verifyTokenSkipsWhenVerificationDisabled() {
+		properties.setVerificationEnabled(false);
+
+		assertThat(service.verifyToken("any-token")).isTrue();
+	}
+
+}


### PR DESCRIPTION
## Summary
- Extract shared `RecaptchaVerificationService`, `@PublicRecaptchaForm`, and `PublicRecaptchaModelAdvice` for the contact form and future public booking (#248).
- Document and ship `ssm-update-recaptcha-keys.sh` for brownfield EC2 `RECAPTCHA_*` updates.
- Production EC2 already configured with minutriporcion.com reCAPTCHA keys (no testing banner on contact form).

Fixes #243

## Test plan
- [x] `RecaptchaPropertiesTest`, `RecaptchaVerificationServiceTest`, `WebControllerTest`
- [x] `./lint.sh` (checkstyle, PMD, SpotBugs, Thymeleaf)
- [x] Production contact page serves production `data-sitekey` (not Google test keys)
- [ ] Manual: submit contact form on https://minutriporcion.com/contact after merge


Made with [Cursor](https://cursor.com)