### PR TITLE
[Public Booking] Calendar — unavailable days and absence windows (#247)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -39,7 +39,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) | `[Public Booking]` epic #245–#248 |
 | [`docs/public-booking/AVAILABILITY.md`](docs/public-booking/AVAILABILITY.md) | Working hours model, timezone, REST (#246) |
 
-**Current next issue (public booking):** [#247 — calendar unavailable days and absence windows](https://github.com/diego-torres/nutriconsultas/issues/247). ~~#246~~ done (branch `issue-246-working-hours`). See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
+**Current next issue (public booking):** [#248 — public slot picker and appointment booking](https://github.com/diego-torres/nutriconsultas/issues/248). ~~#246~~, ~~#247~~ done (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)). See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
 **Current next issue (mobile):** [#134 — POST /rest/mobile/invitations](https://github.com/diego-torres/nutriconsultas/issues/134). ~~#133~~ done (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -606,7 +606,7 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 ## Public booking (tracking)
 
-Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done** (branch `issue-246-working-hours`). **NEXT:** [#247 calendar blocks](https://github.com/diego-torres/nutriconsultas/issues/247) → #248.
+Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)). **NEXT:** [#248 public slot picker + booking](https://github.com/diego-torres/nutriconsultas/issues/248).
 
 ## Resources
 

--- a/ISSUE-PUBLIC-BOOKING.md
+++ b/ISSUE-PUBLIC-BOOKING.md
@@ -3,7 +3,7 @@
 Living index of GitHub issues for **public appointment scheduling** — shareable links, nutritionist availability, and patient self-booking. Update when status changes (commit on the PR that closes work).
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
-**Last updated:** 2026-06-21 — ~~#246~~ **done** (branch `issue-246-working-hours`). **NEXT:** #247. Epic **#245** with child issues **#246–#248** registered.
+**Last updated:** 2026-06-21 — ~~#246~~ **done**; ~~#247~~ **in-progress** (`issue-247-availability-blocks`). **NEXT:** #248 after #247 merge. Epic **#245** with child issues **#246–#248** registered.
 
 > **Scope.** Public routes (`/consultas/{id}/agendar-cita` or equivalent), availability configuration, and calendar blocks. Nutritionist admin UI pieces may live in `/admin/**` but this track owns the **public booking product**. Mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Nutritionist web (non-booking): [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
@@ -40,8 +40,8 @@ Shareable URL for patients to book into a nutritionist's real availability:
 |---|-------|-----|-------|-----------|-------|
 | **245** | Epic — public appointment scheduling link per nutritionist | https://github.com/diego-torres/nutriconsultas/issues/245 | open | — | New track; Liquibase for availability + public slug |
 | **246** | Nutritionist profile — configure working hours and availability | https://github.com/diego-torres/nutriconsultas/issues/246 | **done** | **245** | Branch `issue-246-working-hours`; `GET/PUT /rest/profile/availability`; Liquibase `014` |
-| **247** | Calendar — unavailable days and absence windows | https://github.com/diego-torres/nutriconsultas/issues/247 | **NEXT** | **246** | Blocks subtract from public slots |
-| 248 | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | open | **246**, **247**, ~~**243**~~ | reCAPTCHA via `@PublicRecaptchaForm`; opaque public id |
+| **247** | Calendar — unavailable days and absence windows | https://github.com/diego-torres/nutriconsultas/issues/247 | **in-progress** | **246** | Branch `issue-247-availability-blocks`; blocks table + slot API |
+| 248 | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | open | **246**, ~~**247**~~, ~~**243**~~ | reCAPTCHA via `@PublicRecaptchaForm`; opaque public id |
 
 ---
 

--- a/ISSUE-PUBLIC-BOOKING.md
+++ b/ISSUE-PUBLIC-BOOKING.md
@@ -3,7 +3,7 @@
 Living index of GitHub issues for **public appointment scheduling** — shareable links, nutritionist availability, and patient self-booking. Update when status changes (commit on the PR that closes work).
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
-**Last updated:** 2026-06-21 — ~~#246~~ **done**; ~~#247~~ **in-progress** (`issue-247-availability-blocks`). **NEXT:** #248 after #247 merge. Epic **#245** with child issues **#246–#248** registered.
+**Last updated:** 2026-06-20 — ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)). **NEXT:** #248. Epic **#245** with child issues **#246–#248** registered.
 
 > **Scope.** Public routes (`/consultas/{id}/agendar-cita` or equivalent), availability configuration, and calendar blocks. Nutritionist admin UI pieces may live in `/admin/**` but this track owns the **public booking product**. Mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Nutritionist web (non-booking): [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
@@ -40,8 +40,8 @@ Shareable URL for patients to book into a nutritionist's real availability:
 |---|-------|-----|-------|-----------|-------|
 | **245** | Epic — public appointment scheduling link per nutritionist | https://github.com/diego-torres/nutriconsultas/issues/245 | open | — | New track; Liquibase for availability + public slug |
 | **246** | Nutritionist profile — configure working hours and availability | https://github.com/diego-torres/nutriconsultas/issues/246 | **done** | **245** | Branch `issue-246-working-hours`; `GET/PUT /rest/profile/availability`; Liquibase `014` |
-| **247** | Calendar — unavailable days and absence windows | https://github.com/diego-torres/nutriconsultas/issues/247 | **in-progress** | **246** | Branch `issue-247-availability-blocks`; blocks table + slot API |
-| 248 | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | open | **246**, ~~**247**~~, ~~**243**~~ | reCAPTCHA via `@PublicRecaptchaForm`; opaque public id |
+| **247** | Calendar — unavailable days and absence windows | https://github.com/diego-torres/nutriconsultas/issues/247 | **done** | **246** | PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295); Liquibase `015`, blocks API, slot query |
+| **248** | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | **NEXT** | **246**, ~~**247**~~, ~~**243**~~ | reCAPTCHA via `@PublicRecaptchaForm`; opaque public id |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-21):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: all registered epics **complete** (#221–#242, #271–#272). Public booking **NEXT:** [#247](https://github.com/diego-torres/nutriconsultas/issues/247); ~~#246~~ done (branch `issue-246-working-hours`).
+**On `main` (2026-06-20):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: all registered epics **complete** (#221–#242, #271–#272). Public booking **NEXT:** [#248](https://github.com/diego-torres/nutriconsultas/issues/248); ~~#246~~, ~~#247~~ done (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)).
 
 ## AWS (production infrastructure)
 

--- a/docs/public-booking/AVAILABILITY.md
+++ b/docs/public-booking/AVAILABILITY.md
@@ -22,4 +22,25 @@ Public slot APIs (#248) must convert `LocalDate` + slot start `LocalTime` using 
 
 ## Slot generation
 
-`BookingSlotGenerator.generateSlotStarts(intervals, slotDurationMinutes)` produces sorted slot start times that fit entirely within configured intervals. Used by unit tests now; public booking (#248) will subtract calendar events and absence blocks (#247).
+`BookingSlotGenerator.generateSlotStarts(intervals, slotDurationMinutes)` produces sorted slot start times that fit entirely within configured intervals.
+
+`BookingAvailabilitySlotService.getAvailableSlotStarts(userId, date)` applies working hours, then subtracts:
+
+- `nutritionist_availability_block` rows for that nutritionist (#247)
+- `CalendarEvent` rows with status `SCHEDULED` for that nutritionist's patients
+
+Authenticated preview: `GET /rest/profile/availability/slots?date=YYYY-MM-DD` (same slot list public booking #248 will expose per nutritionist).
+
+## Absence blocks (#247)
+
+| Table | Purpose |
+|-------|---------|
+| `nutritionist_availability_block` | Full-day or time-range unavailability per OAuth `user_id` |
+
+REST (authenticated, calendar UI):
+
+- `GET /rest/calendario/blocks?start=&end=` — FullCalendar feed (merged client-side with appointments)
+- `POST /rest/calendario/blocks` — create block
+- `DELETE /rest/calendario/blocks/{id}` — remove block (SweetAlert confirm in UI)
+
+Admin UI: `/admin/calendario` → **Marcar ausencia**; blocked intervals render in gray with striped styling.

--- a/src/main/java/com/nutriconsultas/booking/AvailabilityBlockDto.java
+++ b/src/main/java/com/nutriconsultas/booking/AvailabilityBlockDto.java
@@ -1,0 +1,27 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalDateTime;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class AvailabilityBlockDto {
+
+	private Long id;
+
+	@NotBlank
+	@Size(max = 200)
+	private String title;
+
+	private boolean allDay;
+
+	@NotNull
+	private LocalDateTime startDateTime;
+
+	@NotNull
+	private LocalDateTime endDateTime;
+
+}

--- a/src/main/java/com/nutriconsultas/booking/AvailabilityBlockValidator.java
+++ b/src/main/java/com/nutriconsultas/booking/AvailabilityBlockValidator.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalDateTime;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Validates nutritionist absence / day-off blocks (#247).
+ */
+public final class AvailabilityBlockValidator {
+
+	private AvailabilityBlockValidator() {
+	}
+
+	public static void validate(final AvailabilityBlockDto block) {
+		if (block == null) {
+			throw new IllegalArgumentException("El bloqueo de disponibilidad es obligatorio");
+		}
+		if (!StringUtils.hasText(block.getTitle())) {
+			throw new IllegalArgumentException("El título del bloqueo es obligatorio");
+		}
+		if (block.getStartDateTime() == null || block.getEndDateTime() == null) {
+			throw new IllegalArgumentException("La fecha de inicio y fin son obligatorias");
+		}
+		if (block.isAllDay()) {
+			normalizeAllDay(block);
+			return;
+		}
+		if (!block.getEndDateTime().isAfter(block.getStartDateTime())) {
+			throw new IllegalArgumentException("La fecha de fin debe ser posterior a la de inicio");
+		}
+	}
+
+	private static void normalizeAllDay(final AvailabilityBlockDto block) {
+		final LocalDateTime start = block.getStartDateTime().toLocalDate().atStartOfDay();
+		final LocalDateTime end = block.getEndDateTime().toLocalDate().plusDays(1).atStartOfDay();
+		block.setStartDateTime(start);
+		block.setEndDateTime(end);
+		if (!end.isAfter(start)) {
+			throw new IllegalArgumentException("El bloqueo de día completo debe abarcar al menos un día");
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/BookingAvailabilitySlotService.java
+++ b/src/main/java/com/nutriconsultas/booking/BookingAvailabilitySlotService.java
@@ -1,0 +1,17 @@
+package com.nutriconsultas.booking;
+
+import org.springframework.lang.NonNull;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+public interface BookingAvailabilitySlotService {
+
+	List<LocalTime> getAvailableSlotStarts(@NonNull String userId, @NonNull LocalDate date);
+
+	LocalDateTime findNextAvailableStart(@NonNull String userId, @NonNull LocalDate date,
+			@NonNull LocalDateTime notBefore);
+
+}

--- a/src/main/java/com/nutriconsultas/booking/BookingAvailabilitySlotServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/booking/BookingAvailabilitySlotServiceImpl.java
@@ -1,0 +1,91 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.calendar.CalendarEventRepository;
+import com.nutriconsultas.calendar.EventStatus;
+
+@Service
+public class BookingAvailabilitySlotServiceImpl implements BookingAvailabilitySlotService {
+
+	private final NutritionistAvailabilityService availabilityService;
+
+	private final NutritionistAvailabilityBlockRepository blockRepository;
+
+	private final CalendarEventRepository calendarEventRepository;
+
+	public BookingAvailabilitySlotServiceImpl(final NutritionistAvailabilityService availabilityService,
+			final NutritionistAvailabilityBlockRepository blockRepository,
+			final CalendarEventRepository calendarEventRepository) {
+		this.availabilityService = availabilityService;
+		this.blockRepository = blockRepository;
+		this.calendarEventRepository = calendarEventRepository;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<LocalTime> getAvailableSlotStarts(@NonNull final String userId, @NonNull final LocalDate date) {
+		final AvailabilityScheduleDto schedule = availabilityService.getSchedule(userId);
+		final ZoneId zoneId = ZoneId.of(schedule.getTimezone());
+		final int dayOfWeek = date.getDayOfWeek().getValue();
+		final List<WorkingHoursIntervalDto> dayIntervals = schedule.getIntervals()
+			.stream()
+			.filter(interval -> dayOfWeek == interval.getDayOfWeek())
+			.toList();
+		final List<LocalTime> rawSlots = BookingSlotGenerator.generateSlotStarts(dayIntervals,
+				schedule.getSlotDurationMinutes());
+		final List<BusyTimeInterval> busyIntervals = loadBusyIntervals(userId, date, zoneId);
+		return BookingSlotFilter.removeBusySlots(rawSlots, date, schedule.getSlotDurationMinutes(), busyIntervals);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public LocalDateTime findNextAvailableStart(@NonNull final String userId, @NonNull final LocalDate date,
+			@NonNull final LocalDateTime notBefore) {
+		final List<LocalTime> slots = getAvailableSlotStarts(userId, date);
+		for (final LocalTime slotStart : slots) {
+			final LocalDateTime candidate = date.atTime(slotStart);
+			if (!candidate.isBefore(notBefore)) {
+				return candidate;
+			}
+		}
+		return null;
+	}
+
+	private List<BusyTimeInterval> loadBusyIntervals(final String userId, final LocalDate date, final ZoneId zoneId) {
+		final LocalDateTime dayStart = date.atStartOfDay();
+		final LocalDateTime dayEnd = date.plusDays(1).atStartOfDay();
+		final List<BusyTimeInterval> busy = new ArrayList<>();
+
+		for (final NutritionistAvailabilityBlock block : blockRepository.findOverlappingRange(userId, dayStart,
+				dayEnd)) {
+			busy.add(new BusyTimeInterval(block.getStartDateTime(), block.getEndDateTime()));
+		}
+
+		final Date rangeStart = Date.from(dayStart.atZone(zoneId).toInstant());
+		final Date rangeEnd = Date.from(dayEnd.atZone(zoneId).toInstant());
+		final List<CalendarEvent> events = calendarEventRepository.findByUserIdAndDateRange(userId, rangeStart,
+				rangeEnd);
+		for (final CalendarEvent event : events) {
+			if (event.getStatus() != EventStatus.SCHEDULED || event.getEventDateTime() == null) {
+				continue;
+			}
+			final LocalDateTime eventStart = event.getEventDateTime().toInstant().atZone(zoneId).toLocalDateTime();
+			final int durationMinutes = event.getDurationMinutes() != null ? event.getDurationMinutes() : 60;
+			busy.add(new BusyTimeInterval(eventStart, eventStart.plusMinutes(durationMinutes)));
+		}
+		return busy;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/BookingSlotFilter.java
+++ b/src/main/java/com/nutriconsultas/booking/BookingSlotFilter.java
@@ -1,0 +1,46 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Removes slot starts that overlap busy intervals (absence blocks, appointments) (#247).
+ */
+public final class BookingSlotFilter {
+
+	private BookingSlotFilter() {
+	}
+
+	public static List<LocalTime> removeBusySlots(final List<LocalTime> slotStarts, final LocalDate date,
+			final int slotDurationMinutes, final List<BusyTimeInterval> busyIntervals) {
+		if (slotStarts == null || slotStarts.isEmpty()) {
+			return List.of();
+		}
+		if (busyIntervals == null || busyIntervals.isEmpty()) {
+			return List.copyOf(slotStarts);
+		}
+		final List<LocalTime> available = new ArrayList<>();
+		for (final LocalTime slotStart : slotStarts) {
+			final LocalDateTime start = date.atTime(slotStart);
+			final LocalDateTime end = start.plusMinutes(slotDurationMinutes);
+			if (!isBusy(start, end, busyIntervals)) {
+				available.add(slotStart);
+			}
+		}
+		return List.copyOf(available);
+	}
+
+	private static boolean isBusy(final LocalDateTime slotStart, final LocalDateTime slotEnd,
+			final List<BusyTimeInterval> busyIntervals) {
+		for (final BusyTimeInterval busy : busyIntervals) {
+			if (busy.overlaps(slotStart, slotEnd)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/BusyTimeInterval.java
+++ b/src/main/java/com/nutriconsultas/booking/BusyTimeInterval.java
@@ -1,0 +1,24 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalDateTime;
+
+/**
+ * Half-open interval {@code [start, end)} used when subtracting busy windows from
+ * bookable slots.
+ */
+public record BusyTimeInterval(LocalDateTime start, LocalDateTime end) {
+
+	public BusyTimeInterval {
+		if (start == null || end == null) {
+			throw new IllegalArgumentException("Busy interval bounds are required");
+		}
+		if (!end.isAfter(start)) {
+			throw new IllegalArgumentException("Busy interval end must be after start");
+		}
+	}
+
+	public boolean overlaps(final LocalDateTime intervalStart, final LocalDateTime intervalEnd) {
+		return intervalStart.isBefore(end) && intervalEnd.isAfter(start);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityBlock.java
+++ b/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityBlock.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Nutritionist absence or day-off window that removes slots from public booking (#247).
+ */
+@Entity
+@Table(name = "nutritionist_availability_block")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NutritionistAvailabilityBlock {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "user_id", nullable = false, length = 255)
+	private String userId;
+
+	@Column(nullable = false, length = 200)
+	private String title;
+
+	@Column(name = "all_day", nullable = false)
+	private boolean allDay;
+
+	@Column(name = "start_date_time", nullable = false)
+	private LocalDateTime startDateTime;
+
+	@Column(name = "end_date_time", nullable = false)
+	private LocalDateTime endDateTime;
+
+}

--- a/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityBlockRepository.java
+++ b/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityBlockRepository.java
@@ -1,0 +1,22 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NutritionistAvailabilityBlockRepository extends JpaRepository<NutritionistAvailabilityBlock, Long> {
+
+	@Query("SELECT b FROM NutritionistAvailabilityBlock b WHERE b.userId = :userId "
+			+ "AND b.endDateTime > :rangeStart AND b.startDateTime < :rangeEnd " + "ORDER BY b.startDateTime ASC")
+	List<NutritionistAvailabilityBlock> findOverlappingRange(@Param("userId") String userId,
+			@Param("rangeStart") LocalDateTime rangeStart, @Param("rangeEnd") LocalDateTime rangeEnd);
+
+	Optional<NutritionistAvailabilityBlock> findByIdAndUserId(Long id, String userId);
+
+}

--- a/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityBlockRestController.java
+++ b/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityBlockRestController.java
@@ -1,0 +1,156 @@
+package com.nutriconsultas.booking;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/calendario/blocks")
+@Slf4j
+public class NutritionistAvailabilityBlockRestController {
+
+	private static final String BLOCK_COLOR = "#858796";
+
+	private final NutritionistAvailabilityBlockService blockService;
+
+	public NutritionistAvailabilityBlockRestController(final NutritionistAvailabilityBlockService blockService) {
+		this.blockService = blockService;
+	}
+
+	@GetMapping
+	public List<Map<String, Object>> listBlocks(
+			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) final Date start,
+			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) final Date end,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = getUserId(principal);
+		if (userId == null || start == null || end == null) {
+			return List.of();
+		}
+		final ZoneId zoneId = ZoneId.systemDefault();
+		final LocalDateTime rangeStart = start.toInstant().atZone(zoneId).toLocalDateTime();
+		final LocalDateTime rangeEnd = end.toInstant().atZone(zoneId).toLocalDateTime();
+		return blockService.findBlocksInRange(userId, rangeStart, rangeEnd)
+			.stream()
+			.map(this::toCalendarBlockMap)
+			.collect(Collectors.toList());
+	}
+
+	@PostMapping
+	public ResponseEntity<Map<String, Object>> createBlock(@Valid @RequestBody final AvailabilityBlockDto block,
+			final BindingResult bindingResult, @AuthenticationPrincipal final OidcUser principal) {
+		final String userId = getUserId(principal);
+		if (userId == null) {
+			return unauthorized();
+		}
+		if (bindingResult.hasErrors()) {
+			return badRequest("Datos del bloqueo no válidos");
+		}
+		try {
+			final AvailabilityBlockDto saved = blockService.createBlock(userId, block);
+			final Map<String, Object> response = new HashMap<>();
+			response.put("success", true);
+			response.put("block", toCalendarBlockMapFromDto(saved));
+			return ResponseEntity.ok(response);
+		}
+		catch (final IllegalArgumentException ex) {
+			log.debug("Block validation failed");
+			return badRequest(ex.getMessage());
+		}
+	}
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<Map<String, Object>> deleteBlock(@PathVariable final Long id,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = getUserId(principal);
+		if (userId == null) {
+			return unauthorized();
+		}
+		try {
+			blockService.deleteBlock(userId, id);
+			final Map<String, Object> response = new HashMap<>();
+			response.put("success", true);
+			return ResponseEntity.ok(response);
+		}
+		catch (final IllegalArgumentException ex) {
+			return badRequest(ex.getMessage());
+		}
+	}
+
+	private Map<String, Object> toCalendarBlockMap(final NutritionistAvailabilityBlock block) {
+		return toCalendarBlockMapFromDto(NutritionistAvailabilityBlockServiceImpl.toDto(block));
+	}
+
+	private Map<String, Object> toCalendarBlockMapFromDto(final AvailabilityBlockDto block) {
+		final Map<String, Object> eventMap = new HashMap<>();
+		eventMap.put("id", "block-" + block.getId());
+		eventMap.put("title", block.getTitle());
+		eventMap.put("start", formatDateTime(block.getStartDateTime()));
+		eventMap.put("end", formatDateTime(block.getEndDateTime()));
+		eventMap.put("allDay", block.isAllDay());
+		eventMap.put("backgroundColor", BLOCK_COLOR);
+		eventMap.put("borderColor", BLOCK_COLOR);
+		eventMap.put("classNames", List.of("availability-block-event"));
+		final Map<String, Object> extendedProps = new HashMap<>();
+		extendedProps.put("type", "BLOCK");
+		extendedProps.put("blockId", block.getId());
+		extendedProps.put("title", block.getTitle());
+		extendedProps.put("allDay", block.isAllDay());
+		eventMap.put("extendedProps", extendedProps);
+		return eventMap;
+	}
+
+	private static String formatDateTime(final LocalDateTime dateTime) {
+		if (dateTime == null) {
+			return null;
+		}
+		final Date date = Date.from(dateTime.atZone(ZoneId.systemDefault()).toInstant());
+		final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+		return dateFormat.format(date);
+	}
+
+	private static String getUserId(final OidcUser principal) {
+		if (principal == null) {
+			return null;
+		}
+		return principal.getSubject();
+	}
+
+	private static ResponseEntity<Map<String, Object>> unauthorized() {
+		final Map<String, Object> body = new HashMap<>();
+		body.put("success", false);
+		body.put("error", "User not authenticated");
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+	}
+
+	private static ResponseEntity<Map<String, Object>> badRequest(final String message) {
+		final Map<String, Object> body = new HashMap<>();
+		body.put("success", false);
+		body.put("error", message);
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityBlockService.java
+++ b/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityBlockService.java
@@ -1,0 +1,17 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.lang.NonNull;
+
+public interface NutritionistAvailabilityBlockService {
+
+	List<NutritionistAvailabilityBlock> findBlocksInRange(@NonNull String userId, @NonNull LocalDateTime rangeStart,
+			@NonNull LocalDateTime rangeEnd);
+
+	AvailabilityBlockDto createBlock(@NonNull String userId, @NonNull AvailabilityBlockDto block);
+
+	void deleteBlock(@NonNull String userId, @NonNull Long blockId);
+
+}

--- a/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityBlockServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityBlockServiceImpl.java
@@ -1,0 +1,69 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class NutritionistAvailabilityBlockServiceImpl implements NutritionistAvailabilityBlockService {
+
+	private final NutritionistAvailabilityBlockRepository blockRepository;
+
+	public NutritionistAvailabilityBlockServiceImpl(final NutritionistAvailabilityBlockRepository blockRepository) {
+		this.blockRepository = blockRepository;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<NutritionistAvailabilityBlock> findBlocksInRange(@NonNull final String userId,
+			@NonNull final LocalDateTime rangeStart, @NonNull final LocalDateTime rangeEnd) {
+		return blockRepository.findOverlappingRange(userId, rangeStart, rangeEnd);
+	}
+
+	@Override
+	@Transactional
+	public AvailabilityBlockDto createBlock(@NonNull final String userId, @NonNull final AvailabilityBlockDto block) {
+		AvailabilityBlockValidator.validate(block);
+		final NutritionistAvailabilityBlock entity = new NutritionistAvailabilityBlock();
+		entity.setUserId(userId);
+		entity.setTitle(block.getTitle().trim());
+		entity.setAllDay(block.isAllDay());
+		entity.setStartDateTime(block.getStartDateTime());
+		entity.setEndDateTime(block.getEndDateTime());
+		final NutritionistAvailabilityBlock saved = blockRepository.save(entity);
+		if (log.isInfoEnabled()) {
+			log.info("Created availability block id={} for user {}", saved.getId(), LogRedaction.redactUserId(userId));
+		}
+		return toDto(saved);
+	}
+
+	@Override
+	@Transactional
+	public void deleteBlock(@NonNull final String userId, @NonNull final Long blockId) {
+		final NutritionistAvailabilityBlock block = blockRepository.findByIdAndUserId(blockId, userId)
+			.orElseThrow(() -> new IllegalArgumentException("Bloqueo no encontrado"));
+		blockRepository.delete(block);
+		if (log.isInfoEnabled()) {
+			log.info("Deleted availability block id={} for user {}", blockId, LogRedaction.redactUserId(userId));
+		}
+	}
+
+	static AvailabilityBlockDto toDto(final NutritionistAvailabilityBlock block) {
+		final AvailabilityBlockDto dto = new AvailabilityBlockDto();
+		dto.setId(block.getId());
+		dto.setTitle(block.getTitle());
+		dto.setAllDay(block.isAllDay());
+		dto.setStartDateTime(block.getStartDateTime());
+		dto.setEndDateTime(block.getEndDateTime());
+		return dto;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityRestController.java
+++ b/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityRestController.java
@@ -12,20 +12,35 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/rest/profile/availability")
 @Slf4j
 public class NutritionistAvailabilityRestController {
 
+	private static final DateTimeFormatter SLOT_TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm");
+
 	private final NutritionistAvailabilityService availabilityService;
 
-	public NutritionistAvailabilityRestController(final NutritionistAvailabilityService availabilityService) {
+	private final BookingAvailabilitySlotService bookingAvailabilitySlotService;
+
+	public NutritionistAvailabilityRestController(final NutritionistAvailabilityService availabilityService,
+			final BookingAvailabilitySlotService bookingAvailabilitySlotService) {
 		this.availabilityService = availabilityService;
+		this.bookingAvailabilitySlotService = bookingAvailabilitySlotService;
 	}
 
 	@GetMapping
@@ -52,6 +67,27 @@ public class NutritionistAvailabilityRestController {
 		catch (final IllegalArgumentException ex) {
 			log.debug("Availability validation failed for user request");
 			return validationErrorResponse(ex.getMessage());
+		}
+	}
+
+	@GetMapping("/slots")
+	public ResponseEntity<Map<String, Object>> getAvailableSlots(@AuthenticationPrincipal final OidcUser principal,
+			@RequestParam final String date) {
+		if (principal == null || principal.getSubject() == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
+		try {
+			final LocalDate parsedDate = LocalDate.parse(date);
+			final List<LocalTime> slots = bookingAvailabilitySlotService.getAvailableSlotStarts(principal.getSubject(),
+					parsedDate);
+			final Map<String, Object> body = new HashMap<>();
+			body.put("date", parsedDate.toString());
+			body.put("slots", slots.stream().map(SLOT_TIME_FORMAT::format).collect(Collectors.toList()));
+			return ResponseEntity.ok(body);
+		}
+		catch (final Exception ex) {
+			log.debug("Invalid slot query date");
+			return validationErrorResponse("Fecha no válida");
 		}
 	}
 

--- a/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityRestController.java
+++ b/src/main/java/com/nutriconsultas/booking/NutritionistAvailabilityRestController.java
@@ -1,7 +1,12 @@
 package com.nutriconsultas.booking;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,14 +22,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/rest/profile/availability")

--- a/src/main/java/com/nutriconsultas/calendar/CalendarEventRestController.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarEventRestController.java
@@ -33,6 +33,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nutriconsultas.booking.BookingAvailabilitySlotService;
 import com.nutriconsultas.controller.AbstractGridController;
 import com.nutriconsultas.dataTables.paging.Column;
 import com.nutriconsultas.dataTables.paging.Direction;
@@ -63,6 +64,9 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 
 	@Autowired
 	private BodyFatCalculatorService bodyFatCalculatorService;
+
+	@Autowired
+	private BookingAvailabilitySlotService bookingAvailabilitySlotService;
 
 	@Override
 	protected List<String> toStringList(final CalendarEvent row) {
@@ -295,11 +299,18 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 	}
 
 	@GetMapping("/next-available-time")
-	public Map<String, Object> getNextAvailableTime(@RequestParam final String date) {
+	public Map<String, Object> getNextAvailableTime(@RequestParam final String date,
+			@AuthenticationPrincipal final OidcUser principal) {
 		log.debug("Finding next available time for date: {}", date);
+		final String userId = getUserId(principal);
+		if (userId == null) {
+			final Map<String, Object> errorResult = new HashMap<>();
+			errorResult.put("available", false);
+			errorResult.put("error", "User not authenticated");
+			return errorResult;
+		}
 		LocalDate parsedLocalDate;
 		try {
-			// Parse date string (format: YYYY-MM-DD)
 			parsedLocalDate = LocalDate.parse(date);
 		}
 		catch (final java.time.format.DateTimeParseException e) {
@@ -310,88 +321,39 @@ public class CalendarEventRestController extends AbstractGridController<Calendar
 			return errorResult;
 		}
 
-		LocalDateTime candidateTime = parsedLocalDate.atTime(8, 0);
-
-		// Check if the requested date is in the past (before today)
-		// For past dates, do not attempt to calculate available time
-		// This allows saving unplanned historical consultation records
 		final LocalDate today = LocalDate.now();
-		final LocalDate requestedDate = parsedLocalDate;
-
-		// If the requested date is in the past, return the date with default time
-		// without calculating availability (for historical records)
-		// No availability calculation is performed for past dates
-		if (requestedDate.isBefore(today)) {
+		if (parsedLocalDate.isBefore(today)) {
 			log.debug("Date {} is in the past, returning default time without availability check", date);
+			final LocalDateTime candidateTime = parsedLocalDate.atTime(8, 0);
 			final Map<String, Object> result = new HashMap<>();
 			result.put("available", true);
 			result.put("dateTime",
 					formatDateForCalendar(Date.from(candidateTime.atZone(ZoneId.systemDefault()).toInstant())));
 			result.put("isPastDate", true);
-			return result; // Exit early - do not attempt to calculate available time
-		}
-		final LocalDateTime endOfDay = parsedLocalDate.atTime(17, 0);
-
-		// Get all events for this date
-		final LocalDateTime startOfDay = parsedLocalDate.atStartOfDay();
-		final LocalDateTime nextDay = parsedLocalDate.plusDays(1).atStartOfDay();
-
-		final Date startDate = Date.from(startOfDay.atZone(ZoneId.systemDefault()).toInstant());
-		final Date endDate = Date.from(nextDay.atZone(ZoneId.systemDefault()).toInstant());
-		final List<CalendarEvent> events = service.findEventsBetweenDates(startDate != null ? startDate : new Date(0),
-				endDate != null ? endDate : new Date(Long.MAX_VALUE));
-
-		// If the requested date is today, start from current time if it's after 8 AM
-		final LocalDateTime nowWithTime = LocalDateTime.now();
-		if (requestedDate.equals(today)) {
-			// It's today, check if current time is after 8 AM
-			if (nowWithTime.toLocalTime().isAfter(LocalTime.of(8, 0))) {
-				// Current time is after 8 AM, start from current time
-				candidateTime = nowWithTime.truncatedTo(ChronoUnit.SECONDS);
-				// Round up to next hour
-				if (candidateTime.getMinute() > 0) {
-					candidateTime = candidateTime.plusHours(1).withMinute(0).withSecond(0);
-				}
-			}
-			// Otherwise, candidateTime is already set to 8:00 AM, which is fine
+			return result;
 		}
 
-		// Find next available hour
-		while (!candidateTime.isAfter(endOfDay)) {
-			final LocalDateTime candidateEnd = candidateTime.plusHours(1);
-
-			// Check if this hour is available (no overlapping events)
-			boolean isAvailable = true;
-			for (final CalendarEvent event : events) {
-				if (event.getEventDateTime() == null) {
-					continue;
-				}
-				final LocalDateTime eventStart = event.getEventDateTime()
-					.toInstant()
-					.atZone(ZoneId.systemDefault())
-					.toLocalDateTime();
-				final int durationMinutes = event.getDurationMinutes() != null ? event.getDurationMinutes() : 60;
-				final LocalDateTime eventEnd = eventStart.plusMinutes(durationMinutes);
-
-				// Check for overlap
-				if (candidateTime.isBefore(eventEnd) && candidateEnd.isAfter(eventStart)) {
-					isAvailable = false;
-					break;
+		LocalDateTime notBefore = parsedLocalDate.atTime(8, 0);
+		if (parsedLocalDate.equals(today)) {
+			final LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+			if (now.toLocalTime().isAfter(LocalTime.of(8, 0))) {
+				notBefore = now;
+				if (notBefore.getMinute() > 0 || notBefore.getSecond() > 0) {
+					notBefore = notBefore.plusHours(1).withMinute(0).withSecond(0).withNano(0);
 				}
 			}
-
-			if (isAvailable) {
-				final Map<String, Object> result = new HashMap<>();
-				result.put("available", true);
-				result.put("dateTime",
-						formatDateForCalendar(Date.from(candidateTime.atZone(ZoneId.systemDefault()).toInstant())));
-				return result;
-			}
-
-			candidateTime = candidateTime.plusHours(1);
 		}
 
-		// No available time found
+		final LocalDateTime nextStart = bookingAvailabilitySlotService.findNextAvailableStart(userId, parsedLocalDate,
+				notBefore);
+		if (nextStart != null) {
+			final Map<String, Object> result = new HashMap<>();
+			result.put("available", true);
+			result.put("dateTime",
+					formatDateForCalendar(Date.from(nextStart.atZone(ZoneId.systemDefault()).toInstant())));
+			return result;
+		}
+
 		final Map<String, Object> result = new HashMap<>();
 		result.put("available", false);
 		return result;

--- a/src/main/resources/db/changelog/changes/015-nutritionist-availability-block.yaml
+++ b/src/main/resources/db/changelog/changes/015-nutritionist-availability-block.yaml
@@ -1,0 +1,54 @@
+databaseChangeLog:
+  - changeSet:
+      id: 015-nutritionist-availability-block
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            tableExists:
+              tableName: nutritionist_availability_block
+      changes:
+        - createTable:
+            tableName: nutritionist_availability_block
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: title
+                  type: VARCHAR(200)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: all_day
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: start_date_time
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: end_date_time
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+        - createIndex:
+            indexName: idx_nab_user_id_start
+            tableName: nutritionist_availability_block
+            columns:
+              - column:
+                  name: user_id
+              - column:
+                  name: start_date_time

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -41,3 +41,6 @@ databaseChangeLog:
   - include:
       file: changes/014-nutritionist-availability.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/015-nutritionist-availability-block.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/templates/sbadmin/calendar/listado.html
+++ b/src/main/resources/templates/sbadmin/calendar/listado.html
@@ -111,6 +111,19 @@
       border-color: #4e73df;
       color: #fff;
     }
+    .availability-block-event {
+      opacity: 0.85;
+      background-image: repeating-linear-gradient(
+        -45deg,
+        rgba(255, 255, 255, 0.15),
+        rgba(255, 255, 255, 0.15) 6px,
+        transparent 6px,
+        transparent 12px
+      ) !important;
+    }
+    .availability-block-event .fc-event-title {
+      font-weight: 600;
+    }
   </style>
 </head>
 
@@ -131,9 +144,14 @@
           <!-- Page Heading -->
           <div class="d-sm-flex align-items-center justify-content-between mb-4">
             <h1 class="h3 mb-0 text-gray-800">Calendario de Citas</h1>
-            <a th:href="@{/admin/calendario/nuevo}" class="d-none d-sm-inline-block btn btn-sm btn-primary shadow-sm">
-              <i class="fas fa-plus fa-sm text-white-50"></i> Nueva Cita
-            </a>
+            <div>
+              <button type="button" id="btnMarcarAusencia" class="d-none d-sm-inline-block btn btn-sm btn-secondary shadow-sm mr-2">
+                <i class="fas fa-ban fa-sm"></i> Marcar ausencia
+              </button>
+              <a th:href="@{/admin/calendario/nuevo}" class="d-none d-sm-inline-block btn btn-sm btn-primary shadow-sm">
+                <i class="fas fa-plus fa-sm text-white-50"></i> Nueva Cita
+              </a>
+            </div>
           </div>
 
           <!-- Content Row -->
@@ -225,6 +243,70 @@
             </div>
           </div>
 
+          <!-- Modal para marcar ausencia / bloqueo -->
+          <div class="modal fade" id="nuevaAusenciaModal" tabindex="-1" role="dialog" aria-labelledby="nuevaAusenciaModalLabel" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <h5 class="modal-title" id="nuevaAusenciaModalLabel">Marcar ausencia</h5>
+                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                  </button>
+                </div>
+                <form id="nuevaAusenciaForm">
+                  <div class="modal-body">
+                    <div class="form-group">
+                      <label for="bloqueoTituloInput">Motivo<span style="color:red;">*</span></label>
+                      <input type="text" class="form-control" id="bloqueoTituloInput" name="title"
+                        placeholder="Vacaciones, conferencia, día libre..." required maxlength="200">
+                    </div>
+                    <div class="form-group form-check">
+                      <input type="checkbox" class="form-check-input" id="bloqueoDiaCompletoInput" name="allDay">
+                      <label class="form-check-label" for="bloqueoDiaCompletoInput">Día completo</label>
+                    </div>
+                    <div class="form-group" id="bloqueoInicioGroup">
+                      <label for="bloqueoInicioInput">Inicio<span style="color:red;">*</span></label>
+                      <input type="datetime-local" class="form-control" id="bloqueoInicioInput" name="startDateTime" required>
+                    </div>
+                    <div class="form-group" id="bloqueoFinGroup">
+                      <label for="bloqueoFinInput">Fin<span style="color:red;">*</span></label>
+                      <input type="datetime-local" class="form-control" id="bloqueoFinInput" name="endDateTime" required>
+                    </div>
+                    <p class="small text-muted mb-0">Los bloqueos impiden reservas públicas y reducen horarios disponibles al agendar citas.</p>
+                  </div>
+                  <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-secondary">Guardar bloqueo</button>
+                  </div>
+                </form>
+              </div>
+            </div>
+          </div>
+
+          <!-- Modal detalle bloqueo -->
+          <div class="modal fade" id="bloqueoDetalleModal" tabindex="-1" role="dialog" aria-labelledby="bloqueoDetalleModalLabel" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <h5 class="modal-title" id="bloqueoDetalleModalLabel">Bloqueo de disponibilidad</h5>
+                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                  </button>
+                </div>
+                <div class="modal-body">
+                  <p><strong>Motivo:</strong> <span id="bloqueoDetalleTitulo"></span></p>
+                  <p><strong>Inicio:</strong> <span id="bloqueoDetalleInicio"></span></p>
+                  <p><strong>Fin:</strong> <span id="bloqueoDetalleFin"></span></p>
+                  <p class="mb-0"><strong>Tipo:</strong> <span id="bloqueoDetalleTipo"></span></p>
+                </div>
+                <div class="modal-footer">
+                  <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                  <button type="button" class="btn btn-danger" id="btnEliminarBloqueo">Eliminar bloqueo</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
         </div>
         <!-- End of Main Content -->
 
@@ -265,6 +347,55 @@
         jQuery(document).ready(function($) {
 
           let calendar;
+          let selectedBlockId = null;
+
+          function formatDateTimeLocal(date) {
+            const year = date.getFullYear();
+            const month = String(date.getMonth() + 1).padStart(2, '0');
+            const day = String(date.getDate()).padStart(2, '0');
+            const hours = String(date.getHours()).padStart(2, '0');
+            const minutes = String(date.getMinutes()).padStart(2, '0');
+            return year + '-' + month + '-' + day + 'T' + hours + ':' + minutes;
+          }
+
+          function formatDisplayDateTime(value) {
+            if (!value) {
+              return '';
+            }
+            const date = new Date(value);
+            return date.toLocaleString('es-MX', { dateStyle: 'short', timeStyle: 'short' });
+          }
+
+          function toggleBloqueoAllDayInputs() {
+            const allDay = $('#bloqueoDiaCompletoInput').is(':checked');
+            if (allDay) {
+              $('#bloqueoInicioInput').attr('type', 'date');
+              $('#bloqueoFinInput').attr('type', 'date');
+            } else {
+              $('#bloqueoInicioInput').attr('type', 'datetime-local');
+              $('#bloqueoFinInput').attr('type', 'datetime-local');
+            }
+          }
+
+          function buildBlockPayload() {
+            const allDay = $('#bloqueoDiaCompletoInput').is(':checked');
+            const title = $('#bloqueoTituloInput').val();
+            let startValue = $('#bloqueoInicioInput').val();
+            let endValue = $('#bloqueoFinInput').val();
+            if (allDay) {
+              startValue = startValue + 'T00:00:00';
+              endValue = endValue + 'T00:00:00';
+            } else {
+              startValue = startValue.length === 16 ? startValue + ':00' : startValue;
+              endValue = endValue.length === 16 ? endValue + ':00' : endValue;
+            }
+            return {
+              title: title,
+              allDay: allDay,
+              startDateTime: startValue,
+              endDateTime: endValue
+            };
+          }
 
           const calendarEl = document.getElementById('calendar');
           if (!calendarEl) {
@@ -289,20 +420,16 @@
           events: function(fetchInfo, successCallback, failureCallback) {
             const start = fetchInfo.start.toISOString();
             const end = fetchInfo.end.toISOString();
-            $.ajax({
-              url: '/rest/calendario/events',
-              type: 'GET',
-              data: {
-                start: start,
-                end: end
-              },
-              success: function(data) {
-                successCallback(data);
-              },
-              error: function(xhr, status, error) {
-                console.error('Error loading calendar events:', error);
-                failureCallback();
-              }
+            $.when(
+              $.ajax({ url: '/rest/calendario/events', type: 'GET', data: { start: start, end: end } }),
+              $.ajax({ url: '/rest/calendario/blocks', type: 'GET', data: { start: start, end: end } })
+            ).done(function(eventsResponse, blocksResponse) {
+              const appointments = eventsResponse[0] || [];
+              const blocks = blocksResponse[0] || [];
+              successCallback(appointments.concat(blocks));
+            }).fail(function(xhr, status, error) {
+              console.error('Error loading calendar events:', error);
+              failureCallback();
             });
           },
           dateClick: function(info) {
@@ -397,7 +524,15 @@
           selectMirror: true,
           eventClick: function(info) {
             info.jsEvent.preventDefault();
-            // Navigate to event detail page
+            if (info.event.extendedProps && info.event.extendedProps.type === 'BLOCK') {
+              selectedBlockId = info.event.extendedProps.blockId;
+              $('#bloqueoDetalleTitulo').text(info.event.title || 'Ausencia');
+              $('#bloqueoDetalleInicio').text(formatDisplayDateTime(info.event.start));
+              $('#bloqueoDetalleFin').text(formatDisplayDateTime(info.event.end));
+              $('#bloqueoDetalleTipo').text(info.event.allDay ? 'Día completo' : 'Rango horario');
+              $('#bloqueoDetalleModal').modal('show');
+              return;
+            }
             const eventId = info.event.id;
             window.location.href = '/admin/calendario/' + eventId;
           },
@@ -427,6 +562,89 @@
         });
 
         calendar.render();
+
+        $('#btnMarcarAusencia').on('click', function() {
+          $('#nuevaAusenciaForm')[0].reset();
+          $('#bloqueoTituloInput').val('No disponible');
+          toggleBloqueoAllDayInputs();
+          $('#nuevaAusenciaModal').modal('show');
+        });
+
+        $('#bloqueoDiaCompletoInput').on('change', toggleBloqueoAllDayInputs);
+
+        $('#nuevaAusenciaModal').on('hidden.bs.modal', function() {
+          $('#nuevaAusenciaForm')[0].reset();
+          toggleBloqueoAllDayInputs();
+        });
+
+        $('#nuevaAusenciaForm').on('submit', function(e) {
+          e.preventDefault();
+          const payload = buildBlockPayload();
+          if (!payload.title || !payload.startDateTime || !payload.endDateTime) {
+            swal({ title: 'Campos requeridos', text: 'Complete motivo, inicio y fin.', type: 'warning', timer: 4000 });
+            return;
+          }
+          const submitButton = $(this).find('button[type="submit"]');
+          submitButton.prop('disabled', true).text('Guardando...');
+          $.ajax({
+            url: '/rest/calendario/blocks',
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify(payload),
+            success: function(response) {
+              if (response.success) {
+                calendar.refetchEvents();
+                $('#nuevaAusenciaModal').modal('hide');
+                swal({ title: 'Bloqueo guardado', text: 'La ausencia se aplicó al calendario.', type: 'success', timer: 2000 });
+              } else {
+                swal({ title: 'Error', text: response.error || 'No se pudo guardar el bloqueo.', type: 'error', timer: 5000 });
+              }
+            },
+            error: function(xhr) {
+              const message = xhr.responseJSON && xhr.responseJSON.error ? xhr.responseJSON.error : 'Error al guardar el bloqueo.';
+              swal({ title: 'Error', text: message, type: 'error', timer: 5000 });
+            },
+            complete: function() {
+              submitButton.prop('disabled', false).text('Guardar bloqueo');
+            }
+          });
+        });
+
+        $('#btnEliminarBloqueo').on('click', function() {
+          if (!selectedBlockId) {
+            return;
+          }
+          swal({
+            title: '¿Eliminar bloqueo?',
+            text: 'Este horario volverá a estar disponible para reservas.',
+            type: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#d33',
+            confirmButtonText: 'Sí, eliminar',
+            cancelButtonText: 'Cancelar'
+          }, function(isConfirm) {
+            if (!isConfirm) {
+              return;
+            }
+            $.ajax({
+              url: '/rest/calendario/blocks/' + selectedBlockId,
+              type: 'DELETE',
+              success: function(response) {
+                if (response.success) {
+                  $('#bloqueoDetalleModal').modal('hide');
+                  calendar.refetchEvents();
+                  swal({ title: 'Bloqueo eliminado', type: 'success', timer: 2000 });
+                } else {
+                  swal({ title: 'Error', text: response.error || 'No se pudo eliminar.', type: 'error', timer: 5000 });
+                }
+              },
+              error: function(xhr) {
+                const message = xhr.responseJSON && xhr.responseJSON.error ? xhr.responseJSON.error : 'Error al eliminar el bloqueo.';
+                swal({ title: 'Error', text: message, type: 'error', timer: 5000 });
+              }
+            });
+          });
+        });
 
         // Cargar lista de pacientes al abrir el modal
         $('#nuevaCitaModal').on('show.bs.modal', function() {

--- a/src/test/java/com/nutriconsultas/booking/AvailabilityBlockValidatorTest.java
+++ b/src/test/java/com/nutriconsultas/booking/AvailabilityBlockValidatorTest.java
@@ -1,0 +1,53 @@
+package com.nutriconsultas.booking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class AvailabilityBlockValidatorTest {
+
+	@Test
+	void validatesTimeRangeBlock() {
+		final AvailabilityBlockDto block = new AvailabilityBlockDto();
+		block.setTitle("Conferencia");
+		block.setAllDay(false);
+		block.setStartDateTime(LocalDateTime.of(2026, 6, 21, 9, 0));
+		block.setEndDateTime(LocalDateTime.of(2026, 6, 21, 12, 0));
+
+		AvailabilityBlockValidator.validate(block);
+
+		assertThat(block.getStartDateTime()).isEqualTo(LocalDateTime.of(2026, 6, 21, 9, 0));
+	}
+
+	@Test
+	void normalizesAllDayBlock() {
+		final AvailabilityBlockDto block = new AvailabilityBlockDto();
+		block.setTitle("Vacaciones");
+		block.setAllDay(true);
+		block.setStartDateTime(LocalDateTime.of(2026, 6, 21, 14, 30));
+		block.setEndDateTime(LocalDateTime.of(2026, 6, 21, 18, 0));
+
+		AvailabilityBlockValidator.validate(block);
+
+		assertThat(block.getStartDateTime()).isEqualTo(LocalDate.of(2026, 6, 21).atStartOfDay());
+		assertThat(block.getEndDateTime()).isEqualTo(LocalDate.of(2026, 6, 22).atStartOfDay());
+	}
+
+	@Test
+	void rejectsEndBeforeStart() {
+		final AvailabilityBlockDto block = new AvailabilityBlockDto();
+		block.setTitle("Error");
+		block.setStartDateTime(LocalDateTime.of(2026, 6, 21, 12, 0));
+		block.setEndDateTime(LocalDateTime.of(2026, 6, 21, 10, 0));
+
+		assertThatThrownBy(() -> AvailabilityBlockValidator.validate(block))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/booking/BookingAvailabilitySlotServiceTest.java
+++ b/src/test/java/com/nutriconsultas/booking/BookingAvailabilitySlotServiceTest.java
@@ -1,0 +1,113 @@
+package com.nutriconsultas.booking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.calendar.CalendarEventRepository;
+import com.nutriconsultas.calendar.EventStatus;
+
+@ExtendWith(MockitoExtension.class)
+class BookingAvailabilitySlotServiceTest {
+
+	private static final String USER_ID = "auth0|nutritionist";
+
+	@InjectMocks
+	private BookingAvailabilitySlotServiceImpl service;
+
+	@Mock
+	private NutritionistAvailabilityService availabilityService;
+
+	@Mock
+	private NutritionistAvailabilityBlockRepository blockRepository;
+
+	@Mock
+	private CalendarEventRepository calendarEventRepository;
+
+	private AvailabilityScheduleDto schedule;
+
+	@BeforeEach
+	void setup() {
+		schedule = new AvailabilityScheduleDto();
+		schedule.setSlotDurationMinutes(60);
+		schedule.setTimezone(BookingAvailabilityConstants.DEFAULT_TIMEZONE_ID);
+		schedule.setIntervals(List.of(new WorkingHoursIntervalDto(1, LocalTime.of(9, 0), LocalTime.of(12, 0))));
+	}
+
+	@Test
+	void subtractsAvailabilityBlocksFromSlots() {
+		final LocalDate monday = LocalDate.of(2026, 6, 22);
+		when(availabilityService.getSchedule(USER_ID)).thenReturn(schedule);
+		when(blockRepository.findOverlappingRange(eq(USER_ID), eq(monday.atStartOfDay()),
+				eq(monday.plusDays(1).atStartOfDay())))
+			.thenReturn(List.of(block(LocalDateTime.of(2026, 6, 22, 9, 0), LocalDateTime.of(2026, 6, 22, 10, 0))));
+		when(calendarEventRepository.findByUserIdAndDateRange(eq(USER_ID), any(Date.class), any(Date.class)))
+			.thenReturn(List.of());
+
+		final List<LocalTime> slots = service.getAvailableSlotStarts(USER_ID, monday);
+
+		assertThat(slots).containsExactly(LocalTime.of(10, 0), LocalTime.of(11, 0));
+	}
+
+	@Test
+	void subtractsScheduledAppointmentsFromSlots() {
+		final LocalDate monday = LocalDate.of(2026, 6, 22);
+		when(availabilityService.getSchedule(USER_ID)).thenReturn(schedule);
+		when(blockRepository.findOverlappingRange(eq(USER_ID), any(), any())).thenReturn(List.of());
+
+		final CalendarEvent event = new CalendarEvent();
+		event.setStatus(EventStatus.SCHEDULED);
+		event.setEventDateTime(Date.from(LocalDateTime.of(2026, 6, 22, 10, 0)
+			.atZone(ZoneId.of(BookingAvailabilityConstants.DEFAULT_TIMEZONE_ID))
+			.toInstant()));
+		event.setDurationMinutes(60);
+		when(calendarEventRepository.findByUserIdAndDateRange(eq(USER_ID), any(Date.class), any(Date.class)))
+			.thenReturn(List.of(event));
+
+		final List<LocalTime> slots = service.getAvailableSlotStarts(USER_ID, monday);
+
+		assertThat(slots).containsExactly(LocalTime.of(9, 0), LocalTime.of(11, 0));
+	}
+
+	@Test
+	void loadsBlocksOnlyForRequestedUser() {
+		final LocalDate monday = LocalDate.of(2026, 6, 22);
+		when(availabilityService.getSchedule(USER_ID)).thenReturn(schedule);
+		when(blockRepository.findOverlappingRange(eq(USER_ID), any(), any())).thenReturn(List.of());
+		when(calendarEventRepository.findByUserIdAndDateRange(eq(USER_ID), any(Date.class), any(Date.class)))
+			.thenReturn(List.of());
+
+		service.getAvailableSlotStarts(USER_ID, monday);
+
+		verify(blockRepository).findOverlappingRange(eq(USER_ID), any(), any());
+	}
+
+	private static NutritionistAvailabilityBlock block(final LocalDateTime start, final LocalDateTime end) {
+		final NutritionistAvailabilityBlock block = new NutritionistAvailabilityBlock();
+		block.setId(1L);
+		block.setUserId(USER_ID);
+		block.setTitle("Ausencia");
+		block.setAllDay(false);
+		block.setStartDateTime(start);
+		block.setEndDateTime(end);
+		return block;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/booking/BookingSlotFilterTest.java
+++ b/src/test/java/com/nutriconsultas/booking/BookingSlotFilterTest.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.booking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class BookingSlotFilterTest {
+
+	@Test
+	void removesSlotsOverlappingBusyInterval() {
+		final List<LocalTime> slots = List.of(LocalTime.of(9, 0), LocalTime.of(10, 0), LocalTime.of(11, 0));
+		final List<BusyTimeInterval> busy = List
+			.of(new BusyTimeInterval(LocalDateTime.of(2026, 6, 21, 9, 30), LocalDateTime.of(2026, 6, 21, 10, 30)));
+
+		final List<LocalTime> available = BookingSlotFilter.removeBusySlots(slots, LocalDate.of(2026, 6, 21), 60, busy);
+
+		assertThat(available).containsExactly(LocalTime.of(11, 0));
+	}
+
+	@Test
+	void keepsAllSlotsWhenNoBusyIntervals() {
+		final List<LocalTime> slots = List.of(LocalTime.of(9, 0), LocalTime.of(10, 0));
+
+		final List<LocalTime> available = BookingSlotFilter.removeBusySlots(slots, LocalDate.of(2026, 6, 21), 60,
+				List.of());
+
+		assertThat(available).containsExactlyElementsOf(slots);
+	}
+
+	@Test
+	void removesSlotFullyInsideBlock() {
+		final List<LocalTime> slots = List.of(LocalTime.of(10, 0));
+		final List<BusyTimeInterval> busy = List
+			.of(new BusyTimeInterval(LocalDateTime.of(2026, 6, 21, 8, 0), LocalDateTime.of(2026, 6, 21, 18, 0)));
+
+		assertThat(BookingSlotFilter.removeBusySlots(slots, LocalDate.of(2026, 6, 21), 60, busy)).isEmpty();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/booking/NutritionistAvailabilityBlockRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/booking/NutritionistAvailabilityBlockRestControllerTest.java
@@ -1,0 +1,66 @@
+package com.nutriconsultas.booking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+@ExtendWith(MockitoExtension.class)
+class NutritionistAvailabilityBlockRestControllerTest {
+
+	@InjectMocks
+	private NutritionistAvailabilityBlockRestController controller;
+
+	@Mock
+	private NutritionistAvailabilityBlockService blockService;
+
+	@Mock
+	private OidcUser principal;
+
+	@Test
+	void listBlocksRequiresRangeAndAuth() {
+		assertThat(controller.listBlocks(new Date(), new Date(), null)).isEmpty();
+	}
+
+	@Test
+	void createBlockReturnsCalendarPayload() {
+		when(principal.getSubject()).thenReturn("auth0|user1");
+		final AvailabilityBlockDto dto = new AvailabilityBlockDto();
+		dto.setTitle("Conferencia");
+		dto.setAllDay(false);
+		dto.setStartDateTime(LocalDateTime.of(2026, 6, 21, 13, 0));
+		dto.setEndDateTime(LocalDateTime.of(2026, 6, 21, 17, 0));
+		dto.setId(3L);
+		when(blockService.createBlock("auth0|user1", dto)).thenReturn(dto);
+
+		final ResponseEntity<Map<String, Object>> response = controller.createBlock(dto,
+				new org.springframework.validation.BeanPropertyBindingResult(dto, "block"), principal);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("success", true);
+	}
+
+	@Test
+	void deleteBlockReturnsSuccess() {
+		when(principal.getSubject()).thenReturn("auth0|user1");
+
+		final ResponseEntity<Map<String, Object>> response = controller.deleteBlock(8L, principal);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		verify(blockService).deleteBlock("auth0|user1", 8L);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/booking/NutritionistAvailabilityBlockServiceTest.java
+++ b/src/test/java/com/nutriconsultas/booking/NutritionistAvailabilityBlockServiceTest.java
@@ -1,0 +1,72 @@
+package com.nutriconsultas.booking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NutritionistAvailabilityBlockServiceTest {
+
+	private static final String USER_ID = "auth0|nutritionist";
+
+	@InjectMocks
+	private NutritionistAvailabilityBlockServiceImpl service;
+
+	@Mock
+	private NutritionistAvailabilityBlockRepository blockRepository;
+
+	@Test
+	void createBlockPersistsEntity() {
+		final AvailabilityBlockDto dto = new AvailabilityBlockDto();
+		dto.setTitle("Vacaciones");
+		dto.setAllDay(true);
+		dto.setStartDateTime(LocalDateTime.of(2026, 7, 1, 0, 0));
+		dto.setEndDateTime(LocalDateTime.of(2026, 7, 1, 0, 0));
+		when(blockRepository.save(any(NutritionistAvailabilityBlock.class))).thenAnswer(invocation -> {
+			final NutritionistAvailabilityBlock saved = invocation.getArgument(0);
+			saved.setId(10L);
+			return saved;
+		});
+
+		final AvailabilityBlockDto result = service.createBlock(USER_ID, dto);
+
+		assertThat(result.getId()).isEqualTo(10L);
+		assertThat(result.getTitle()).isEqualTo("Vacaciones");
+		final ArgumentCaptor<NutritionistAvailabilityBlock> captor = ArgumentCaptor
+			.forClass(NutritionistAvailabilityBlock.class);
+		verify(blockRepository).save(captor.capture());
+		assertThat(captor.getValue().getUserId()).isEqualTo(USER_ID);
+	}
+
+	@Test
+	void deleteBlockRequiresOwnership() {
+		when(blockRepository.findByIdAndUserId(5L, USER_ID)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.deleteBlock(USER_ID, 5L)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void findBlocksInRangeDelegatesToRepository() {
+		final LocalDateTime start = LocalDateTime.of(2026, 6, 1, 0, 0);
+		final LocalDateTime end = LocalDateTime.of(2026, 6, 30, 0, 0);
+		when(blockRepository.findOverlappingRange(USER_ID, start, end)).thenReturn(List.of());
+
+		assertThat(service.findBlocksInRange(USER_ID, start, end)).isEmpty();
+		verify(blockRepository).findOverlappingRange(eq(USER_ID), eq(start), eq(end));
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/booking/NutritionistAvailabilityRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/booking/NutritionistAvailabilityRestControllerTest.java
@@ -29,6 +29,9 @@ class NutritionistAvailabilityRestControllerTest {
 	private NutritionistAvailabilityService availabilityService;
 
 	@Mock
+	private BookingAvailabilitySlotService bookingAvailabilitySlotService;
+
+	@Mock
 	private OidcUser principal;
 
 	private AvailabilityScheduleDto schedule;
@@ -73,6 +76,19 @@ class NutritionistAvailabilityRestControllerTest {
 		@SuppressWarnings("unchecked")
 		final Map<String, Object> body = (Map<String, Object>) response.getBody();
 		assertThat(body).containsEntry("success", false);
+	}
+
+	@Test
+	void getAvailableSlotsReturnsFormattedTimes() {
+		when(principal.getSubject()).thenReturn("auth0|user1");
+		when(bookingAvailabilitySlotService.getAvailableSlotStarts("auth0|user1", java.time.LocalDate.of(2026, 6, 22)))
+			.thenReturn(List.of(LocalTime.of(9, 0), LocalTime.of(10, 0)));
+
+		final ResponseEntity<Map<String, Object>> response = controller.getAvailableSlots(principal, "2026-06-22");
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("date", "2026-06-22");
+		assertThat(response.getBody().get("slots")).isEqualTo(List.of("09:00", "10:00"));
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/calendar/CalendarEventRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/calendar/CalendarEventRestControllerTest.java
@@ -40,6 +40,10 @@ import com.nutriconsultas.paciente.NivelPeso;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.paciente.projection.PacienteCalendarView;
+import com.nutriconsultas.booking.BookingAvailabilitySlotService;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -60,6 +64,9 @@ public class CalendarEventRestControllerTest {
 
 	@Mock
 	private BodyFatCalculatorService bodyFatCalculatorService;
+
+	@Mock
+	private BookingAvailabilitySlotService bookingAvailabilitySlotService;
 
 	private List<CalendarEvent> events;
 
@@ -955,114 +962,63 @@ public class CalendarEventRestControllerTest {
 	@Test
 	public void testGetNextAvailableTimeWithNoEvents() {
 		log.info("starting testGetNextAvailableTimeWithNoEvents");
-		// Arrange - Use a future date
 		final Calendar futureCal = Calendar.getInstance();
-		futureCal.add(Calendar.DAY_OF_MONTH, 7); // 7 days from now
+		futureCal.add(Calendar.DAY_OF_MONTH, 7);
 		final String dateStr = String.format("%04d-%02d-%02d", futureCal.get(Calendar.YEAR),
 				futureCal.get(Calendar.MONTH) + 1, futureCal.get(Calendar.DAY_OF_MONTH));
-		// NOSONAR - Mockito matcher
-		when(service.findEventsBetweenDates(any(Date.class), any(Date.class))).thenReturn(new ArrayList<>());
+		final LocalDate parsedDate = LocalDate.parse(dateStr);
+		when(bookingAvailabilitySlotService.findNextAvailableStart(org.mockito.ArgumentMatchers.eq(TEST_USER_ID),
+				org.mockito.ArgumentMatchers.eq(parsedDate), any(LocalDateTime.class)))
+			.thenReturn(parsedDate.atTime(8, 0));
 
-		// Act
-		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr);
+		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr, principal);
 
-		// Assert
 		assertThat(result).isNotNull();
 		assertThat(result.get("available")).isEqualTo(true);
 		assertThat(result).containsKey("dateTime");
-		verify(service).findEventsBetweenDates(any(Date.class), any(Date.class));
+		verify(bookingAvailabilitySlotService).findNextAvailableStart(org.mockito.ArgumentMatchers.eq(TEST_USER_ID),
+				org.mockito.ArgumentMatchers.eq(parsedDate), any(LocalDateTime.class));
 		log.info("finished testGetNextAvailableTimeWithNoEvents");
 	}
 
 	@Test
 	public void testGetNextAvailableTimeWithEvents() {
 		log.info("starting testGetNextAvailableTimeWithEvents");
-		// Arrange - Use a future date
 		final Calendar futureCal = Calendar.getInstance();
-		futureCal.add(Calendar.DAY_OF_MONTH, 7); // 7 days from now
-		futureCal.set(Calendar.HOUR_OF_DAY, 0);
-		futureCal.set(Calendar.MINUTE, 0);
-		futureCal.set(Calendar.SECOND, 0);
-		futureCal.set(Calendar.MILLISECOND, 0);
+		futureCal.add(Calendar.DAY_OF_MONTH, 7);
 		final String dateStr = String.format("%04d-%02d-%02d", futureCal.get(Calendar.YEAR),
 				futureCal.get(Calendar.MONTH) + 1, futureCal.get(Calendar.DAY_OF_MONTH));
-		final List<CalendarEvent> existingEvents = new ArrayList<>();
+		final LocalDate parsedDate = LocalDate.parse(dateStr);
+		when(bookingAvailabilitySlotService.findNextAvailableStart(org.mockito.ArgumentMatchers.eq(TEST_USER_ID),
+				org.mockito.ArgumentMatchers.eq(parsedDate), any(LocalDateTime.class)))
+			.thenReturn(parsedDate.atTime(8, 0));
 
-		// Create an event at 9 AM (8-9 AM should be available)
-		final Calendar cal = Calendar.getInstance();
-		cal.setTime(futureCal.getTime());
-		cal.set(Calendar.HOUR_OF_DAY, 9);
-		cal.set(Calendar.MINUTE, 0);
-		cal.set(Calendar.SECOND, 0);
-		cal.set(Calendar.MILLISECOND, 0);
+		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr, principal);
 
-		final CalendarEvent event9AM = new CalendarEvent();
-		event9AM.setId(1L);
-		event9AM.setTitle("Event at 9 AM");
-		event9AM.setEventDateTime(cal.getTime());
-		event9AM.setDurationMinutes(60);
-		event9AM.setStatus(EventStatus.SCHEDULED);
-		existingEvents.add(event9AM);
-
-		// NOSONAR - Mockito matcher
-		when(service.findEventsBetweenDates(any(Date.class), any(Date.class))).thenReturn(existingEvents);
-
-		// Act
-		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr);
-
-		// Assert
 		assertThat(result).isNotNull();
 		assertThat(result.get("available")).isEqualTo(true);
-		assertThat(result).containsKey("dateTime");
-		// Should return 8 AM as it's the first available hour
 		final String dateTime = (String) result.get("dateTime");
 		assertThat(dateTime).contains("08:00:00");
-		verify(service).findEventsBetweenDates(any(Date.class), any(Date.class));
 		log.info("finished testGetNextAvailableTimeWithEvents");
 	}
 
 	@Test
 	public void testGetNextAvailableTimeWithFullDay() {
 		log.info("starting testGetNextAvailableTimeWithFullDay");
-		// Arrange - Use a future date and create events for every hour from 8 AM to 5 PM
 		final Calendar futureCal = Calendar.getInstance();
-		futureCal.add(Calendar.DAY_OF_MONTH, 7); // 7 days from now
-		futureCal.set(Calendar.HOUR_OF_DAY, 0);
-		futureCal.set(Calendar.MINUTE, 0);
-		futureCal.set(Calendar.SECOND, 0);
-		futureCal.set(Calendar.MILLISECOND, 0);
+		futureCal.add(Calendar.DAY_OF_MONTH, 7);
 		final String dateStr = String.format("%04d-%02d-%02d", futureCal.get(Calendar.YEAR),
 				futureCal.get(Calendar.MONTH) + 1, futureCal.get(Calendar.DAY_OF_MONTH));
-		final List<CalendarEvent> existingEvents = new ArrayList<>();
+		final LocalDate parsedDate = LocalDate.parse(dateStr);
+		when(bookingAvailabilitySlotService.findNextAvailableStart(org.mockito.ArgumentMatchers.eq(TEST_USER_ID),
+				org.mockito.ArgumentMatchers.eq(parsedDate), any(LocalDateTime.class)))
+			.thenReturn(null);
 
-		for (int hour = 8; hour <= 17; hour++) {
-			final Calendar cal = Calendar.getInstance();
-			cal.setTime(futureCal.getTime());
-			cal.set(Calendar.HOUR_OF_DAY, hour);
-			cal.set(Calendar.MINUTE, 0);
-			cal.set(Calendar.SECOND, 0);
-			cal.set(Calendar.MILLISECOND, 0);
+		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr, principal);
 
-			final CalendarEvent event = new CalendarEvent();
-			event.setId((long) hour);
-			event.setTitle("Event at " + hour + " AM");
-			event.setEventDateTime(cal.getTime());
-			event.setDurationMinutes(60);
-			event.setStatus(EventStatus.SCHEDULED);
-			existingEvents.add(event);
-		}
-
-		// NOSONAR - Mockito matcher
-		when(service.findEventsBetweenDates(any(Date.class), any(Date.class))).thenReturn(existingEvents);
-
-		// Act
-		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr);
-
-		// Assert
 		assertThat(result).isNotNull();
 		assertThat(result.get("available")).isEqualTo(false);
 		assertThat(result).doesNotContainKey("dateTime");
-		verify(service).findEventsBetweenDates(any(Date.class), any(Date.class));
 		log.info("finished testGetNextAvailableTimeWithFullDay");
 	}
 
@@ -1073,7 +1029,7 @@ public class CalendarEventRestControllerTest {
 		final String invalidDateStr = "invalid-date";
 
 		// Act
-		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(invalidDateStr);
+		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(invalidDateStr, principal);
 
 		// Assert
 		assertThat(result).isNotNull();
@@ -1086,112 +1042,41 @@ public class CalendarEventRestControllerTest {
 	@Test
 	public void testGetNextAvailableTimeWithPartialDay() {
 		log.info("starting testGetNextAvailableTimeWithPartialDay");
-		// Arrange - Use a future date and create events at 8 AM, 10 AM, 12 PM (9 AM, 11
-		// AM should be available)
 		final Calendar futureCal = Calendar.getInstance();
-		futureCal.add(Calendar.DAY_OF_MONTH, 7); // 7 days from now
-		futureCal.set(Calendar.HOUR_OF_DAY, 0);
-		futureCal.set(Calendar.MINUTE, 0);
-		futureCal.set(Calendar.SECOND, 0);
-		futureCal.set(Calendar.MILLISECOND, 0);
+		futureCal.add(Calendar.DAY_OF_MONTH, 7);
 		final String dateStr = String.format("%04d-%02d-%02d", futureCal.get(Calendar.YEAR),
 				futureCal.get(Calendar.MONTH) + 1, futureCal.get(Calendar.DAY_OF_MONTH));
-		final List<CalendarEvent> existingEvents = new ArrayList<>();
+		final LocalDate parsedDate = LocalDate.parse(dateStr);
+		when(bookingAvailabilitySlotService.findNextAvailableStart(org.mockito.ArgumentMatchers.eq(TEST_USER_ID),
+				org.mockito.ArgumentMatchers.eq(parsedDate), any(LocalDateTime.class)))
+			.thenReturn(parsedDate.atTime(9, 0));
 
-		final int[] hours = { 8, 10, 12 };
-		for (final int hour : hours) {
-			final Calendar cal = Calendar.getInstance();
-			cal.setTime(futureCal.getTime());
-			cal.set(Calendar.HOUR_OF_DAY, hour);
-			cal.set(Calendar.MINUTE, 0);
-			cal.set(Calendar.SECOND, 0);
-			cal.set(Calendar.MILLISECOND, 0);
+		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr, principal);
 
-			final CalendarEvent event = new CalendarEvent();
-			event.setId((long) hour);
-			event.setTitle("Event at " + hour + " AM");
-			event.setEventDateTime(cal.getTime());
-			event.setDurationMinutes(60);
-			event.setStatus(EventStatus.SCHEDULED);
-			existingEvents.add(event);
-		}
-
-		// NOSONAR - Mockito matcher
-		when(service.findEventsBetweenDates(any(Date.class), any(Date.class))).thenReturn(existingEvents);
-
-		// Act
-		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr);
-
-		// Assert
 		assertThat(result).isNotNull();
 		assertThat(result.get("available")).isEqualTo(true);
-		assertThat(result).containsKey("dateTime");
-		// Should return 9 AM as it's the first available hour
 		final String dateTime = (String) result.get("dateTime");
 		assertThat(dateTime).contains("09:00:00");
-		verify(service).findEventsBetweenDates(any(Date.class), any(Date.class));
 		log.info("finished testGetNextAvailableTimeWithPartialDay");
 	}
 
 	@Test
 	public void testGetNextAvailableTimeWithOverlappingEvents() {
 		log.info("starting testGetNextAvailableTimeWithOverlappingEvents");
-		// Arrange - Use a future date and create overlapping events
 		final Calendar futureCal = Calendar.getInstance();
-		futureCal.add(Calendar.DAY_OF_MONTH, 7); // 7 days from now
-		futureCal.set(Calendar.HOUR_OF_DAY, 0);
-		futureCal.set(Calendar.MINUTE, 0);
-		futureCal.set(Calendar.SECOND, 0);
-		futureCal.set(Calendar.MILLISECOND, 0);
+		futureCal.add(Calendar.DAY_OF_MONTH, 7);
 		final String dateStr = String.format("%04d-%02d-%02d", futureCal.get(Calendar.YEAR),
 				futureCal.get(Calendar.MONTH) + 1, futureCal.get(Calendar.DAY_OF_MONTH));
-		final List<CalendarEvent> existingEvents = new ArrayList<>();
+		final LocalDate parsedDate = LocalDate.parse(dateStr);
+		when(bookingAvailabilitySlotService.findNextAvailableStart(org.mockito.ArgumentMatchers.eq(TEST_USER_ID),
+				org.mockito.ArgumentMatchers.eq(parsedDate), any(LocalDateTime.class)))
+			.thenReturn(parsedDate.atTime(10, 30));
 
-		// Event from 8:00 to 9:30
-		final Calendar cal1 = Calendar.getInstance();
-		cal1.setTime(futureCal.getTime());
-		cal1.set(Calendar.HOUR_OF_DAY, 8);
-		cal1.set(Calendar.MINUTE, 0);
-		cal1.set(Calendar.SECOND, 0);
-		cal1.set(Calendar.MILLISECOND, 0);
-		final CalendarEvent event1 = new CalendarEvent();
-		event1.setId(1L);
-		event1.setTitle("Event 1");
-		event1.setEventDateTime(cal1.getTime());
-		event1.setDurationMinutes(90); // 1.5 hours
-		event1.setStatus(EventStatus.SCHEDULED);
-		existingEvents.add(event1);
+		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr, principal);
 
-		// Event from 9:30 to 10:30
-		final Calendar cal2 = Calendar.getInstance();
-		cal2.setTime(futureCal.getTime());
-		cal2.set(Calendar.HOUR_OF_DAY, 9);
-		cal2.set(Calendar.MINUTE, 30);
-		cal2.set(Calendar.SECOND, 0);
-		cal2.set(Calendar.MILLISECOND, 0);
-		final CalendarEvent event2 = new CalendarEvent();
-		event2.setId(2L);
-		event2.setTitle("Event 2");
-		event2.setEventDateTime(cal2.getTime());
-		event2.setDurationMinutes(60);
-		event2.setStatus(EventStatus.SCHEDULED);
-		existingEvents.add(event2);
-
-		// NOSONAR - Mockito matcher
-		when(service.findEventsBetweenDates(any(Date.class), any(Date.class))).thenReturn(existingEvents);
-
-		// Act
-		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr);
-
-		// Assert
 		assertThat(result).isNotNull();
 		assertThat(result.get("available")).isEqualTo(true);
-		assertThat(result).containsKey("dateTime");
-		// Should return 10:30 or later as 8-10:30 is blocked
-		final String dateTime = (String) result.get("dateTime");
-		// Verify it's after 10:30
-		assertThat(dateTime).isNotNull();
-		verify(service).findEventsBetweenDates(any(Date.class), any(Date.class));
+		assertThat((String) result.get("dateTime")).contains("10:30:00");
 		log.info("finished testGetNextAvailableTimeWithOverlappingEvents");
 	}
 
@@ -1209,7 +1094,7 @@ public class CalendarEventRestControllerTest {
 				pastCal.get(Calendar.MONTH) + 1, pastCal.get(Calendar.DAY_OF_MONTH));
 
 		// Act
-		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr);
+		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr, principal);
 
 		// Assert
 		assertThat(result).isNotNull();
@@ -1219,9 +1104,8 @@ public class CalendarEventRestControllerTest {
 		// Should return default time (8:00 AM) without calculating availability
 		final String dateTime = (String) result.get("dateTime");
 		assertThat(dateTime).contains("08:00:00");
-		// Verify that findEventsBetweenDates was NOT called (no availability calculation)
-		// NOSONAR - Mockito matcher
-		verify(service, never()).findEventsBetweenDates(any(Date.class), any(Date.class));
+		// Verify that slot lookup was NOT called for past dates
+		verify(bookingAvailabilitySlotService, never()).findNextAvailableStart(any(), any(), any());
 		log.info("finished testGetNextAvailableTimeWithPastDate");
 	}
 
@@ -1239,7 +1123,7 @@ public class CalendarEventRestControllerTest {
 				pastCal.get(Calendar.MONTH) + 1, pastCal.get(Calendar.DAY_OF_MONTH));
 
 		// Act
-		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr);
+		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr, principal);
 
 		// Assert
 		assertThat(result).isNotNull();
@@ -1253,9 +1137,7 @@ public class CalendarEventRestControllerTest {
 		final String expectedDatePart = String.format("%04d-%02d-%02d", pastCal.get(Calendar.YEAR),
 				pastCal.get(Calendar.MONTH) + 1, pastCal.get(Calendar.DAY_OF_MONTH));
 		assertThat(dateTime).startsWith(expectedDatePart);
-		// Verify that findEventsBetweenDates was NOT called (no availability calculation)
-		// NOSONAR - Mockito matcher
-		verify(service, never()).findEventsBetweenDates(any(Date.class), any(Date.class));
+		verify(bookingAvailabilitySlotService, never()).findNextAvailableStart(any(), any(), any());
 		log.info("finished testGetNextAvailableTimeWithPastDateMultipleDaysAgo");
 	}
 
@@ -1290,11 +1172,9 @@ public class CalendarEventRestControllerTest {
 			event.setStatus(EventStatus.SCHEDULED);
 			blockingEvents.add(event);
 		}
-		// NOSONAR - Mockito matcher
-		lenient().when(service.findEventsBetweenDates(any(Date.class), any(Date.class))).thenReturn(blockingEvents);
 
 		// Act
-		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr);
+		final Map<String, Object> result = calendarEventRestController.getNextAvailableTime(dateStr, principal);
 
 		// Assert
 		assertThat(result).isNotNull();
@@ -1304,10 +1184,7 @@ public class CalendarEventRestControllerTest {
 		// Should return default time (8:00 AM) even though events would block it
 		final String dateTime = (String) result.get("dateTime");
 		assertThat(dateTime).contains("08:00:00");
-		// Verify that findEventsBetweenDates was NOT called (no availability calculation
-		// for past dates)
-		// NOSONAR - Mockito matcher
-		verify(service, never()).findEventsBetweenDates(any(Date.class), any(Date.class));
+		verify(bookingAvailabilitySlotService, never()).findNextAvailableStart(any(), any(), any());
 		log.info("finished testGetNextAvailableTimeWithPastDateDoesNotCheckAvailability");
 	}
 


### PR DESCRIPTION
## Summary
- Add `nutritionist_availability_block` table (Liquibase 015) and booking services to persist per-nutritionist absence windows
- Admin calendar: "Marcar ausencia" modal, gray striped FullCalendar events, SweetAlert delete confirm; blocks merged with appointments via `/rest/calendario/blocks`
- Public slot API `GET /rest/profile/availability/slots?date=YYYY-MM-DD` and next-available-time now subtract blocks plus scheduled appointments from working hours
- Tracking docs updated (`ISSUE-PUBLIC-BOOKING.md`, `AGENTS.md`, `AGENT-WORKFLOW.md`, `README.md`) — **NEXT:** #248

Fixes #247

## Test plan
- [x] `/admin/calendario` — create full-day block; gray striped event appears
- [x] Create time-range block (e.g. 10:00–12:00); renders and blocks overlapping slots
- [x] Delete block via SweetAlert confirm; event disappears
- [x] `GET /rest/profile/availability/slots?date=` returns slots excluding blocks and existing appointments
- [x] `mvn test` and `./lint.sh` pass locally
- [x] Browser UI smoke test on localhost:3000 (create/view/delete blocks, slots API)
- [ ] User A cannot delete User B's blocks (multi-tenant) — covered by unit tests