### PR TITLE
[Public Booking] Public slot picker and appointment booking (#248)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -39,7 +39,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) | `[Public Booking]` epic #245–#248 |
 | [`docs/public-booking/AVAILABILITY.md`](docs/public-booking/AVAILABILITY.md) | Working hours model, timezone, REST (#246) |
 
-**Current next issue (public booking):** [#248 — public slot picker and appointment booking](https://github.com/diego-torres/nutriconsultas/issues/248). ~~#246~~, ~~#247~~ done (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)). See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
+**Current next issue (public booking):** [#297 — display and copy public booking link](https://github.com/diego-torres/nutriconsultas/issues/297). ~~#246~~, ~~#247~~, ~~#248~~ done (~~#247~~ PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295); ~~#248~~ `issue-248-public-booking`, `ef67600`). See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
 **Current next issue (mobile):** [#134 — POST /rest/mobile/invitations](https://github.com/diego-torres/nutriconsultas/issues/134). ~~#133~~ done (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -606,7 +606,7 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 ## Public booking (tracking)
 
-Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)). **NEXT:** [#248 public slot picker + booking](https://github.com/diego-torres/nutriconsultas/issues/248).
+Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)). **NEXT:** [#248 public slot picker + booking](https://github.com/diego-torres/nutriconsultas/issues/248) **in-progress** (`issue-248-public-booking`).
 
 ## Resources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -606,7 +606,7 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 ## Public booking (tracking)
 
-Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)). **NEXT:** [#248 public slot picker + booking](https://github.com/diego-torres/nutriconsultas/issues/248) **in-progress** (`issue-248-public-booking`).
+Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)); ~~#248~~ **done** (`issue-248-public-booking`, `ef67600`). **NEXT:** [#297 copy public booking link](https://github.com/diego-torres/nutriconsultas/issues/297).
 
 ## Resources
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -221,7 +221,7 @@ Inline **cantidad** editing on the catalog platillo form (`/admin/platillos/{id}
 | #280 / #281 Diet nutrients | Full nutrient modal (#280); in-row platillo edit on ingesta grid (#281) — refresh dieta rollup |
 | ~~#285~~ Platillo form | Inline cantidad edit on catalog `#ingredientesGrid` + diet ingesta grid — branch `issue-285-platillo-inline-cantidad` |
 | ~~#243~~ / #244 Subscription | reCAPTCHA **done**; Solicitar acceso pre-fill — public funnel, not admin UI |
-| #245–#248 Public booking | ~~#246~~ done (branch `issue-246-working-hours`); nutritionist hours in profile — separate track |
+| #245–#248 Public booking | ~~#246~~, ~~#247~~, ~~#248~~ done; **NEXT** #297 (copy booking link) — separate track |
 
 ---
 

--- a/ISSUE-PUBLIC-BOOKING.md
+++ b/ISSUE-PUBLIC-BOOKING.md
@@ -3,7 +3,7 @@
 Living index of GitHub issues for **public appointment scheduling** — shareable links, nutritionist availability, and patient self-booking. Update when status changes (commit on the PR that closes work).
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
-**Last updated:** 2026-06-21 — ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)). **NEXT:** #248 **in-progress** (`issue-248-public-booking`); then #297. Epic **#245** with child issues **#246–#248**, **#297**.
+**Last updated:** 2026-06-21 — ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)); ~~#248~~ **done** (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)). **NEXT:** #297. Epic **#245** with child issues **#246–#248**, **#297**.
 
 > **Scope.** Public routes (`/consultas/{id}/agendar-cita` or equivalent), availability configuration, and calendar blocks. Nutritionist admin UI pieces may live in `/admin/**` but this track owns the **public booking product**. Mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Nutritionist web (non-booking): [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
@@ -43,8 +43,8 @@ Shareable URL for patients to book into a nutritionist's real availability:
 | **245** | Epic — public appointment scheduling link per nutritionist | https://github.com/diego-torres/nutriconsultas/issues/245 | open | — | New track; Liquibase for availability + public slug |
 | **246** | Nutritionist profile — configure working hours and availability | https://github.com/diego-torres/nutriconsultas/issues/246 | **done** | **245** | Branch `issue-246-working-hours`; `GET/PUT /rest/profile/availability`; Liquibase `014` |
 | **247** | Calendar — unavailable days and absence windows | https://github.com/diego-torres/nutriconsultas/issues/247 | **done** | **246** | PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295); Liquibase `015`, blocks API, slot query |
-| **248** | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | **in-progress** | **246**, ~~**247**~~, ~~**243**~~ | Branch `issue-248-public-booking`; reCAPTCHA; opaque public id; **2-day min advance** (UI + API) |
-| **297** | Nutritionist profile — display and copy public booking link | https://github.com/diego-torres/nutriconsultas/issues/297 | **open** | **248** | Admin `sbadmin/profile/formulario.html`; copy-to-clipboard + `swal` |
+| **248** | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | **done** | **246**, ~~**247**~~, ~~**243**~~ | PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298); Liquibase `016`, public REST + `agendar-cita`; 2-day min advance |
+| **297** | Nutritionist profile — display and copy public booking link | https://github.com/diego-torres/nutriconsultas/issues/297 | **NEXT** | ~~**248**~~ | Admin `sbadmin/profile/formulario.html`; copy-to-clipboard + `swal` |
 
 ---
 
@@ -52,7 +52,7 @@ Shareable URL for patients to book into a nutritionist's real availability:
 
 | Track | Interaction |
 |-------|-------------|
-| ~~#243~~ reCAPTCHA | **done** — `RecaptchaVerificationService` + production keys; reuse on public booking (#248) |
+| ~~#243~~ reCAPTCHA | **done** — `RecaptchaVerificationService` + production keys; reused on public booking (~~#248~~) |
 | #244 Solicitar acceso | Orthogonal — nutritionist onboarding vs patient booking |
 | `CalendarEvent` | Existing appointments; clarify vs availability blocks |
 | #236 Nutritionist profile | Same profile area for hours (#246) and logo |

