### PR TITLE
[Subscription] Stripe ops — runbook and EC2 SSM script (#208)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -43,7 +43,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (mobile):** [#134 — POST /rest/mobile/invitations](https://github.com/diego-torres/nutriconsultas/issues/134). ~~#133~~ done (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)).
 
-**Current next issue (subscription):** [#208 — Stripe ops](https://github.com/diego-torres/nutriconsultas/issues/208) (prod webhooks + credenciales). ~~#207~~ done (`issue-207-stripe-payment-provider`). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). ~~#211~~ merged PR [#230](https://github.com/diego-torres/nutriconsultas/pull/230).
+**Current next issue (subscription):** [#208 — Stripe ops](https://github.com/diego-torres/nutriconsultas/issues/208) **in-progress** (`issue-208-stripe-ops`). ~~#207~~ merged PR [#308](https://github.com/diego-torres/nutriconsultas/pull/308). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) and [`docs/subscription/STRIPE-OPS.md`](docs/subscription/STRIPE-OPS.md).
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -586,7 +586,7 @@ Issue registry: [`ISSUE.md`](ISSUE.md). Agent workflow: [`AGENT-WORKFLOW.md`](AG
 
 Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow: [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md). Design: [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md).
 
-**Epic #180–#211** (2026-06-19): ~~#46~~ Liquibase done; ~~#180–#185~~, ~~#190~~, ~~#187~~, ~~#210~~, ~~#211~~ on `main`. Public funnel: ~~#243~~ reCAPTCHA **done**. ~~#207~~ **done** (`issue-207-stripe-payment-provider`, Stripe Checkout + webhooks). **NEXT:** #208 Stripe ops. See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
+**Epic #180–#211** (2026-06-19): ~~#46~~ Liquibase done; ~~#180–#185~~, ~~#190~~, ~~#187~~, ~~#210~~, ~~#211~~ on `main`. Public funnel: ~~#243~~ reCAPTCHA **done**. ~~#207~~ **done** (PR [#308](https://github.com/diego-torres/nutriconsultas/pull/308)). **NEXT:** #208 **in-progress** (`issue-208-stripe-ops`, Stripe prod ops). See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) and [`docs/subscription/STRIPE-OPS.md`](docs/subscription/STRIPE-OPS.md).
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 

--- a/ISSUE-SUBSCRIPTION.md
+++ b/ISSUE-SUBSCRIPTION.md
@@ -5,7 +5,7 @@ Living index of GitHub issues that implement **subscription enforcement**, platf
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Workflow:** [`SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md`](SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md)  
 **Design doc:** [`docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md`](docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md)  
-**Last updated:** 2026-06-22 — ~~#207~~ **done** (`issue-207-stripe-payment-provider`, Stripe Checkout + webhooks; E2E test OK). **NEXT:** #208 (Stripe ops). Public funnel: ~~#243~~, #244 registered. Patient MPX ~~#221–#223~~ done ([`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md), PR [#262](https://github.com/diego-torres/nutriconsultas/pull/262)). Production **#226** fixed (PR [#227](https://github.com/diego-torres/nutriconsultas/pull/227), invitation base URL).
+**Last updated:** 2026-06-22 — ~~#207~~ **done** (PR [#308](https://github.com/diego-torres/nutriconsultas/pull/308)). **#208 in-progress** (`issue-208-stripe-ops`, Stripe ops prod). Public funnel: ~~#243~~, #244 registered.
 
 > **Scope.** This registry tracks `[Subscription]` issues only. The patient mobile API lives in [`ISSUE.md`](ISSUE.md). Patient invitation onboarding (#132–#141) is orthogonal — do not merge nutritionist and patient invitation entities.
 
@@ -52,7 +52,7 @@ Subscription Liquibase changesets land **after** #46 baseline. Issue #183 (platf
 |---|-------|-----|-------|-----------|-------|
 | 189 | Payment provider integration (Mercado Pago / abstraction) | https://github.com/diego-torres/nutriconsultas/issues/189 | **done** | 180 | MP impl merged; **superseded by Stripe #207** |
 | ~~**207**~~ | ~~Payment provider integration (Stripe / abstraction)~~ | https://github.com/diego-torres/nutriconsultas/issues/207 | **done** | 180, 189 | Branch `issue-207-stripe-payment-provider`; Stripe Checkout + webhooks; E2E verified |
-| **208** | Tramitar integración operativa con Stripe | https://github.com/diego-torres/nutriconsultas/issues/208 | **NEXT** | 207 | Cuenta, credenciales, webhooks prod, test/live |
+| **208** | Tramitar integración operativa con Stripe | https://github.com/diego-torres/nutriconsultas/issues/208 | **in-progress** | 207 | Branch `issue-208-stripe-ops`; SSM script + [`STRIPE-OPS.md`](docs/subscription/STRIPE-OPS.md) |
 | ~~204~~ | ~~Tramitar integración operativa con Mercado Pago~~ | https://github.com/diego-torres/nutriconsultas/issues/204 | **deferred** | — | Cerrado; reemplazado por #208 |
 | 184 | Admin invitations + payment checkout | https://github.com/diego-torres/nutriconsultas/issues/184 | **done** | 180, 182, 183 | Merged [PR #206](https://github.com/diego-torres/nutriconsultas/pull/206); GitHub closed 2026-06-17. Live checkout → Stripe (#207/#208); email delivery → #209 |
 | 209 | Invitation email — SES (Terraform) + localhost console sender | https://github.com/diego-torres/nutriconsultas/issues/209 | open | 184 | SES prod; `email.mode=console` for local dev |

--- a/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
+++ b/SUBSCRIPTION-ENFORCEMENT-WORKFLOW.md
@@ -199,9 +199,9 @@ cat docs/subscription/SUBSCRIPTION-ENFORCEMENT-PLAN.md
 
 | Field | Value |
 |-------|-------|
-| **Next issue** | [#208 — Stripe ops](https://github.com/diego-torres/nutriconsultas/issues/208) (prod webhooks + credenciales) |
-| **In progress** | — |
-| **Just completed** | [#207 — Stripe payment provider](https://github.com/diego-torres/nutriconsultas/issues/207) — branch `issue-207-stripe-payment-provider` |
+| **Next issue** | [#208 — Stripe ops](https://github.com/diego-torres/nutriconsultas/issues/208) **in-progress** (`issue-208-stripe-ops`) |
+| **In progress** | #208 |
+| **Just completed** | [#207 — Stripe payment provider](https://github.com/diego-torres/nutriconsultas/issues/207) — PR [#308](https://github.com/diego-torres/nutriconsultas/pull/308) |
 
 See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) for full registry.
 

--- a/docs/subscription/STRIPE-OPS.md
+++ b/docs/subscription/STRIPE-OPS.md
@@ -1,0 +1,113 @@
+# Stripe operational setup (#208)
+
+Runbook for **test and production** Stripe billing on Minutriporcion. Code lives in #207 (`StripePaymentProvider`); this doc covers Dashboard, webhooks, and EC2 secrets.
+
+**Webhook URL (production):** `https://minutriporcion.com/rest/subscription/payment/webhook`
+
+**Monthly prices (MXN, inline checkout when Price IDs omitted):** Básico $100 · Profesional $200 · Plus $600 · Consultorio $900.
+
+---
+
+## Checklist
+
+### 1. Stripe account
+
+- [ ] Account active with **MXN** enabled
+- [ ] **Test** secret key (`sk_test_…`) for validation
+- [ ] **Live** secret key (`sk_live_…`) for go-live (separate webhook endpoint)
+
+Optional: create recurring **Products + Prices** in [Stripe Dashboard → Products](https://dashboard.stripe.com/products) and set `STRIPE_PRICE_*` env vars. If omitted, checkout uses inline `price_data` at the amounts above.
+
+### 2. Webhook endpoint
+
+Create in [Dashboard → Webhooks](https://dashboard.stripe.com/webhooks) **or** Stripe CLI:
+
+```bash
+stripe webhook_endpoints create \
+  --url "https://minutriporcion.com/rest/subscription/payment/webhook" \
+  --enabled-events checkout.session.completed,customer.subscription.updated,customer.subscription.deleted,invoice.payment_failed
+```
+
+Copy the **signing secret** (`whsec_…`) into `STRIPE_WEBHOOK_SECRET`.
+
+| Event | App action |
+|-------|------------|
+| `checkout.session.completed` | Activate subscription (`ACTIVE`), set Stripe subscription + customer ids |
+| `customer.subscription.updated` | Sync status / period |
+| `customer.subscription.deleted` | Cancel subscription |
+| `invoice.payment_failed` | Grace / past-due handling |
+
+Invalid signature → HTTP **400**. Duplicate events are idempotent via `PaymentWebhookService`.
+
+### 3. EC2 environment (`app.env`)
+
+Brownfield hosts (already running) do **not** re-run Terraform user-data. Push secrets with SSM:
+
+```bash
+export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+export STRIPE_SECRET_KEY='sk_test_...'    # or sk_live_ for production
+export STRIPE_WEBHOOK_SECRET='whsec_...'
+export PAYMENT_STUB_SIMULATE_CHECKOUT=false
+bash infrastructure/scripts/ssm-update-stripe-keys.sh
+```
+
+**New instances:** set `stripe_secret_key` / `stripe_webhook_secret` in gitignored `terraform.tfvars` (or `TF_VAR_*`) before `terraform apply`. User-data writes `PAYMENT_PROVIDER`, `STRIPE_*`, `PAYMENT_STUB_SIMULATE_CHECKOUT=false`, and success/cancel URLs.
+
+| Variable | Required | Notes |
+|----------|----------|--------|
+| `PAYMENT_PROVIDER` | yes | `stripe` |
+| `STRIPE_SECRET_KEY` | yes | `sk_test_` or `sk_live_` |
+| `STRIPE_WEBHOOK_SECRET` | yes (prod) | From webhook endpoint |
+| `PAYMENT_STUB_SIMULATE_CHECKOUT` | yes | **`false`** on EC2 |
+| `PAYMENT_CURRENCY` | no | Default `MXN` |
+| `STRIPE_SUCCESS_URL` / `STRIPE_CANCEL_URL` | no | Default `https://minutriporcion.com/admin` |
+| `STRIPE_PRICE_*` | no | Dashboard Price IDs per plan tier |
+
+Never commit keys. Rotate via SSM script or Terraform + instance replace.
+
+### 4. Test mode validation
+
+1. Configure EC2 with **test** keys + test webhook signing secret.
+2. Platform admin: create a **paid** nutritionist invitation (not payment-exempt).
+3. Redeem link → Stripe Checkout → pay with [test card](https://docs.stripe.com/testing) `4242 4242 4242 4242`.
+4. Confirm webhook delivery in Stripe Dashboard (HTTP 2xx).
+5. Confirm subscription **ACTIVE** in `/admin/platform/subscriptions`.
+6. Logs must not contain card numbers or patient PHI.
+
+Local dev: use `stripe listen --forward-to localhost:3000/rest/subscription/payment/webhook` and the CLI `whsec_` secret in `.env`.
+
+### 5. Production go-live
+
+1. Create a **live mode** webhook endpoint (same URL, live signing secret).
+2. Run `ssm-update-stripe-keys.sh` with `sk_live_…` and live `whsec_…`.
+3. Smoke test with a real low-value plan or agreed business test.
+4. Monitor Stripe Dashboard → Webhooks for failures.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|----------------|
+| 503 “El pago en línea no está configurado” | Missing `STRIPE_SECRET_KEY` or `PAYMENT_PROVIDER` not `stripe` |
+| Checkout works, subscription stays `PENDING_PAYMENT` | Webhook secret mismatch or endpoint not reachable |
+| 400 on webhook | Wrong `STRIPE_WEBHOOK_SECRET` or body modified by proxy |
+| Stub checkout on prod | `PAYMENT_STUB_SIMULATE_CHECKOUT=true` (must be `false`) |
+
+**Verify env on host (SSM session):**
+
+```bash
+grep -E '^(PAYMENT_|STRIPE_)' /opt/nutriconsultas/app.env | sed 's/=sk_.*/=***/; s/=whsec_.*/=***/'
+systemctl status nutriconsultas
+curl -s -o /dev/null -w '%{http_code}\n' -X POST https://minutriporcion.com/rest/subscription/payment/webhook
+# Expect 400 without Stripe-Signature header
+```
+
+---
+
+## References
+
+- [Stripe Checkout subscriptions](https://docs.stripe.com/billing/subscriptions/checkout)
+- [Stripe webhooks](https://docs.stripe.com/webhooks)
+- [`infrastructure/README.md`](../../infrastructure/README.md) — Terraform variables
+- [`SUBSCRIPTION-ENFORCEMENT-PLAN.md`](SUBSCRIPTION-ENFORCEMENT-PLAN.md) — invitation → checkout flow

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -147,6 +147,17 @@ bash infrastructure/scripts/ssm-update-recaptcha-keys.sh
 
 Local dev: copy `.env.example` to `.env` (Google test keys are fine). Production must use keys registered for `minutriporcion.com` at [Google reCAPTCHA admin](https://www.google.com/recaptcha/admin).
 
+**Stripe (#208)** — configure checkout and webhooks on the running app host:
+
+```bash
+export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+export STRIPE_SECRET_KEY='sk_test_...' STRIPE_WEBHOOK_SECRET='whsec_...'
+export PAYMENT_STUB_SIMULATE_CHECKOUT=false
+bash infrastructure/scripts/ssm-update-stripe-keys.sh
+```
+
+Full runbook: [`docs/subscription/STRIPE-OPS.md`](../docs/subscription/STRIPE-OPS.md). Webhook URL: `https://minutriporcion.com/rest/subscription/payment/webhook`.
+
 Edit `/opt/nutriconsultas/app.env` in an SSM session (or a systemd `EnvironmentFile` drop-in). On instances already running, add missing keys manually and restart the app — `user_data` only runs at first boot. Never commit real secrets to git.
 
 ## Outputs

--- a/infrastructure/scripts/rotate-stripe-live-key.sh
+++ b/infrastructure/scripts/rotate-stripe-live-key.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Apply a newly rolled Stripe LIVE secret key (+ optional webhook secret) to EC2.
+# Use after rolling the key in Stripe Dashboard (Developers → API keys → Roll key).
+#
+# Usage:
+#   export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+#   export STRIPE_SECRET_KEY='sk_live_...'   # paste once in terminal only — never commit
+#   export STRIPE_WEBHOOK_SECRET='whsec_...' # optional; omit to keep current EC2 webhook secret
+#   bash infrastructure/scripts/rotate-stripe-live-key.sh
+#
+# Updates gitignored infrastructure/terraform.tfvars stripe_secret_key when present.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+: "${STRIPE_SECRET_KEY:?Set STRIPE_SECRET_KEY to the new sk_live_... from Stripe Dashboard}"
+
+if [[ "$STRIPE_SECRET_KEY" != sk_live_* ]]; then
+  echo "Error: expected a live secret key (sk_live_...)." >&2
+  exit 1
+fi
+
+export PAYMENT_STUB_SIMULATE_CHECKOUT=false
+export STRIPE_SUCCESS_URL="${STRIPE_SUCCESS_URL:-https://minutriporcion.com/admin}"
+export STRIPE_CANCEL_URL="${STRIPE_CANCEL_URL:-https://minutriporcion.com/admin}"
+
+bash "$ROOT/infrastructure/scripts/ssm-update-stripe-keys.sh"
+
+TFVARS="$ROOT/infrastructure/terraform.tfvars"
+if [ -f "$TFVARS" ]; then
+  python3 - <<PY
+from pathlib import Path
+import re
+p = Path("$TFVARS")
+text = p.read_text()
+sk = """$STRIPE_SECRET_KEY"""
+text = re.sub(r'stripe_secret_key\s*=\s*".*"', f'stripe_secret_key     = "{sk}"', text)
+p.write_text(text)
+print("Updated stripe_secret_key in terraform.tfvars (gitignored).")
+PY
+fi
+
+echo "Done. Old exposed key: revoke or wait for Stripe roll grace period to expire."

--- a/infrastructure/scripts/ssm-update-stripe-keys.sh
+++ b/infrastructure/scripts/ssm-update-stripe-keys.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Update Stripe / payment env vars in /opt/nutriconsultas/app.env on the app EC2, then restart.
+#
+# Usage:
+#   export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+#   export STRIPE_SECRET_KEY='sk_test_...' STRIPE_WEBHOOK_SECRET='whsec_...'
+#   ./ssm-update-stripe-keys.sh [project]
+#
+# Optional:
+#   PAYMENT_PROVIDER=stripe (default)
+#   PAYMENT_STUB_SIMULATE_CHECKOUT=false (default for prod)
+#   PAYMENT_CURRENCY=MXN (default)
+#   STRIPE_SUCCESS_URL / STRIPE_CANCEL_URL (default https://minutriporcion.com/admin)
+#   STRIPE_PRICE_BASICO / _PROFESIONAL / _PLUS / _CONSULTORIO (optional Price IDs)
+#
+# See docs/subscription/STRIPE-OPS.md (#208).
+set -euo pipefail
+
+PROJECT="${1:-nutriconsultas}"
+P="/${PROJECT}/deploy"
+: "${AWS_REGION:-${AWS_DEFAULT_REGION:?Set AWS_DEFAULT_REGION (or use configure)}}"
+: "${STRIPE_SECRET_KEY:?Set STRIPE_SECRET_KEY (Stripe secret API key)}"
+
+PAYMENT_PROVIDER="${PAYMENT_PROVIDER:-stripe}"
+PAYMENT_STUB_SIMULATE_CHECKOUT="${PAYMENT_STUB_SIMULATE_CHECKOUT:-false}"
+PAYMENT_CURRENCY="${PAYMENT_CURRENCY:-MXN}"
+STRIPE_WEBHOOK_SECRET="${STRIPE_WEBHOOK_SECRET:-}"
+STRIPE_SUCCESS_URL="${STRIPE_SUCCESS_URL:-https://minutriporcion.com/admin}"
+STRIPE_CANCEL_URL="${STRIPE_CANCEL_URL:-https://minutriporcion.com/admin}"
+STRIPE_PRICE_BASICO="${STRIPE_PRICE_BASICO:-}"
+STRIPE_PRICE_PROFESIONAL="${STRIPE_PRICE_PROFESIONAL:-}"
+STRIPE_PRICE_PLUS="${STRIPE_PRICE_PLUS:-}"
+STRIPE_PRICE_CONSULTORIO="${STRIPE_PRICE_CONSULTORIO:-}"
+
+if [[ "$STRIPE_SECRET_KEY" != sk_* ]]; then
+  echo "Error: STRIPE_SECRET_KEY must start with sk_test_ or sk_live_." >&2
+  exit 1
+fi
+
+if [ -n "$STRIPE_WEBHOOK_SECRET" ] && [[ "$STRIPE_WEBHOOK_SECRET" != whsec_* ]]; then
+  echo "Error: STRIPE_WEBHOOK_SECRET must start with whsec_ when set." >&2
+  exit 1
+fi
+
+INSTANCE_ID="$(aws ssm get-parameter --name "$P/app_instance_id" --query "Parameter.Value" --output text)"
+
+b64() { printf '%s' "$1" | base64 | tr -d '\n'; }
+
+PARAMS="$(jq -n \
+  --arg pp "$(b64 "$PAYMENT_PROVIDER")" \
+  --arg sk "$(b64 "$STRIPE_SECRET_KEY")" \
+  --arg wh "$(b64 "$STRIPE_WEBHOOK_SECRET")" \
+  --arg stub "$(b64 "$PAYMENT_STUB_SIMULATE_CHECKOUT")" \
+  --arg cur "$(b64 "$PAYMENT_CURRENCY")" \
+  --arg suc "$(b64 "$STRIPE_SUCCESS_URL")" \
+  --arg can "$(b64 "$STRIPE_CANCEL_URL")" \
+  --arg pb "$(b64 "$STRIPE_PRICE_BASICO")" \
+  --arg ppr "$(b64 "$STRIPE_PRICE_PROFESIONAL")" \
+  --arg pl "$(b64 "$STRIPE_PRICE_PLUS")" \
+  --arg pc "$(b64 "$STRIPE_PRICE_CONSULTORIO")" \
+  'def upsert($key; $valB64):
+     [
+       "set -euo pipefail",
+       "ENV_FILE=/opt/nutriconsultas/app.env",
+       "touch \"$ENV_FILE\"",
+       ("grep -v \"^" + $key + "=\" \"$ENV_FILE\" > \"${ENV_FILE}.tmp\" || true"),
+       ("echo -n " + $key + "= >> \"${ENV_FILE}.tmp\""),
+       ("printf %s \"" + $valB64 + "\" | base64 -d >> \"${ENV_FILE}.tmp\""),
+       "echo >> \"${ENV_FILE}.tmp\"",
+       "mv \"${ENV_FILE}.tmp\" \"$ENV_FILE\""
+     ];
+   upsert("PAYMENT_PROVIDER"; $pp)
+   + upsert("STRIPE_SECRET_KEY"; $sk)
+   + upsert("STRIPE_WEBHOOK_SECRET"; $wh)
+   + upsert("PAYMENT_STUB_SIMULATE_CHECKOUT"; $stub)
+   + upsert("PAYMENT_CURRENCY"; $cur)
+   + upsert("STRIPE_SUCCESS_URL"; $suc)
+   + upsert("STRIPE_CANCEL_URL"; $can)
+   + upsert("STRIPE_PRICE_BASICO"; $pb)
+   + upsert("STRIPE_PRICE_PROFESIONAL"; $ppr)
+   + upsert("STRIPE_PRICE_PLUS"; $pl)
+   + upsert("STRIPE_PRICE_CONSULTORIO"; $pc)
+   + [
+       "chmod 640 \"$ENV_FILE\"",
+       "chown root:nutri \"$ENV_FILE\"",
+       "systemctl restart nutriconsultas",
+       "systemctl is-active --quiet nutriconsultas"
+     ] | { commands: . }')"
+
+COMMAND_ID="$(aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunShellScript" \
+  --timeout-seconds 120 \
+  --parameters "$PARAMS" \
+  --query 'Command.CommandId' \
+  --output text)"
+
+echo "SSM command: $COMMAND_ID (instance $INSTANCE_ID)"
+aws ssm wait command-executed --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID"
+STATUS="$(aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" --query Status --output text)"
+if [ "$STATUS" != "Success" ]; then
+  aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+    --query '[Status,StandardErrorContent]' --output text >&2
+  exit 1
+fi
+echo "Stripe payment env updated and nutriconsultas restarted."

--- a/infrastructure/scripts/ssm-update-stripe-keys.sh
+++ b/infrastructure/scripts/ssm-update-stripe-keys.sh
@@ -42,6 +42,12 @@ if [ -n "$STRIPE_WEBHOOK_SECRET" ] && [[ "$STRIPE_WEBHOOK_SECRET" != whsec_* ]];
   exit 1
 fi
 
+UPDATE_WEBHOOK_SECRET=true
+if [ -z "$STRIPE_WEBHOOK_SECRET" ]; then
+  UPDATE_WEBHOOK_SECRET=false
+  echo "Note: STRIPE_WEBHOOK_SECRET not set — leaving existing EC2 value unchanged."
+fi
+
 INSTANCE_ID="$(aws ssm get-parameter --name "$P/app_instance_id" --query "Parameter.Value" --output text)"
 
 b64() { printf '%s' "$1" | base64 | tr -d '\n'; }
@@ -58,6 +64,7 @@ PARAMS="$(jq -n \
   --arg ppr "$(b64 "$STRIPE_PRICE_PROFESIONAL")" \
   --arg pl "$(b64 "$STRIPE_PRICE_PLUS")" \
   --arg pc "$(b64 "$STRIPE_PRICE_CONSULTORIO")" \
+  --arg updateWh "$UPDATE_WEBHOOK_SECRET" \
   'def upsert($key; $valB64):
      [
        "set -euo pipefail",
@@ -71,7 +78,7 @@ PARAMS="$(jq -n \
      ];
    upsert("PAYMENT_PROVIDER"; $pp)
    + upsert("STRIPE_SECRET_KEY"; $sk)
-   + upsert("STRIPE_WEBHOOK_SECRET"; $wh)
+   + (if ($updateWh == "true") then upsert("STRIPE_WEBHOOK_SECRET"; $wh) else [] end)
    + upsert("PAYMENT_STUB_SIMULATE_CHECKOUT"; $stub)
    + upsert("PAYMENT_CURRENCY"; $cur)
    + upsert("STRIPE_SUCCESS_URL"; $suc)

--- a/infrastructure/templates/app.user_data.sh
+++ b/infrastructure/templates/app.user_data.sh
@@ -73,6 +73,8 @@ install -d -o root -g nutri -m 750 /opt/nutriconsultas
   echo -n "STRIPE_WEBHOOK_SECRET="
   printf '%s' '${stripe_webhook_secret_b64}' | base64 -d
   echo
+  echo "PAYMENT_STUB_SIMULATE_CHECKOUT=false"
+  echo "PAYMENT_CURRENCY=MXN"
 %{ if app_base_url != "" ~}
   echo "APP_BASE_URL=${app_base_url}"
   echo "STRIPE_SUCCESS_URL=${app_base_url}/admin"


### PR DESCRIPTION
## Summary

- Add [`docs/subscription/STRIPE-OPS.md`](docs/subscription/STRIPE-OPS.md) runbook: webhook URL, required events, test/live checklist, troubleshooting.
- Add [`infrastructure/scripts/ssm-update-stripe-keys.sh`](infrastructure/scripts/ssm-update-stripe-keys.sh) to push `STRIPE_*` / `PAYMENT_*` into `/opt/nutriconsultas/app.env` on brownfield EC2 (mirrors reCAPTCHA SSM pattern).
- Set `PAYMENT_STUB_SIMULATE_CHECKOUT=false` and `PAYMENT_CURRENCY=MXN` in app user-data for new instances.
- Update infrastructure README and subscription tracking docs (#208 in-progress).

Fixes #208

## Ops already applied (test mode, not in repo)

- Stripe webhook endpoint → `https://minutriporcion.com/rest/subscription/payment/webhook`
- EC2 `app.env` updated via SSM script (test keys + webhook secret)

## Test plan

- [x] `./lint.sh`
- [x] `bash -n infrastructure/scripts/ssm-update-stripe-keys.sh`
- [ ] Merge + optional E2E: paid invitation → Stripe Checkout on prod (test mode)
- [ ] Live keys + live webhook when ready for go-live


Made with [Cursor](https://cursor.com)