### PR TITLE
[Public Booking] Nutritionist profile — copy public booking link (#297)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -39,7 +39,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) | `[Public Booking]` epic #245–#248 |
 | [`docs/public-booking/AVAILABILITY.md`](docs/public-booking/AVAILABILITY.md) | Working hours model, timezone, REST (#246) |
 
-**Current next issue (public booking):** [#297 — display and copy public booking link](https://github.com/diego-torres/nutriconsultas/issues/297). ~~#246~~, ~~#247~~, ~~#248~~ done (~~#247~~ PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295); ~~#248~~ `issue-248-public-booking`, `ef67600`). See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
+**Current next issue (public booking):** [#297 — display and copy public booking link](https://github.com/diego-torres/nutriconsultas/issues/297) **in-progress** (`issue-297-copy-booking-link`). ~~#246~~, ~~#247~~, ~~#248~~ done. See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
 **Current next issue (mobile):** [#134 — POST /rest/mobile/invitations](https://github.com/diego-torres/nutriconsultas/issues/134). ~~#133~~ done (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)).
 

--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -39,7 +39,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) | `[Public Booking]` epic #245–#248 |
 | [`docs/public-booking/AVAILABILITY.md`](docs/public-booking/AVAILABILITY.md) | Working hours model, timezone, REST (#246) |
 
-**Current next issue (public booking):** [#297 — display and copy public booking link](https://github.com/diego-torres/nutriconsultas/issues/297) **in-progress** (`issue-297-copy-booking-link`). ~~#246~~, ~~#247~~, ~~#248~~ done. See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
+**Current next issue (public booking):** None — ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~ done (~~#297~~ PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)). Epic **#245** umbrella open. See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
 **Current next issue (mobile):** [#134 — POST /rest/mobile/invitations](https://github.com/diego-torres/nutriconsultas/issues/134). ~~#133~~ done (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -606,7 +606,7 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 ## Public booking (tracking)
 
-Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)); ~~#248~~ **done** (`issue-248-public-booking`, `ef67600`). **NEXT:** [#297 copy public booking link](https://github.com/diego-torres/nutriconsultas/issues/297).
+Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)); ~~#248~~ **done** (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)). **NEXT:** [#297 copy public booking link](https://github.com/diego-torres/nutriconsultas/issues/297) **in-progress** (`issue-297-copy-booking-link`).
 
 ## Resources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -606,7 +606,7 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 ## Public booking (tracking)
 
-Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)); ~~#248~~ **done** (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)). **NEXT:** [#297 copy public booking link](https://github.com/diego-torres/nutriconsultas/issues/297) **in-progress** (`issue-297-copy-booking-link`).
+Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248**, **#297** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)); ~~#248~~ **done** (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)); ~~#297~~ **done** (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)). Epic **#245** child issues complete.
 
 ## Resources
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -221,7 +221,7 @@ Inline **cantidad** editing on the catalog platillo form (`/admin/platillos/{id}
 | #280 / #281 Diet nutrients | Full nutrient modal (#280); in-row platillo edit on ingesta grid (#281) — refresh dieta rollup |
 | ~~#285~~ Platillo form | Inline cantidad edit on catalog `#ingredientesGrid` + diet ingesta grid — branch `issue-285-platillo-inline-cantidad` |
 | ~~#243~~ / #244 Subscription | reCAPTCHA **done**; Solicitar acceso pre-fill — public funnel, not admin UI |
-| #245–#248 Public booking | ~~#246~~, ~~#247~~, ~~#248~~ done; **NEXT** #297 (copy booking link) — separate track |
+| #245–#248 Public booking | ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~ **done** — separate track; epic **#245** open |
 
 ---
 

--- a/ISSUE-PUBLIC-BOOKING.md
+++ b/ISSUE-PUBLIC-BOOKING.md
@@ -3,7 +3,7 @@
 Living index of GitHub issues for **public appointment scheduling** — shareable links, nutritionist availability, and patient self-booking. Update when status changes (commit on the PR that closes work).
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
-**Last updated:** 2026-06-21 — ~~#248~~ **done** (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)). **NEXT:** #297 **in-progress** (`issue-297-copy-booking-link`). Epic **#245** with child issues **#246–#248**, **#297**.
+**Last updated:** 2026-06-21 — ~~#248~~ **done** (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)); ~~#297~~ **done** (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)). Child issues **#246–#248**, **#297** complete; epic **#245** open for follow-ups.
 
 > **Scope.** Public routes (`/consultas/{id}/agendar-cita` or equivalent), availability configuration, and calendar blocks. Nutritionist admin UI pieces may live in `/admin/**` but this track owns the **public booking product**. Mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Nutritionist web (non-booking): [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
@@ -44,7 +44,7 @@ Shareable URL for patients to book into a nutritionist's real availability:
 | **246** | Nutritionist profile — configure working hours and availability | https://github.com/diego-torres/nutriconsultas/issues/246 | **done** | **245** | Branch `issue-246-working-hours`; `GET/PUT /rest/profile/availability`; Liquibase `014` |
 | **247** | Calendar — unavailable days and absence windows | https://github.com/diego-torres/nutriconsultas/issues/247 | **done** | **246** | PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295); Liquibase `015`, blocks API, slot query |
 | **248** | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | **done** | **246**, ~~**247**~~, ~~**243**~~ | PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298); Liquibase `016`, public REST + `agendar-cita`; 2-day min advance |
-| **297** | Nutritionist profile — display and copy public booking link | https://github.com/diego-torres/nutriconsultas/issues/297 | **in-progress** | ~~**248**~~ | Branch `issue-297-copy-booking-link`; profile form copy-to-clipboard + `swal` |
+| **297** | Nutritionist profile — display and copy public booking link | https://github.com/diego-torres/nutriconsultas/issues/297 | **done** | ~~**248**~~ | PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299); profile form copy-to-clipboard + `swal` |
 
 ---
 

--- a/ISSUE-PUBLIC-BOOKING.md
+++ b/ISSUE-PUBLIC-BOOKING.md
@@ -3,7 +3,7 @@
 Living index of GitHub issues for **public appointment scheduling** — shareable links, nutritionist availability, and patient self-booking. Update when status changes (commit on the PR that closes work).
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
-**Last updated:** 2026-06-21 — ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)); ~~#248~~ **done** (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)). **NEXT:** #297. Epic **#245** with child issues **#246–#248**, **#297**.
+**Last updated:** 2026-06-21 — ~~#248~~ **done** (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)). **NEXT:** #297 **in-progress** (`issue-297-copy-booking-link`). Epic **#245** with child issues **#246–#248**, **#297**.
 
 > **Scope.** Public routes (`/consultas/{id}/agendar-cita` or equivalent), availability configuration, and calendar blocks. Nutritionist admin UI pieces may live in `/admin/**` but this track owns the **public booking product**. Mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Nutritionist web (non-booking): [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
@@ -44,7 +44,7 @@ Shareable URL for patients to book into a nutritionist's real availability:
 | **246** | Nutritionist profile — configure working hours and availability | https://github.com/diego-torres/nutriconsultas/issues/246 | **done** | **245** | Branch `issue-246-working-hours`; `GET/PUT /rest/profile/availability`; Liquibase `014` |
 | **247** | Calendar — unavailable days and absence windows | https://github.com/diego-torres/nutriconsultas/issues/247 | **done** | **246** | PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295); Liquibase `015`, blocks API, slot query |
 | **248** | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | **done** | **246**, ~~**247**~~, ~~**243**~~ | PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298); Liquibase `016`, public REST + `agendar-cita`; 2-day min advance |
-| **297** | Nutritionist profile — display and copy public booking link | https://github.com/diego-torres/nutriconsultas/issues/297 | **NEXT** | ~~**248**~~ | Admin `sbadmin/profile/formulario.html`; copy-to-clipboard + `swal` |
+| **297** | Nutritionist profile — display and copy public booking link | https://github.com/diego-torres/nutriconsultas/issues/297 | **in-progress** | ~~**248**~~ | Branch `issue-297-copy-booking-link`; profile form copy-to-clipboard + `swal` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-21):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: all registered epics **complete** (#221–#242, #271–#272). Public booking **NEXT:** [#297](https://github.com/diego-torres/nutriconsultas/issues/297); ~~#246~~, ~~#247~~ (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)), ~~#248~~ done (`issue-248-public-booking`, `ef67600`).
+**On `main` (2026-06-21):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: all registered epics **complete** (#221–#242, #271–#272). Public booking: ~~#246~~, ~~#247~~ (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)), ~~#248~~ (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)), ~~#297~~ (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)) **done**; epic **#245** child issues complete.
 
 ## AWS (production infrastructure)
 

--- a/src/main/java/com/nutriconsultas/profile/NutritionistProfileController.java
+++ b/src/main/java/com/nutriconsultas/profile/NutritionistProfileController.java
@@ -5,6 +5,8 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
+import java.util.Optional;
+
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -13,20 +15,25 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.nutriconsultas.controller.AbstractAuthorizedController;
 import com.nutriconsultas.subscription.Entitlement;
+import com.nutriconsultas.subscription.Subscription;
 import com.nutriconsultas.subscription.SubscriptionEntitlementService;
 import com.nutriconsultas.subscription.lifecycle.SubscriptionAccessService;
 import com.nutriconsultas.util.LogRedaction;
 
 import lombok.extern.slf4j.Slf4j;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Controller for managing the nutritionist's professional profile.
@@ -64,10 +71,11 @@ public class NutritionistProfileController extends AbstractAuthorizedController 
 	 * @return the Thymeleaf template name
 	 */
 	@GetMapping("/admin/perfil")
-	public String perfil(@AuthenticationPrincipal final OidcUser principal, final Model model) {
+	public String perfil(@AuthenticationPrincipal final OidcUser principal, final Model model,
+			final HttpServletRequest request) {
 		log.debug("Loading profile page");
 		model.addAttribute("activeMenu", "perfil");
-		populateProfileModel(model, principal.getSubject());
+		populateProfileModel(model, principal.getSubject(), request);
 		return "sbadmin/profile/formulario";
 	}
 
@@ -121,20 +129,20 @@ public class NutritionistProfileController extends AbstractAuthorizedController 
 	 */
 	@PostMapping("/admin/perfil/logo")
 	public String uploadLogo(@RequestParam("logoFile") final MultipartFile file,
-			@AuthenticationPrincipal final OidcUser principal, final Model model) {
+			@AuthenticationPrincipal final OidcUser principal, final Model model, final HttpServletRequest request) {
 		log.debug("Uploading logo");
 		model.addAttribute("activeMenu", "perfil");
 		final String userId = principal.getSubject();
 		String result;
 		if (!subscriptionEntitlementService.hasEntitlement(userId, Entitlement.REPORTS_BRANDED)) {
-			populateProfileModel(model, userId);
+			populateProfileModel(model, userId, request);
 			model.addAttribute("errorMessage",
 					"La personalización con logo está disponible en los planes Profesional y superiores.");
 			result = "sbadmin/profile/formulario";
 		}
 		else if (file.isEmpty()) {
 			log.error("Logo upload failed: file is empty");
-			populateProfileModel(model, userId);
+			populateProfileModel(model, userId, request);
 			model.addAttribute("errorMessage", "El archivo está vacío");
 			result = "sbadmin/profile/formulario";
 		}
@@ -155,7 +163,7 @@ public class NutritionistProfileController extends AbstractAuthorizedController 
 			}
 			catch (final IOException e) {
 				log.error("Failed to upload logo for user: {}", LogRedaction.redactUserId(userId), e);
-				populateProfileModel(model, userId);
+				populateProfileModel(model, userId, request);
 				model.addAttribute("errorMessage", "Error al subir el logo");
 				result = "sbadmin/profile/formulario";
 			}
@@ -163,7 +171,7 @@ public class NutritionistProfileController extends AbstractAuthorizedController 
 		return result;
 	}
 
-	private void populateProfileModel(final Model model, final String userId) {
+	private void populateProfileModel(final Model model, final String userId, final HttpServletRequest request) {
 		final NutritionistProfile profile = profileService.getOrCreateProfile(userId);
 		log.info("Loaded profile: {}", LogRedaction.redactNutritionistProfile(profile.getId()));
 		model.addAttribute("profile", profile);
@@ -173,12 +181,41 @@ public class NutritionistProfileController extends AbstractAuthorizedController 
 		if (brandedReportsEnabled && profile.getLogoExtension() != null && !profile.getLogoExtension().isBlank()) {
 			model.addAttribute("logoUrl", "/admin/perfil/logo");
 		}
-		subscriptionAccessService.findGrantingSubscriptionForUser(userId).ifPresent(subscription -> {
+		final Optional<Subscription> grantingSubscription = subscriptionAccessService
+			.findGrantingSubscriptionForUser(userId);
+		populatePublicBookingLink(model, profile, grantingSubscription, request);
+		grantingSubscription.ifPresent(subscription -> {
 			model.addAttribute("subscriptionPlanLabel", subscription.getPlanTier().getDisplayName());
 			model.addAttribute("subscriptionStatus", subscription.getStatus());
 			model.addAttribute("subscriptionPeriodStartLabel", formatVigencia(subscription.getPeriodStart()));
 			model.addAttribute("subscriptionPeriodEndLabel", formatVigencia(subscription.getPeriodEnd()));
 		});
+	}
+
+	private void populatePublicBookingLink(final Model model, final NutritionistProfile profile,
+			final Optional<Subscription> grantingSubscription, final HttpServletRequest request) {
+		if (grantingSubscription.isEmpty()) {
+			model.addAttribute("publicBookingLinkEnabled", false);
+			model.addAttribute("publicBookingLinkDisabledMessage",
+					"Necesitas una suscripción activa para compartir tu enlace de agendamiento.");
+			return;
+		}
+		if (!StringUtils.hasText(profile.getPublicBookingId())) {
+			model.addAttribute("publicBookingLinkEnabled", false);
+			model.addAttribute("publicBookingLinkDisabledMessage",
+					"Tu enlace de agendamiento aún no está disponible. Guarda tu perfil e inténtalo de nuevo.");
+			return;
+		}
+		model.addAttribute("publicBookingLinkEnabled", true);
+		model.addAttribute("publicBookingUrl", buildPublicBookingUrl(request, profile.getPublicBookingId()));
+	}
+
+	static String buildPublicBookingUrl(final HttpServletRequest request, final String publicBookingId) {
+		return ServletUriComponentsBuilder.fromRequest(request)
+			.replacePath("/consultas/{publicBookingId}/agendar-cita")
+			.replaceQuery(null)
+			.buildAndExpand(publicBookingId)
+			.toUriString();
 	}
 
 	private static String resolveLogoMediaType(final String extension) {

--- a/src/main/java/com/nutriconsultas/profile/ProfileTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/profile/ProfileTemplateValidator.java
@@ -30,6 +30,9 @@ public class ProfileTemplateValidator extends BaseTemplateValidator {
 		variables.put("subscriptionPeriodEndLabel", "01/07/2026");
 		variables.put("brandedReportsEnabled", true);
 		variables.put("logoUrl", "/admin/perfil/logo");
+		variables.put("publicBookingLinkEnabled", true);
+		variables.put("publicBookingUrl",
+				"https://minutriporcion.com/consultas/11111111-2222-4333-8444-555555555555/agendar-cita");
 		return variables;
 	}
 
@@ -40,6 +43,7 @@ public class ProfileTemplateValidator extends BaseTemplateValidator {
 		profile.setDisplayName("Dra. Prueba Validación");
 		profile.setCedulaProfesional("12345678");
 		profile.setLogoExtension("png");
+		profile.setPublicBookingId("11111111-2222-4333-8444-555555555555");
 		return profile;
 	}
 

--- a/src/main/resources/templates/sbadmin/profile/formulario.html
+++ b/src/main/resources/templates/sbadmin/profile/formulario.html
@@ -211,6 +211,43 @@
                 </div>
               </div>
 
+              <!-- Public booking link (#297) -->
+              <div class="col-12">
+                <div class="card shadow mb-4">
+                  <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">
+                      <i class="fas fa-link"></i> Enlace público de agendamiento
+                    </h6>
+                  </div>
+                  <div class="card-body">
+                    <p class="text-muted small mb-3">
+                      Comparte este enlace con tus pacientes para que agenden citas en línea según tu horario
+                      configurado.
+                    </p>
+                    <div th:if="${publicBookingLinkEnabled}">
+                      <label for="publicBookingUrlText" class="sr-only">Enlace de agendamiento</label>
+                      <div class="input-group">
+                        <input type="text"
+                          class="form-control"
+                          id="publicBookingUrlText"
+                          readonly
+                          th:value="${publicBookingUrl}" />
+                        <div class="input-group-append">
+                          <button type="button" id="copyPublicBookingUrlBtn" class="btn btn-primary">
+                            <i class="fas fa-copy"></i> Copiar enlace
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div th:unless="${publicBookingLinkEnabled}" class="alert alert-info mb-0" role="status">
+                      <span th:text="${publicBookingLinkDisabledMessage}">
+                        Necesitas una suscripción activa para compartir tu enlace de agendamiento.
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
               <!-- Public booking: working hours (#246) -->
               <div class="col-12">
                 <div class="card shadow mb-4">
@@ -390,6 +427,27 @@
         });
 
         loadAvailability();
+      })(jQuery);
+    </script>
+    <script lang="javascript">
+      'use strict';
+      (function ($) {
+        $('#copyPublicBookingUrlBtn').on('click', function () {
+          var text = $('#publicBookingUrlText').val();
+          if (!text) {
+            return;
+          }
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(function () {
+              swal({
+                title: 'Copiado',
+                text: 'Enlace de agendamiento copiado al portapapeles.',
+                type: 'success',
+                timer: 2000
+              });
+            });
+          }
+        });
       })(jQuery);
     </script>
     <script lang="javascript">

--- a/src/test/java/com/nutriconsultas/profile/NutritionistProfileControllerTest.java
+++ b/src/test/java/com/nutriconsultas/profile/NutritionistProfileControllerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -69,6 +70,7 @@ public class NutritionistProfileControllerTest {
 		mockProfile.setUserId("auth0|test123");
 		mockProfile.setCedulaProfesional("12345678");
 		mockProfile.setDisplayName("Dra. Test");
+		mockProfile.setPublicBookingId("11111111-2222-4333-8444-555555555555");
 	}
 
 	@Test
@@ -85,13 +87,14 @@ public class NutritionistProfileControllerTest {
 			.thenReturn(Optional.of(subscription));
 
 		final Model model = new ExtendedModelMap();
+		final MockHttpServletRequest request = bookingProfileRequest("http", "localhost", 3000);
 		final String view = controller.perfil(org.mockito.Mockito
 			.mock(org.springframework.security.oauth2.core.oidc.user.OidcUser.class, invocation -> {
 				if ("getSubject".equals(invocation.getMethod().getName())) {
 					return "auth0|test123";
 				}
 				return org.mockito.Mockito.RETURNS_DEFAULTS.answer(invocation);
-			}), model);
+			}), model, request);
 
 		assertThat(view).isEqualTo("sbadmin/profile/formulario");
 		assertThat(model.getAttribute("subscriptionPlanLabel")).isEqualTo("Básico");
@@ -100,6 +103,31 @@ public class NutritionistProfileControllerTest {
 		assertThat(model.getAttribute("subscriptionPeriodEndLabel")).isEqualTo("01/07/2026");
 		assertThat(model.getAttribute("brandedReportsEnabled")).isEqualTo(false);
 		assertThat(model.getAttribute("logoUrl")).isNull();
+		assertThat(model.getAttribute("publicBookingLinkEnabled")).isEqualTo(true);
+		assertThat(model.getAttribute("publicBookingUrl"))
+			.isEqualTo("http://localhost:3000/consultas/11111111-2222-4333-8444-555555555555/agendar-cita");
+	}
+
+	@Test
+	public void perfilHidesPublicBookingUrlWhenSubscriptionInactive() {
+		when(profileService.getOrCreateProfile("auth0|test123")).thenReturn(mockProfile);
+		when(subscriptionEntitlementService.hasEntitlement("auth0|test123", Entitlement.REPORTS_BRANDED))
+			.thenReturn(false);
+		when(subscriptionAccessService.findGrantingSubscriptionForUser("auth0|test123")).thenReturn(Optional.empty());
+
+		final Model model = new ExtendedModelMap();
+		final MockHttpServletRequest request = new MockHttpServletRequest();
+		final String view = controller.perfil(org.mockito.Mockito
+			.mock(org.springframework.security.oauth2.core.oidc.user.OidcUser.class, invocation -> {
+				if ("getSubject".equals(invocation.getMethod().getName())) {
+					return "auth0|test123";
+				}
+				return org.mockito.Mockito.RETURNS_DEFAULTS.answer(invocation);
+			}), model, request);
+
+		assertThat(view).isEqualTo("sbadmin/profile/formulario");
+		assertThat(model.getAttribute("publicBookingLinkEnabled")).isEqualTo(false);
+		assertThat(model.getAttribute("publicBookingUrl")).isNull();
 	}
 
 	@Test
@@ -111,13 +139,14 @@ public class NutritionistProfileControllerTest {
 		when(subscriptionAccessService.findGrantingSubscriptionForUser("auth0|test123")).thenReturn(Optional.empty());
 
 		final Model model = new ExtendedModelMap();
+		final MockHttpServletRequest request = new MockHttpServletRequest();
 		final String view = controller.perfil(org.mockito.Mockito
 			.mock(org.springframework.security.oauth2.core.oidc.user.OidcUser.class, invocation -> {
 				if ("getSubject".equals(invocation.getMethod().getName())) {
 					return "auth0|test123";
 				}
 				return org.mockito.Mockito.RETURNS_DEFAULTS.answer(invocation);
-			}), model);
+			}), model, request);
 
 		assertThat(view).isEqualTo("sbadmin/profile/formulario");
 		assertThat(model.getAttribute("brandedReportsEnabled")).isEqualTo(true);
