### PR TITLE
Allowlist Google reCAPTCHA test keys for leak scanners

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,10 @@ POSTGRES_PORT=5432
 JDBC_DATABASE_URL=jdbc:postgresql://localhost:5432/nutriconsultas
 JDBC_DATABASE_USERNAME=nutriconsultas
 JDBC_DATABASE_PASSWORD=nutriconsultas
-RECAPTCHA_SECRET_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
-# Google reCAPTCHA v2 site key (public; pair with RECAPTCHA_SECRET_KEY). Register at
-# https://www.google.com/recaptcha/admin for minutriporcion.com
-RECAPTCHA_SITE_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
+# Local dev: omit both vars to use Google test keys (application.properties defaults), or set
+# production keys from https://www.google.com/recaptcha/admin for minutriporcion.com
+# RECAPTCHA_SECRET_KEY=EXAMPLE_recaptcha_secret_for_local_dev
+# RECAPTCHA_SITE_KEY=EXAMPLE_recaptcha_site_key_for_local_dev
 
 # Optional: Maps API Key (if using maps functionality)
 # MAPS_KEY=your_maps_key_here

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,10 @@
+# Red Hat PwnedAlert / rh-pre-commit allowlist (top-level [allowlist] only).
+# Google reCAPTCHA v2 public test keys — not production secrets.
+# https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
+[allowlist]
+  description = "Google reCAPTCHA v2 public test keys (dev/CI only)"
+
+  regexes = [
+    '''6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe''',
+    '''6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI''',
+  ]

--- a/src/main/java/com/nutriconsultas/recaptcha/RecaptchaProperties.java
+++ b/src/main/java/com/nutriconsultas/recaptcha/RecaptchaProperties.java
@@ -6,9 +6,9 @@ import org.springframework.util.StringUtils;
 @ConfigurationProperties(prefix = "recaptcha")
 public class RecaptchaProperties {
 
-	public static final String GOOGLE_TEST_SITE_KEY = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI";
+	public static final String GOOGLE_TEST_SITE_KEY = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"; // notsecret
 
-	public static final String GOOGLE_TEST_SECRET_KEY = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe";
+	public static final String GOOGLE_TEST_SECRET_KEY = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"; // notsecret
 
 	private String siteKey = GOOGLE_TEST_SITE_KEY;
 

--- a/src/test/java/com/nutriconsultas/controller/WebControllerTest.java
+++ b/src/test/java/com/nutriconsultas/controller/WebControllerTest.java
@@ -28,9 +28,9 @@ import lombok.extern.slf4j.Slf4j;
 @ActiveProfiles("test")
 public class WebControllerTest {
 
-	private static final String TEST_SITE_KEY = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI";
+	private static final String TEST_SITE_KEY = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"; // notsecret
 
-	private static final String TEST_SECRET_KEY = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe";
+	private static final String TEST_SECRET_KEY = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"; // notsecret
 
 	@DynamicPropertySource
 	static void recaptchaTestKeys(final DynamicPropertyRegistry registry) {

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -24,8 +24,8 @@ amazon.s3.key=${AWS_KEY:noval}
 amazon.s3.secret=${AWS_SECRET:noval}
 amazon.s3.region=us-east-1
 # reCAPTCHA configuration (Google test keys for testing)
-recaptcha.site-key=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
-recaptcha.secret-key=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+recaptcha.site-key=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI # notsecret
+recaptcha.secret-key=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe # notsecret
 nutriconsultas.platform.admin-user-ids=auth0|platform-admin-test
 # Existing controller tests assume open admin access; dedicated tests cover invitation-only gate.
 nutriconsultas.subscription.enforce-nutritionist-access=false


### PR DESCRIPTION
## Summary
- Adds root `.gitleaks.toml` allowlist for Google's public reCAPTCHA v2 test keys (Red Hat PwnedAlert / rh-pre-commit).
- Marks test key lines with `# notsecret` in `RecaptchaProperties`, `WebControllerTest`, and `application-test.properties`.
- Replaces literal reCAPTCHA keys in `.env.example` with commented `EXAMPLE_*` placeholders; local dev still uses `application.properties` defaults when vars are omitted.

## Context
Red Hat PwnedAlert flagged Google reCAPTCHA test keys as generic secrets. These are documented public test credentials, not production leaks — no rotation or history rewrite needed.

## Test plan
- [ ] Merge to `main` so PwnedAlert deep scan picks up `.gitleaks.toml`
- [ ] Optional: run `rh-gitleaks --path=. -v --additional-config=.gitleaks.toml` if rh-gitleaks is installed
- [ ] Submit Red Hat false-positive feedback form referencing this PR
- [ ] Confirm `cp .env.example .env` + local boot still works without `RECAPTCHA_*` set


Made with [Cursor](https://cursor.com)