### PR TITLE
Assign patient-specific diet copies with caloric indicator (#320)

### DIFF
--- a/src/main/java/com/nutriconsultas/dieta/Dieta.java
+++ b/src/main/java/com/nutriconsultas/dieta/Dieta.java
@@ -34,6 +34,12 @@ public class Dieta extends AbstractMacroNutrible {
 	@Column(nullable = false, length = 255)
 	private String userId;
 
+	/**
+	 * When set, this diet is a patient-specific copy (not shown in the catalog).
+	 */
+	@Column(name = "paciente_id")
+	private Long pacienteId;
+
 	@OneToMany(mappedBy = "dieta", cascade = jakarta.persistence.CascadeType.ALL, orphanRemoval = true,
 			targetEntity = Ingesta.class, fetch = jakarta.persistence.FetchType.LAZY)
 	@ToString.Exclude

--- a/src/main/java/com/nutriconsultas/dieta/DietaAuthorization.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaAuthorization.java
@@ -1,11 +1,10 @@
 package com.nutriconsultas.dieta;
 
-import java.util.Objects;
-
 import org.springframework.lang.NonNull;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Component;
 
+import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.platform.PlatformAdminAuditService;
 import com.nutriconsultas.platform.PlatformAdminService;
 
@@ -14,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Diet mutation access: nutritionists may edit their own diets; platform admins may also
  * edit system template diets ({@link DietaCatalogConstants#SYSTEM_TEMPLATE_USER_ID}).
+ * Patient-assigned copies are editable by the nutritionist who owns the patient.
  */
 @Component
 @Slf4j
@@ -23,18 +23,34 @@ public class DietaAuthorization {
 
 	private final PlatformAdminAuditService platformAdminAuditService;
 
+	private final PacienteRepository pacienteRepository;
+
 	public DietaAuthorization(final PlatformAdminService platformAdminService,
-			final PlatformAdminAuditService platformAdminAuditService) {
+			final PlatformAdminAuditService platformAdminAuditService, final PacienteRepository pacienteRepository) {
 		this.platformAdminService = platformAdminService;
 		this.platformAdminAuditService = platformAdminAuditService;
+		this.pacienteRepository = pacienteRepository;
 	}
 
 	public boolean canModify(final Dieta dieta, final String userId, final OidcUser principal) {
 		if (dieta == null || userId == null) {
 			return false;
 		}
-		return Objects.equals(userId, dieta.getUserId())
+		if (DietaCatalogConstants.isPatientAssignment(dieta)) {
+			return ownsPatientDieta(dieta, userId);
+		}
+		return java.util.Objects.equals(userId, dieta.getUserId())
 				|| (platformAdminService.isPlatformAdmin(principal) && DietaCatalogConstants.isSystemTemplate(dieta));
+	}
+
+	public boolean canView(final Dieta dieta, final String userId, final OidcUser principal) {
+		if (dieta == null || userId == null) {
+			return false;
+		}
+		if (DietaCatalogConstants.isPatientAssignment(dieta)) {
+			return ownsPatientDieta(dieta, userId);
+		}
+		return true;
 	}
 
 	public void verifyCanModify(final Dieta dieta, final String userId, final OidcUser principal) {
@@ -49,8 +65,24 @@ public class DietaAuthorization {
 		}
 	}
 
+	public void verifyCanView(final Dieta dieta, final String userId, final OidcUser principal) {
+		if (dieta == null) {
+			throw new IllegalArgumentException("Dieta no encontrada");
+		}
+		if (!canView(dieta, userId, principal)) {
+			throw new IllegalArgumentException("No tiene permiso para ver esta dieta");
+		}
+	}
+
 	public Dieta resolveForMutation(@NonNull final Long id, @NonNull final String userId, final OidcUser principal,
 			final DietaService dietaService) {
+		final Dieta dieta = dietaService.getDieta(id);
+		if (dieta == null) {
+			return null;
+		}
+		if (DietaCatalogConstants.isPatientAssignment(dieta)) {
+			return ownsPatientDieta(dieta, userId) ? dieta : null;
+		}
 		final Dieta owned = dietaService.getDietaByIdAndUserId(id, userId);
 		if (owned != null) {
 			return owned;
@@ -58,8 +90,7 @@ public class DietaAuthorization {
 		if (!platformAdminService.isPlatformAdmin(principal)) {
 			return null;
 		}
-		final Dieta dieta = dietaService.getDieta(id);
-		if (dieta != null && DietaCatalogConstants.isSystemTemplate(dieta)) {
+		if (DietaCatalogConstants.isSystemTemplate(dieta)) {
 			return dieta;
 		}
 		return null;
@@ -86,6 +117,13 @@ public class DietaAuthorization {
 			return DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID;
 		}
 		return oauthUserId;
+	}
+
+	private boolean ownsPatientDieta(final Dieta dieta, final String userId) {
+		if (dieta.getPacienteId() == null) {
+			return false;
+		}
+		return pacienteRepository.findByIdAndUserId(dieta.getPacienteId(), userId).isPresent();
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/dieta/DietaAuthorization.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaAuthorization.java
@@ -47,10 +47,7 @@ public class DietaAuthorization {
 		if (dieta == null || userId == null) {
 			return false;
 		}
-		if (DietaCatalogConstants.isPatientAssignment(dieta)) {
-			return ownsPatientDieta(dieta, userId);
-		}
-		return true;
+		return !DietaCatalogConstants.isPatientAssignment(dieta) || ownsPatientDieta(dieta, userId);
 	}
 
 	public void verifyCanModify(final Dieta dieta, final String userId, final OidcUser principal) {
@@ -120,10 +117,8 @@ public class DietaAuthorization {
 	}
 
 	private boolean ownsPatientDieta(final Dieta dieta, final String userId) {
-		if (dieta.getPacienteId() == null) {
-			return false;
-		}
-		return pacienteRepository.findByIdAndUserId(dieta.getPacienteId(), userId).isPresent();
+		return dieta.getPacienteId() != null
+				&& pacienteRepository.findByIdAndUserId(dieta.getPacienteId(), userId).isPresent();
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/dieta/DietaCaloricFit.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaCaloricFit.java
@@ -1,0 +1,58 @@
+package com.nutriconsultas.dieta;
+
+/**
+ * Compares a diet's total kcal against a patient's caloric requirement.
+ */
+public final class DietaCaloricFit {
+
+	public enum Fit {
+
+		MATCH, UNDER, OVER, UNKNOWN
+
+	}
+
+	private DietaCaloricFit() {
+	}
+
+	public static Fit classify(final double dietKcal, final Double requerimientoKcal) {
+		if (requerimientoKcal == null || dietKcal <= 0) {
+			return Fit.UNKNOWN;
+		}
+		final double tolerance = Math.max(50, requerimientoKcal * 0.05);
+		final double diff = dietKcal - requerimientoKcal;
+		if (Math.abs(diff) <= tolerance) {
+			return Fit.MATCH;
+		}
+		if (diff < 0) {
+			return Fit.UNDER;
+		}
+		return Fit.OVER;
+	}
+
+	public static String label(final Fit fit, final double dietKcal, final Double requerimientoKcal) {
+		if (fit == Fit.UNKNOWN || requerimientoKcal == null) {
+			return "Sin comparación";
+		}
+		final double diff = dietKcal - requerimientoKcal;
+		return switch (fit) {
+			case MATCH -> "Adecuada";
+			case UNDER -> "Por debajo (" + formatKcal(Math.abs(diff)) + " kcal)";
+			case OVER -> "Por encima (+" + formatKcal(diff) + " kcal)";
+			case UNKNOWN -> "Sin comparación";
+		};
+	}
+
+	public static String cssClass(final Fit fit) {
+		return switch (fit) {
+			case MATCH -> "success";
+			case UNDER -> "warning";
+			case OVER -> "danger";
+			case UNKNOWN -> "secondary";
+		};
+	}
+
+	private static String formatKcal(final double value) {
+		return String.valueOf(Math.round(value));
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/dieta/DietaCatalogConstants.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaCatalogConstants.java
@@ -14,4 +14,12 @@ public final class DietaCatalogConstants {
 		return dieta != null && SYSTEM_TEMPLATE_USER_ID.equals(dieta.getUserId());
 	}
 
+	public static boolean isPatientAssignment(final Dieta dieta) {
+		return dieta != null && dieta.getPacienteId() != null;
+	}
+
+	public static boolean isCatalogDieta(final Dieta dieta) {
+		return dieta != null && dieta.getPacienteId() == null;
+	}
+
 }

--- a/src/main/java/com/nutriconsultas/dieta/DietaController.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaController.java
@@ -25,6 +25,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.nutriconsultas.alimentos.Alimento;
 import com.nutriconsultas.alimentos.AlimentoService;
 import com.nutriconsultas.controller.AbstractAuthorizedController;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.platillos.IngestaFormModel;
 import com.nutriconsultas.platillos.Ingrediente;
 import com.nutriconsultas.platillos.Platillo;
@@ -49,6 +51,9 @@ public class DietaController extends AbstractAuthorizedController {
 
 	@Autowired
 	private DietaAuthorization dietaAuthorization;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
 
 	/**
 	 * Gets the user ID from the OAuth2 principal.
@@ -100,36 +105,45 @@ public class DietaController extends AbstractAuthorizedController {
 	public String editar(@PathVariable @NonNull final Long id, final Model model,
 			@AuthenticationPrincipal final OidcUser principal) {
 		LOGGER.debug("Editar dieta con id {}", id);
-		model.addAttribute("activeMenu", "dietas");
+		final String userId = getUserId(principal);
+		if (userId == null) {
+			throw new IllegalArgumentException("No se pudo identificar al usuario");
+		}
 
 		final Dieta dieta = dietaService.getDieta(id);
 		if (dieta == null) {
 			throw new IllegalArgumentException("Dieta no encontrada");
 		}
-		LOGGER.debug("Dieta encontrada: {}", dieta);
-		model.addAttribute("dieta", dieta);
+		dietaAuthorization.verifyCanView(dieta, userId, principal);
 
-		// Check edit permission and pass to model
-		final String userId = getUserId(principal);
+		final boolean patientDiet = DietaCatalogConstants.isPatientAssignment(dieta);
+		model.addAttribute("activeMenu", patientDiet ? "plan-alimentario" : "dietas");
+		model.addAttribute("dieta", dieta);
+		model.addAttribute("patientDiet", patientDiet);
+
 		final boolean isOwner = dietaAuthorization.canModify(dieta, userId, principal);
 		model.addAttribute("isOwner", isOwner);
 
-		// Sort the ingestas list by id
+		if (patientDiet && dieta.getPacienteId() != null) {
+			pacienteRepository.findByIdAndUserId(dieta.getPacienteId(), userId).ifPresent(paciente -> {
+				model.addAttribute("paciente", paciente);
+				model.addAttribute("requerimientoKcal", resolveRequerimientoKcal(paciente));
+				model.addAttribute("patientDietPlanUrl", "/admin/pacientes/" + paciente.getId() + "/dietas");
+			});
+		}
+
 		final List<Ingesta> sortedIngestas = dieta.getIngestas()
 			.stream()
 			.sorted(Comparator.comparingLong(Ingesta::getId))
 			.collect(Collectors.toList());
 		model.addAttribute("ingestas", sortedIngestas);
 
-		// calculate the minimun id in ingestas
 		final Long minId = sortedIngestas.isEmpty() ? Long.valueOf(0L) : sortedIngestas.get(0).getId();
 		model.addAttribute("minId", minId);
 
 		model.addAttribute("platillos", platilloService.findAll());
-
 		model.addAttribute("alimentos", alimentoService.findAll());
 
-		// Calculate distribution percentages for pie chart and macro summary table
 		final Double totalProteina = getTotalProteina(dieta);
 		final Double totalLipidos = getTotalLipidos(dieta);
 		final Double totalHidratosDeCarbono = getTotalHidratosDeCarbono(dieta);
@@ -146,6 +160,13 @@ public class DietaController extends AbstractAuthorizedController {
 			model.addAttribute("distribucionLipido", distLipido);
 			model.addAttribute("distribucionHidratoCarbono", distHidratoCarbono);
 			model.addAttribute("hasDistribucion", true);
+			if (patientDiet && model.containsAttribute("requerimientoKcal")) {
+				final Double requerimientoKcal = (Double) model.getAttribute("requerimientoKcal");
+				final DietaCaloricFit.Fit fit = DietaCaloricFit.classify(kCal, requerimientoKcal);
+				model.addAttribute("caloricFit", fit.name());
+				model.addAttribute("caloricFitLabel", DietaCaloricFit.label(fit, kCal, requerimientoKcal));
+				model.addAttribute("caloricFitCss", DietaCaloricFit.cssClass(fit));
+			}
 		}
 		else {
 			model.addAttribute("hasDistribucion", false);
@@ -154,6 +175,13 @@ public class DietaController extends AbstractAuthorizedController {
 		addNutrientSummaryAttributes(model, sortedIngestas, dieta);
 
 		return "sbadmin/dietas/formulario";
+	}
+
+	private Double resolveRequerimientoKcal(final Paciente paciente) {
+		if (paciente.getTotalAdjustedKcal() != null) {
+			return paciente.getTotalAdjustedKcal();
+		}
+		return paciente.getGetKcal();
 	}
 
 	private void addNutrientSummaryAttributes(final Model model, final List<Ingesta> sortedIngestas,

--- a/src/main/java/com/nutriconsultas/dieta/DietaRepository.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaRepository.java
@@ -10,4 +10,15 @@ public interface DietaRepository extends JpaRepository<Dieta, Long> {
 
 	java.util.List<Dieta> findByUserId(String userId);
 
+	java.util.List<Dieta> findByPacienteId(Long pacienteId);
+
+	@org.springframework.data.jpa.repository.Query("SELECT d FROM Dieta d WHERE d.pacienteId IS NULL")
+	java.util.List<Dieta> findAllCatalogDiets();
+
+	@org.springframework.data.jpa.repository.Query("SELECT d FROM Dieta d WHERE d.userId = :userId AND d.pacienteId IS NULL")
+	java.util.List<Dieta> findByUserIdAndPacienteIdIsNull(
+			@org.springframework.data.repository.query.Param("userId") String userId);
+
+	void deleteByPacienteId(Long pacienteId);
+
 }

--- a/src/main/java/com/nutriconsultas/dieta/DietaService.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaService.java
@@ -42,4 +42,7 @@ public interface DietaService {
 
 	Dieta duplicateDieta(@NonNull Long id, @NonNull String userId);
 
+	Dieta copyDietaForPatientAssignment(@NonNull Long sourceDietaId, @NonNull Long pacienteId,
+			@NonNull String nutritionistUserId);
+
 }

--- a/src/main/java/com/nutriconsultas/dieta/DietaServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaServiceImpl.java
@@ -69,7 +69,7 @@ public class DietaServiceImpl implements DietaService {
 	public List<Dieta> getDietasForCatalogFilter(final DietaCatalogFilter filter, final String userId) {
 		if (filter == null || filter == DietaCatalogFilter.TODAS) {
 			log.info("Getting all dietas for catalog filter todas");
-			return dietaRepository.findAll();
+			return dietaRepository.findAllCatalogDiets();
 		}
 		if (filter == DietaCatalogFilter.SISTEMA) {
 			log.info("Getting system template dietas for catalog filter sistema");
@@ -80,7 +80,7 @@ public class DietaServiceImpl implements DietaService {
 			return List.of();
 		}
 		log.info("Getting owned dietas for catalog filter propias, userId present");
-		return dietaRepository.findByUserId(userId);
+		return dietaRepository.findByUserIdAndPacienteIdIsNull(userId);
 	}
 
 	private static final int PICKER_MAX_PAGE_SIZE = 50;
@@ -93,7 +93,7 @@ public class DietaServiceImpl implements DietaService {
 		final int safeSize = Math.min(Math.max(size, 1), PICKER_MAX_PAGE_SIZE);
 		final int safePage = Math.max(page, 0);
 
-		final List<DietaPickerItemDto> filtered = dietaRepository.findAll(Sort.by("nombre"))
+		final List<DietaPickerItemDto> filtered = dietaRepository.findAllCatalogDiets()
 			.stream()
 			.filter(dieta -> matchesPickerSearch(dieta, term))
 			.map(this::toPickerItem)
@@ -436,33 +436,57 @@ public class DietaServiceImpl implements DietaService {
 			log.warn("Dieta with id {} not found for duplication", id);
 			return null;
 		}
+		if (DietaCatalogConstants.isPatientAssignment(originalDieta)) {
+			log.warn("Cannot duplicate patient-assigned dieta {}", id);
+			return null;
+		}
 
-		// Create new dieta with "Copy of [Original Name]"
-		final Dieta newDieta = new Dieta();
 		final String originalNombre = originalDieta.getNombre() != null ? originalDieta.getNombre() : "Dieta";
-		newDieta.setNombre("Copia de " + originalNombre);
-		newDieta.setUserId(userId);
+		final Dieta newDieta = buildDietaCopy(originalDieta, "Copia de " + originalNombre, userId, null);
+		final Dieta savedDieta = dietaRepository.save(newDieta);
+		log.info("Successfully duplicated dieta with id {} to new dieta with id {}", id, savedDieta.getId());
+		return savedDieta;
+	}
 
-		// Copy nutritional values from AbstractMacroNutrible
+	@Override
+	public Dieta copyDietaForPatientAssignment(@NonNull final Long sourceDietaId, @NonNull final Long pacienteId,
+			@NonNull final String nutritionistUserId) {
+		log.info("Copying dieta {} for patient assignment, pacienteId present", sourceDietaId);
+		final Dieta source = dietaRepository.findById(sourceDietaId)
+			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado dieta con id " + sourceDietaId));
+		if (DietaCatalogConstants.isPatientAssignment(source)) {
+			throw new IllegalArgumentException("No se puede asignar una copia de dieta de otro paciente");
+		}
+		final String nombre = source.getNombre() != null ? source.getNombre() : "Dieta";
+		final Dieta copy = buildDietaCopy(source, nombre, nutritionistUserId, pacienteId);
+		final Dieta saved = dietaRepository.save(copy);
+		log.info("Created patient diet copy with id {} from source {}", saved.getId(), sourceDietaId);
+		return saved;
+	}
+
+	private Dieta buildDietaCopy(final Dieta originalDieta, final String nombre, final String userId,
+			final Long pacienteId) {
+		final Dieta newDieta = new Dieta();
+		newDieta.setNombre(nombre);
+		newDieta.setUserId(userId);
+		newDieta.setPacienteId(pacienteId);
+
 		newDieta.setEnergia(originalDieta.getEnergia());
 		newDieta.setProteina(originalDieta.getProteina());
 		newDieta.setLipidos(originalDieta.getLipidos());
 		newDieta.setHidratosDeCarbono(originalDieta.getHidratosDeCarbono());
 
-		// Copy all ingestas
 		final List<Ingesta> newIngestas = new ArrayList<>();
 		for (final Ingesta originalIngesta : originalDieta.getIngestas()) {
 			final Ingesta newIngesta = new Ingesta();
 			newIngesta.setNombre(originalIngesta.getNombre());
 			newIngesta.setDieta(newDieta);
 
-			// Copy nutritional values from AbstractMacroNutrible
 			newIngesta.setEnergia(originalIngesta.getEnergia());
 			newIngesta.setProteina(originalIngesta.getProteina());
 			newIngesta.setLipidos(originalIngesta.getLipidos());
 			newIngesta.setHidratosDeCarbono(originalIngesta.getHidratosDeCarbono());
 
-			// Copy platillos
 			final List<PlatilloIngesta> newPlatillos = new ArrayList<>();
 			for (final PlatilloIngesta originalPlatillo : originalIngesta.getPlatillos()) {
 				final PlatilloIngesta newPlatillo = copyPlatilloIngesta(originalPlatillo);
@@ -471,7 +495,6 @@ public class DietaServiceImpl implements DietaService {
 			}
 			newIngesta.setPlatillos(newPlatillos);
 
-			// Copy alimentos
 			final List<AlimentoIngesta> newAlimentos = new ArrayList<>();
 			for (final AlimentoIngesta originalAlimento : originalIngesta.getAlimentos()) {
 				final AlimentoIngesta newAlimento = copyAlimentoIngesta(originalAlimento);
@@ -483,11 +506,7 @@ public class DietaServiceImpl implements DietaService {
 			newIngestas.add(newIngesta);
 		}
 		newDieta.setIngestas(newIngestas);
-
-		// Save and return the duplicated dieta
-		final Dieta savedDieta = dietaRepository.save(newDieta);
-		log.info("Successfully duplicated dieta with id {} to new dieta with id {}", id, savedDieta.getId());
-		return savedDieta;
+		return newDieta;
 	}
 
 	private PlatilloIngesta copyPlatilloIngesta(final PlatilloIngesta original) {

--- a/src/main/java/com/nutriconsultas/dieta/DietaServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaServiceImpl.java
@@ -5,7 +5,6 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Sort;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDeletionServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDeletionServiceImpl.java
@@ -13,6 +13,9 @@ import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
 import com.nutriconsultas.clinical.exam.AnthropometricMeasurementService;
 import com.nutriconsultas.clinical.exam.ClinicalExam;
 import com.nutriconsultas.clinical.exam.ClinicalExamService;
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.dieta.DietaCatalogConstants;
+import com.nutriconsultas.dieta.DietaService;
 import com.nutriconsultas.message.PatientMessageRepository;
 import com.nutriconsultas.paciente.metrics.BodyMetricRecordRepository;
 import com.nutriconsultas.util.LogRedaction;
@@ -39,13 +42,15 @@ public class PacienteDeletionServiceImpl implements PacienteDeletionService {
 
 	private final BodyMetricRecordRepository bodyMetricRecordRepository;
 
+	private final DietaService dietaService;
+
 	public PacienteDeletionServiceImpl(final PacienteRepository pacienteRepository,
 			final PatientMessageRepository patientMessageRepository,
 			final PatientInvitationRepository patientInvitationRepository,
 			final PacienteDietaRepository pacienteDietaRepository, final CalendarEventService calendarEventService,
 			final ClinicalExamService clinicalExamService,
 			final AnthropometricMeasurementService anthropometricMeasurementService,
-			final BodyMetricRecordRepository bodyMetricRecordRepository) {
+			final BodyMetricRecordRepository bodyMetricRecordRepository, final DietaService dietaService) {
 		this.pacienteRepository = pacienteRepository;
 		this.patientMessageRepository = patientMessageRepository;
 		this.patientInvitationRepository = patientInvitationRepository;
@@ -54,6 +59,7 @@ public class PacienteDeletionServiceImpl implements PacienteDeletionService {
 		this.clinicalExamService = clinicalExamService;
 		this.anthropometricMeasurementService = anthropometricMeasurementService;
 		this.bodyMetricRecordRepository = bodyMetricRecordRepository;
+		this.dietaService = dietaService;
 	}
 
 	@Override
@@ -84,6 +90,12 @@ public class PacienteDeletionServiceImpl implements PacienteDeletionService {
 			patientInvitationRepository.deleteAll(invitations);
 		}
 		final List<PacienteDieta> dietAssignments = pacienteDietaRepository.findByPacienteId(pacienteId);
+		for (final PacienteDieta assignment : dietAssignments) {
+			final Dieta dieta = assignment.getDieta();
+			if (dieta != null && dieta.getId() != null && DietaCatalogConstants.isPatientAssignment(dieta)) {
+				dietaService.deleteDieta(dieta.getId());
+			}
+		}
 		if (!dietAssignments.isEmpty()) {
 			pacienteDietaRepository.deleteAll(dietAssignments);
 		}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaRepository.java
@@ -48,4 +48,7 @@ public interface PacienteDietaRepository extends JpaRepository<PacienteDieta, Lo
 	List<PacienteDieta> findByUserIdAndDateRange(@Param("userId") String userId, @Param("startDate") Date startDate,
 			@Param("endDate") Date endDate);
 
+	@Query("SELECT pd FROM PacienteDieta pd JOIN pd.dieta d WHERE d.pacienteId IS NULL")
+	List<PacienteDieta> findAssignmentsReferencingSharedDieta();
+
 }

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaServiceImpl.java
@@ -3,13 +3,14 @@ package com.nutriconsultas.paciente;
 import java.util.List;
 import java.util.Objects;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.dieta.DietaCatalogConstants;
 import com.nutriconsultas.dieta.DietaRepository;
+import com.nutriconsultas.dieta.DietaService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,14 +19,22 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class PacienteDietaServiceImpl implements PacienteDietaService {
 
-	@Autowired
-	private PacienteDietaRepository pacienteDietaRepository;
+	private final PacienteDietaRepository pacienteDietaRepository;
 
-	@Autowired
-	private PacienteRepository pacienteRepository;
+	private final PacienteRepository pacienteRepository;
 
-	@Autowired
-	private DietaRepository dietaRepository;
+	private final DietaRepository dietaRepository;
+
+	private final DietaService dietaService;
+
+	public PacienteDietaServiceImpl(final PacienteDietaRepository pacienteDietaRepository,
+			final PacienteRepository pacienteRepository, final DietaRepository dietaRepository,
+			final DietaService dietaService) {
+		this.pacienteDietaRepository = pacienteDietaRepository;
+		this.pacienteRepository = pacienteRepository;
+		this.dietaRepository = dietaRepository;
+		this.dietaService = dietaService;
+	}
 
 	@Override
 	public PacienteDieta assignDieta(@NonNull final Long pacienteId, @NonNull final Long dietaId,
@@ -33,14 +42,17 @@ public class PacienteDietaServiceImpl implements PacienteDietaService {
 		log.info("Assigning dieta {} to paciente {} for user {}", dietaId, pacienteId, userId);
 		final Paciente paciente = pacienteRepository.findByIdAndUserId(pacienteId, userId)
 			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado paciente con id " + pacienteId));
-		final Dieta dieta = dietaRepository.findById(dietaId)
+		final Dieta sourceDieta = dietaRepository.findById(dietaId)
 			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado dieta con id " + dietaId));
+		if (DietaCatalogConstants.isPatientAssignment(sourceDieta)) {
+			throw new IllegalArgumentException("No se puede asignar una dieta exclusiva de otro paciente");
+		}
 
-		// Create a new PacienteDieta to avoid issues with existing IDs from form binding
-		// This ensures we're creating a new entity, not trying to update an existing one
+		final Dieta patientCopy = dietaService.copyDietaForPatientAssignment(dietaId, pacienteId, userId);
+
 		final PacienteDieta newAssignment = new PacienteDieta();
 		newAssignment.setPaciente(paciente);
-		newAssignment.setDieta(dieta);
+		newAssignment.setDieta(patientCopy);
 		newAssignment.setStartDate(pacienteDieta.getStartDate());
 		newAssignment.setEndDate(pacienteDieta.getEndDate());
 		newAssignment

--- a/src/main/java/com/nutriconsultas/paciente/PatientAssignedDietaMigrationRunner.java
+++ b/src/main/java/com/nutriconsultas/paciente/PatientAssignedDietaMigrationRunner.java
@@ -1,0 +1,74 @@
+package com.nutriconsultas.paciente;
+
+import java.util.List;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.dieta.DietaService;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * One-time idempotent migration: existing {@link PacienteDieta} rows that still reference
+ * shared catalog diets are repointed to patient-specific copies (#320).
+ */
+@Component
+@Profile("!test")
+@Slf4j
+public class PatientAssignedDietaMigrationRunner {
+
+	private final PacienteDietaRepository pacienteDietaRepository;
+
+	private final DietaService dietaService;
+
+	public PatientAssignedDietaMigrationRunner(final PacienteDietaRepository pacienteDietaRepository,
+			final DietaService dietaService) {
+		this.pacienteDietaRepository = pacienteDietaRepository;
+		this.dietaService = dietaService;
+	}
+
+	@EventListener(ApplicationReadyEvent.class)
+	@Transactional
+	public void migrateSharedAssignmentsToPatientCopies() {
+		final List<PacienteDieta> assignments = pacienteDietaRepository.findAssignmentsReferencingSharedDieta();
+		if (assignments.isEmpty()) {
+			return;
+		}
+		if (log.isInfoEnabled()) {
+			log.info("Migrating {} patient diet assignment(s) to patient-specific copies", assignments.size());
+		}
+		for (final PacienteDieta assignment : assignments) {
+			migrateAssignment(assignment);
+		}
+	}
+
+	private void migrateAssignment(@NonNull final PacienteDieta assignment) {
+		final Paciente paciente = assignment.getPaciente();
+		final Dieta sharedDieta = assignment.getDieta();
+		if (paciente == null || paciente.getId() == null || sharedDieta == null || sharedDieta.getId() == null) {
+			return;
+		}
+		final String nutritionistUserId = paciente.getUserId();
+		if (nutritionistUserId == null || nutritionistUserId.isBlank()) {
+			log.warn("Skipping diet assignment migration for paciente {} without userId",
+					LogRedaction.redactPaciente(paciente.getId()));
+			return;
+		}
+		final Dieta patientCopy = dietaService.copyDietaForPatientAssignment(sharedDieta.getId(), paciente.getId(),
+				nutritionistUserId);
+		assignment.setDieta(patientCopy);
+		pacienteDietaRepository.save(assignment);
+		if (log.isInfoEnabled()) {
+			log.info("Migrated assignment {} to patient diet copy {}", LogRedaction.redactPacienteDieta(assignment),
+					patientCopy.getId());
+		}
+	}
+
+}

--- a/src/main/resources/db/changelog/changes/019-dieta-paciente-id.yaml
+++ b/src/main/resources/db/changelog/changes/019-dieta-paciente-id.yaml
@@ -1,0 +1,32 @@
+databaseChangeLog:
+  - changeSet:
+      id: 019-dieta-paciente-id-column
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            columnExists:
+              tableName: dieta
+              columnName: paciente_id
+      changes:
+        - addColumn:
+            tableName: dieta
+            columns:
+              - column:
+                  name: paciente_id
+                  type: BIGINT
+                  constraints:
+                    nullable: true
+        - addForeignKeyConstraint:
+            baseTableName: dieta
+            baseColumnNames: paciente_id
+            referencedTableName: paciente
+            referencedColumnNames: id
+            constraintName: fk_dieta_paciente
+            onDelete: CASCADE
+        - createIndex:
+            indexName: idx_dieta_paciente_id
+            tableName: dieta
+            columns:
+              - column:
+                  name: paciente_id

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -53,3 +53,6 @@ databaseChangeLog:
   - include:
       file: changes/018-contact-inquiry-plan-role-slug.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/019-dieta-paciente-id.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -50,3 +50,6 @@ databaseChangeLog:
   - include:
       file: changes/018-contact-inquiry-plan-role-slug.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/019-dieta-paciente-id.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/templates/sbadmin/dietas/formulario.html
+++ b/src/main/resources/templates/sbadmin/dietas/formulario.html
@@ -80,6 +80,22 @@
         font-style: italic;
         padding: 1rem 0.25rem;
       }
+      .patient-caloric-indicator {
+        position: fixed;
+        bottom: 1.5rem;
+        right: 1.5rem;
+        z-index: 1050;
+        min-width: 18rem;
+        max-width: 22rem;
+        box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+      }
+      @media (max-width: 576px) {
+        .patient-caloric-indicator {
+          left: 1rem;
+          right: 1rem;
+          max-width: none;
+        }
+      }
       .platillo-ingredientes-panel {
         border-top: 1px solid #e3e6f0;
         padding-top: 0.75rem;
@@ -599,7 +615,7 @@
             <div class="d-sm-flex align-items-center justify-content-between mb-4">
               <h1 th:if="${dieta == null || dieta.id == null || dieta.id ==0}" class="h3 mb-0 text-gray-800">Nueva Dieta</h1>
               <h1 th:unless="${dieta == null || dieta.id == null || dieta.id ==0}" class="h3 mb-0 text-gray-800" th:text="${dieta != null ? dieta.nombre : 'Modificar Dieta'}">Modificar Dieta</h1>
-              <div th:if="${dieta != null && dieta.id != null && dieta.id != 0}">
+              <div th:if="${dieta != null && dieta.id != null && dieta.id != 0 && (patientDiet == null || !patientDiet)}">
                 <button 
                    type="button"
                    class="btn btn-sm btn-info shadow-sm" 
@@ -613,9 +629,25 @@
                   <i class="fas fa-file-pdf fa-sm text-white-50"></i> Imprimir PDF
                 </a>
               </div>
+              <div th:if="${dieta != null && dieta.id != null && dieta.id != 0 && patientDiet != null && patientDiet}">
+                <a th:if="${patientDietPlanUrl != null}" th:href="@{${patientDietPlanUrl}}"
+                   class="btn btn-sm btn-secondary shadow-sm mr-2">
+                  <i class="fas fa-arrow-left fa-sm"></i> Plan alimentario
+                </a>
+                <a th:href="@{/admin/pacientes/{pacienteId}/dietas/{dietaId}/print(pacienteId=${paciente.id}, dietaId=${dieta.id})}"
+                   class="btn btn-sm btn-primary shadow-sm"
+                   target="_blank">
+                  <i class="fas fa-file-pdf fa-sm text-white-50"></i> Imprimir PDF
+                </a>
+              </div>
             </div>
             <!-- Ownership indicator -->
-            <div th:if="${dieta != null && dieta.id != null && dieta.id != 0 && isOwner != null && !isOwner}" 
+            <div th:if="${patientDiet != null && patientDiet}" class="alert alert-primary mb-4" role="alert">
+              <i class="fas fa-user"></i>
+              <strong>Dieta del paciente:</strong>
+              Los cambios solo aplican a este plan alimentario asignado.
+            </div>
+            <div th:if="${dieta != null && dieta.id != null && dieta.id != 0 && isOwner != null && !isOwner && (patientDiet == null || !patientDiet)}" 
                  class="alert alert-info mb-4" role="alert">
               <i class="fas fa-info-circle"></i> 
               <strong>Dieta de otro usuario:</strong> Puedes ver y copiar esta dieta, pero no puedes modificarla.
@@ -2182,6 +2214,53 @@
             document.getElementById('macroHidratosKcal').textContent = Math.round(totalHidratosDeCarbono * 4) + ' kcal';
             document.getElementById('macroHidratosPct').textContent = distribucionHidratoCarbono.toFixed(1) + ' %';
             document.getElementById('macroTotalKcal').textContent = Math.round(kCal) + ' kcal';
+            updatePatientCaloricIndicator(kCal);
+          }
+
+          var requerimientoKcal = /*[[${requerimientoKcal}]]*/ null;
+
+          function classifyCaloricFit(dietKcal) {
+            if (requerimientoKcal == null || dietKcal == null || dietKcal <= 0) {
+              return { fit: 'unknown', label: 'Sin comparación', css: 'secondary' };
+            }
+            var tolerance = Math.max(50, requerimientoKcal * 0.05);
+            var diff = dietKcal - requerimientoKcal;
+            if (Math.abs(diff) <= tolerance) {
+              return { fit: 'match', label: 'Adecuada', css: 'success' };
+            }
+            if (diff < 0) {
+              return {
+                fit: 'under',
+                label: 'Por debajo (' + Math.round(Math.abs(diff)).toLocaleString('es-MX') + ' kcal)',
+                css: 'warning'
+              };
+            }
+            return {
+              fit: 'over',
+              label: 'Por encima (+' + Math.round(diff).toLocaleString('es-MX') + ' kcal)',
+              css: 'danger'
+            };
+          }
+
+          function updatePatientCaloricIndicator(dietKcal) {
+            var indicator = document.getElementById('patientCaloricIndicator');
+            if (!indicator || requerimientoKcal == null) {
+              return;
+            }
+            var fitInfo = classifyCaloricFit(dietKcal);
+            var badge = indicator.querySelector('[data-role="fit-badge"]');
+            var dietKcalEl = indicator.querySelector('[data-role="diet-kcal"]');
+            var reqKcalEl = indicator.querySelector('[data-role="req-kcal"]');
+            if (badge) {
+              badge.className = 'badge badge-' + fitInfo.css;
+              badge.textContent = fitInfo.label;
+            }
+            if (dietKcalEl) {
+              dietKcalEl.textContent = Math.round(dietKcal).toLocaleString('es-MX') + ' kcal';
+            }
+            if (reqKcalEl) {
+              reqKcalEl.textContent = Math.round(requerimientoKcal).toLocaleString('es-MX') + ' kcal/día';
+            }
           }
 
           var nutrientFieldDecimals = {
@@ -2359,5 +2438,30 @@
         });
       })(jQuery);
     </script>
+
+    <div th:if="${patientDiet != null && patientDiet && requerimientoKcal != null}"
+         id="patientCaloricIndicator"
+         class="card patient-caloric-indicator border-left-primary">
+      <div class="card-body py-3">
+        <div class="small text-muted mb-1">Requerimiento calórico del paciente</div>
+        <div class="font-weight-bold mb-2" data-role="req-kcal"
+             th:text="${#numbers.formatDecimal(requerimientoKcal, 1, 'COMMA', 0, 'POINT')} + ' kcal/día'">
+          0 kcal/día
+        </div>
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
+            <div class="small text-muted">Dieta actual</div>
+            <div class="font-weight-bold" data-role="diet-kcal"
+                 th:text="${totalEnergia != null ? totalEnergia + ' kcal' : '0 kcal'}">0 kcal</div>
+          </div>
+          <span class="badge"
+                data-role="fit-badge"
+                th:classappend="' badge-' + ${caloricFitCss != null ? caloricFitCss : 'secondary'}"
+                th:text="${caloricFitLabel != null ? caloricFitLabel : 'Sin comparación'}">
+            Sin comparación
+          </span>
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/src/test/java/com/nutriconsultas/dieta/DietaAuthorizationTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaAuthorizationTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
+import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.platform.PlatformAdminAuditService;
 import com.nutriconsultas.platform.PlatformAdminService;
 
@@ -22,11 +23,16 @@ class DietaAuthorizationTest {
 
 	private static final String PLATFORM_ADMIN_USER_ID = "auth0|platform-admin-test";
 
+	private static final Long PACIENTE_ID = 42L;
+
 	@Mock
 	private PlatformAdminService platformAdminService;
 
 	@Mock
 	private PlatformAdminAuditService platformAdminAuditService;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
 
 	@Mock
 	private DietaService dietaService;
@@ -39,17 +45,39 @@ class DietaAuthorizationTest {
 
 	private DietaAuthorization dietaAuthorization;
 
+	@org.junit.jupiter.api.BeforeEach
+	void setUp() {
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService,
+				pacienteRepository);
+	}
+
 	@Test
 	void canModify_returnsTrueForOwnedDiet() {
-		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
 		final Dieta dieta = ownedDiet(10L, NUTRITIONIST_USER_ID);
 
 		assertThat(dietaAuthorization.canModify(dieta, NUTRITIONIST_USER_ID, nutritionistPrincipal)).isTrue();
 	}
 
 	@Test
+	void canModify_returnsTrueForPatientDietWhenNutritionistOwnsPatient() {
+		final Dieta dieta = patientDiet(20L, PACIENTE_ID, NUTRITIONIST_USER_ID);
+		when(pacienteRepository.findByIdAndUserId(PACIENTE_ID, NUTRITIONIST_USER_ID))
+			.thenReturn(java.util.Optional.of(new com.nutriconsultas.paciente.Paciente()));
+
+		assertThat(dietaAuthorization.canModify(dieta, NUTRITIONIST_USER_ID, nutritionistPrincipal)).isTrue();
+	}
+
+	@Test
+	void canModify_returnsFalseForPatientDietWhenNutritionistDoesNotOwnPatient() {
+		final Dieta dieta = patientDiet(20L, PACIENTE_ID, NUTRITIONIST_USER_ID);
+		when(pacienteRepository.findByIdAndUserId(PACIENTE_ID, "auth0|other-user"))
+			.thenReturn(java.util.Optional.empty());
+
+		assertThat(dietaAuthorization.canModify(dieta, "auth0|other-user", nutritionistPrincipal)).isFalse();
+	}
+
+	@Test
 	void canModify_returnsTrueForPlatformAdminOnSystemTemplate() {
-		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
 		final Dieta dieta = systemDiet(8L);
 		when(platformAdminService.isPlatformAdmin(platformAdminPrincipal)).thenReturn(true);
 
@@ -58,7 +86,6 @@ class DietaAuthorizationTest {
 
 	@Test
 	void canModify_returnsFalseForNutritionistOnSystemTemplate() {
-		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
 		final Dieta dieta = systemDiet(8L);
 		when(platformAdminService.isPlatformAdmin(nutritionistPrincipal)).thenReturn(false);
 
@@ -67,7 +94,6 @@ class DietaAuthorizationTest {
 
 	@Test
 	void canModify_returnsFalseForPlatformAdminOnOtherUserDiet() {
-		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
 		final Dieta dieta = ownedDiet(11L, "auth0|other-user");
 		when(platformAdminService.isPlatformAdmin(platformAdminPrincipal)).thenReturn(true);
 
@@ -76,7 +102,6 @@ class DietaAuthorizationTest {
 
 	@Test
 	void verifyCanModify_throwsForUnauthorizedUser() {
-		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
 		final Dieta dieta = systemDiet(8L);
 		when(platformAdminService.isPlatformAdmin(nutritionistPrincipal)).thenReturn(false);
 
@@ -87,8 +112,8 @@ class DietaAuthorizationTest {
 
 	@Test
 	void resolveForMutation_returnsOwnedDietWithoutAdminCheck() {
-		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
 		final Dieta owned = ownedDiet(5L, NUTRITIONIST_USER_ID);
+		when(dietaService.getDieta(5L)).thenReturn(owned);
 		when(dietaService.getDietaByIdAndUserId(5L, NUTRITIONIST_USER_ID)).thenReturn(owned);
 
 		final Dieta result = dietaAuthorization.resolveForMutation(5L, NUTRITIONIST_USER_ID, nutritionistPrincipal,
@@ -100,8 +125,8 @@ class DietaAuthorizationTest {
 
 	@Test
 	void resolveForMutation_returnsSystemDietForPlatformAdmin() {
-		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
 		final Dieta system = systemDiet(8L);
+		when(dietaService.getDieta(8L)).thenReturn(system);
 		when(dietaService.getDietaByIdAndUserId(8L, PLATFORM_ADMIN_USER_ID)).thenReturn(null);
 		when(platformAdminService.isPlatformAdmin(platformAdminPrincipal)).thenReturn(true);
 		when(dietaService.getDieta(8L)).thenReturn(system);
@@ -114,7 +139,8 @@ class DietaAuthorizationTest {
 
 	@Test
 	void resolveForMutation_returnsNullForNutritionistOnSystemDiet() {
-		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		final Dieta system = systemDiet(8L);
+		when(dietaService.getDieta(8L)).thenReturn(system);
 		when(dietaService.getDietaByIdAndUserId(8L, NUTRITIONIST_USER_ID)).thenReturn(null);
 		when(platformAdminService.isPlatformAdmin(nutritionistPrincipal)).thenReturn(false);
 
@@ -126,7 +152,6 @@ class DietaAuthorizationTest {
 
 	@Test
 	void auditSystemDietMutationIfNeeded_recordsPlatformAdminAction() {
-		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
 		final Dieta system = systemDiet(8L);
 		when(platformAdminService.isPlatformAdmin(platformAdminPrincipal)).thenReturn(true);
 		when(platformAdminService.resolveActorUserId(platformAdminPrincipal)).thenReturn(PLATFORM_ADMIN_USER_ID);
@@ -138,7 +163,6 @@ class DietaAuthorizationTest {
 
 	@Test
 	void auditSystemDietMutationIfNeeded_skipsNonSystemDiet() {
-		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
 		final Dieta owned = ownedDiet(5L, NUTRITIONIST_USER_ID);
 
 		dietaAuthorization.auditSystemDietMutationIfNeeded(platformAdminPrincipal, owned, "dietas.save");
@@ -149,7 +173,6 @@ class DietaAuthorizationTest {
 
 	@Test
 	void resolveCreateUserId_returnsSystemTemplateUserIdForPlatformAdmin() {
-		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
 		when(platformAdminService.isPlatformAdmin(platformAdminPrincipal)).thenReturn(true);
 
 		assertThat(dietaAuthorization.resolveCreateUserId(platformAdminPrincipal, PLATFORM_ADMIN_USER_ID))
@@ -158,7 +181,6 @@ class DietaAuthorizationTest {
 
 	@Test
 	void resolveCreateUserId_returnsOAuthUserIdForNutritionist() {
-		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
 		when(platformAdminService.isPlatformAdmin(nutritionistPrincipal)).thenReturn(false);
 
 		assertThat(dietaAuthorization.resolveCreateUserId(nutritionistPrincipal, NUTRITIONIST_USER_ID))
@@ -178,6 +200,15 @@ class DietaAuthorizationTest {
 		dieta.setId(id);
 		dieta.setNombre("Plantilla: Menú vegetal 02");
 		dieta.setUserId(DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID);
+		return dieta;
+	}
+
+	private static Dieta patientDiet(final Long id, final Long pacienteId, final String userId) {
+		final Dieta dieta = new Dieta();
+		dieta.setId(id);
+		dieta.setNombre("Dieta paciente");
+		dieta.setUserId(userId);
+		dieta.setPacienteId(pacienteId);
 		return dieta;
 	}
 

--- a/src/test/java/com/nutriconsultas/dieta/DietaCaloricFitTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaCaloricFitTest.java
@@ -1,0 +1,37 @@
+package com.nutriconsultas.dieta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DietaCaloricFitTest {
+
+	@Test
+	void classify_returnsMatchWithinTolerance() {
+		assertThat(DietaCaloricFit.classify(2000, 2000.0)).isEqualTo(DietaCaloricFit.Fit.MATCH);
+		assertThat(DietaCaloricFit.classify(1980, 2000.0)).isEqualTo(DietaCaloricFit.Fit.MATCH);
+	}
+
+	@Test
+	void classify_returnsUnderWhenBelowRequirement() {
+		assertThat(DietaCaloricFit.classify(1700, 2000.0)).isEqualTo(DietaCaloricFit.Fit.UNDER);
+	}
+
+	@Test
+	void classify_returnsOverWhenAboveRequirement() {
+		assertThat(DietaCaloricFit.classify(2300, 2000.0)).isEqualTo(DietaCaloricFit.Fit.OVER);
+	}
+
+	@Test
+	void classify_returnsUnknownWithoutRequirement() {
+		assertThat(DietaCaloricFit.classify(1800, null)).isEqualTo(DietaCaloricFit.Fit.UNKNOWN);
+	}
+
+	@Test
+	void label_describesFitInSpanish() {
+		assertThat(DietaCaloricFit.label(DietaCaloricFit.Fit.MATCH, 2000, 2000.0)).isEqualTo("Adecuada");
+		assertThat(DietaCaloricFit.label(DietaCaloricFit.Fit.UNDER, 1700, 2000.0)).isEqualTo("Por debajo (300 kcal)");
+		assertThat(DietaCaloricFit.label(DietaCaloricFit.Fit.OVER, 2300, 2000.0)).isEqualTo("Por encima (+300 kcal)");
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/dieta/DietaControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaControllerTest.java
@@ -356,7 +356,7 @@ public class DietaControllerTest {
 		when(platilloService.findAll()).thenReturn(platillos);
 
 		// Perform GET request
-		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/1"))
+		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/1").with(oidcLogin(TEST_USER_ID)))
 			.andExpect(status().isOk())
 			.andExpect(MockMvcResultMatchers.view().name("sbadmin/dietas/formulario"))
 			.andExpect(MockMvcResultMatchers.model().attribute("activeMenu", "dietas"))
@@ -383,7 +383,7 @@ public class DietaControllerTest {
 
 		when(platilloService.findAll()).thenReturn(List.of(platillo));
 
-		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/1"))
+		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/1").with(oidcLogin(TEST_USER_ID)))
 			.andExpect(status().isOk())
 			.andExpect(MockMvcResultMatchers.model().attribute("hasDistribucion", true))
 			.andExpect(MockMvcResultMatchers.model().attribute("totalProteina", 30.0))
@@ -409,7 +409,7 @@ public class DietaControllerTest {
 
 		when(platilloService.findAll()).thenReturn(List.of(platillo));
 
-		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/1"))
+		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/1").with(oidcLogin(TEST_USER_ID)))
 			.andExpect(status().isOk())
 			.andExpect(content().string(containsString("/admin/platillos/97")))
 			.andExpect(content().string(not(containsString("/admin/platillos/32"))));
@@ -564,7 +564,7 @@ public class DietaControllerTest {
 		when(alimentoService.findAll()).thenReturn(alimentos);
 
 		// Perform GET request
-		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/1"))
+		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/1").with(oidcLogin(TEST_USER_ID)))
 			.andExpect(status().isOk())
 			.andExpect(MockMvcResultMatchers.view().name("sbadmin/dietas/formulario"))
 			.andExpect(MockMvcResultMatchers.model().attribute("activeMenu", "dietas"))

--- a/src/test/java/com/nutriconsultas/dieta/DietaDeletionServiceTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaDeletionServiceTest.java
@@ -14,6 +14,7 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.nutriconsultas.paciente.PacienteDietaRepository;
+import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.platform.PlatformAdminAuditService;
 import com.nutriconsultas.platform.PlatformAdminService;
 
@@ -41,6 +42,9 @@ class DietaDeletionServiceTest {
 	private PlatformAdminAuditService platformAdminAuditService;
 
 	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Mock
 	private OidcUser nutritionistPrincipal;
 
 	@Mock
@@ -51,13 +55,14 @@ class DietaDeletionServiceTest {
 	@BeforeEach
 	void setUp() {
 		final DietaAuthorization dietaAuthorization = new DietaAuthorization(platformAdminService,
-				platformAdminAuditService);
+				platformAdminAuditService, pacienteRepository);
 		service = new DietaDeletionServiceImpl(dietaService, dietaAuthorization, pacienteDietaRepository);
 	}
 
 	@Test
 	void deleteDieta_deletesOwnedDietWhenNotAssigned() {
 		final Dieta dieta = ownedDiet(5L);
+		when(dietaService.getDieta(5L)).thenReturn(dieta);
 		when(dietaService.getDietaByIdAndUserId(5L, NUTRITIONIST_USER_ID)).thenReturn(dieta);
 		when(pacienteDietaRepository.countByDietaIdAndPacienteUserId(5L, NUTRITIONIST_USER_ID)).thenReturn(0L);
 
@@ -70,6 +75,7 @@ class DietaDeletionServiceTest {
 	@Test
 	void deleteDieta_blocksWhenOwnedDietAssignedToPatients() {
 		final Dieta dieta = ownedDiet(6L);
+		when(dietaService.getDieta(6L)).thenReturn(dieta);
 		when(dietaService.getDietaByIdAndUserId(6L, NUTRITIONIST_USER_ID)).thenReturn(dieta);
 		when(pacienteDietaRepository.countByDietaIdAndPacienteUserId(6L, NUTRITIONIST_USER_ID)).thenReturn(2L);
 
@@ -96,8 +102,6 @@ class DietaDeletionServiceTest {
 
 	@Test
 	void deleteDieta_returnsNotFoundWhenDietMissing() {
-		when(dietaService.getDietaByIdAndUserId(99L, NUTRITIONIST_USER_ID)).thenReturn(null);
-		when(platformAdminService.isPlatformAdmin(nutritionistPrincipal)).thenReturn(false);
 		when(dietaService.getDieta(99L)).thenReturn(null);
 
 		final DietaDeleteResult result = service.deleteDieta(99L, NUTRITIONIST_USER_ID, nutritionistPrincipal);

--- a/src/test/java/com/nutriconsultas/dieta/DietaServiceImplPickerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaServiceImplPickerTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Sort;
 
 @ExtendWith(MockitoExtension.class)
 class DietaServiceImplPickerTest {
@@ -32,7 +31,7 @@ class DietaServiceImplPickerTest {
 			dieta.setNombre("Dieta " + i);
 			dietas.add(dieta);
 		});
-		when(dietaRepository.findAll(Sort.by("nombre"))).thenReturn(dietas);
+		when(dietaRepository.findAllCatalogDiets()).thenReturn(dietas);
 
 		final DietaPickerPageDto page = dietaService.findPickerPage(null, 0, 20, null);
 
@@ -49,7 +48,7 @@ class DietaServiceImplPickerTest {
 		final Dieta other = new Dieta();
 		other.setId(2L);
 		other.setNombre("Otra dieta");
-		when(dietaRepository.findAll(Sort.by("nombre"))).thenReturn(List.of(match, other));
+		when(dietaRepository.findAllCatalogDiets()).thenReturn(List.of(match, other));
 
 		final DietaPickerPageDto page = dietaService.findPickerPage("2000", 0, 20, null);
 

--- a/src/test/java/com/nutriconsultas/dieta/DietaServiceTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaServiceTest.java
@@ -417,12 +417,12 @@ public class DietaServiceTest {
 		systemDieta.setId(8L);
 		systemDieta.setUserId(DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID);
 		final List<Dieta> allDietas = Arrays.asList(originalDieta, systemDieta);
-		when(dietaRepository.findAll()).thenReturn(allDietas);
+		when(dietaRepository.findAllCatalogDiets()).thenReturn(allDietas);
 
 		final List<Dieta> result = dietaService.getDietasForCatalogFilter(DietaCatalogFilter.TODAS, TEST_USER_ID);
 
 		assertThat(result).hasSize(2);
-		verify(dietaRepository).findAll();
+		verify(dietaRepository).findAllCatalogDiets();
 	}
 
 	@Test
@@ -441,12 +441,12 @@ public class DietaServiceTest {
 
 	@Test
 	public void testGetDietasForCatalogFilterPropiasReturnsOwnedDietas() {
-		when(dietaRepository.findByUserId(TEST_USER_ID)).thenReturn(List.of(originalDieta));
+		when(dietaRepository.findByUserIdAndPacienteIdIsNull(TEST_USER_ID)).thenReturn(List.of(originalDieta));
 
 		final List<Dieta> result = dietaService.getDietasForCatalogFilter(DietaCatalogFilter.PROPIAS, TEST_USER_ID);
 
 		assertThat(result).containsExactly(originalDieta);
-		verify(dietaRepository).findByUserId(TEST_USER_ID);
+		verify(dietaRepository).findByUserIdAndPacienteIdIsNull(TEST_USER_ID);
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/dieta/DietasRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietasRestControllerTest.java
@@ -34,6 +34,7 @@ import com.nutriconsultas.dataTables.paging.PageArray;
 import com.nutriconsultas.dataTables.paging.PagingRequest;
 import com.nutriconsultas.dataTables.paging.Search;
 import com.nutriconsultas.model.ApiResponse;
+import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.platform.PlatformAdminAuditService;
 import com.nutriconsultas.platform.PlatformAdminService;
 
@@ -56,6 +57,9 @@ public class DietasRestControllerTest {
 
 	@Mock
 	private PlatformAdminAuditService platformAdminAuditService;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
 
 	@Mock
 	private DietaDeletionService dietaDeletionService;
@@ -89,9 +93,22 @@ public class DietasRestControllerTest {
 		return oidcUser;
 	}
 
+	private void stubMutationAccess(final Long dietaId, final String userId, final Dieta dieta) {
+		if (dieta.getUserId() == null) {
+			dieta.setUserId(userId);
+		}
+		when(dietaService.getDieta(dietaId)).thenReturn(dieta);
+		when(dietaService.getDietaByIdAndUserId(dietaId, userId)).thenReturn(dieta);
+	}
+
+	private void stubMutationNotFound(final Long dietaId) {
+		when(dietaService.getDieta(dietaId)).thenReturn(null);
+	}
+
 	@BeforeEach
 	public void setup() {
-		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService,
+				pacienteRepository);
 		ReflectionTestUtils.setField(dietasRestController, "dietaAuthorization", dietaAuthorization);
 
 		// Create empty diet
@@ -398,8 +415,7 @@ public class DietasRestControllerTest {
 		ingestaAfterDelete.setPlatillos(new ArrayList<>());
 		dietaAfterDelete.getIngestas().add(ingestaAfterDelete);
 
-		dietaBeforeDelete.setUserId(TEST_USER_ID);
-		when(dietaService.getDietaByIdAndUserId(dietaId, TEST_USER_ID)).thenReturn(dietaBeforeDelete);
+		stubMutationAccess(dietaId, TEST_USER_ID, dietaBeforeDelete);
 		when(dietaService.saveDieta(dietaBeforeDelete)).thenReturn(dietaAfterDelete);
 
 		// Act
@@ -434,7 +450,7 @@ public class DietasRestControllerTest {
 		Long ingestaId = 2L;
 		Long platilloIngestaId = 1L;
 
-		when(dietaService.getDietaByIdAndUserId(dietaId, TEST_USER_ID)).thenReturn(null);
+		stubMutationNotFound(dietaId);
 
 		// Act
 		ResponseEntity<ApiResponse<Dieta>> result = dietasRestController.deletePlatilloIngesta(dietaId, ingestaId,
@@ -469,7 +485,8 @@ public class DietasRestControllerTest {
 		dieta.getIngestas().add(otherIngesta);
 
 		dieta.setUserId(TEST_USER_ID);
-		when(dietaService.getDietaByIdAndUserId(dietaId, TEST_USER_ID)).thenReturn(dieta);
+		dieta.setUserId(TEST_USER_ID);
+		stubMutationAccess(dietaId, TEST_USER_ID, dieta);
 		when(dietaService.saveDieta(dieta)).thenReturn(dieta);
 
 		// Act
@@ -509,7 +526,8 @@ public class DietasRestControllerTest {
 		dieta.getIngestas().add(ingesta);
 
 		dieta.setUserId(TEST_USER_ID);
-		when(dietaService.getDietaByIdAndUserId(dietaId, TEST_USER_ID)).thenReturn(dieta);
+		dieta.setUserId(TEST_USER_ID);
+		stubMutationAccess(dietaId, TEST_USER_ID, dieta);
 		when(dietaService.saveDieta(dieta)).thenReturn(dieta);
 
 		// Act
@@ -589,8 +607,7 @@ public class DietasRestControllerTest {
 		ingestaAfterDelete.getPlatillos().add(remainingPlatillo);
 		dietaAfterDelete.getIngestas().add(ingestaAfterDelete);
 
-		dietaBeforeDelete.setUserId(TEST_USER_ID);
-		when(dietaService.getDietaByIdAndUserId(dietaId, TEST_USER_ID)).thenReturn(dietaBeforeDelete);
+		stubMutationAccess(dietaId, TEST_USER_ID, dietaBeforeDelete);
 		when(dietaService.saveDieta(dietaBeforeDelete)).thenReturn(dietaAfterDelete);
 
 		// Act
@@ -657,8 +674,7 @@ public class DietasRestControllerTest {
 		ingestaAfterDelete.setAlimentos(new ArrayList<>());
 		dietaAfterDelete.getIngestas().add(ingestaAfterDelete);
 
-		dietaBeforeDelete.setUserId(TEST_USER_ID);
-		when(dietaService.getDietaByIdAndUserId(dietaId, TEST_USER_ID)).thenReturn(dietaBeforeDelete);
+		stubMutationAccess(dietaId, TEST_USER_ID, dietaBeforeDelete);
 		when(dietaService.saveDieta(dietaBeforeDelete)).thenReturn(dietaAfterDelete);
 
 		// Act
@@ -693,7 +709,7 @@ public class DietasRestControllerTest {
 		Long ingestaId = 2L;
 		Long alimentoIngestaId = 1L;
 
-		when(dietaService.getDietaByIdAndUserId(dietaId, TEST_USER_ID)).thenReturn(null);
+		stubMutationNotFound(dietaId);
 
 		// Act
 		ResponseEntity<ApiResponse<Dieta>> result = dietasRestController.deleteAlimentoIngesta(dietaId, ingestaId,
@@ -1270,7 +1286,7 @@ public class DietasRestControllerTest {
 		ingesta.getPlatillos().add(platilloIngesta);
 		dieta.getIngestas().add(ingesta);
 
-		when(dietaService.getDietaByIdAndUserId(1L, TEST_USER_ID)).thenReturn(dieta);
+		stubMutationAccess(1L, TEST_USER_ID, dieta);
 		when(dietaService.saveDieta(any(Dieta.class))).thenReturn(dieta);
 
 		// Create mock OidcUser
@@ -1293,7 +1309,12 @@ public class DietasRestControllerTest {
 		log.info("Starting testDeletePlatilloIngestaRejectsOtherUserDiet");
 
 		// Arrange - diet belongs to other user
+		final Dieta otherUserDieta = new Dieta();
+		otherUserDieta.setId(1L);
+		otherUserDieta.setUserId(TEST_USER_ID);
+		when(dietaService.getDieta(1L)).thenReturn(otherUserDieta);
 		when(dietaService.getDietaByIdAndUserId(1L, OTHER_USER_ID)).thenReturn(null);
+		when(platformAdminService.isPlatformAdmin(org.mockito.ArgumentMatchers.any(OidcUser.class))).thenReturn(false);
 
 		// Create mock OidcUser
 		OidcUser principal = org.mockito.Mockito.mock(OidcUser.class);
@@ -1387,6 +1408,10 @@ public class DietasRestControllerTest {
 
 	@Test
 	public void testDeletePlatilloIngestaRejectsNutritionistOnSystemTemplate() {
+		final Dieta systemDieta = new Dieta();
+		systemDieta.setId(8L);
+		systemDieta.setUserId(DietaCatalogConstants.SYSTEM_TEMPLATE_USER_ID);
+		when(dietaService.getDieta(8L)).thenReturn(systemDieta);
 		when(dietaService.getDietaByIdAndUserId(8L, TEST_USER_ID)).thenReturn(null);
 		when(platformAdminService.isPlatformAdmin(org.mockito.ArgumentMatchers.any(OidcUser.class))).thenReturn(false);
 

--- a/src/test/java/com/nutriconsultas/dieta/IngredientePlatilloIngestaRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/IngredientePlatilloIngestaRestControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.nutriconsultas.alimentos.Alimento;
 import com.nutriconsultas.model.ApiResponse;
 import com.nutriconsultas.platillos.IngredienteFormModel;
+import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.platform.PlatformAdminAuditService;
 import com.nutriconsultas.platform.PlatformAdminService;
 
@@ -45,6 +46,9 @@ public class IngredientePlatilloIngestaRestControllerTest {
 	@Mock
 	private PlatformAdminAuditService platformAdminAuditService;
 
+	@Mock
+	private PacienteRepository pacienteRepository;
+
 	private DietaAuthorization dietaAuthorization;
 
 	private static final String TEST_USER_ID = "test-user-id-123";
@@ -57,7 +61,8 @@ public class IngredientePlatilloIngestaRestControllerTest {
 
 	@BeforeEach
 	public void setup() {
-		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService);
+		dietaAuthorization = new DietaAuthorization(platformAdminService, platformAdminAuditService,
+				pacienteRepository);
 		ReflectionTestUtils.setField(controller, "dietaAuthorization", dietaAuthorization);
 
 		dieta = new Dieta();
@@ -106,6 +111,8 @@ public class IngredientePlatilloIngestaRestControllerTest {
 
 	@Test
 	public void testDeleteIngredienteReturnsUpdatedDieta() {
+		when(dietaService.getDieta(1L)).thenReturn(dieta);
+		when(dietaService.getDieta(1L)).thenReturn(dieta);
 		when(dietaService.getDietaByIdAndUserId(1L, TEST_USER_ID)).thenReturn(dieta);
 		when(dietaService.saveDieta(dieta)).thenReturn(dieta);
 
@@ -132,6 +139,7 @@ public class IngredientePlatilloIngestaRestControllerTest {
 		added.setId(40L);
 		added.setAlimento(alimento);
 
+		when(dietaService.getDieta(1L)).thenReturn(dieta);
 		when(dietaService.getDietaByIdAndUserId(1L, TEST_USER_ID)).thenReturn(dieta);
 		when(dietaService.addIngredientePlatilloIngesta(platilloIngesta, 7L, "1", 90)).thenReturn(added);
 		when(dietaService.saveDieta(dieta)).thenReturn(dieta);
@@ -146,6 +154,7 @@ public class IngredientePlatilloIngestaRestControllerTest {
 
 	@Test
 	public void testUpdateIngredienteReturnsUpdatedDieta() {
+		when(dietaService.getDieta(1L)).thenReturn(dieta);
 		when(dietaService.getDietaByIdAndUserId(1L, TEST_USER_ID)).thenReturn(dieta);
 		when(dietaService.saveDieta(dieta)).thenReturn(dieta);
 

--- a/src/test/java/com/nutriconsultas/paciente/PacienteDeletionServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteDeletionServiceTest.java
@@ -22,6 +22,8 @@ import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
 import com.nutriconsultas.clinical.exam.AnthropometricMeasurementService;
 import com.nutriconsultas.clinical.exam.ClinicalExam;
 import com.nutriconsultas.clinical.exam.ClinicalExamService;
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.dieta.DietaService;
 import com.nutriconsultas.message.PatientMessageRepository;
 import com.nutriconsultas.paciente.metrics.BodyMetricRecordRepository;
 
@@ -59,6 +61,9 @@ class PacienteDeletionServiceTest {
 	@Mock
 	private BodyMetricRecordRepository bodyMetricRecordRepository;
 
+	@Mock
+	private DietaService dietaService;
+
 	private Paciente paciente;
 
 	@BeforeEach
@@ -80,6 +85,10 @@ class PacienteDeletionServiceTest {
 		measurement.setId(30L);
 		final PacienteDieta assignment = new PacienteDieta();
 		assignment.setId(40L);
+		final Dieta patientDieta = new Dieta();
+		patientDieta.setId(60L);
+		patientDieta.setPacienteId(7L);
+		assignment.setDieta(patientDieta);
 		final PatientInvitation invitation = new PatientInvitation();
 		invitation.setId(50L);
 
@@ -94,6 +103,7 @@ class PacienteDeletionServiceTest {
 
 		verify(patientMessageRepository).deleteByPacienteId(7L);
 		verify(patientInvitationRepository).deleteAll(List.of(invitation));
+		verify(dietaService).deleteDieta(60L);
 		verify(pacienteDietaRepository).deleteAll(List.of(assignment));
 		verify(calendarEventService).delete(10L);
 		verify(clinicalExamService).deleteById(20L);

--- a/src/test/java/com/nutriconsultas/paciente/PacienteDietaServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteDietaServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import com.nutriconsultas.dieta.Dieta;
 import com.nutriconsultas.dieta.DietaRepository;
+import com.nutriconsultas.dieta.DietaService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -42,9 +43,14 @@ public class PacienteDietaServiceTest {
 	@Mock
 	private DietaRepository dietaRepository;
 
+	@Mock
+	private DietaService dietaService;
+
 	private Paciente paciente;
 
-	private Dieta dieta;
+	private Dieta sourceDieta;
+
+	private Dieta patientCopyDieta;
 
 	private PacienteDieta pacienteDieta;
 
@@ -60,14 +66,20 @@ public class PacienteDietaServiceTest {
 		paciente.setEmail("juan@example.com");
 		paciente.setUserId(TEST_USER_ID);
 
-		dieta = new Dieta();
-		dieta.setId(1L);
-		dieta.setNombre("Dieta de Prueba");
+		sourceDieta = new Dieta();
+		sourceDieta.setId(1L);
+		sourceDieta.setNombre("Dieta de Prueba");
+
+		patientCopyDieta = new Dieta();
+		patientCopyDieta.setId(99L);
+		patientCopyDieta.setNombre("Dieta de Prueba");
+		patientCopyDieta.setPacienteId(1L);
+		patientCopyDieta.setUserId(TEST_USER_ID);
 
 		pacienteDieta = new PacienteDieta();
 		pacienteDieta.setId(1L);
 		pacienteDieta.setPaciente(paciente);
-		pacienteDieta.setDieta(dieta);
+		pacienteDieta.setDieta(patientCopyDieta);
 		pacienteDieta.setStartDate(new Date());
 		pacienteDieta.setStatus(PacienteDietaStatus.ACTIVE);
 		pacienteDieta.setNotes("Notas de prueba");
@@ -80,36 +92,35 @@ public class PacienteDietaServiceTest {
 		log.info("starting testAssignDieta");
 		// Arrange
 		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(Optional.of(paciente));
-		when(dietaRepository.findById(1L)).thenReturn(Optional.of(dieta));
+		when(dietaRepository.findById(1L)).thenReturn(Optional.of(sourceDieta));
+		when(dietaService.copyDietaForPatientAssignment(1L, 1L, TEST_USER_ID)).thenReturn(patientCopyDieta);
 		when(pacienteDietaRepository.save(any(PacienteDieta.class))).thenAnswer(invocation -> {
 			final PacienteDieta pd = invocation.getArgument(0);
-			// Simulate database assigning ID
 			pd.setId(1L);
 			return pd;
 		});
 
 		final Date startDate = new Date();
-		final Date endDate = new Date(System.currentTimeMillis() + 86400000); // Tomorrow
+		final Date endDate = new Date(System.currentTimeMillis() + 86400000);
 		final PacienteDieta newAssignment = new PacienteDieta();
 		newAssignment.setStartDate(startDate);
 		newAssignment.setEndDate(endDate);
 		newAssignment.setStatus(PacienteDietaStatus.ACTIVE);
 		newAssignment.setNotes("Nueva asignación");
 
-		// Act
 		final PacienteDieta result = service.assignDieta(1L, 1L, newAssignment, TEST_USER_ID);
 
-		// Assert
 		assertThat(result).isNotNull();
-		assertThat(result.getId()).isNotNull(); // ID assigned by repository
+		assertThat(result.getId()).isNotNull();
 		assertThat(result.getPaciente()).isEqualTo(paciente);
-		assertThat(result.getDieta()).isEqualTo(dieta);
+		assertThat(result.getDieta()).isEqualTo(patientCopyDieta);
 		assertThat(result.getStartDate()).isEqualTo(startDate);
 		assertThat(result.getEndDate()).isEqualTo(endDate);
 		assertThat(result.getStatus()).isEqualTo(PacienteDietaStatus.ACTIVE);
 		assertThat(result.getNotes()).isEqualTo("Nueva asignación");
 		verify(pacienteRepository).findByIdAndUserId(1L, TEST_USER_ID);
 		verify(dietaRepository).findById(1L);
+		verify(dietaService).copyDietaForPatientAssignment(1L, 1L, TEST_USER_ID);
 		verify(pacienteDietaRepository).save(any(PacienteDieta.class));
 		log.info("finished testAssignDieta");
 	}
@@ -119,7 +130,8 @@ public class PacienteDietaServiceTest {
 		log.info("starting testAssignDietaWithDefaultStatus");
 		// Arrange
 		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(Optional.of(paciente));
-		when(dietaRepository.findById(1L)).thenReturn(Optional.of(dieta));
+		when(dietaRepository.findById(1L)).thenReturn(Optional.of(sourceDieta));
+		when(dietaService.copyDietaForPatientAssignment(1L, 1L, TEST_USER_ID)).thenReturn(patientCopyDieta);
 		when(pacienteDietaRepository.save(any(PacienteDieta.class))).thenAnswer(invocation -> {
 			final PacienteDieta pd = invocation.getArgument(0);
 			pd.setId(1L);
@@ -137,7 +149,7 @@ public class PacienteDietaServiceTest {
 		assertThat(result).isNotNull();
 		assertThat(result.getStatus()).isEqualTo(PacienteDietaStatus.ACTIVE);
 		assertThat(result.getPaciente()).isEqualTo(paciente);
-		assertThat(result.getDieta()).isEqualTo(dieta);
+		assertThat(result.getDieta()).isEqualTo(patientCopyDieta);
 		log.info("finished testAssignDietaWithDefaultStatus");
 	}
 
@@ -181,7 +193,8 @@ public class PacienteDietaServiceTest {
 		// binding),
 		// a new object is created to avoid StaleObjectStateException
 		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(Optional.of(paciente));
-		when(dietaRepository.findById(1L)).thenReturn(Optional.of(dieta));
+		when(dietaRepository.findById(1L)).thenReturn(Optional.of(sourceDieta));
+		when(dietaService.copyDietaForPatientAssignment(1L, 1L, TEST_USER_ID)).thenReturn(patientCopyDieta);
 		when(pacienteDietaRepository.save(any(PacienteDieta.class))).thenAnswer(invocation -> {
 			final PacienteDieta pd = invocation.getArgument(0);
 			// Verify that the saved object has no ID (is a new entity)
@@ -204,7 +217,7 @@ public class PacienteDietaServiceTest {
 		assertThat(result).isNotNull();
 		assertThat(result.getId()).isEqualTo(2L); // New ID assigned by repository
 		assertThat(result.getPaciente()).isEqualTo(paciente);
-		assertThat(result.getDieta()).isEqualTo(dieta);
+		assertThat(result.getDieta()).isEqualTo(patientCopyDieta);
 		assertThat(result.getStartDate()).isEqualTo(startDate);
 		assertThat(result.getStatus()).isEqualTo(PacienteDietaStatus.ACTIVE);
 		assertThat(result.getNotes()).isEqualTo("Test notes");
@@ -219,7 +232,8 @@ public class PacienteDietaServiceTest {
 		log.info("starting testAssignDietaCopiesAllFieldsCorrectly");
 		// Arrange
 		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(Optional.of(paciente));
-		when(dietaRepository.findById(1L)).thenReturn(Optional.of(dieta));
+		when(dietaRepository.findById(1L)).thenReturn(Optional.of(sourceDieta));
+		when(dietaService.copyDietaForPatientAssignment(1L, 1L, TEST_USER_ID)).thenReturn(patientCopyDieta);
 		when(pacienteDietaRepository.save(any(PacienteDieta.class))).thenAnswer(invocation -> {
 			final PacienteDieta pd = invocation.getArgument(0);
 			pd.setId(1L);
@@ -246,7 +260,7 @@ public class PacienteDietaServiceTest {
 		assertThat(result.getStatus()).isEqualTo(PacienteDietaStatus.COMPLETED);
 		assertThat(result.getNotes()).isEqualTo(notes);
 		assertThat(result.getPaciente()).isEqualTo(paciente);
-		assertThat(result.getDieta()).isEqualTo(dieta);
+		assertThat(result.getDieta()).isEqualTo(patientCopyDieta);
 		log.info("finished testAssignDietaCopiesAllFieldsCorrectly");
 	}
 


### PR DESCRIPTION
## Summary
- Deep-copy catalog diets when assigning to a patient (`dieta.paciente_id`), keeping template names but isolating edits per patient
- Exclude patient copies from the global `/admin/dietas` catalog and diet picker; access only via the patient's plan or direct link with ownership checks
- Show patient-diet banner, back link to plan, and floating caloric fit indicator when editing an assigned diet
- Liquibase `019-dieta-paciente-id` + idempotent boot migration for existing `paciente_dieta` rows that still reference shared templates

Fixes #320

## Test plan
- [x] `./lint.sh` (checkstyle, SpotBugs, PMD, Thymeleaf)
- [x] `mvn test` (1319 tests)
- [x] Browser UI: catalog hides patient copies, assign creates copy, plan + editor banner/indicator verified locally


Made with [Cursor](https://cursor.com)