@@ -160,6 +189,24 @@ public class NutritionistProfileControllerTest {
 		assertThat(response.getStatusCode()).isEqualTo(org.springframework.http.HttpStatus.OK);
 		assertThat(response.getBody()).isEqualTo(logoBytes);
 		assertThat(response.getHeaders().getContentType()).isEqualTo(org.springframework.http.MediaType.IMAGE_PNG);
+	}
+
+	@Test
+	public void buildPublicBookingUrlUsesOpaquePublicId() {
+		final MockHttpServletRequest request = bookingProfileRequest("https", "minutriporcion.com", 443);
+		final String url = NutritionistProfileController.buildPublicBookingUrl(request,
+				"11111111-2222-4333-8444-555555555555");
+		assertThat(url)
+			.isEqualTo("https://minutriporcion.com/consultas/11111111-2222-4333-8444-555555555555/agendar-cita");
+	}
+
+	private static MockHttpServletRequest bookingProfileRequest(final String scheme, final String serverName,
+			final int serverPort) {
+		final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/admin/perfil");
+		request.setScheme(scheme);
+		request.setServerName(serverName);
+		request.setServerPort(serverPort);
+		return request;
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Show the nutritionist's public booking URL on **Mi Perfil Profesional** when they have an active subscription (same gate as #248 public booking).
- Add read-only URL field + **Copiar enlace** with Spanish `swal` success feedback.
- Disabled info state when subscription is inactive or `public_booking_id` is unavailable.

Fixes #297

## Test plan
- [x] `NutritionistProfileControllerTest` — URL in model when subscription active; hidden when inactive; URL builder test
- [x] `./lint.sh` — Checkstyle, PMD, SpotBugs, Thymeleaf
- [ ] CI green on PR
- [ ] Manual: `/admin/perfil` → copy link → open in incognito → public booking page loads


Made with [Cursor](https://cursor.com)