### PR TITLE
feat(mobile-api): nutritionist create patient invitation (#134)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -409,7 +409,7 @@ gh pr create ...
 | Field | Value |
 |-------|-------|
 | **Next issue** | [#134 — POST /rest/mobile/invitations](https://github.com/diego-torres/nutriconsultas/issues/134) |
-| **Status** | **NEXT** — ~~#133~~ ✓ merged (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)) |
+| **Status** | **in-progress** — branch `mobile-api/134-create-invitation` |
 | **Phase** | Nutritionist JWT creates `Paciente` + `PatientInvitation` with token hash |
 | **Just completed** | [#133 token service](https://github.com/diego-torres/nutriconsultas/issues/133) — PR #229, deployed EC2 |
 | **In scope for #134** | `POST /rest/mobile/invitations`; persist hash only; return invite URL + human code |

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) · **Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-19 — ~~#133~~ **done** (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229), deployed EC2). **NEXT:** [#134 create invitation](https://github.com/diego-torres/nutriconsultas/issues/134).
+**Last updated:** 2026-06-22 — ~~#133~~ **done** (PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229)). **NEXT:** [#134 create invitation](https://github.com/diego-torres/nutriconsultas/issues/134) (**in-progress** on `mobile-api/134-create-invitation`).
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -143,7 +143,7 @@ Invite-only patient onboarding replaces manual Afiliación linkage (#109) for ne
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | 133 | Invitation token generation & hashing service | https://github.com/diego-torres/nutriconsultas/issues/133 | **done** | ~~132~~ ✓ | Merged PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229): `PatientInvitationTokenService`, human code, SHA-256 hash, optional offline JWS (#140) |
-| 134 | `POST /rest/mobile/invitations` — nutritionist creates patient + invitation | https://github.com/diego-torres/nutriconsultas/issues/134 | **NEXT** | ~~132~~ ✓, ~~133~~ ✓ | Nutritionist JWT (not patient); creates `Paciente` + `Invitation` |
+| 134 | `POST /rest/mobile/invitations` — nutritionist creates patient + invitation | https://github.com/diego-torres/nutriconsultas/issues/134 | **in-progress** | ~~132~~ ✓, ~~133~~ ✓ | Nutritionist JWT (not patient); creates `Paciente` + `Invitation` |
 | 135 | `GET /rest/mobile/invitations/{token}/preview` — public rate-limited preview | https://github.com/diego-torres/nutriconsultas/issues/135 | open | ~~133~~ ✓ | Public; enumeration protection (#141) |
 | 136 | `POST /rest/mobile/invitations/{token}/redeem` — bind Auth0 sub → patient | https://github.com/diego-torres/nutriconsultas/issues/136 | open | ~~132~~ ✓, ~~133~~ ✓, 107 | **Authoritative** redeem gate; patient JWT required |
 | 137 | CurrentPatient resolver + onboarding data gate (403 onboarding required) | https://github.com/diego-torres/nutriconsultas/issues/137 | open | ~~132~~ ✓, 107 | Centralizes `sub → Paciente`; 403 until onboarded |

--- a/docs/api/openapi-mobile.yaml
+++ b/docs/api/openapi-mobile.yaml
@@ -15,6 +15,8 @@ security:
 tags:
 - name: Mobile
   description: Patient mobile API
+- name: Mobile Invitations
+  description: Nutritionist-initiated patient onboarding
 paths:
   /rest/mobile/patient/messages:
     get:
@@ -100,6 +102,39 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/ApiResponsePatientMessageSummaryDto"
+  /rest/mobile/invitations:
+    post:
+      tags:
+      - Mobile Invitations
+      summary: Create patient invitation
+      description: Nutritionist JWT creates Paciente (INVITED) + pending invitation;
+        returns deep link and human code.
+      operationId: createInvitation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreatePatientInvitationRequest"
+        required: true
+      responses:
+        "201":
+          description: Patient and invitation created
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseCreatedPatientInvitationDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseCreatedPatientInvitationDto"
+        "403":
+          description: Subscription limit or entitlement denied
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseCreatedPatientInvitationDto"
   /rest/mobile/patient/visits:
     get:
       tags:
@@ -460,8 +495,95 @@ components:
           type: boolean
         senderDisplayName:
           type: string
-          description: Nutritionist display name when senderRole is NUTRITIONIST; omitted otherwise
-          nullable: true
+    CreatePatientInvitationRequest:
+      type: object
+      description: Create patient + invitation
+      properties:
+        name:
+          type: string
+          description: Patient legal/clinical name
+          example: María López
+          maxLength: 100
+          minLength: 0
+        email:
+          type: string
+          description: Delivery email for the invite
+          example: maria@example.com
+          maxLength: 100
+          minLength: 0
+        dob:
+          type: string
+          format: date
+          description: Date of birth (ISO-8601 date)
+          example: 1990-05-15
+        gender:
+          type: string
+          description: Gender (M/F)
+          example: F
+          pattern: "(?i)^[MF]$"
+        phone:
+          type: string
+          description: Optional phone
+          example: "+525512345678"
+          maxLength: 25
+          minLength: 0
+        assignedId:
+          type: string
+          description: Optional clinic-facing identifier; auto-generated when omitted
+          example: P-CLINIC-001
+          maxLength: 50
+          minLength: 0
+        displayName:
+          type: string
+          description: Optional display name for onboarding UI
+          example: María
+          maxLength: 100
+          minLength: 0
+      required:
+      - dob
+      - email
+      - gender
+      - name
+    ApiResponseCreatedPatientInvitationDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/CreatedPatientInvitationDto"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    CreatedPatientInvitationDto:
+      type: object
+      description: Created patient invitation
+      properties:
+        invitationId:
+          type: integer
+          format: int64
+          description: Invitation row id
+          example: 42
+        pacienteId:
+          type: integer
+          format: int64
+          description: Created Paciente id
+          example: 1001
+        inviteUrl:
+          type: string
+          description: Deep link for the patient app
+          example: https://links.example.com/i/abc...
+        humanCode:
+          type: string
+          description: Human-readable onboarding code
+          example: NUTRI-ABCD-EFGH
+        expiresAt:
+          type: string
+          format: date-time
+          description: Invitation expiry (ISO-8601 instant)
+        offlineJws:
+          type: string
+          description: Optional offline JWS when PATIENT_INVITATION_JWS_SECRET is
+            configured
     ApiResponsePagedResponseVisitSummaryDto:
       type: object
       properties:
@@ -637,6 +759,10 @@ components:
           format: double
         circumferences:
           $ref: "#/components/schemas/ProgressCircumferenceDto"
+        avatarId:
+          type: string
+        avatarUrl:
+          type: string
     ProgressCircumferenceDto:
       type: object
       properties:

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -12,7 +12,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`MOBILE-E2E-STATUS.md`](MOBILE-E2E-STATUS.md) | Live E2E status, Auth0 setup, HTTP code matrix |
 | [`../api/openapi-mobile.yaml`](../api/openapi-mobile.yaml) | OpenAPI 3.1 export (#112, PR #164); regen: `scripts/export-openapi-mobile.sh` |
 
-**Status (2026-06-19):** ~~#132~~ ~~#133~~ done on `main` (PRs #214, [#229](https://github.com/diego-torres/nutriconsultas/pull/229)). **NEXT:** [#134](https://github.com/diego-torres/nutriconsultas/issues/134) create invitation.
+**Status (2026-06-22):** ~~#132~~ ~~#133~~ done on `main` (PRs #214, [#229](https://github.com/diego-torres/nutriconsultas/pull/229)). **in-progress:** [#134](https://github.com/diego-torres/nutriconsultas/issues/134) create invitation (`mobile-api/134-create-invitation`).
 
 ## Related registries (same repo)
 

--- a/src/main/java/com/nutriconsultas/mobile/MobileApiErrorResponses.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobileApiErrorResponses.java
@@ -39,6 +39,8 @@ public final class MobileApiErrorResponses {
 
 	public static final String KEY_VALIDATION_FAILED = "error.validation.failed";
 
+	public static final String KEY_INVITATION_ASSIGNED_ID_TAKEN = "error.invitation.assigned_id.taken";
+
 	private final MessageSource messageSource;
 
 	private final ObjectMapper objectMapper;

--- a/src/main/java/com/nutriconsultas/mobile/MobileApiExceptionHandler.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobileApiExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.nutriconsultas.mobile;
 
+import java.time.Instant;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +11,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.subscription.SubscriptionErrorResponses;
+import com.nutriconsultas.subscription.SubscriptionLimitExceededException;
 
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import lombok.extern.slf4j.Slf4j;
@@ -24,8 +28,12 @@ public class MobileApiExceptionHandler {
 
 	private final MobileApiErrorResponses errorResponses;
 
-	public MobileApiExceptionHandler(final MobileApiErrorResponses errorResponses) {
+	private final SubscriptionErrorResponses subscriptionErrorResponses;
+
+	public MobileApiExceptionHandler(final MobileApiErrorResponses errorResponses,
+			final SubscriptionErrorResponses subscriptionErrorResponses) {
 		this.errorResponses = errorResponses;
+		this.subscriptionErrorResponses = subscriptionErrorResponses;
 	}
 
 	@ExceptionHandler(PatientNotLinkedException.class)
@@ -37,16 +45,32 @@ public class MobileApiExceptionHandler {
 			.body(errorResponses.error(MobileApiErrorResponses.KEY_PATIENT_NOT_LINKED));
 	}
 
+	@ExceptionHandler(SubscriptionLimitExceededException.class)
+	public ResponseEntity<ApiResponse<Void>> handleSubscriptionLimit(final SubscriptionLimitExceededException ex) {
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile API subscription limit exceeded: messageKey={}", ex.getMessageKey());
+		}
+		final String message = subscriptionErrorResponses.resolve(ex);
+		return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ApiResponse<>(null, message, Instant.now()));
+	}
+
 	@ExceptionHandler(ResponseStatusException.class)
 	public ResponseEntity<ApiResponse<Void>> handleResponseStatus(final ResponseStatusException ex) {
-		if (!errorResponses.isNotFound(ex)) {
-			throw ex;
+		if (errorResponses.isNotFound(ex)) {
+			if (log.isDebugEnabled()) {
+				log.debug("Mobile API resource not found");
+			}
+			return ResponseEntity.status(HttpStatus.NOT_FOUND)
+				.body(errorResponses.error(MobileApiErrorResponses.KEY_RESOURCE_NOT_FOUND));
 		}
-		if (log.isDebugEnabled()) {
-			log.debug("Mobile API resource not found");
+		if (ex.getStatusCode().value() == HttpStatus.CONFLICT.value()) {
+			if (log.isDebugEnabled()) {
+				log.debug("Mobile API conflict");
+			}
+			return ResponseEntity.status(HttpStatus.CONFLICT)
+				.body(errorResponses.error(MobileApiErrorResponses.KEY_INVITATION_ASSIGNED_ID_TAKEN));
 		}
-		return ResponseEntity.status(HttpStatus.NOT_FOUND)
-			.body(errorResponses.error(MobileApiErrorResponses.KEY_RESOURCE_NOT_FOUND));
+		throw ex;
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/nutriconsultas/mobile/MobileInvitationController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobileInvitationController.java
@@ -1,0 +1,62 @@
+package com.nutriconsultas.mobile;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nutriconsultas.mobile.config.MobileOpenApiResponses;
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.CreatePatientInvitationRequest;
+import com.nutriconsultas.mobile.dto.CreatedPatientInvitationDto;
+import com.nutriconsultas.paciente.invitation.CreatedPatientInvitationResult;
+import com.nutriconsultas.paciente.invitation.PatientInvitationCreateService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/mobile/invitations")
+@Tag(name = "Mobile Invitations", description = "Nutritionist-initiated patient onboarding")
+@Slf4j
+public class MobileInvitationController {
+
+	private final PatientInvitationCreateService patientInvitationCreateService;
+
+	public MobileInvitationController(final PatientInvitationCreateService patientInvitationCreateService) {
+		this.patientInvitationCreateService = patientInvitationCreateService;
+	}
+
+	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
+	@Operation(summary = "Create patient invitation",
+			description = "Nutritionist JWT creates Paciente (INVITED) + pending invitation; returns deep link and human code.")
+	@MobileOpenApiResponses.AuthenticatedNutritionist
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201",
+			description = "Patient and invitation created")
+	public ApiResponse<CreatedPatientInvitationDto> createInvitation(@AuthenticationPrincipal final Jwt jwt,
+			@Valid @RequestBody final CreatePatientInvitationRequest request) {
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile create patient invitation request from nutritionist sub present={}",
+					jwt != null && jwt.getSubject() != null);
+		}
+		final String nutritionistUserId = requireSubject(jwt);
+		final CreatedPatientInvitationResult created = patientInvitationCreateService
+			.createInvitation(nutritionistUserId, request);
+		return ApiResponse.ok(CreatedPatientInvitationDto.from(created));
+	}
+
+	private static String requireSubject(final Jwt jwt) {
+		if (jwt == null || jwt.getSubject() == null || jwt.getSubject().isBlank()) {
+			throw new IllegalArgumentException("Authenticated nutritionist subject is required");
+		}
+		return jwt.getSubject();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/config/MobileOpenApiResponses.java
+++ b/src/main/java/com/nutriconsultas/mobile/config/MobileOpenApiResponses.java
@@ -23,6 +23,14 @@ public interface MobileOpenApiResponses {
 
 	@Target({ ElementType.METHOD, ElementType.TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
+	@ApiResponses({ @ApiResponse(responseCode = "401", description = "Missing or invalid JWT"),
+			@ApiResponse(responseCode = "403", description = "Subscription limit or entitlement denied") })
+	@interface AuthenticatedNutritionist {
+
+	}
+
+	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Retention(RetentionPolicy.RUNTIME)
 	@ApiResponses({ @ApiResponse(responseCode = "404", description = "Resource not found or not owned by patient") })
 	@interface NotFoundWhenMissing {
 

--- a/src/main/java/com/nutriconsultas/mobile/dto/CreatePatientInvitationRequest.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/CreatePatientInvitationRequest.java
@@ -1,0 +1,29 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.time.LocalDate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Nutritionist request to create a patient and issue an onboarding invitation (#134).
+ */
+@Schema(description = "Create patient + invitation")
+public record CreatePatientInvitationRequest(
+		@NotBlank @Size(max = 100) @Schema(description = "Patient legal/clinical name",
+				example = "María López") String name,
+		@NotBlank @Email @Size(max = 100) @Schema(description = "Delivery email for the invite",
+				example = "maria@example.com") String email,
+		@NotNull @Schema(description = "Date of birth (ISO-8601 date)", example = "1990-05-15") LocalDate dob,
+		@NotBlank @Pattern(regexp = "(?i)^[MF]$", message = "must be M or F") @Schema(description = "Gender (M/F)",
+				example = "F") String gender,
+		@Size(max = 25) @Schema(description = "Optional phone", example = "+525512345678") String phone,
+		@Size(max = 50) @Schema(description = "Optional clinic-facing identifier; auto-generated when omitted",
+				example = "P-CLINIC-001") String assignedId,
+		@Size(max = 100) @Schema(description = "Optional display name for onboarding UI",
+				example = "María") String displayName) {
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/CreatedPatientInvitationDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/CreatedPatientInvitationDto.java
@@ -1,0 +1,30 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import com.nutriconsultas.paciente.invitation.CreatedPatientInvitationResult;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Response after a nutritionist creates a patient invitation (#134). Contains the raw
+ * invite URL and human code — never log these values.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Created patient invitation")
+public record CreatedPatientInvitationDto(@Schema(description = "Invitation row id", example = "42") Long invitationId,
+		@Schema(description = "Created Paciente id", example = "1001") Long pacienteId,
+		@Schema(description = "Deep link for the patient app",
+				example = "https://links.example.com/i/abc...") String inviteUrl,
+		@Schema(description = "Human-readable onboarding code", example = "NUTRI-ABCD-EFGH") String humanCode,
+		@Schema(description = "Invitation expiry (ISO-8601 instant)") Instant expiresAt,
+		@Schema(description = "Optional offline JWS when PATIENT_INVITATION_JWS_SECRET is configured") String offlineJws) {
+
+	public static CreatedPatientInvitationDto from(final CreatedPatientInvitationResult result) {
+		return new CreatedPatientInvitationDto(result.invitationId(), result.pacienteId(), result.inviteUrl(),
+				result.humanCode(), result.expiresAt(), result.offlineJws());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/logging/PhiLogTurboFilter.java
+++ b/src/main/java/com/nutriconsultas/mobile/logging/PhiLogTurboFilter.java
@@ -19,9 +19,15 @@ public final class PhiLogTurboFilter extends TurboFilter {
 
 	private static final String MOBILE_LOGGER_PREFIX = "com.nutriconsultas.mobile";
 
+	private static final String PATIENT_INVITATION_LOGGER_PREFIX = "com.nutriconsultas.paciente.invitation";
+
 	private static final Pattern EMAIL = Pattern.compile("[\\w.+-]+@[\\w.-]+\\.[A-Za-z]{2,}");
 
 	private static final Pattern RAW_AUTH0_SUB = Pattern.compile("auth0\\|[^\\s\\[.]{8,}");
+
+	private static final Pattern HUMAN_INVITATION_CODE = Pattern.compile("NUTRI-[0-9A-Z]{4}-[0-9A-Z]{4}");
+
+	private static final Pattern INVITE_URL_TOKEN = Pattern.compile("/i/[A-Za-z0-9_-]{40,50}\\b");
 
 	@Override
 	public FilterReply decide(final Marker marker, final Logger logger, final Level level, final String format,
@@ -29,7 +35,7 @@ public final class PhiLogTurboFilter extends TurboFilter {
 		if (level == null || !level.isGreaterOrEqual(Level.INFO)) {
 			return FilterReply.NEUTRAL;
 		}
-		if (logger == null || !logger.getName().startsWith(MOBILE_LOGGER_PREFIX)) {
+		if (logger == null || !isProtectedLogger(logger.getName())) {
 			return FilterReply.NEUTRAL;
 		}
 		final String message = buildMessage(format, params, throwable);
@@ -42,7 +48,17 @@ public final class PhiLogTurboFilter extends TurboFilter {
 		if (RAW_AUTH0_SUB.matcher(message).find() && !message.contains("REDACTED")) {
 			return FilterReply.DENY;
 		}
+		if (HUMAN_INVITATION_CODE.matcher(message).find()) {
+			return FilterReply.DENY;
+		}
+		if (INVITE_URL_TOKEN.matcher(message).find()) {
+			return FilterReply.DENY;
+		}
 		return FilterReply.NEUTRAL;
+	}
+
+	private static boolean isProtectedLogger(final String loggerName) {
+		return loggerName.startsWith(MOBILE_LOGGER_PREFIX) || loggerName.startsWith(PATIENT_INVITATION_LOGGER_PREFIX);
 	}
 
 	private static String buildMessage(final String format, final Object[] params, final Throwable throwable) {

--- a/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
@@ -86,4 +86,6 @@ public interface PacienteRepository extends JpaRepository<Paciente, Long> {
 	Optional<Paciente> findFirstByUserIdAndEmailIgnoreCase(@Param("userId") String userId,
 			@Param("email") String email);
 
+	boolean existsByAssignedId(String assignedId);
+
 }

--- a/src/main/java/com/nutriconsultas/paciente/invitation/ConsolePatientInvitationEmailSender.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/ConsolePatientInvitationEmailSender.java
@@ -1,0 +1,35 @@
+package com.nutriconsultas.paciente.invitation;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Local/dev sender for patient invitations (#134). Does not log invite URLs or human
+ * codes.
+ */
+@Component
+@ConditionalOnProperty(prefix = "nutriconsultas.subscription.invitation.email", name = "mode", havingValue = "console",
+		matchIfMissing = true)
+@Slf4j
+public class ConsolePatientInvitationEmailSender implements PatientInvitationEmailSender {
+
+	private final PatientInvitationEmailTemplateRenderer templateRenderer;
+
+	public ConsolePatientInvitationEmailSender(final PatientInvitationEmailTemplateRenderer templateRenderer) {
+		this.templateRenderer = templateRenderer;
+	}
+
+	@Override
+	public void sendPatientInvitation(final String recipientEmail, final String humanCode, final String inviteUrl) {
+		final String body = templateRenderer.renderHtmlBody(humanCode, inviteUrl);
+		if (log.isInfoEnabled()) {
+			log.info("Patient invitation email queued (console mode): recipient={}, bodyLength={}",
+					LogRedaction.redactEmail(recipientEmail), body.length());
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/CreatedPatientInvitationResult.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/CreatedPatientInvitationResult.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.paciente.invitation;
+
+import java.time.Instant;
+
+/**
+ * Service-layer result for nutritionist-created patient invitations (#134).
+ */
+public record CreatedPatientInvitationResult(Long invitationId, Long pacienteId, String inviteUrl, String humanCode,
+		Instant expiresAt, String offlineJws) {
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientAssignedIdGenerator.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientAssignedIdGenerator.java
@@ -1,0 +1,23 @@
+package com.nutriconsultas.paciente.invitation;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * Generates unique clinic-facing {@code assignedId} values when the nutritionist does not
+ * supply one at invite time (#134).
+ */
+public final class PatientAssignedIdGenerator {
+
+	private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+	private PatientAssignedIdGenerator() {
+	}
+
+	public static String generate() {
+		final byte[] bytes = new byte[6];
+		SECURE_RANDOM.nextBytes(bytes);
+		return "P-" + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationCreateService.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationCreateService.java
@@ -1,0 +1,12 @@
+package com.nutriconsultas.paciente.invitation;
+
+import com.nutriconsultas.mobile.dto.CreatePatientInvitationRequest;
+
+/**
+ * Nutritionist-initiated patient onboarding invitations (#134).
+ */
+public interface PatientInvitationCreateService {
+
+	CreatedPatientInvitationResult createInvitation(String nutritionistUserId, CreatePatientInvitationRequest request);
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationCreateService.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationCreateService.java
@@ -5,6 +5,7 @@ import com.nutriconsultas.mobile.dto.CreatePatientInvitationRequest;
 /**
  * Nutritionist-initiated patient onboarding invitations (#134).
  */
+@FunctionalInterface
 public interface PatientInvitationCreateService {
 
 	CreatedPatientInvitationResult createInvitation(String nutritionistUserId, CreatePatientInvitationRequest request);

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationCreateServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationCreateServiceImpl.java
@@ -1,0 +1,147 @@
+package com.nutriconsultas.paciente.invitation;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Optional;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nutriconsultas.mobile.dto.CreatePatientInvitationRequest;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.PatientInvitation;
+import com.nutriconsultas.paciente.PatientInvitationRepository;
+import com.nutriconsultas.paciente.PatientInvitationStatus;
+import com.nutriconsultas.subscription.SubscriptionEntitlementService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class PatientInvitationCreateServiceImpl implements PatientInvitationCreateService {
+
+	private final SubscriptionEntitlementService subscriptionEntitlementService;
+
+	private final PacienteRepository pacienteRepository;
+
+	private final PatientInvitationRepository patientInvitationRepository;
+
+	private final PatientInvitationTokenService patientInvitationTokenService;
+
+	private final PatientInvitationProperties invitationProperties;
+
+	private final PatientInvitationEmailSender patientInvitationEmailSender;
+
+	public PatientInvitationCreateServiceImpl(final SubscriptionEntitlementService subscriptionEntitlementService,
+			final PacienteRepository pacienteRepository, final PatientInvitationRepository patientInvitationRepository,
+			final PatientInvitationTokenService patientInvitationTokenService,
+			final PatientInvitationProperties invitationProperties,
+			final PatientInvitationEmailSender patientInvitationEmailSender) {
+		this.subscriptionEntitlementService = subscriptionEntitlementService;
+		this.pacienteRepository = pacienteRepository;
+		this.patientInvitationRepository = patientInvitationRepository;
+		this.patientInvitationTokenService = patientInvitationTokenService;
+		this.invitationProperties = invitationProperties;
+		this.patientInvitationEmailSender = patientInvitationEmailSender;
+	}
+
+	@Override
+	@Transactional
+	public CreatedPatientInvitationResult createInvitation(final String nutritionistUserId,
+			final CreatePatientInvitationRequest request) {
+		if (!StringUtils.hasText(nutritionistUserId)) {
+			throw new IllegalArgumentException("nutritionistUserId is required");
+		}
+		subscriptionEntitlementService.assertCanCreatePatient(nutritionistUserId);
+
+		final String normalizedEmail = normalizeEmail(request.email());
+		final String assignedId = resolveAssignedId(request.assignedId());
+		final PatientInvitationTokenBundle tokenBundle = patientInvitationTokenService.generate();
+		final Instant expiresAt = Instant.now().plus(invitationProperties.getExpiryDays(), ChronoUnit.DAYS);
+
+		final Paciente paciente = buildPaciente(nutritionistUserId, request, normalizedEmail, assignedId);
+		final Paciente savedPaciente = pacienteRepository.save(paciente);
+
+		final PatientInvitation invitation = new PatientInvitation();
+		invitation.setTokenHash(tokenBundle.tokenHash());
+		invitation.setPaciente(savedPaciente);
+		invitation.setNutritionistUserId(nutritionistUserId);
+		invitation.setStatus(PatientInvitationStatus.PENDING);
+		invitation.setExpiresAt(expiresAt);
+		invitation.setMaxUses(1);
+		final PatientInvitation savedInvitation = patientInvitationRepository.save(invitation);
+
+		final String inviteUrl = invitationProperties.buildInviteUrl(tokenBundle.urlToken());
+		patientInvitationEmailSender.sendPatientInvitation(normalizedEmail, tokenBundle.humanCode(), inviteUrl);
+
+		final Optional<String> offlineJws = patientInvitationTokenService.createOfflineJws(savedPaciente.getId(),
+				tokenBundle.urlToken(), expiresAt);
+
+		if (log.isInfoEnabled()) {
+			log.info("Created patient invitation: invitationId={}, pacienteId={}", savedInvitation.getId(),
+					savedPaciente.getId());
+		}
+
+		return new CreatedPatientInvitationResult(savedInvitation.getId(), savedPaciente.getId(), inviteUrl,
+				tokenBundle.humanCode(), expiresAt, offlineJws.orElse(null));
+	}
+
+	private Paciente buildPaciente(final String nutritionistUserId, final CreatePatientInvitationRequest request,
+			final String normalizedEmail, final String assignedId) {
+		final Paciente paciente = new Paciente();
+		paciente.setUserId(nutritionistUserId);
+		paciente.setName(request.name().trim());
+		paciente.setEmail(normalizedEmail);
+		paciente.setEmailHint(normalizedEmail);
+		paciente.setStatus(PacienteStatus.INVITED);
+		paciente.setAssignedId(assignedId);
+		paciente.setDob(toDate(request.dob()));
+		paciente.setGender(request.gender().trim().toUpperCase(Locale.ROOT));
+		if (StringUtils.hasText(request.phone())) {
+			paciente.setPhone(request.phone().trim());
+		}
+		if (StringUtils.hasText(request.displayName())) {
+			paciente.setDisplayName(request.displayName().trim());
+		}
+		else {
+			paciente.setDisplayName(request.name().trim());
+		}
+		return paciente;
+	}
+
+	private String resolveAssignedId(final String requestedAssignedId) {
+		if (StringUtils.hasText(requestedAssignedId)) {
+			final String assignedId = requestedAssignedId.trim();
+			if (pacienteRepository.existsByAssignedId(assignedId)) {
+				throw new ResponseStatusException(HttpStatus.CONFLICT, "assignedId already in use");
+			}
+			return assignedId;
+		}
+		String candidate = PatientAssignedIdGenerator.generate();
+		while (pacienteRepository.existsByAssignedId(candidate)) {
+			candidate = PatientAssignedIdGenerator.generate();
+		}
+		return candidate;
+	}
+
+	private static String normalizeEmail(final String email) {
+		if (!StringUtils.hasText(email)) {
+			throw new IllegalArgumentException("email is required");
+		}
+		return email.trim().toLowerCase(Locale.ROOT);
+	}
+
+	private static Date toDate(final LocalDate dob) {
+		return Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationEmailSender.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationEmailSender.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.paciente.invitation;
+
+/**
+ * Sends patient onboarding invitation emails (#134). Implementations must never log raw
+ * tokens or human codes at INFO+.
+ */
+public interface PatientInvitationEmailSender {
+
+	void sendPatientInvitation(String recipientEmail, String humanCode, String inviteUrl);
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationEmailSender.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationEmailSender.java
@@ -4,6 +4,7 @@ package com.nutriconsultas.paciente.invitation;
  * Sends patient onboarding invitation emails (#134). Implementations must never log raw
  * tokens or human codes at INFO+.
  */
+@FunctionalInterface
 public interface PatientInvitationEmailSender {
 
 	void sendPatientInvitation(String recipientEmail, String humanCode, String inviteUrl);

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationEmailTemplateRenderer.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationEmailTemplateRenderer.java
@@ -1,0 +1,30 @@
+package com.nutriconsultas.paciente.invitation;
+
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+/**
+ * Renders patient onboarding invitation HTML (#134).
+ */
+@Component
+public class PatientInvitationEmailTemplateRenderer {
+
+	private static final String TEMPLATE = "email/patient-invitation";
+
+	static final String SUBJECT = "Invitación a la app Minutriporción";
+
+	private final SpringTemplateEngine templateEngine;
+
+	public PatientInvitationEmailTemplateRenderer(final SpringTemplateEngine templateEngine) {
+		this.templateEngine = templateEngine;
+	}
+
+	public String renderHtmlBody(final String humanCode, final String inviteUrl) {
+		final Context context = new Context();
+		context.setVariable("humanCode", humanCode);
+		context.setVariable("inviteUrl", inviteUrl);
+		return templateEngine.process(TEMPLATE, context);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationProperties.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationProperties.java
@@ -19,6 +19,12 @@ public class PatientInvitationProperties {
 	 */
 	private String jwsSecret = "";
 
+	/**
+	 * Base URL for patient invite deep links ({@code {baseUrl}/i/{token}}). Production
+	 * typically uses the links subdomain (e.g. {@code https://links.minutriporcion.com}).
+	 */
+	private String baseUrl = "http://localhost:3000";
+
 	public int getExpiryDays() {
 		return expiryDays;
 	}
@@ -45,6 +51,19 @@ public class PatientInvitationProperties {
 
 	public boolean isJwsEnabled() {
 		return StringUtils.hasText(jwsSecret);
+	}
+
+	public String getBaseUrl() {
+		return baseUrl;
+	}
+
+	public void setBaseUrl(final String baseUrl) {
+		this.baseUrl = baseUrl;
+	}
+
+	public String buildInviteUrl(final String rawUrlToken) {
+		final String normalizedBase = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+		return normalizedBase + "/i/" + rawUrlToken;
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/paciente/invitation/SesPatientInvitationEmailSender.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/SesPatientInvitationEmailSender.java
@@ -1,0 +1,76 @@
+package com.nutriconsultas.paciente.invitation;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.subscription.invitation.InvitationEmailProperties;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.Body;
+import software.amazon.awssdk.services.sesv2.model.Content;
+import software.amazon.awssdk.services.sesv2.model.Destination;
+import software.amazon.awssdk.services.sesv2.model.EmailContent;
+import software.amazon.awssdk.services.sesv2.model.Message;
+import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
+import software.amazon.awssdk.services.sesv2.model.SesV2Exception;
+
+/**
+ * Sends patient onboarding invitation emails via Amazon SES (#134).
+ */
+@Component
+@ConditionalOnProperty(prefix = "nutriconsultas.subscription.invitation.email", name = "mode", havingValue = "ses")
+@Slf4j
+public class SesPatientInvitationEmailSender implements PatientInvitationEmailSender {
+
+	private final InvitationEmailProperties invitationEmailProperties;
+
+	private final PatientInvitationEmailTemplateRenderer templateRenderer;
+
+	private final SesV2Client sesV2Client;
+
+	public SesPatientInvitationEmailSender(final InvitationEmailProperties invitationEmailProperties,
+			final PatientInvitationEmailTemplateRenderer templateRenderer, final SesV2Client sesV2Client) {
+		this.invitationEmailProperties = invitationEmailProperties;
+		this.templateRenderer = templateRenderer;
+		this.sesV2Client = sesV2Client;
+	}
+
+	@Override
+	public void sendPatientInvitation(final String recipientEmail, final String humanCode, final String inviteUrl) {
+		final String fromAddress = invitationEmailProperties.getFromAddress();
+		if (!StringUtils.hasText(fromAddress)) {
+			throw new IllegalStateException(
+					"MAIL_FROM / nutriconsultas.subscription.invitation.email.from-address is required in ses mode");
+		}
+		final String htmlBody = templateRenderer.renderHtmlBody(humanCode, inviteUrl);
+		final SendEmailRequest request = SendEmailRequest.builder()
+			.fromEmailAddress(fromAddress)
+			.destination(Destination.builder().toAddresses(recipientEmail).build())
+			.content(EmailContent.builder()
+				.simple(Message.builder()
+					.subject(Content.builder()
+						.data(PatientInvitationEmailTemplateRenderer.SUBJECT)
+						.charset("UTF-8")
+						.build())
+					.body(Body.builder().html(Content.builder().data(htmlBody).charset("UTF-8").build()).build())
+					.build())
+				.build())
+			.build();
+		try {
+			sesV2Client.sendEmail(request);
+			if (log.isInfoEnabled()) {
+				log.info("Patient invitation email sent via SES: recipient={}",
+						LogRedaction.redactEmail(recipientEmail));
+			}
+		}
+		catch (SesV2Exception ex) {
+			log.error("Failed to send patient invitation email via SES: recipient={}",
+					LogRedaction.redactEmail(recipientEmail), ex);
+			throw ex;
+		}
+	}
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -87,6 +87,7 @@ nutriconsultas.subscription.invitation.base-url=${APP_BASE_URL:http://localhost:
 nutriconsultas.subscription.invitation.email.mode=${INVITATION_EMAIL_MODE:console}
 nutriconsultas.subscription.invitation.email.from-address=${MAIL_FROM:}
 nutriconsultas.subscription.invitation.email.ses-region=${AWS_SES_REGION:us-east-1}
+nutriconsultas.patient.invitation.base-url=${PATIENT_INVITATION_BASE_URL:${APP_BASE_URL:http://localhost:3000}}
 nutriconsultas.patient.invitation.expiry-days=${PATIENT_INVITATION_EXPIRY_DAYS:14}
 nutriconsultas.patient.invitation.human-code-prefix=NUTRI
 # TODO: move PATIENT_INVITATION_JWS_SECRET to GCP Secret Manager in production

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -4,6 +4,7 @@ error.message.too.long=Message is too long.
 error.message.required=Message text is required.
 error.rate.limit.exceeded=Too many requests. Please try again in a minute.
 error.validation.failed=Invalid request.
+error.invitation.assigned_id.taken=That patient identifier is already in use.
 error.subscription.patient_limit=Your plan allows up to {0} patients. Upgrade your subscription to add more.
 error.subscription.create_patient_denied=You cannot add patients with your current subscription status.
 error.subscription.nutritionist_limit=Your plan allows up to {0} nutritionists in the clinic.

--- a/src/main/resources/messages_es_MX.properties
+++ b/src/main/resources/messages_es_MX.properties
@@ -4,6 +4,7 @@ error.message.too.long=El mensaje es demasiado largo.
 error.message.required=El texto del mensaje es obligatorio.
 error.rate.limit.exceeded=Demasiadas solicitudes. Inténtalo de nuevo en un minuto.
 error.validation.failed=Solicitud inválida.
+error.invitation.assigned_id.taken=Ese identificador de paciente ya está en uso.
 error.subscription.patient_limit=Tu plan permite hasta {0} pacientes. Actualiza tu suscripción para agregar más.
 error.subscription.create_patient_denied=No puedes agregar pacientes con el estado actual de tu suscripción.
 error.subscription.nutritionist_limit=Tu plan permite hasta {0} nutriólogos en el consultorio.

--- a/src/main/resources/templates/email/patient-invitation.html
+++ b/src/main/resources/templates/email/patient-invitation.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="utf-8">
+  <title>Invitación paciente Minutriporción</title>
+</head>
+<body>
+  <p>Hola,</p>
+  <p>Tu nutriólogo te invitó a usar la app Minutriporción.</p>
+  <p>
+    Abre el siguiente enlace en tu teléfono (válido por tiempo limitado):
+  </p>
+  <p>
+    <a th:href="${inviteUrl}" th:text="${inviteUrl}">https://links.example.com/i/token</a>
+  </p>
+  <p>
+    También puedes ingresar este código en la app:
+    <strong th:text="${humanCode}">NUTRI-XXXX-XXXX</strong>
+  </p>
+  <p>Si no esperabas este mensaje, puedes ignorarlo.</p>
+  <p>— Equipo Minutriporción</p>
+</body>
+</html>

--- a/src/test/java/com/nutriconsultas/mobile/MobileApiExceptionHandlerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileApiExceptionHandlerTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.SendPatientMessageRequest;
+import com.nutriconsultas.subscription.SubscriptionErrorResponses;
 
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 
@@ -32,6 +33,9 @@ class MobileApiExceptionHandlerTest {
 
 	@Mock
 	private MessageSource messageSource;
+
+	@Mock
+	private SubscriptionErrorResponses subscriptionErrorResponses;
 
 	private MobileApiErrorResponses errorResponses;
 
@@ -42,7 +46,7 @@ class MobileApiExceptionHandlerTest {
 		final ObjectMapper objectMapper = new ObjectMapper();
 		objectMapper.registerModule(new JavaTimeModule());
 		errorResponses = new MobileApiErrorResponses(messageSource, objectMapper);
-		handler = new MobileApiExceptionHandler(errorResponses);
+		handler = new MobileApiExceptionHandler(errorResponses, subscriptionErrorResponses);
 	}
 
 	@AfterEach

--- a/src/test/java/com/nutriconsultas/mobile/MobileInvitationControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileInvitationControllerTest.java
@@ -1,0 +1,52 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.CreatePatientInvitationRequest;
+import com.nutriconsultas.mobile.dto.CreatedPatientInvitationDto;
+import com.nutriconsultas.paciente.invitation.CreatedPatientInvitationResult;
+import com.nutriconsultas.paciente.invitation.PatientInvitationCreateService;
+
+@ExtendWith(MockitoExtension.class)
+class MobileInvitationControllerTest {
+
+	private static final String NUTRITIONIST_SUB = "auth0|nutritionist-mobile-invite";
+
+	@InjectMocks
+	private MobileInvitationController controller;
+
+	@Mock
+	private PatientInvitationCreateService patientInvitationCreateService;
+
+	@Test
+	void createInvitation_returnsApiResponseEnvelope() {
+		final CreatePatientInvitationRequest request = new CreatePatientInvitationRequest("Juan Pérez",
+				"juan@example.com", java.time.LocalDate.of(1988, 1, 2), "M", null, null, null);
+		final CreatedPatientInvitationResult result = new CreatedPatientInvitationResult(10L, 20L,
+				"https://links.test/i/token", "NUTRI-WXYZ-1234", Instant.parse("2026-07-01T00:00:00Z"), null);
+		final Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject(NUTRITIONIST_SUB).build();
+
+		when(patientInvitationCreateService.createInvitation(NUTRITIONIST_SUB, request)).thenReturn(result);
+
+		final ApiResponse<CreatedPatientInvitationDto> response = controller.createInvitation(jwt, request);
+
+		assertThat(response.data().invitationId()).isEqualTo(10L);
+		assertThat(response.data().pacienteId()).isEqualTo(20L);
+		assertThat(response.data().humanCode()).isEqualTo("NUTRI-WXYZ-1234");
+		assertThat(response.timestamp()).isNotNull();
+		verify(patientInvitationCreateService).createInvitation(NUTRITIONIST_SUB, request);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobileInvitationIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileInvitationIntegrationTest.java
@@ -1,0 +1,118 @@
+package com.nutriconsultas.mobile;
+
+import static com.nutriconsultas.mobile.MobileIntegrationTestJwt.mobileJwt;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.PatientInvitationRepository;
+import com.nutriconsultas.paciente.PatientInvitationStatus;
+import com.nutriconsultas.subscription.SubscriptionEntitlementService;
+import com.nutriconsultas.util.InvitationTokenHasher;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MobileInvitationIntegrationTest {
+
+	private static final String NUTRITIONIST_SUB = "auth0|mobile-invitation-nutritionist";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@Autowired
+	private PatientInvitationRepository patientInvitationRepository;
+
+	@MockBean
+	private SubscriptionEntitlementService subscriptionEntitlementService;
+
+	@Test
+	void createInvitation_withoutJwt_returnsUnauthorized() throws Exception {
+		mockMvc
+			.perform(post("/rest/mobile/invitations").contentType(MediaType.APPLICATION_JSON)
+				.content(validRequestJson("ana.unauth@example.com")))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void createInvitation_withNutritionistJwt_createsInvitedPatientAndPendingInvitation() throws Exception {
+		final String email = "ana.invite." + UUID.randomUUID() + "@example.com";
+		final MvcResult result = mockMvc
+			.perform(post("/rest/mobile/invitations").with(mobileJwt(NUTRITIONIST_SUB))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(validRequestJson(email)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.data.invitationId").isNumber())
+			.andExpect(jsonPath("$.data.pacienteId").isNumber())
+			.andExpect(jsonPath("$.data.inviteUrl").isString())
+			.andExpect(jsonPath("$.data.humanCode").value(org.hamcrest.Matchers.startsWith("NUTRI-")))
+			.andExpect(jsonPath("$.data.expiresAt").exists())
+			.andReturn();
+
+		final JsonNode data = objectMapper.readTree(result.getResponse().getContentAsString()).path("data");
+		final long pacienteId = data.path("pacienteId").asLong();
+		final long invitationId = data.path("invitationId").asLong();
+		final String inviteUrl = data.path("inviteUrl").asText();
+		final String humanCode = data.path("humanCode").asText();
+		final String rawToken = inviteUrl.substring(inviteUrl.lastIndexOf('/') + 1);
+
+		assertThat(inviteUrl).contains("/i/");
+		assertThat(humanCode).matches("NUTRI-[0-9A-Z]{4}-[0-9A-Z]{4}");
+
+		final var paciente = pacienteRepository.findById(pacienteId).orElseThrow();
+		assertThat(paciente.getStatus()).isEqualTo(PacienteStatus.INVITED);
+		assertThat(paciente.getUserId()).isEqualTo(NUTRITIONIST_SUB);
+		assertThat(paciente.getPatientAuthSub()).isNull();
+		assertThat(paciente.getAssignedId()).isNotBlank();
+
+		final var invitation = patientInvitationRepository.findById(invitationId).orElseThrow();
+		assertThat(invitation.getStatus()).isEqualTo(PatientInvitationStatus.PENDING);
+		assertThat(invitation.getTokenHash()).hasSize(64);
+		assertThat(InvitationTokenHasher.verifyToken(rawToken, invitation.getTokenHash())).isTrue();
+	}
+
+	@Test
+	void createInvitation_doesNotRequirePatientLinkage() throws Exception {
+		final String email = "solo.nutri." + UUID.randomUUID() + "@example.com";
+		mockMvc
+			.perform(post("/rest/mobile/invitations").with(mobileJwt("auth0|unlinked-nutritionist-only"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(validRequestJson(email)))
+			.andExpect(status().isCreated());
+	}
+
+	private static String validRequestJson(final String email) {
+		return """
+				{
+				  "name": "Ana Test",
+				  "email": "%s",
+				  "dob": "1992-03-10",
+				  "gender": "F"
+				}
+				""".formatted(email);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobileOpenApiIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileOpenApiIntegrationTest.java
@@ -32,7 +32,7 @@ class MobileOpenApiIntegrationTest {
 			"/rest/mobile/patient/visits/{visitId}", "/rest/mobile/patient/diet-plans",
 			"/rest/mobile/patient/diet-plans/{assignmentId}", "/rest/mobile/patient/diet-plans/{assignmentId}/pdf",
 			"/rest/mobile/patient/messages", "/rest/mobile/patient/progress",
-			"/rest/mobile/patient/progress/measurements");
+			"/rest/mobile/patient/progress/measurements", "/rest/mobile/invitations");
 
 	@Autowired
 	private MockMvc mockMvc;

--- a/src/test/java/com/nutriconsultas/mobile/MobileSecurityIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileSecurityIntegrationTest.java
@@ -9,11 +9,13 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -37,9 +39,15 @@ class MobileSecurityIntegrationTest {
 
 	@BeforeEach
 	void seedLinkedPatient() {
+		SecurityContextHolder.clearContext();
 		if (pacienteRepository.findByPatientAuthSub(LINKED_SUB).isEmpty()) {
 			pacienteRepository.saveAndFlush(samplePaciente(LINKED_SUB));
 		}
+	}
+
+	@AfterEach
+	void clearSecurityContext() {
+		SecurityContextHolder.clearContext();
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/mobile/logging/PhiLogTurboFilterTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/logging/PhiLogTurboFilterTest.java
@@ -72,4 +72,26 @@ class PhiLogTurboFilterTest {
 		assertThat(reply).isEqualTo(FilterReply.NEUTRAL);
 	}
 
+	@Test
+	void deniesHumanInvitationCodeInPatientInvitationPackage() {
+		filter.start();
+		final Logger invitationLogger = logger(
+				"com.nutriconsultas.paciente.invitation.ConsolePatientInvitationEmailSender");
+
+		final FilterReply reply = filter.decide(null, invitationLogger, Level.INFO, "code={}",
+				new Object[] { "NUTRI-ABCD-EFGH" }, null);
+
+		assertThat(reply).isEqualTo(FilterReply.DENY);
+	}
+
+	@Test
+	void deniesInviteUrlTokenInMobilePackage() {
+		filter.start();
+
+		final FilterReply reply = filter.decide(null, mobileLogger, Level.INFO, "url={}",
+				new Object[] { "https://links.test/i/abcdefghijklmnopqrstuvwxyz0123456789ABCDE" }, null);
+
+		assertThat(reply).isEqualTo(FilterReply.DENY);
+	}
+
 }

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationCreateServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationCreateServiceTest.java
@@ -1,0 +1,184 @@
+package com.nutriconsultas.paciente.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nutriconsultas.mobile.dto.CreatePatientInvitationRequest;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.PatientInvitation;
+import com.nutriconsultas.paciente.PatientInvitationRepository;
+import com.nutriconsultas.paciente.PatientInvitationStatus;
+import com.nutriconsultas.subscription.SubscriptionEntitlementService;
+import com.nutriconsultas.subscription.SubscriptionLimitExceededException;
+import com.nutriconsultas.subscription.SubscriptionErrorResponses;
+
+@ExtendWith(MockitoExtension.class)
+class PatientInvitationCreateServiceTest {
+
+	private static final String NUTRITIONIST_SUB = "auth0|nutritionist-create-invite";
+
+	private static final CreatePatientInvitationRequest REQUEST = new CreatePatientInvitationRequest("María López",
+			"maria@example.com", LocalDate.of(1990, 5, 15), "F", "+525512345678", null, "María");
+
+	@Mock
+	private SubscriptionEntitlementService subscriptionEntitlementService;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Mock
+	private PatientInvitationRepository patientInvitationRepository;
+
+	@Mock
+	private PatientInvitationTokenService patientInvitationTokenService;
+
+	@Mock
+	private PatientInvitationEmailSender patientInvitationEmailSender;
+
+	private PatientInvitationProperties invitationProperties;
+
+	private PatientInvitationCreateServiceImpl service;
+
+	@BeforeEach
+	void setUp() {
+		invitationProperties = new PatientInvitationProperties();
+		invitationProperties.setBaseUrl("https://links.test.example");
+		service = new PatientInvitationCreateServiceImpl(subscriptionEntitlementService, pacienteRepository,
+				patientInvitationRepository, patientInvitationTokenService, invitationProperties,
+				patientInvitationEmailSender);
+	}
+
+	@Test
+	void createInvitation_persistsHashOnlyAndReturnsLinkAndCode() {
+		when(patientInvitationTokenService.generate())
+			.thenReturn(new PatientInvitationTokenBundle("url-token-value", "NUTRI-ABCD-EFGH", "abc123hash"));
+		when(pacienteRepository.existsByAssignedId(any())).thenReturn(false);
+		when(pacienteRepository.save(any(Paciente.class))).thenAnswer(invocation -> {
+			final Paciente paciente = invocation.getArgument(0);
+			paciente.setId(100L);
+			return paciente;
+		});
+		when(patientInvitationRepository.save(any(PatientInvitation.class))).thenAnswer(invocation -> {
+			final PatientInvitation invitation = invocation.getArgument(0);
+			invitation.setId(55L);
+			return invitation;
+		});
+
+		final CreatedPatientInvitationResult created = service.createInvitation(NUTRITIONIST_SUB, REQUEST);
+
+		assertThat(created.invitationId()).isEqualTo(55L);
+		assertThat(created.pacienteId()).isEqualTo(100L);
+		assertThat(created.inviteUrl()).isEqualTo("https://links.test.example/i/url-token-value");
+		assertThat(created.humanCode()).isEqualTo("NUTRI-ABCD-EFGH");
+		assertThat(created.expiresAt()).isAfter(Instant.now());
+
+		final ArgumentCaptor<Paciente> pacienteCaptor = ArgumentCaptor.forClass(Paciente.class);
+		verify(pacienteRepository).save(pacienteCaptor.capture());
+		assertThat(pacienteCaptor.getValue().getStatus()).isEqualTo(PacienteStatus.INVITED);
+		assertThat(pacienteCaptor.getValue().getUserId()).isEqualTo(NUTRITIONIST_SUB);
+		assertThat(pacienteCaptor.getValue().getEmail()).isEqualTo("maria@example.com");
+		assertThat(pacienteCaptor.getValue().getPatientAuthSub()).isNull();
+
+		final ArgumentCaptor<PatientInvitation> invitationCaptor = ArgumentCaptor.forClass(PatientInvitation.class);
+		verify(patientInvitationRepository).save(invitationCaptor.capture());
+		assertThat(invitationCaptor.getValue().getTokenHash()).isEqualTo("abc123hash");
+		assertThat(invitationCaptor.getValue().getStatus()).isEqualTo(PatientInvitationStatus.PENDING);
+		assertThat(invitationCaptor.getValue().getNutritionistUserId()).isEqualTo(NUTRITIONIST_SUB);
+
+		verify(patientInvitationEmailSender).sendPatientInvitation(eq("maria@example.com"), eq("NUTRI-ABCD-EFGH"),
+				eq("https://links.test.example/i/url-token-value"));
+		verify(subscriptionEntitlementService).assertCanCreatePatient(NUTRITIONIST_SUB);
+	}
+
+	@Test
+	void createInvitation_rejectsDuplicateAssignedId() {
+		when(pacienteRepository.existsByAssignedId("CLINIC-1")).thenReturn(true);
+		final CreatePatientInvitationRequest request = new CreatePatientInvitationRequest(REQUEST.name(),
+				REQUEST.email(), REQUEST.dob(), REQUEST.gender(), REQUEST.phone(), "CLINIC-1", REQUEST.displayName());
+
+		assertThatThrownBy(() -> service.createInvitation(NUTRITIONIST_SUB, request))
+			.isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode().value())
+			.isEqualTo(HttpStatus.CONFLICT.value());
+	}
+
+	@Test
+	void createInvitation_propagatesSubscriptionLimit() {
+		doThrow(new SubscriptionLimitExceededException(SubscriptionErrorResponses.KEY_PATIENT_LIMIT, 10))
+			.when(subscriptionEntitlementService)
+			.assertCanCreatePatient(NUTRITIONIST_SUB);
+
+		assertThatThrownBy(() -> service.createInvitation(NUTRITIONIST_SUB, REQUEST))
+			.isInstanceOf(SubscriptionLimitExceededException.class);
+	}
+
+	@Test
+	void createInvitation_setsExpiryFromProperties() {
+		invitationProperties.setExpiryDays(7);
+		when(patientInvitationTokenService.generate())
+			.thenReturn(new PatientInvitationTokenBundle("token", "NUTRI-AAAA-BBBB", "hash"));
+		when(pacienteRepository.existsByAssignedId(any())).thenReturn(false);
+		when(pacienteRepository.save(any(Paciente.class))).thenAnswer(invocation -> {
+			final Paciente paciente = invocation.getArgument(0);
+			paciente.setId(1L);
+			return paciente;
+		});
+		when(patientInvitationRepository.save(any(PatientInvitation.class))).thenAnswer(invocation -> {
+			final PatientInvitation invitation = invocation.getArgument(0);
+			invitation.setId(2L);
+			return invitation;
+		});
+
+		final Instant before = Instant.now();
+		final CreatedPatientInvitationResult created = service.createInvitation(NUTRITIONIST_SUB, REQUEST);
+		final Instant after = Instant.now().plus(7, ChronoUnit.DAYS).plusSeconds(5);
+
+		assertThat(created.expiresAt()).isBetween(before.plus(7, ChronoUnit.DAYS).minusSeconds(5), after);
+	}
+
+	@Test
+	void createInvitation_includesOfflineJwsWhenConfigured() {
+		invitationProperties.setJwsSecret("test-secret-at-least-32-characters-long");
+		when(patientInvitationTokenService.generate())
+			.thenReturn(new PatientInvitationTokenBundle("token", "NUTRI-CCCC-DDDD", "hash"));
+		when(patientInvitationTokenService.createOfflineJws(eq(9L), eq("token"), any(Instant.class)))
+			.thenReturn(Optional.of("offline.jws.token"));
+		when(pacienteRepository.existsByAssignedId(any())).thenReturn(false);
+		when(pacienteRepository.save(any(Paciente.class))).thenAnswer(invocation -> {
+			final Paciente paciente = invocation.getArgument(0);
+			paciente.setId(9L);
+			return paciente;
+		});
+		when(patientInvitationRepository.save(any(PatientInvitation.class))).thenAnswer(invocation -> {
+			final PatientInvitation invitation = invocation.getArgument(0);
+			invitation.setId(3L);
+			return invitation;
+		});
+
+		final CreatedPatientInvitationResult created = service.createInvitation(NUTRITIONIST_SUB, REQUEST);
+
+		assertThat(created.offlineJws()).isEqualTo("offline.jws.token");
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationPropertiesTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationPropertiesTest.java
@@ -1,0 +1,25 @@
+package com.nutriconsultas.paciente.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PatientInvitationPropertiesTest {
+
+	@Test
+	void buildInviteUrlUsesConfiguredBaseUrl() {
+		final PatientInvitationProperties properties = new PatientInvitationProperties();
+		properties.setBaseUrl("https://links.minutriporcion.com");
+
+		assertThat(properties.buildInviteUrl("abc123")).isEqualTo("https://links.minutriporcion.com/i/abc123");
+	}
+
+	@Test
+	void buildInviteUrlStripsTrailingSlashFromBaseUrl() {
+		final PatientInvitationProperties properties = new PatientInvitationProperties();
+		properties.setBaseUrl("http://localhost:3000/");
+
+		assertThat(properties.buildInviteUrl("abc123")).isEqualTo("http://localhost:3000/i/abc123");
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds `POST /rest/mobile/invitations` for nutritionist JWTs to create an `INVITED` `Paciente`, persist a pending `PatientInvitation` (hash only), send the invite email, and return deep link + human code in `ApiResponse`.
- Extends invitation config (`PATIENT_INVITATION_BASE_URL`), PHI log filtering for tokens/codes, mobile subscription-limit handling, OpenAPI export, and registry docs (#134 in-progress).

## Test plan
- [x] `./lint.sh && bash scripts/audit-logging.sh && bash scripts/audit-mobile-logging.sh && mvn -B verify` (Java 21)
- [x] `PatientInvitationCreateServiceTest` — cap check, hash persistence, email trigger, assignedId conflict
- [x] `MobileInvitationIntegrationTest` — 201 response, DB rows, no patient linkage required
- [x] `scripts/export-openapi-mobile.sh` — `/rest/mobile/invitations` documented

Closes #134

Made with [Cursor](https://cursor.com)