### PR TITLE
[Public Booking] Create prospect patient on first public book (#300)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -39,7 +39,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) | `[Public Booking]` epic #245–#248 |
 | [`docs/public-booking/AVAILABILITY.md`](docs/public-booking/AVAILABILITY.md) | Working hours model, timezone, REST (#246) |
 
-**Current next issue (public booking):** None — ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~ done (~~#297~~ PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)). Epic **#245** umbrella open. See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
+**Current next issue (public booking):** None — ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~, ~~#300~~ done. Epic **#245** umbrella open. See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
 **Current next issue (mobile):** [#134 — POST /rest/mobile/invitations](https://github.com/diego-torres/nutriconsultas/issues/134). ~~#133~~ done (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -606,7 +606,7 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 ## Public booking (tracking)
 
-Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248**, **#297** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)); ~~#248~~ **done** (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)); ~~#297~~ **done** (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)). Epic **#245** child issues complete.
+Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248**, **#297**, **#300** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)); ~~#248~~ **done** (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)); ~~#297~~ **done** (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)); ~~#300~~ **done**. Epic **#245** child issues complete.
 
 ## Resources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -606,7 +606,7 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 ## Public booking (tracking)
 
-Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248**, **#297**, **#300** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)); ~~#248~~ **done** (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)); ~~#297~~ **done** (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)); ~~#300~~ **done**. Epic **#245** child issues complete.
+Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic **#245–#248**, **#297**, **#300** (2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)); ~~#248~~ **done** (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)); ~~#297~~ **done** (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)); ~~#300~~ **done** (PR [#301](https://github.com/diego-torres/nutriconsultas/pull/301)). Epic **#245** child issues complete.
 
 ## Resources
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -221,7 +221,7 @@ Inline **cantidad** editing on the catalog platillo form (`/admin/platillos/{id}
 | #280 / #281 Diet nutrients | Full nutrient modal (#280); in-row platillo edit on ingesta grid (#281) — refresh dieta rollup |
 | ~~#285~~ Platillo form | Inline cantidad edit on catalog `#ingredientesGrid` + diet ingesta grid — branch `issue-285-platillo-inline-cantidad` |
 | ~~#243~~ / #244 Subscription | reCAPTCHA **done**; Solicitar acceso pre-fill — public funnel, not admin UI |
-| #245–#248 Public booking | ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~ **done** — separate track; epic **#245** open |
+| #245–#248 Public booking | ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~, ~~#300~~ **done** — separate track; epic **#245** open |
 
 ---
 

--- a/ISSUE-PUBLIC-BOOKING.md
+++ b/ISSUE-PUBLIC-BOOKING.md
@@ -3,7 +3,7 @@
 Living index of GitHub issues for **public appointment scheduling** — shareable links, nutritionist availability, and patient self-booking. Update when status changes (commit on the PR that closes work).
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
-**Last updated:** 2026-06-21 — ~~#297~~ **done** (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)); ~~#300~~ **done** (PR pending). Child issues **#246–#248**, **#297**, **#300** complete; epic **#245** open for follow-ups.
+**Last updated:** 2026-06-21 — ~~#297~~ **done** (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)); ~~#300~~ **done** (PR [#301](https://github.com/diego-torres/nutriconsultas/pull/301)). Child issues **#246–#248**, **#297**, **#300** complete; epic **#245** open for follow-ups.
 
 > **Scope.** Public routes (`/consultas/{id}/agendar-cita` or equivalent), availability configuration, and calendar blocks. Nutritionist admin UI pieces may live in `/admin/**` but this track owns the **public booking product**. Mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Nutritionist web (non-booking): [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
@@ -46,7 +46,7 @@ Shareable URL for patients to book into a nutritionist's real availability:
 | **247** | Calendar — unavailable days and absence windows | https://github.com/diego-torres/nutriconsultas/issues/247 | **done** | **246** | PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295); Liquibase `015`, blocks API, slot query |
 | **248** | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | **done** | **246**, ~~**247**~~, ~~**243**~~ | PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298); Liquibase `016`, public REST + `agendar-cita`; 2-day min advance |
 | **297** | Nutritionist profile — display and copy public booking link | https://github.com/diego-torres/nutriconsultas/issues/297 | **done** | ~~**248**~~ | PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299); profile form copy-to-clipboard + `swal` |
-| **300** | Public booking — create patient record on first book (minimal profile) | https://github.com/diego-torres/nutriconsultas/issues/300 | **done** | ~~**248**~~ | `PublicBookingPatientFactory`; `ONBOARDING` + placeholder demographics |
+| **300** | Public booking — create patient record on first book (minimal profile) | https://github.com/diego-torres/nutriconsultas/issues/300 | **done** | ~~**248**~~ | PR [#301](https://github.com/diego-torres/nutriconsultas/pull/301); `ONBOARDING` + placeholder demographics |
 
 ---
 

--- a/ISSUE-PUBLIC-BOOKING.md
+++ b/ISSUE-PUBLIC-BOOKING.md
@@ -3,7 +3,7 @@
 Living index of GitHub issues for **public appointment scheduling** — shareable links, nutritionist availability, and patient self-booking. Update when status changes (commit on the PR that closes work).
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
-**Last updated:** 2026-06-21 — ~~#248~~ **done** (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)); ~~#297~~ **done** (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)). Child issues **#246–#248**, **#297** complete; epic **#245** open for follow-ups.
+**Last updated:** 2026-06-21 — ~~#297~~ **done** (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)); ~~#300~~ **done** (PR pending). Child issues **#246–#248**, **#297**, **#300** complete; epic **#245** open for follow-ups.
 
 > **Scope.** Public routes (`/consultas/{id}/agendar-cita` or equivalent), availability configuration, and calendar blocks. Nutritionist admin UI pieces may live in `/admin/**` but this track owns the **public booking product**. Mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Nutritionist web (non-booking): [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
@@ -35,8 +35,9 @@ Shareable URL for patients to book into a nutritionist's real availability:
 | Public page: slot picker + booking | #248 |
 | Minimum 2-day booking advance (public only) | #248 |
 | Profile: display + copy public booking link | #297 |
+| Public booking: create patient on first book | #300 |
 
-**Suggested order:** #246 → #247 → #248 → #297.
+**Suggested order:** #246 → #247 → #248 → #297 → #300.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
@@ -45,6 +46,7 @@ Shareable URL for patients to book into a nutritionist's real availability:
 | **247** | Calendar — unavailable days and absence windows | https://github.com/diego-torres/nutriconsultas/issues/247 | **done** | **246** | PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295); Liquibase `015`, blocks API, slot query |
 | **248** | Public page — slot picker and appointment booking | https://github.com/diego-torres/nutriconsultas/issues/248 | **done** | **246**, ~~**247**~~, ~~**243**~~ | PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298); Liquibase `016`, public REST + `agendar-cita`; 2-day min advance |
 | **297** | Nutritionist profile — display and copy public booking link | https://github.com/diego-torres/nutriconsultas/issues/297 | **done** | ~~**248**~~ | PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299); profile form copy-to-clipboard + `swal` |
+| **300** | Public booking — create patient record on first book (minimal profile) | https://github.com/diego-torres/nutriconsultas/issues/300 | **done** | ~~**248**~~ | `PublicBookingPatientFactory`; `ONBOARDING` + placeholder demographics |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-21):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: all registered epics **complete** (#221–#242, #271–#272). Public booking: ~~#246~~, ~~#247~~ (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)), ~~#248~~ (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)), ~~#297~~ (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)) **done**; epic **#245** child issues complete.
+**On `main` (2026-06-21):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: all registered epics **complete** (#221–#242, #271–#272). Public booking: ~~#246~~, ~~#247~~ (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)), ~~#248~~ (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)), ~~#297~~ (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)), ~~#300~~ **done**; epic **#245** child issues complete.
 
 ## AWS (production infrastructure)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-21):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: all registered epics **complete** (#221–#242, #271–#272). Public booking: ~~#246~~, ~~#247~~ (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)), ~~#248~~ (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)), ~~#297~~ (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)), ~~#300~~ **done**; epic **#245** child issues complete.
+**On `main` (2026-06-21):** Mobile **NEXT:** #134. Subscription **NEXT:** #207. Nutritionist web: all registered epics **complete** (#221–#242, #271–#272). Public booking: ~~#246~~, ~~#247~~ (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)), ~~#248~~ (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)), ~~#297~~ (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)), ~~#300~~ (PR [#301](https://github.com/diego-torres/nutriconsultas/pull/301)) **done**; epic **#245** child issues complete.
 
 ## AWS (production infrastructure)
 

--- a/docs/public-booking/AVAILABILITY.md
+++ b/docs/public-booking/AVAILABILITY.md
@@ -40,6 +40,8 @@ Authenticated preview: `GET /rest/profile/availability/slots?date=YYYY-MM-DD` (s
 | `GET /rest/public/booking/{publicBookingId}/slots?date=` | Public | Available slots (respects 2-day advance) |
 | `POST /rest/public/booking/{publicBookingId}/book` | Public | Create patient (if needed) + `CalendarEvent`; reCAPTCHA + rate limit |
 
+New patients from public booking get `PacienteStatus.ONBOARDING` with placeholder DOB/gender until the nutritionist completes the profile (~~#300~~).
+
 Opaque **`public_booking_id`** (UUID) on `nutritionist_profile` — never expose OAuth `userId` in public URLs.
 
 ## Minimum booking advance (~~#248~~)

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingPatientFactory.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingPatientFactory.java
@@ -1,0 +1,42 @@
+package com.nutriconsultas.booking;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteStatus;
+
+/**
+ * Builds minimal {@link Paciente} rows for first-time public self-booking (#300). Full
+ * demographics are completed later by the nutritionist in admin.
+ */
+public final class PublicBookingPatientFactory {
+
+	/**
+	 * Sentinel date of birth until the nutritionist completes the clinical profile.
+	 */
+	static final LocalDate PLACEHOLDER_DATE_OF_BIRTH = LocalDate.of(1900, 1, 1);
+
+	static final String PLACEHOLDER_GENDER = "M";
+
+	private PublicBookingPatientFactory() {
+	}
+
+	static Paciente buildProspect(final String userId, final PublicBookingRequestDto request) {
+		final Paciente paciente = new Paciente();
+		paciente.setUserId(userId);
+		paciente.setName(request.getPatientName().trim());
+		paciente.setEmail(request.getPatientEmail().trim());
+		if (StringUtils.hasText(request.getPatientPhone())) {
+			paciente.setPhone(request.getPatientPhone().trim());
+		}
+		paciente.setStatus(PacienteStatus.ONBOARDING);
+		paciente.setDob(Date.from(PLACEHOLDER_DATE_OF_BIRTH.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		paciente.setGender(PLACEHOLDER_GENDER);
+		return paciente;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/booking/PublicBookingServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/booking/PublicBookingServiceImpl.java
@@ -153,14 +153,7 @@ public class PublicBookingServiceImpl implements PublicBookingService {
 			}
 			return paciente;
 		}
-		final Paciente paciente = new Paciente();
-		paciente.setUserId(userId);
-		paciente.setName(request.getPatientName().trim());
-		paciente.setEmail(email);
-		if (StringUtils.hasText(request.getPatientPhone())) {
-			paciente.setPhone(request.getPatientPhone().trim());
-		}
-		return pacienteService.save(paciente);
+		return pacienteService.save(PublicBookingPatientFactory.buildProspect(userId, request));
 	}
 
 	private static String resolveDisplayName(final NutritionistProfile profile) {

--- a/src/test/java/com/nutriconsultas/booking/PublicBookingPatientFactoryTest.java
+++ b/src/test/java/com/nutriconsultas/booking/PublicBookingPatientFactoryTest.java
@@ -1,0 +1,43 @@
+package com.nutriconsultas.booking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteStatus;
+
+class PublicBookingPatientFactoryTest {
+
+	private static final String USER_ID = "auth0|nutritionist";
+
+	@Test
+	void buildProspectSetsRequiredFieldsAndOnboardingStatus() {
+		final PublicBookingRequestDto request = new PublicBookingRequestDto();
+		request.setPatientName("  Ana Pérez  ");
+		request.setPatientEmail("ana@example.com");
+		request.setPatientPhone(" 5551234 ");
+
+		final Paciente paciente = PublicBookingPatientFactory.buildProspect(USER_ID, request);
+
+		assertThat(paciente.getUserId()).isEqualTo(USER_ID);
+		assertThat(paciente.getName()).isEqualTo("Ana Pérez");
+		assertThat(paciente.getEmail()).isEqualTo("ana@example.com");
+		assertThat(paciente.getPhone()).isEqualTo("5551234");
+		assertThat(paciente.getStatus()).isEqualTo(PacienteStatus.ONBOARDING);
+		assertThat(paciente.getGender()).isEqualTo(PublicBookingPatientFactory.PLACEHOLDER_GENDER);
+		assertThat(paciente.getDob()).isNotNull();
+	}
+
+	@Test
+	void buildProspectOmitsPhoneWhenBlank() {
+		final PublicBookingRequestDto request = new PublicBookingRequestDto();
+		request.setPatientName("Carlos");
+		request.setPatientEmail("carlos@example.com");
+
+		final Paciente paciente = PublicBookingPatientFactory.buildProspect(USER_ID, request);
+
+		assertThat(paciente.getPhone()).isNull();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/booking/PublicBookingPatientPersistenceTest.java
+++ b/src/test/java/com/nutriconsultas/booking/PublicBookingPatientPersistenceTest.java
@@ -1,0 +1,38 @@
+package com.nutriconsultas.booking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteStatus;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class PublicBookingPatientPersistenceTest {
+
+	private static final String USER_ID = "auth0|public-booking-persist";
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@Test
+	void prospectPatientPersistsWithPlaceholderDemographics() {
+		final PublicBookingRequestDto request = new PublicBookingRequestDto();
+		request.setPatientName("Prospect Patient");
+		request.setPatientEmail("prospect@example.com");
+
+		final Paciente saved = pacienteRepository.save(PublicBookingPatientFactory.buildProspect(USER_ID, request));
+
+		assertThat(saved.getId()).isNotNull();
+		final Paciente reloaded = pacienteRepository.findById(saved.getId()).orElseThrow();
+		assertThat(reloaded.getStatus()).isEqualTo(PacienteStatus.ONBOARDING);
+		assertThat(reloaded.getGender()).isEqualTo(PublicBookingPatientFactory.PLACEHOLDER_GENDER);
+		assertThat(reloaded.getDob()).isNotNull();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/booking/PublicBookingServiceTest.java
+++ b/src/test/java/com/nutriconsultas/booking/PublicBookingServiceTest.java
@@ -30,6 +30,7 @@ import com.nutriconsultas.calendar.EventStatus;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.paciente.PacienteService;
+import com.nutriconsultas.paciente.PacienteStatus;
 import com.nutriconsultas.profile.NutritionistProfile;
 import com.nutriconsultas.profile.NutritionistProfileRepository;
 import com.nutriconsultas.subscription.Subscription;
@@ -133,6 +134,9 @@ class PublicBookingServiceTest {
 		final PublicBookingConfirmation confirmation = service.book(PUBLIC_ID, request);
 
 		assertThat(confirmation.eventId()).isEqualTo(99L);
+		final ArgumentCaptor<Paciente> patientCaptor = ArgumentCaptor.forClass(Paciente.class);
+		verify(pacienteService).save(patientCaptor.capture());
+		assertThat(patientCaptor.getValue().getStatus()).isEqualTo(PacienteStatus.ONBOARDING);
 		final ArgumentCaptor<CalendarEvent> captor = ArgumentCaptor.forClass(CalendarEvent.class);
 		verify(calendarEventService).save(captor.capture());
 		assertThat(captor.getValue().getStatus()).isEqualTo(EventStatus.SCHEDULED);


### PR DESCRIPTION
## Summary
- Add `PublicBookingPatientFactory` to create minimal `Paciente` records when a new email books via the public page (`ONBOARDING` status, placeholder DOB/gender).
- Wire factory into `PublicBookingServiceImpl.findOrCreatePatient` so public booking POST persists successfully.
- Mark #300 **done** in tracking docs (`ISSUE-PUBLIC-BOOKING.md`, `AGENTS.md`, etc.).

Fixes #300

## Test plan
- [x] `PublicBookingPatientFactoryTest` — required fields + ONBOARDING
- [x] `PublicBookingPatientPersistenceTest` — H2 persist
- [x] `PublicBookingServiceTest` — create path uses ONBOARDING
- [x] `./lint.sh` — Checkstyle, SpotBugs, PMD, Thymeleaf
- [x] Browser QA — full book flow creates patient + calendar event + success banner


Made with [Cursor](https://cursor.com)