### PR TITLE
Document 2-day minimum advance for public booking (#248)

### DIFF
--- a/ISSUE-PUBLIC-BOOKING.md
+++ b/ISSUE-PUBLIC-BOOKING.md
@@ -3,7 +3,7 @@
 Living index of GitHub issues for **public appointment scheduling** — shareable links, nutritionist availability, and patient self-booking. Update when status changes (commit on the PR that closes work).
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
-**Last updated:** 2026-06-20 — ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)). **NEXT:** #248. Epic **#245** with child issues **#246–#248** registered.
+**Last updated:** 2026-06-21 — ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)). **NEXT:** #248. Epic **#245** with child issues **#246–#248** registered.
 
 > **Scope.** Public routes (`/consultas/{id}/agendar-cita` or equivalent), availability configuration, and calendar blocks. Nutritionist admin UI pieces may live in `/admin/**` but this track owns the **public booking product**. Mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Nutritionist web (non-booking): [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
@@ -33,6 +33,7 @@ Shareable URL for patients to book into a nutritionist's real availability:
 | Profile: working hours / availability | #246 |
 | Calendar: unavailable days & absence windows | #247 |
 | Public page: slot picker + booking | #248 |
+| Minimum 2-day booking advance (public only) | #248 |
 
 **Suggested order:** #246 → #247 → #248.
 
@@ -41,7 +42,7 @@ Shareable URL for patients to book into a nutritionist's real availability:
 | **245** | Epic — public appointment scheduling link per nutritionist | https://github.com/diego-torres/nutriconsultas/issues/245 | open | — | New track; Liquibase for availability + public slug |
 | **246** | Nutritionist profile — configure working hours and availability | https://github.com/diego-torres/nutriconsultas/issues/246 | **done** | **245** | Branch `issue-246-working-hours`; `GET/PUT /rest/profile/availability`; Liquibase `014` |
 | **247** | Calendar — unavailable days and absence windows | https://github.com/diego-torres/nutriconsultas/issues/247 | **done** | **246** | PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295); Liquibase `015`, blocks API, slot query |
-| **248** | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | **NEXT** | **246**, ~~**247**~~, ~~**243**~~ | reCAPTCHA via `@PublicRecaptchaForm`; opaque public id |
+| **248** | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | **NEXT** | **246**, ~~**247**~~, ~~**243**~~ | reCAPTCHA; opaque public id; **2-day min advance** (UI + API) |
 
 ---
 

--- a/docs/public-booking/AVAILABILITY.md
+++ b/docs/public-booking/AVAILABILITY.md
@@ -44,3 +44,17 @@ REST (authenticated, calendar UI):
 - `DELETE /rest/calendario/blocks/{id}` — remove block (SweetAlert confirm in UI)
 
 Admin UI: `/admin/calendario` → **Marcar ausencia**; blocked intervals render in gray with striped styling.
+
+## Minimum booking advance (#248)
+
+Public self-booking requires **at least 2 calendar days of anticipation** (nutritionist timezone). The earliest bookable date is **today + 2 days** — not today or tomorrow.
+
+| Layer | Rule |
+|-------|------|
+| **Public slot API** | Return no slots (or reject the date) when `date` is before `today + 2 days` in the nutritionist's timezone |
+| **Public booking POST** | Reject submissions where `slotStart < today + 2 days` (server-side; do not rely on UI alone) |
+| **Public UI** | Date picker disables/blocks the next 2 calendar days; Spanish copy e.g. *Las citas requieren al menos 2 días de anticipación* |
+
+Implementation note: add `MIN_BOOKING_ADVANCE_DAYS = 2` to `BookingAvailabilityConstants` (or equivalent) and apply in the public slot path and booking validator — **not** in the nutritionist admin calendar preview (`GET /rest/profile/availability/slots` remains unrestricted for staff).
+
+Tests: slot API empty for D+0/D+1; booking rejected inside window; first eligible day is D+2; timezone boundary at midnight `America/Mexico_City`.


### PR DESCRIPTION
## Summary
- Add **minimum 2-day booking advance** to public booking tracking (`ISSUE-PUBLIC-BOOKING.md`)
- Document API, POST, and UI rules in `docs/public-booking/AVAILABILITY.md`
- Aligns with updated GitHub issues [#245](https://github.com/diego-torres/nutriconsultas/issues/245) and [#248](https://github.com/diego-torres/nutriconsultas/issues/248)

Relates to #248

## Test plan
- [x] Docs-only change — no code behavior change
- [x] CI lint + build pass


Made with [Cursor](https://cursor.com)