--- a/ISSUE-PUBLIC-BOOKING.md
+++ b/ISSUE-PUBLIC-BOOKING.md
@@ -3,7 +3,7 @@
 Living index of GitHub issues for **public appointment scheduling** — shareable links, nutritionist availability, and patient self-booking. Update when status changes (commit on the PR that closes work).
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
-**Last updated:** 2026-06-21 — ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)). **NEXT:** #248. Epic **#245** with child issues **#246–#248** registered.
+**Last updated:** 2026-06-21 — ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)). **NEXT:** #248 **in-progress** (`issue-248-public-booking`); then #297. Epic **#245** with child issues **#246–#248**, **#297**.
 
 > **Scope.** Public routes (`/consultas/{id}/agendar-cita` or equivalent), availability configuration, and calendar blocks. Nutritionist admin UI pieces may live in `/admin/**` but this track owns the **public booking product**. Mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Nutritionist web (non-booking): [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
@@ -34,15 +34,17 @@ Shareable URL for patients to book into a nutritionist's real availability:
 | Calendar: unavailable days & absence windows | #247 |
 | Public page: slot picker + booking | #248 |
 | Minimum 2-day booking advance (public only) | #248 |
+| Profile: display + copy public booking link | #297 |
 
-**Suggested order:** #246 → #247 → #248.
+**Suggested order:** #246 → #247 → #248 → #297.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | **245** | Epic — public appointment scheduling link per nutritionist | https://github.com/diego-torres/nutriconsultas/issues/245 | open | — | New track; Liquibase for availability + public slug |
 | **246** | Nutritionist profile — configure working hours and availability | https://github.com/diego-torres/nutriconsultas/issues/246 | **done** | **245** | Branch `issue-246-working-hours`; `GET/PUT /rest/profile/availability`; Liquibase `014` |
 | **247** | Calendar — unavailable days and absence windows | https://github.com/diego-torres/nutriconsultas/issues/247 | **done** | **246** | PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295); Liquibase `015`, blocks API, slot query |
-| **248** | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | **NEXT** | **246**, ~~**247**~~, ~~**243**~~ | reCAPTCHA; opaque public id; **2-day min advance** (UI + API) |
+| **248** | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | **in-progress** | **246**, ~~**247**~~, ~~**243**~~ | Branch `issue-248-public-booking`; reCAPTCHA; opaque public id; **2-day min advance** (UI + API) |
+| **297** | Nutritionist profile — display and copy public booking link | https://github.com/diego-torres/nutriconsultas/issues/297 | **open** | **248** | Admin `sbadmin/profile/formulario.html`; copy-to-clipboard + `swal` |
 
 ---
 

--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -89,7 +89,7 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 | 243 | Production reCAPTCHA keys for minutriporcion.com | https://github.com/diego-torres/nutriconsultas/issues/243 | **done** | — | EC2 `RECAPTCHA_*` + `RecaptchaVerificationService` / `@PublicRecaptchaForm` |
 | 244 | Pre-fill contact form when clicking Solicitar Acceso for a plan | https://github.com/diego-torres/nutriconsultas/issues/244 | open | — | Plan slug on `ContactInquiry`; pairs with #184 |
 
-**Suggested order:** ~~#243~~ → #244 (or parallel). Public booking (#248) reuses `@PublicRecaptchaForm` + `RecaptchaVerificationService`.
+**Suggested order:** ~~#243~~ → #244 (or parallel). Public booking (~~#248~~) reuses `@PublicRecaptchaForm` + `RecaptchaVerificationService`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-20):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: all registered epics **complete** (#221–#242, #271–#272). Public booking **NEXT:** [#248](https://github.com/diego-torres/nutriconsultas/issues/248); ~~#246~~, ~~#247~~ done (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)).
+**On `main` (2026-06-21):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: all registered epics **complete** (#221–#242, #271–#272). Public booking **NEXT:** [#297](https://github.com/diego-torres/nutriconsultas/issues/297); ~~#246~~, ~~#247~~ (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)), ~~#248~~ done (`issue-248-public-booking`, `ef67600`).
 
 ## AWS (production infrastructure)
 

--- a/docs/public-booking/AVAILABILITY.md
+++ b/docs/public-booking/AVAILABILITY.md
@@ -29,9 +29,9 @@ Public slot APIs convert `LocalDate` + slot start `LocalTime` using the nutritio
 - `nutritionist_availability_block` rows for that nutritionist (#247)
 - `CalendarEvent` rows with status `SCHEDULED` for that nutritionist's patients
 
-Authenticated preview: `GET /rest/profile/availability/slots?date=YYYY-MM-DD` (same slot list public booking #248 will expose per nutritionist).
+Authenticated preview: `GET /rest/profile/availability/slots?date=YYYY-MM-DD` (same slot list as public booking per nutritionist).
 
-## Public booking (#248)
+## Public booking (~~#248~~ — shipped)
 
 | Endpoint | Auth | Purpose |
 |----------|------|---------|
@@ -42,7 +42,7 @@ Authenticated preview: `GET /rest/profile/availability/slots?date=YYYY-MM-DD` (s
 
 Opaque **`public_booking_id`** (UUID) on `nutritionist_profile` — never expose OAuth `userId` in public URLs.
 
-## Minimum booking advance (#248)
+## Minimum booking advance (~~#248~~)
 
 Public self-booking requires **at least 2 calendar days of anticipation** (nutritionist timezone). The earliest bookable date is **today + 2 days** — not today or tomorrow.
 

--- a/docs/public-booking/AVAILABILITY.md
+++ b/docs/public-booking/AVAILABILITY.md
@@ -31,6 +31,31 @@ Public slot APIs (#248) must convert `LocalDate` + slot start `LocalTime` using 
 
 Authenticated preview: `GET /rest/profile/availability/slots?date=YYYY-MM-DD` (same slot list public booking #248 will expose per nutritionist).
 
+## Public booking (#248)
+
+| Endpoint | Auth | Purpose |
+|----------|------|---------|
+| `GET /consultas/{publicBookingId}/agendar-cita` | Public | Thymeleaf slot picker + booking form |
+| `GET /rest/public/booking/{publicBookingId}/context` | Public | Display name, timezone, advance days |
+| `GET /rest/public/booking/{publicBookingId}/slots?date=` | Public | Available slots (respects 2-day advance) |
+| `POST /rest/public/booking/{publicBookingId}/book` | Public | Create patient (if needed) + `CalendarEvent`; reCAPTCHA + rate limit |
+
+Opaque **`public_booking_id`** (UUID) on `nutritionist_profile` — never expose OAuth `userId` in public URLs.
+
+## Minimum booking advance (#248)
+
+Public self-booking requires **at least 2 calendar days of anticipation** (nutritionist timezone). The earliest bookable date is **today + 2 days** — not today or tomorrow.
+
+| Layer | Rule |
+|-------|------|
+| **Public slot API** | Return no slots (or reject the date) when `date` is before `today + 2 days` in the nutritionist's timezone |
+| **Public booking POST** | Reject submissions where `slotStart < today + 2 days` (server-side; do not rely on UI alone) |
+| **Public UI** | Date picker disables/blocks the next 2 calendar days; Spanish copy e.g. *Las citas requieren al menos 2 días de anticipación* |
+
+Implementation: `MIN_BOOKING_ADVANCE_DAYS = 2` in `BookingAvailabilityConstants`; `PublicBookingAdvanceRules` applies on public paths only — admin preview (`GET /rest/profile/availability/slots`) stays unrestricted.
+
+Tests: slot API empty for D+0/D+1; booking rejected inside window; first eligible day is D+2; timezone boundary at midnight `America/Mexico_City`.
+
 ## Absence blocks (#247)
 
 | Table | Purpose |

--- a/docs/public-booking/AVAILABILITY.md
+++ b/docs/public-booking/AVAILABILITY.md
@@ -1,12 +1,12 @@
 # Nutritionist availability (#246)
 
-Working hours and slot duration configured at **`/admin/perfil`** feed future public booking slot generation (#248).
+Working hours and slot duration configured at **`/admin/perfil`** feed public booking slot generation (~~#248~~).
 
 ## Timezone
 
 All availability windows are interpreted in **`America/Mexico_City`** (CST/CDT). The REST API persists this value on `nutritionist_availability_settings.timezone`; the profile UI displays it read-only until multi-timezone support is added.
 
-Public slot APIs (#248) must convert `LocalDate` + slot start `LocalTime` using the nutritionist's stored zone, not the JVM default or the visitor's browser zone.
+Public slot APIs convert `LocalDate` + slot start `LocalTime` using the nutritionist's stored zone, not the JVM default or the visitor's browser zone.
 
 ## Data model
 

--- a/src/main/java/com/nutriconsultas/SecurityConfig.java
+++ b/src/main/java/com/nutriconsultas/SecurityConfig.java
@@ -38,6 +38,8 @@ public class SecurityConfig {
 			.headers(headers -> headers.frameOptions(options -> options.sameOrigin()))
 			.authorizeHttpRequests(ar -> ar.requestMatchers("/rest/subscription/payment/webhook")
 				.permitAll()
+				.requestMatchers("/rest/public/booking/**")
+				.permitAll()
 				.requestMatchers("/invitation/nutritionist/redeem", "/invitation/nutritionist/dev-checkout")
 				.authenticated()
 				.requestMatchers("/invitation/**")

--- a/src/main/java/com/nutriconsultas/booking/BookingAvailabilityConstants.java
+++ b/src/main/java/com/nutriconsultas/booking/BookingAvailabilityConstants.java
@@ -17,6 +17,8 @@ public final class BookingAvailabilityConstants {
 
 	public static final int MAX_SLOT_DURATION_MINUTES = 120;
 
+	public static final int MIN_BOOKING_ADVANCE_DAYS = 2;
+
 	private BookingAvailabilityConstants() {
 	}
 

--- a/src/main/java/com/nutriconsultas/booking/ClientIpResolver.java
+++ b/src/main/java/com/nutriconsultas/booking/ClientIpResolver.java
@@ -1,0 +1,24 @@
+package com.nutriconsultas.booking;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Resolves client IP for anonymous rate limiting (#248).
+ */
+public final class ClientIpResolver {
+
+	private ClientIpResolver() {
+	}
+
+	public static String resolve(final HttpServletRequest request) {
+		if (request == null) {
+			return "unknown";
+		}
+		final String forwarded = request.getHeader("X-Forwarded-For");
+		if (forwarded != null && !forwarded.isBlank()) {
+			return forwarded.split(",")[0].trim();
+		}
+		return request.getRemoteAddr();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingAdvanceRules.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingAdvanceRules.java
@@ -18,17 +18,11 @@ public final class PublicBookingAdvanceRules {
 	}
 
 	public static boolean isDateBookable(final LocalDate date, final ZoneId zoneId) {
-		if (date == null) {
-			return false;
-		}
-		return !date.isBefore(earliestBookableDate(zoneId));
+		return date != null && !date.isBefore(earliestBookableDate(zoneId));
 	}
 
 	public static boolean isSlotBookable(final LocalDateTime slotStart, final ZoneId zoneId) {
-		if (slotStart == null) {
-			return false;
-		}
-		return !slotStart.toLocalDate().isBefore(earliestBookableDate(zoneId));
+		return slotStart != null && !slotStart.toLocalDate().isBefore(earliestBookableDate(zoneId));
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingAdvanceRules.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingAdvanceRules.java
@@ -1,0 +1,34 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+/**
+ * Public booking lead-time rules (#248). Nutritionist admin preview endpoints do not use
+ * these checks.
+ */
+public final class PublicBookingAdvanceRules {
+
+	private PublicBookingAdvanceRules() {
+	}
+
+	public static LocalDate earliestBookableDate(final ZoneId zoneId) {
+		return LocalDate.now(zoneId).plusDays(BookingAvailabilityConstants.MIN_BOOKING_ADVANCE_DAYS);
+	}
+
+	public static boolean isDateBookable(final LocalDate date, final ZoneId zoneId) {
+		if (date == null) {
+			return false;
+		}
+		return !date.isBefore(earliestBookableDate(zoneId));
+	}
+
+	public static boolean isSlotBookable(final LocalDateTime slotStart, final ZoneId zoneId) {
+		if (slotStart == null) {
+			return false;
+		}
+		return !slotStart.toLocalDate().isBefore(earliestBookableDate(zoneId));
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingConfirmation.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingConfirmation.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.booking;
+
+/**
+ * Result of a successful public booking (#248).
+ */
+public record PublicBookingConfirmation(long eventId, String date, String time) {
+}

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingController.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingController.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.booking;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nutriconsultas.recaptcha.PublicRecaptchaForm;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@Slf4j
+@PublicRecaptchaForm
+public class PublicBookingController {
+
+	private final PublicBookingService publicBookingService;
+
+	public PublicBookingController(final PublicBookingService publicBookingService) {
+		this.publicBookingService = publicBookingService;
+	}
+
+	@GetMapping("/consultas/{publicBookingId}/agendar-cita")
+	public String bookingPage(@PathVariable final String publicBookingId, final Model model) {
+		log.debug("Public booking page requested");
+		try {
+			final PublicBookingNutritionistContext context = publicBookingService.resolveContext(publicBookingId);
+			model.addAttribute("nutritionistDisplayName", context.displayName());
+			model.addAttribute("publicBookingId", context.publicBookingId());
+			model.addAttribute("minAdvanceDays", context.minAdvanceDays());
+			model.addAttribute("minBookableDate",
+					PublicBookingAdvanceRules.earliestBookableDate(java.time.ZoneId.of(context.timezone())).toString());
+			model.addAttribute("advanceNotice",
+					"Las citas requieren al menos " + context.minAdvanceDays() + " días de anticipación.");
+			return "eterna/agendar-cita";
+		}
+		catch (PublicBookingNotFoundException ex) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Enlace de reserva no disponible");
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingController.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingController.java
@@ -37,7 +37,7 @@ public class PublicBookingController {
 			return "eterna/agendar-cita";
 		}
 		catch (PublicBookingNotFoundException ex) {
-			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Enlace de reserva no disponible");
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Enlace de reserva no disponible", ex);
 		}
 	}
 

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingExceptionHandler.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.booking;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+
+@RestControllerAdvice(basePackages = "com.nutriconsultas.booking")
+public class PublicBookingExceptionHandler {
+
+	@ExceptionHandler(PublicBookingNotFoundException.class)
+	public ResponseEntity<Map<String, Object>> handleNotFound(final PublicBookingNotFoundException ex) {
+		return error(HttpStatus.NOT_FOUND, "Enlace de reserva no disponible");
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<Map<String, Object>> handleBadRequest(final IllegalArgumentException ex) {
+		return error(HttpStatus.BAD_REQUEST, ex.getMessage());
+	}
+
+	@ExceptionHandler(RequestNotPermitted.class)
+	public ResponseEntity<Map<String, Object>> handleRateLimit(final RequestNotPermitted ex) {
+		final Map<String, Object> body = errorBody("Demasiadas solicitudes. Intente más tarde.");
+		body.put("retryAfterSeconds", 3600);
+		return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).header("Retry-After", "3600").body(body);
+	}
+
+	private static ResponseEntity<Map<String, Object>> error(final HttpStatus status, final String message) {
+		return ResponseEntity.status(status).body(errorBody(message));
+	}
+
+	private static Map<String, Object> errorBody(final String message) {
+		final Map<String, Object> body = new HashMap<>();
+		body.put("success", false);
+		body.put("error", message);
+		return body;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingNotFoundException.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingNotFoundException.java
@@ -1,8 +1,8 @@
 package com.nutriconsultas.booking;
 
-import org.springframework.lang.NonNull;
-
 public class PublicBookingNotFoundException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
 
 	public PublicBookingNotFoundException() {
 		super("Nutritionist booking link not found");

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingNotFoundException.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingNotFoundException.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.booking;
+
+import org.springframework.lang.NonNull;
+
+public class PublicBookingNotFoundException extends RuntimeException {
+
+	public PublicBookingNotFoundException() {
+		super("Nutritionist booking link not found");
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingNutritionistContext.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingNutritionistContext.java
@@ -1,0 +1,9 @@
+package com.nutriconsultas.booking;
+
+/**
+ * Resolved nutritionist context for a public booking page (no internal {@code userId} in
+ * responses).
+ */
+public record PublicBookingNutritionistContext(String publicBookingId, String displayName, String timezone,
+		int minAdvanceDays) {
+}

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingRateLimiter.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingRateLimiter.java
@@ -1,0 +1,41 @@
+package com.nutriconsultas.booking;
+
+import java.util.concurrent.Callable;
+
+import org.springframework.stereotype.Component;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+
+/**
+ * Rate limits anonymous public booking submissions (#248).
+ */
+@Component
+public final class PublicBookingRateLimiter {
+
+	public static final String PUBLIC_BOOKING = "publicBooking";
+
+	private final RateLimiterRegistry rateLimiterRegistry;
+
+	public PublicBookingRateLimiter(final RateLimiterRegistry rateLimiterRegistry) {
+		this.rateLimiterRegistry = rateLimiterRegistry;
+	}
+
+	public <T> T execute(final String clientKey, final Callable<T> callable) {
+		final RateLimiter templateLimiter = rateLimiterRegistry.rateLimiter(PUBLIC_BOOKING);
+		final RateLimiterConfig config = templateLimiter.getRateLimiterConfig();
+		final RateLimiter limiter = rateLimiterRegistry.rateLimiter(PUBLIC_BOOKING + ":" + clientKey, config);
+		try {
+			return RateLimiter.decorateCallable(limiter, callable).call();
+		}
+		catch (RequestNotPermitted ex) {
+			throw ex;
+		}
+		catch (Exception ex) {
+			throw new IllegalStateException("Rate-limited public booking call failed", ex);
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingRequestDto.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingRequestDto.java
@@ -1,0 +1,33 @@
+package com.nutriconsultas.booking;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class PublicBookingRequestDto {
+
+	@NotBlank(message = "El nombre es obligatorio")
+	@Size(max = 100)
+	private String patientName;
+
+	@NotBlank(message = "El correo es obligatorio")
+	@Email(message = "Correo no válido")
+	@Size(max = 100)
+	private String patientEmail;
+
+	@Size(max = 30)
+	private String patientPhone;
+
+	@NotNull(message = "La fecha es obligatoria")
+	private String date;
+
+	@NotBlank(message = "La hora es obligatoria")
+	private String time;
+
+	@NotBlank(message = "Complete la verificación reCAPTCHA")
+	private String recaptchaResponse;
+
+}

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingRestController.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingRestController.java
@@ -1,0 +1,90 @@
+package com.nutriconsultas.booking;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nutriconsultas.recaptcha.RecaptchaVerificationService;
+
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/public/booking")
+@Slf4j
+public class PublicBookingRestController {
+
+	private final PublicBookingService publicBookingService;
+
+	private final PublicBookingRateLimiter publicBookingRateLimiter;
+
+	private final RecaptchaVerificationService recaptchaVerificationService;
+
+	public PublicBookingRestController(final PublicBookingService publicBookingService,
+			final PublicBookingRateLimiter publicBookingRateLimiter,
+			final RecaptchaVerificationService recaptchaVerificationService) {
+		this.publicBookingService = publicBookingService;
+		this.publicBookingRateLimiter = publicBookingRateLimiter;
+		this.recaptchaVerificationService = recaptchaVerificationService;
+	}
+
+	@GetMapping("/{publicBookingId}/context")
+	public PublicBookingNutritionistContext getContext(@PathVariable final String publicBookingId) {
+		return publicBookingService.resolveContext(publicBookingId);
+	}
+
+	@GetMapping("/{publicBookingId}/slots")
+	public PublicBookingSlotsResponse getSlots(@PathVariable final String publicBookingId,
+			@RequestParam final String date) {
+		return publicBookingService.getPublicSlots(publicBookingId, date);
+	}
+
+	@PostMapping("/{publicBookingId}/book")
+	public ResponseEntity<Map<String, Object>> book(@PathVariable final String publicBookingId,
+			@Valid @RequestBody final PublicBookingRequestDto request, final BindingResult bindingResult,
+			final HttpServletRequest httpRequest) {
+		if (bindingResult.hasErrors()) {
+			return validationError("Complete todos los campos requeridos correctamente.");
+		}
+		if (!recaptchaVerificationService.verifyToken(request.getRecaptchaResponse())) {
+			return validationError("La verificación reCAPTCHA falló. Intente nuevamente.");
+		}
+		final String clientKey = ClientIpResolver.resolve(httpRequest);
+		try {
+			final PublicBookingConfirmation confirmation = publicBookingRateLimiter.execute(clientKey,
+					() -> publicBookingService.book(publicBookingId, request));
+			final Map<String, Object> body = new HashMap<>();
+			body.put("success", true);
+			body.put("eventId", confirmation.eventId());
+			body.put("date", confirmation.date());
+			body.put("time", confirmation.time());
+			return ResponseEntity.ok(body);
+		}
+		catch (RequestNotPermitted ex) {
+			throw ex;
+		}
+		catch (IllegalArgumentException ex) {
+			return validationError(ex.getMessage());
+		}
+	}
+
+	private static ResponseEntity<Map<String, Object>> validationError(final String message) {
+		final Map<String, Object> body = new HashMap<>();
+		body.put("success", false);
+		body.put("error", message);
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingRestController.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingRestController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.nutriconsultas.recaptcha.RecaptchaVerificationService;
 
-import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
@@ -71,9 +70,6 @@ public class PublicBookingRestController {
 			body.put("date", confirmation.date());
 			body.put("time", confirmation.time());
 			return ResponseEntity.ok(body);
-		}
-		catch (RequestNotPermitted ex) {
-			throw ex;
 		}
 		catch (IllegalArgumentException ex) {
 			return validationError(ex.getMessage());

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingService.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingService.java
@@ -1,0 +1,13 @@
+package com.nutriconsultas.booking;
+
+import org.springframework.lang.NonNull;
+
+public interface PublicBookingService {
+
+	PublicBookingNutritionistContext resolveContext(@NonNull String publicBookingId);
+
+	PublicBookingSlotsResponse getPublicSlots(@NonNull String publicBookingId, @NonNull String date);
+
+	PublicBookingConfirmation book(@NonNull String publicBookingId, @NonNull PublicBookingRequestDto request);
+
+}

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingServiceImpl.java
@@ -1,0 +1,173 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.calendar.CalendarEventService;
+import com.nutriconsultas.calendar.EventStatus;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteService;
+import com.nutriconsultas.profile.NutritionistProfile;
+import com.nutriconsultas.profile.NutritionistProfileRepository;
+import com.nutriconsultas.subscription.lifecycle.SubscriptionAccessService;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class PublicBookingServiceImpl implements PublicBookingService {
+
+	private static final DateTimeFormatter SLOT_TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm");
+
+	private static final String DEFAULT_DISPLAY_NAME = "Consulta nutricional";
+
+	private static final String ADVANCE_NOTICE = "Las citas requieren al menos 2 días de anticipación.";
+
+	private final NutritionistProfileRepository profileRepository;
+
+	private final SubscriptionAccessService subscriptionAccessService;
+
+	private final NutritionistAvailabilityService availabilityService;
+
+	private final BookingAvailabilitySlotService bookingAvailabilitySlotService;
+
+	private final PacienteRepository pacienteRepository;
+
+	private final PacienteService pacienteService;
+
+	private final CalendarEventService calendarEventService;
+
+	public PublicBookingServiceImpl(final NutritionistProfileRepository profileRepository,
+			final SubscriptionAccessService subscriptionAccessService,
+			final NutritionistAvailabilityService availabilityService,
+			final BookingAvailabilitySlotService bookingAvailabilitySlotService,
+			final PacienteRepository pacienteRepository, final PacienteService pacienteService,
+			final CalendarEventService calendarEventService) {
+		this.profileRepository = profileRepository;
+		this.subscriptionAccessService = subscriptionAccessService;
+		this.availabilityService = availabilityService;
+		this.bookingAvailabilitySlotService = bookingAvailabilitySlotService;
+		this.pacienteRepository = pacienteRepository;
+		this.pacienteService = pacienteService;
+		this.calendarEventService = calendarEventService;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public PublicBookingNutritionistContext resolveContext(@NonNull final String publicBookingId) {
+		final NutritionistProfile profile = resolveActiveProfile(publicBookingId);
+		final AvailabilityScheduleDto schedule = availabilityService.getSchedule(profile.getUserId());
+		return new PublicBookingNutritionistContext(profile.getPublicBookingId(), resolveDisplayName(profile),
+				schedule.getTimezone(), BookingAvailabilityConstants.MIN_BOOKING_ADVANCE_DAYS);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public PublicBookingSlotsResponse getPublicSlots(@NonNull final String publicBookingId,
+			@NonNull final String date) {
+		final NutritionistProfile profile = resolveActiveProfile(publicBookingId);
+		final AvailabilityScheduleDto schedule = availabilityService.getSchedule(profile.getUserId());
+		final ZoneId zoneId = ZoneId.of(schedule.getTimezone());
+		final LocalDate parsedDate = LocalDate.parse(date);
+		final LocalDate minBookableDate = PublicBookingAdvanceRules.earliestBookableDate(zoneId);
+		if (!PublicBookingAdvanceRules.isDateBookable(parsedDate, zoneId)) {
+			return new PublicBookingSlotsResponse(parsedDate.toString(), minBookableDate,
+					BookingAvailabilityConstants.MIN_BOOKING_ADVANCE_DAYS, List.of(), ADVANCE_NOTICE);
+		}
+		final List<String> slots = bookingAvailabilitySlotService
+			.getAvailableSlotStarts(profile.getUserId(), parsedDate)
+			.stream()
+			.map(SLOT_TIME_FORMAT::format)
+			.collect(Collectors.toList());
+		return new PublicBookingSlotsResponse(parsedDate.toString(), minBookableDate,
+				BookingAvailabilityConstants.MIN_BOOKING_ADVANCE_DAYS, slots, null);
+	}
+
+	@Override
+	@Transactional
+	public PublicBookingConfirmation book(@NonNull final String publicBookingId,
+			@NonNull final PublicBookingRequestDto request) {
+		final NutritionistProfile profile = resolveActiveProfile(publicBookingId);
+		final String userId = profile.getUserId();
+		final AvailabilityScheduleDto schedule = availabilityService.getSchedule(userId);
+		final ZoneId zoneId = ZoneId.of(schedule.getTimezone());
+		final LocalDate date = LocalDate.parse(request.getDate());
+		final LocalTime time = LocalTime.parse(request.getTime(), SLOT_TIME_FORMAT);
+		final LocalDateTime slotStart = date.atTime(time);
+		if (!PublicBookingAdvanceRules.isSlotBookable(slotStart, zoneId)) {
+			throw new IllegalArgumentException(ADVANCE_NOTICE);
+		}
+		final List<LocalTime> available = bookingAvailabilitySlotService.getAvailableSlotStarts(userId, date);
+		if (!available.contains(time)) {
+			throw new IllegalArgumentException("El horario seleccionado ya no está disponible");
+		}
+		final Paciente paciente = findOrCreatePatient(userId, request);
+		final CalendarEvent event = new CalendarEvent();
+		event.setPaciente(paciente);
+		event.setTitle("Consulta");
+		event.setDescription("Reserva en línea");
+		event.setStatus(EventStatus.SCHEDULED);
+		event.setDurationMinutes(schedule.getSlotDurationMinutes());
+		event.setEventDateTime(Date.from(slotStart.atZone(zoneId).toInstant()));
+		final CalendarEvent saved = calendarEventService.save(event);
+		log.info("Public booking created event id={} for nutritionist userId={}", saved.getId(),
+				LogRedaction.redactUserId(userId));
+		return new PublicBookingConfirmation(saved.getId(), date.toString(), SLOT_TIME_FORMAT.format(time));
+	}
+
+	private NutritionistProfile resolveActiveProfile(final String publicBookingId) {
+		if (!StringUtils.hasText(publicBookingId)) {
+			throw new PublicBookingNotFoundException();
+		}
+		final NutritionistProfile profile = profileRepository.findByPublicBookingId(publicBookingId.trim())
+			.orElseThrow(PublicBookingNotFoundException::new);
+		if (subscriptionAccessService.findGrantingSubscriptionForUser(profile.getUserId()).isEmpty()) {
+			throw new PublicBookingNotFoundException();
+		}
+		return profile;
+	}
+
+	private Paciente findOrCreatePatient(final String userId, final PublicBookingRequestDto request) {
+		final String email = request.getPatientEmail().trim();
+		final Optional<Paciente> existing = pacienteRepository.findFirstByUserIdAndEmailIgnoreCase(userId, email);
+		if (existing.isPresent()) {
+			final Paciente paciente = existing.get();
+			if (StringUtils.hasText(request.getPatientPhone()) && !StringUtils.hasText(paciente.getPhone())) {
+				paciente.setPhone(request.getPatientPhone().trim());
+				return pacienteRepository.save(paciente);
+			}
+			return paciente;
+		}
+		final Paciente paciente = new Paciente();
+		paciente.setUserId(userId);
+		paciente.setName(request.getPatientName().trim());
+		paciente.setEmail(email);
+		if (StringUtils.hasText(request.getPatientPhone())) {
+			paciente.setPhone(request.getPatientPhone().trim());
+		}
+		return pacienteService.save(paciente);
+	}
+
+	private static String resolveDisplayName(final NutritionistProfile profile) {
+		if (profile.getDisplayName() != null && !profile.getDisplayName().isBlank()) {
+			return profile.getDisplayName().trim();
+		}
+		return DEFAULT_DISPLAY_NAME;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingSlotsResponse.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingSlotsResponse.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Public slots response for a single day (#248).
+ */
+public record PublicBookingSlotsResponse(String date, LocalDate minBookableDate, int minAdvanceDays, List<String> slots,
+		String notice) {
+}

--- a/src/main/java/com/nutriconsultas/dieta/IngredientePlatilloIngestaRestController.java
+++ b/src/main/java/com/nutriconsultas/dieta/IngredientePlatilloIngestaRestController.java
@@ -232,8 +232,8 @@ public class IngredientePlatilloIngestaRestController extends AbstractGridContro
 						+ "data-id='" + row.getId() + "' title='Eliminar'>"
 						+ "<i class='fas fa-trash fa-sm fa-fw'></i></button>"
 				: "";
-		return Arrays.asList(row.getAlimento().getNombreAlimento(), buildCantidadCell(row, canModify),
-				row.getUnidad(), row.getPesoNeto().toString(), actions);
+		return Arrays.asList(row.getAlimento().getNombreAlimento(), buildCantidadCell(row, canModify), row.getUnidad(),
+				row.getPesoNeto().toString(), actions);
 	}
 
 	private String buildCantidadCell(final IngredientePlatilloIngesta row, final boolean canModify) {

--- a/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
@@ -77,4 +77,8 @@ public interface PacienteRepository extends JpaRepository<Paciente, Long> {
 
 	boolean existsByUserIdAndNameIgnoreCaseAndDob(String userId, String name, Date dob);
 
+	@Query("SELECT p FROM Paciente p WHERE p.userId = :userId AND LOWER(p.email) = LOWER(:email)")
+	Optional<Paciente> findFirstByUserIdAndEmailIgnoreCase(@Param("userId") String userId,
+			@Param("email") String email);
+
 }

--- a/src/main/java/com/nutriconsultas/profile/NutritionistProfile.java
+++ b/src/main/java/com/nutriconsultas/profile/NutritionistProfile.java
@@ -44,6 +44,9 @@ public class NutritionistProfile {
 	@Column(nullable = false, unique = true, length = 255)
 	private String userId;
 
+	@Column(nullable = false, unique = true, length = 36)
+	private String publicBookingId;
+
 	/**
 	 * Optional display name override. Falls back to the OIDC {@code name} claim when
 	 * blank.

--- a/src/main/java/com/nutriconsultas/profile/NutritionistProfileRepository.java
+++ b/src/main/java/com/nutriconsultas/profile/NutritionistProfileRepository.java
@@ -16,4 +16,6 @@ public interface NutritionistProfileRepository extends JpaRepository<Nutritionis
 	 */
 	Optional<NutritionistProfile> findByUserId(String userId);
 
+	Optional<NutritionistProfile> findByPublicBookingId(String publicBookingId);
+
 }

--- a/src/main/java/com/nutriconsultas/profile/NutritionistProfileServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/profile/NutritionistProfileServiceImpl.java
@@ -2,6 +2,8 @@ package com.nutriconsultas.profile;
 
 import java.util.Base64;
 
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.NonNull;
@@ -59,10 +61,11 @@ public class NutritionistProfileServiceImpl implements NutritionistProfileServic
 	@NonNull
 	public NutritionistProfile getOrCreateProfile(@NonNull final String userId) {
 		log.info("Retrieving profile for user id: {}", LogRedaction.redactUserId(userId));
-		return repository.findByUserId(userId).orElseGet(() -> {
+		return repository.findByUserId(userId).map(this::ensurePublicBookingId).orElseGet(() -> {
 			log.info("No profile found, creating empty profile for user id: {}", LogRedaction.redactUserId(userId));
 			final NutritionistProfile emptyProfile = new NutritionistProfile();
 			emptyProfile.setUserId(userId);
+			emptyProfile.setPublicBookingId(UUID.randomUUID().toString());
 			return repository.save(emptyProfile);
 		});
 	}
@@ -141,6 +144,14 @@ public class NutritionistProfileServiceImpl implements NutritionistProfileServic
 
 	private String buildLogoKey(final String userId, final String extension) {
 		return LOGO_KEY_PREFIX + userId + LOGO_FILE_NAME + extension;
+	}
+
+	private NutritionistProfile ensurePublicBookingId(final NutritionistProfile profile) {
+		if (profile.getPublicBookingId() != null && !profile.getPublicBookingId().isBlank()) {
+			return profile;
+		}
+		profile.setPublicBookingId(UUID.randomUUID().toString());
+		return repository.save(profile);
 	}
 
 	private String resolveMimeType(final String extension) {

--- a/src/main/java/com/nutriconsultas/validation/template/EternaTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/validation/template/EternaTemplateValidator.java
@@ -17,6 +17,11 @@ public class EternaTemplateValidator extends BaseTemplateValidator {
 	public Map<String, Object> createMockModelVariables() {
 		final Map<String, Object> variables = super.createMockModelVariables();
 		variables.put("recaptchaSiteKey", "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI");
+		variables.put("nutritionistDisplayName", "Dra. Ejemplo");
+		variables.put("publicBookingId", "00000000-0000-4000-8000-000000000001");
+		variables.put("minAdvanceDays", 2);
+		variables.put("minBookableDate", "2026-06-22");
+		variables.put("advanceNotice", "Las citas requieren al menos 2 días de anticipación.");
 		return variables;
 	}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,6 +49,9 @@ springdoc.paths-to-match=/rest/mobile/**
 resilience4j.ratelimiter.instances.patientMessages.limit-for-period=10
 resilience4j.ratelimiter.instances.patientMessages.limit-refresh-period=1m
 resilience4j.ratelimiter.instances.patientMessages.timeout-duration=0s
+resilience4j.ratelimiter.instances.publicBooking.limit-for-period=10
+resilience4j.ratelimiter.instances.publicBooking.limit-refresh-period=1h
+resilience4j.ratelimiter.instances.publicBooking.timeout-duration=0s
 # Auth0 Management API — optional; enables patient mobile linkage by email (#109)
 app.auth0.management.client-id=${AUTH0_MGMT_CLIENT_ID:}
 app.auth0.management.client-secret=${AUTH0_MGMT_CLIENT_SECRET:}

--- a/src/main/resources/db/changelog/changes/016-nutritionist-public-booking-id.yaml
+++ b/src/main/resources/db/changelog/changes/016-nutritionist-public-booking-id.yaml
@@ -1,0 +1,61 @@
+databaseChangeLog:
+  - changeSet:
+      id: 016-nutritionist-public-booking-id-column
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            columnExists:
+              tableName: nutritionist_profile
+              columnName: public_booking_id
+      changes:
+        - addColumn:
+            tableName: nutritionist_profile
+            columns:
+              - column:
+                  name: public_booking_id
+                  type: VARCHAR(36)
+  - changeSet:
+      id: 016-nutritionist-public-booking-id-backfill-postgresql
+      author: nutriconsultas
+      dbms: postgresql
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: nutritionist_profile
+            columnName: public_booking_id
+      changes:
+        - sql:
+            sql: UPDATE nutritionist_profile SET public_booking_id = gen_random_uuid()::text WHERE public_booking_id IS NULL
+  - changeSet:
+      id: 016-nutritionist-public-booking-id-backfill-h2
+      author: nutriconsultas
+      dbms: h2
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: nutritionist_profile
+            columnName: public_booking_id
+      changes:
+        - sql:
+            sql: UPDATE nutritionist_profile SET public_booking_id = CAST(RANDOM_UUID() AS VARCHAR) WHERE public_booking_id IS NULL
+  - changeSet:
+      id: 016-nutritionist-public-booking-id-constraints
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: nutritionist_profile
+            columnName: public_booking_id
+        - not:
+            indexExists:
+              indexName: uk_nutritionist_profile_public_booking_id
+      changes:
+        - addNotNullConstraint:
+            tableName: nutritionist_profile
+            columnName: public_booking_id
+            columnDataType: VARCHAR(36)
+        - addUniqueConstraint:
+            tableName: nutritionist_profile
+            constraintName: uk_nutritionist_profile_public_booking_id
+            columnNames: public_booking_id

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -44,3 +44,6 @@ databaseChangeLog:
   - include:
       file: changes/015-nutritionist-availability-block.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/016-nutritionist-public-booking-id.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -38,3 +38,9 @@ databaseChangeLog:
   - include:
       file: changes/014-nutritionist-availability.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/015-nutritionist-availability-block.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: changes/016-nutritionist-public-booking-id.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/templates/eterna/agendar-cita.html
+++ b/src/main/resources/templates/eterna/agendar-cita.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+
+<head>
+  <meta charset="utf-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+  <title th:text="'Agendar cita — ' + ${nutritionistDisplayName}">Agendar cita</title>
+  <link th:href="@{/eterna/assets/img/favicon.png}" rel="icon">
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Raleway:300,300i,400,400i,500,500i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
+  <link th:href="@{/eterna/assets/vendor/bootstrap/css/bootstrap.min.css}" rel="stylesheet">
+  <link th:href="@{/eterna/assets/vendor/bootstrap-icons/bootstrap-icons.css}" rel="stylesheet">
+  <link th:href="@{/eterna/assets/vendor/boxicons/css/boxicons.min.css}" rel="stylesheet">
+  <link th:href="@{/eterna/assets/css/style.css}" rel="stylesheet">
+  <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+  <style>
+    #main { padding-top: 150px; }
+    .slot-btn { margin: 0.25rem; }
+    .slot-btn.active { background-color: #0880e8; color: #fff; border-color: #0880e8; }
+    #advanceNotice { display: none; }
+    #bookingSuccess { display: none; }
+  </style>
+</head>
+
+<body>
+
+  <header id="header" class="d-flex align-items-center">
+    <div class="container d-flex justify-content-between align-items-center">
+      <div class="logo">
+        <a th:href="@{/}" class="d-flex align-items-center">
+          <img th:src="@{/eterna/assets/img/favicon.png}" alt="Minutriporcion" style="height: 40px; margin-right: 10px;">
+          <h1 class="mb-0">Minutriporcion</h1>
+        </a>
+      </div>
+      <nav id="navbar" class="navbar">
+        <ul>
+          <li><a th:href="@{/}">Inicio</a></li>
+          <li><a th:href="@{/contact}">Contacto</a></li>
+          <li><a th:href="@{/admin}">Ingresar</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="breadcrumbs">
+      <div class="container">
+        <h2>Agendar cita</h2>
+        <p class="mb-0" th:text="${nutritionistDisplayName}">Nutricionista</p>
+      </div>
+    </section>
+
+    <section class="contact">
+      <div class="container col-lg-8">
+
+        <div id="bookingSuccess" class="alert alert-success" role="alert">
+          <strong>¡Cita reservada!</strong> Recibirá confirmación por correo próximamente.
+          <span id="confirmedSlot"></span>
+        </div>
+
+        <form id="bookingForm">
+          <input type="hidden" id="publicBookingId" th:value="${publicBookingId}">
+          <input type="hidden" id="selectedTime" name="time">
+
+          <div class="row mb-3">
+            <div class="col-md-6">
+              <label for="patientName" class="form-label">Nombre completo *</label>
+              <input type="text" class="form-control" id="patientName" name="patientName" required maxlength="100">
+            </div>
+            <div class="col-md-6">
+              <label for="patientEmail" class="form-label">Correo electrónico *</label>
+              <input type="email" class="form-control" id="patientEmail" name="patientEmail" required maxlength="100">
+            </div>
+          </div>
+
+          <div class="row mb-3">
+            <div class="col-md-6">
+              <label for="patientPhone" class="form-label">Teléfono</label>
+              <input type="tel" class="form-control" id="patientPhone" name="patientPhone" maxlength="30">
+            </div>
+            <div class="col-md-6">
+              <label for="appointmentDate" class="form-label">Fecha *</label>
+              <input type="date" class="form-control" id="appointmentDate" name="date" required
+                th:attr="min=${minBookableDate}">
+              <small class="text-muted" th:text="${advanceNotice}">Anticipación mínima</small>
+            </div>
+          </div>
+
+          <div class="mb-3">
+            <label class="form-label">Horario disponible *</label>
+            <div id="advanceNotice" class="alert alert-warning py-2" th:text="${advanceNotice}"></div>
+            <div id="slotsContainer" class="d-flex flex-wrap"></div>
+            <div id="slotsEmpty" class="text-muted small" style="display:none;">No hay horarios disponibles este día.</div>
+          </div>
+
+          <div class="mb-3">
+            <div class="g-recaptcha" th:attr="data-sitekey=${recaptchaSiteKey}"></div>
+          </div>
+
+          <button type="submit" class="btn btn-primary" id="submitBooking">Reservar cita</button>
+          <div id="bookingError" class="text-danger mt-2" style="display:none;"></div>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer id="footer">
+    <div class="container">
+      <div class="copyright">&copy; Copyright <strong><span>Minutriporcion</span></strong> México</div>
+    </div>
+  </footer>
+
+  <script th:src="@{/eterna/assets/vendor/bootstrap/js/bootstrap.bundle.min.js}"></script>
+  <script th:src="@{/eterna/assets/js/main.js}"></script>
+  <script th:inline="javascript">
+    (function () {
+      const publicBookingId = document.getElementById('publicBookingId').value;
+      const minBookableDate = /*[[${minBookableDate}]]*/ '';
+      const dateInput = document.getElementById('appointmentDate');
+      const slotsContainer = document.getElementById('slotsContainer');
+      const slotsEmpty = document.getElementById('slotsEmpty');
+      const advanceNotice = document.getElementById('advanceNotice');
+      const selectedTimeInput = document.getElementById('selectedTime');
+      const bookingError = document.getElementById('bookingError');
+      const bookingSuccess = document.getElementById('bookingSuccess');
+      const bookingForm = document.getElementById('bookingForm');
+
+      function clearSlots() {
+        slotsContainer.innerHTML = '';
+        selectedTimeInput.value = '';
+        slotsEmpty.style.display = 'none';
+        advanceNotice.style.display = 'none';
+      }
+
+      function renderSlots(data) {
+        clearSlots();
+        if (data.notice) {
+          advanceNotice.textContent = data.notice;
+          advanceNotice.style.display = 'block';
+          return;
+        }
+        if (!data.slots || data.slots.length === 0) {
+          slotsEmpty.style.display = 'block';
+          return;
+        }
+        data.slots.forEach(function (slot) {
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'btn btn-outline-primary slot-btn';
+          btn.textContent = slot;
+          btn.addEventListener('click', function () {
+            document.querySelectorAll('.slot-btn').forEach(function (b) { b.classList.remove('active'); });
+            btn.classList.add('active');
+            selectedTimeInput.value = slot;
+          });
+          slotsContainer.appendChild(btn);
+        });
+      }
+
+      function loadSlots() {
+        const date = dateInput.value;
+        if (!date) {
+          clearSlots();
+          return;
+        }
+        fetch('/rest/public/booking/' + encodeURIComponent(publicBookingId) + '/slots?date=' + encodeURIComponent(date))
+          .then(function (r) { return r.json(); })
+          .then(renderSlots)
+          .catch(function () {
+            bookingError.textContent = 'No se pudieron cargar los horarios.';
+            bookingError.style.display = 'block';
+          });
+      }
+
+      dateInput.addEventListener('change', loadSlots);
+      if (dateInput.min) {
+        dateInput.addEventListener('input', function () {
+          if (dateInput.value && dateInput.value < minBookableDate) {
+            advanceNotice.style.display = 'block';
+            clearSlots();
+          }
+        });
+      }
+
+      bookingForm.addEventListener('submit', function (e) {
+        e.preventDefault();
+        bookingError.style.display = 'none';
+        const recaptchaResponse = typeof grecaptcha !== 'undefined' ? grecaptcha.getResponse() : '';
+        if (!selectedTimeInput.value) {
+          bookingError.textContent = 'Seleccione un horario disponible.';
+          bookingError.style.display = 'block';
+          return;
+        }
+        const payload = {
+          patientName: document.getElementById('patientName').value,
+          patientEmail: document.getElementById('patientEmail').value,
+          patientPhone: document.getElementById('patientPhone').value,
+          date: dateInput.value,
+          time: selectedTimeInput.value,
+          recaptchaResponse: recaptchaResponse
+        };
+        fetch('/rest/public/booking/' + encodeURIComponent(publicBookingId) + '/book', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        }).then(function (r) { return r.json().then(function (body) { return { ok: r.ok, body: body }; }); })
+          .then(function (result) {
+            if (result.ok && result.body.success) {
+              bookingForm.style.display = 'none';
+              document.getElementById('confirmedSlot').textContent =
+                ' ' + result.body.date + ' a las ' + result.body.time + '.';
+              bookingSuccess.style.display = 'block';
+            } else {
+              bookingError.textContent = result.body.error || 'No se pudo reservar la cita.';
+              bookingError.style.display = 'block';
+              if (typeof grecaptcha !== 'undefined') { grecaptcha.reset(); }
+            }
+          })
+          .catch(function () {
+            bookingError.textContent = 'Error de conexión. Intente nuevamente.';
+            bookingError.style.display = 'block';
+          });
+      });
+    })();
+  </script>
+</body>
+
+</html>

--- a/src/test/java/com/nutriconsultas/booking/PublicBookingAdvanceRulesTest.java
+++ b/src/test/java/com/nutriconsultas/booking/PublicBookingAdvanceRulesTest.java
@@ -1,0 +1,33 @@
+package com.nutriconsultas.booking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.Test;
+
+class PublicBookingAdvanceRulesTest {
+
+	private static final ZoneId ZONE = ZoneId.of("America/Mexico_City");
+
+	@Test
+	void earliestBookableDateIsTodayPlusTwoDays() {
+		final LocalDate expected = LocalDate.now(ZONE).plusDays(2);
+		assertThat(PublicBookingAdvanceRules.earliestBookableDate(ZONE)).isEqualTo(expected);
+	}
+
+	@Test
+	void blocksTodayAndTomorrow() {
+		final LocalDate today = LocalDate.now(ZONE);
+		assertThat(PublicBookingAdvanceRules.isDateBookable(today, ZONE)).isFalse();
+		assertThat(PublicBookingAdvanceRules.isDateBookable(today.plusDays(1), ZONE)).isFalse();
+	}
+
+	@Test
+	void allowsDayAfterAdvanceWindow() {
+		final LocalDate eligible = LocalDate.now(ZONE).plusDays(2);
+		assertThat(PublicBookingAdvanceRules.isDateBookable(eligible, ZONE)).isTrue();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/booking/PublicBookingRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/booking/PublicBookingRestControllerTest.java
@@ -1,0 +1,96 @@
+package com.nutriconsultas.booking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+
+import com.nutriconsultas.recaptcha.RecaptchaVerificationService;
+
+@ExtendWith(MockitoExtension.class)
+class PublicBookingRestControllerTest {
+
+	private static final String PUBLIC_ID = "11111111-2222-4333-8444-555555555555";
+
+	@InjectMocks
+	private PublicBookingRestController controller;
+
+	@Mock
+	private PublicBookingService publicBookingService;
+
+	@Mock
+	private PublicBookingRateLimiter publicBookingRateLimiter;
+
+	@Mock
+	private RecaptchaVerificationService recaptchaVerificationService;
+
+	@Test
+	void getSlotsReturnsServiceResponse() {
+		final LocalDate minDate = PublicBookingAdvanceRules
+			.earliestBookableDate(ZoneId.of(BookingAvailabilityConstants.DEFAULT_TIMEZONE_ID));
+		when(publicBookingService.getPublicSlots(PUBLIC_ID, minDate.toString()))
+			.thenReturn(new PublicBookingSlotsResponse(minDate.toString(), minDate, 2, List.of("09:00"), null));
+
+		final PublicBookingSlotsResponse response = controller.getSlots(PUBLIC_ID, minDate.toString());
+
+		assertThat(response.slots()).containsExactly("09:00");
+	}
+
+	@Test
+	void bookReturnsSuccessWhenRecaptchaValid() throws Exception {
+		when(publicBookingRateLimiter.execute(any(), any()))
+			.thenAnswer(invocation -> ((java.util.concurrent.Callable<?>) invocation.getArgument(1)).call());
+		when(recaptchaVerificationService.verifyToken("good")).thenReturn(true);
+		when(publicBookingService.book(eq(PUBLIC_ID), any()))
+			.thenReturn(new PublicBookingConfirmation(1L, "2026-06-22", "09:00"));
+
+		final PublicBookingRequestDto request = bookingRequest("good");
+		final BindingResult bindingResult = new BeanPropertyBindingResult(request, "request");
+
+		final ResponseEntity<Map<String, Object>> response = controller.book(PUBLIC_ID, request, bindingResult,
+				new MockHttpServletRequest());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("success", true);
+	}
+
+	@Test
+	void bookRejectsInvalidRecaptcha() {
+		when(recaptchaVerificationService.verifyToken("bad")).thenReturn(false);
+		final PublicBookingRequestDto request = bookingRequest("bad");
+		final BindingResult bindingResult = new BeanPropertyBindingResult(request, "request");
+
+		final ResponseEntity<Map<String, Object>> response = controller.book(PUBLIC_ID, request, bindingResult,
+				new MockHttpServletRequest());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+		assertThat(response.getBody()).containsEntry("success", false);
+	}
+
+	private static PublicBookingRequestDto bookingRequest(final String recaptcha) {
+		final PublicBookingRequestDto request = new PublicBookingRequestDto();
+		request.setPatientName("Ana");
+		request.setPatientEmail("ana@example.com");
+		request.setDate("2026-06-22");
+		request.setTime("09:00");
+		request.setRecaptchaResponse(recaptcha);
+		return request;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/booking/PublicBookingServiceTest.java
+++ b/src/test/java/com/nutriconsultas/booking/PublicBookingServiceTest.java
@@ -1,0 +1,161 @@
+package com.nutriconsultas.booking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.calendar.CalendarEventService;
+import com.nutriconsultas.calendar.EventStatus;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteService;
+import com.nutriconsultas.profile.NutritionistProfile;
+import com.nutriconsultas.profile.NutritionistProfileRepository;
+import com.nutriconsultas.subscription.Subscription;
+import com.nutriconsultas.subscription.lifecycle.SubscriptionAccessService;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PublicBookingServiceTest {
+
+	private static final String PUBLIC_ID = "11111111-2222-4333-8444-555555555555";
+
+	private static final String USER_ID = "auth0|nutritionist";
+
+	@InjectMocks
+	private PublicBookingServiceImpl service;
+
+	@Mock
+	private NutritionistProfileRepository profileRepository;
+
+	@Mock
+	private SubscriptionAccessService subscriptionAccessService;
+
+	@Mock
+	private NutritionistAvailabilityService availabilityService;
+
+	@Mock
+	private BookingAvailabilitySlotService bookingAvailabilitySlotService;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Mock
+	private PacienteService pacienteService;
+
+	@Mock
+	private CalendarEventService calendarEventService;
+
+	private NutritionistProfile profile;
+
+	private AvailabilityScheduleDto schedule;
+
+	@BeforeEach
+	void setup() {
+		profile = new NutritionistProfile();
+		profile.setUserId(USER_ID);
+		profile.setPublicBookingId(PUBLIC_ID);
+		profile.setDisplayName("Dra. Ejemplo");
+		schedule = new AvailabilityScheduleDto();
+		schedule.setSlotDurationMinutes(60);
+		schedule.setTimezone(BookingAvailabilityConstants.DEFAULT_TIMEZONE_ID);
+		when(profileRepository.findByPublicBookingId(PUBLIC_ID)).thenReturn(Optional.of(profile));
+		when(subscriptionAccessService.findGrantingSubscriptionForUser(USER_ID))
+			.thenReturn(Optional.of(new Subscription()));
+		when(availabilityService.getSchedule(USER_ID)).thenReturn(schedule);
+	}
+
+	@Test
+	void getPublicSlotsReturnsEmptyForDatesInsideAdvanceWindow() {
+		final LocalDate tomorrow = LocalDate.now(ZoneId.of(schedule.getTimezone())).plusDays(1);
+
+		final PublicBookingSlotsResponse response = service.getPublicSlots(PUBLIC_ID, tomorrow.toString());
+
+		assertThat(response.slots()).isEmpty();
+		assertThat(response.notice()).contains("anticipación");
+		verify(bookingAvailabilitySlotService, never()).getAvailableSlotStarts(any(), any());
+	}
+
+	@Test
+	void getPublicSlotsDelegatesWhenDateEligible() {
+		final LocalDate eligible = LocalDate.now(ZoneId.of(schedule.getTimezone())).plusDays(2);
+		when(bookingAvailabilitySlotService.getAvailableSlotStarts(USER_ID, eligible))
+			.thenReturn(List.of(LocalTime.of(9, 0)));
+
+		final PublicBookingSlotsResponse response = service.getPublicSlots(PUBLIC_ID, eligible.toString());
+
+		assertThat(response.slots()).containsExactly("09:00");
+		assertThat(response.notice()).isNull();
+	}
+
+	@Test
+	void bookCreatesCalendarEventForEligibleSlot() {
+		final LocalDate eligible = LocalDate.now(ZoneId.of(schedule.getTimezone())).plusDays(2);
+		when(bookingAvailabilitySlotService.getAvailableSlotStarts(USER_ID, eligible))
+			.thenReturn(List.of(LocalTime.of(10, 0)));
+		when(pacienteRepository.findFirstByUserIdAndEmailIgnoreCase(eq(USER_ID), eq("paciente@example.com")))
+			.thenReturn(Optional.empty());
+		final Paciente savedPatient = new Paciente();
+		savedPatient.setId(5L);
+		when(pacienteService.save(any(Paciente.class))).thenReturn(savedPatient);
+		final CalendarEvent savedEvent = new CalendarEvent();
+		savedEvent.setId(99L);
+		when(calendarEventService.save(any(CalendarEvent.class))).thenReturn(savedEvent);
+
+		final PublicBookingRequestDto request = new PublicBookingRequestDto();
+		request.setPatientName("Paciente Test");
+		request.setPatientEmail("paciente@example.com");
+		request.setDate(eligible.toString());
+		request.setTime("10:00");
+		request.setRecaptchaResponse("token");
+
+		final PublicBookingConfirmation confirmation = service.book(PUBLIC_ID, request);
+
+		assertThat(confirmation.eventId()).isEqualTo(99L);
+		final ArgumentCaptor<CalendarEvent> captor = ArgumentCaptor.forClass(CalendarEvent.class);
+		verify(calendarEventService).save(captor.capture());
+		assertThat(captor.getValue().getStatus()).isEqualTo(EventStatus.SCHEDULED);
+		assertThat(captor.getValue().getPaciente().getId()).isEqualTo(5L);
+	}
+
+	@Test
+	void bookRejectsSlotInsideAdvanceWindow() {
+		final LocalDate tomorrow = LocalDate.now(ZoneId.of(schedule.getTimezone())).plusDays(1);
+		final PublicBookingRequestDto request = new PublicBookingRequestDto();
+		request.setPatientName("Paciente Test");
+		request.setPatientEmail("paciente@example.com");
+		request.setDate(tomorrow.toString());
+		request.setTime("10:00");
+
+		assertThatThrownBy(() -> service.book(PUBLIC_ID, request)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void resolveContextThrowsWhenSubscriptionInactive() {
+		when(subscriptionAccessService.findGrantingSubscriptionForUser(USER_ID)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.resolveContext(PUBLIC_ID)).isInstanceOf(PublicBookingNotFoundException.class);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/booking/PublicBookingWebControllerTest.java
+++ b/src/test/java/com/nutriconsultas/booking/PublicBookingWebControllerTest.java
@@ -1,0 +1,49 @@
+package com.nutriconsultas.booking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.web.server.ResponseStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class PublicBookingWebControllerTest {
+
+	private static final String PUBLIC_ID = "11111111-2222-4333-8444-555555555555";
+
+	@InjectMocks
+	private PublicBookingController controller;
+
+	@Mock
+	private PublicBookingService publicBookingService;
+
+	@Test
+	void bookingPageRendersView() {
+		when(publicBookingService.resolveContext(PUBLIC_ID)).thenReturn(new PublicBookingNutritionistContext(PUBLIC_ID,
+				"Dra. Ejemplo", BookingAvailabilityConstants.DEFAULT_TIMEZONE_ID, 2));
+
+		final String view = controller.bookingPage(PUBLIC_ID, new ExtendedModelMap());
+
+		assertThat(view).isEqualTo("eterna/agendar-cita");
+	}
+
+	@Test
+	void bookingPageReturns404WhenLinkInvalid() {
+		when(publicBookingService.resolveContext(PUBLIC_ID)).thenThrow(new PublicBookingNotFoundException());
+
+		try {
+			controller.bookingPage(PUBLIC_ID, new ExtendedModelMap());
+		}
+		catch (ResponseStatusException ex) {
+			assertThat(ex.getStatusCode().value()).isEqualTo(404);
+			return;
+		}
+		throw new AssertionError("Expected ResponseStatusException");
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/message/PatientMessageIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/message/PatientMessageIntegrationTest.java
@@ -23,6 +23,8 @@ import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.profile.NutritionistProfile;
 import com.nutriconsultas.profile.NutritionistProfileRepository;
 
+import java.util.UUID;
+
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 
 @SpringBootTest
@@ -66,6 +68,9 @@ class PatientMessageIntegrationTest {
 			.orElseGet(NutritionistProfile::new);
 		profile.setUserId(NUTRITIONIST_SUB);
 		profile.setDisplayName("Lic. Ana López");
+		if (profile.getPublicBookingId() == null || profile.getPublicBookingId().isBlank()) {
+			profile.setPublicBookingId(UUID.randomUUID().toString());
+		}
 		nutritionistProfileRepository.saveAndFlush(profile);
 	}
 

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,6 +76,9 @@ class MobilePatientMessageIntegrationTest {
 			.orElseGet(NutritionistProfile::new);
 		profile.setUserId(linkedPaciente.getUserId());
 		profile.setDisplayName("Lic. Nutri Minutriporcion");
+		if (profile.getPublicBookingId() == null || profile.getPublicBookingId().isBlank()) {
+			profile.setPublicBookingId(UUID.randomUUID().toString());
+		}
 		nutritionistProfileRepository.saveAndFlush(profile);
 	}
 

--- a/src/test/java/com/nutriconsultas/profile/NutritionistProfileServiceTest.java
+++ b/src/test/java/com/nutriconsultas/profile/NutritionistProfileServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,19 @@ public class NutritionistProfileServiceTest {
 		existingProfile.setUserId(TEST_USER_ID);
 		existingProfile.setCedulaProfesional("12345678");
 		existingProfile.setDisplayName("Dra. Test");
+		existingProfile.setPublicBookingId(UUID.randomUUID().toString());
+	}
+
+	@Test
+	public void testGetOrCreateProfile_WhenProfileExistsWithoutPublicId_AssignsAndSaves() {
+		existingProfile.setPublicBookingId(null);
+		when(repository.findByUserId(TEST_USER_ID)).thenReturn(Optional.of(existingProfile));
+		when(repository.save(any(NutritionistProfile.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		final NutritionistProfile result = service.getOrCreateProfile(TEST_USER_ID);
+
+		assertThat(result.getPublicBookingId()).isNotBlank();
+		verify(repository).save(existingProfile);
 	}
 
 	@Test

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -31,6 +31,9 @@ nutriconsultas.platform.admin-user-ids=auth0|platform-admin-test
 resilience4j.ratelimiter.instances.patientMessages.limit-for-period=2
 resilience4j.ratelimiter.instances.patientMessages.limit-refresh-period=1m
 resilience4j.ratelimiter.instances.patientMessages.timeout-duration=0s
+resilience4j.ratelimiter.instances.publicBooking.limit-for-period=5
+resilience4j.ratelimiter.instances.publicBooking.limit-refresh-period=1h
+resilience4j.ratelimiter.instances.publicBooking.timeout-duration=0s
 # OpenAPI spec generation in tests (#112)
 springdoc.api-docs.enabled=true
 springdoc.swagger-ui.enabled=true


### PR DESCRIPTION
## Summary
- Add public booking page at `/consultas/{publicBookingId}/agendar-cita` with date/slot picker, patient form, reCAPTCHA, and 2-day minimum advance (UI + server).
- Introduce public REST API (`/rest/public/booking/**`), opaque `public_booking_id` on `nutritionist_profile` (Liquibase `016`), rate limiting, and `CalendarEvent` creation on book.
- Update tracking docs: ~~#248~~ done, **NEXT** #297 (copy booking link).

Fixes #248

## Test plan
- [x] `mvn test` — public booking unit/integration tests pass
- [x] `./lint.sh` — Checkstyle, SpotBugs, PMD, Thymeleaf
- [x] Manual browser QA on `agendar-cita` (page load, slot AJAX, advance rule, 404 for invalid id)
- [ ] CI green on PR
- [ ] Smoke test public book flow on staging after merge (reCAPTCHA + working hours configured)


Made with [Cursor](https://cursor.com)