### PR TITLE
feat(mobile-api): CurrentPatient resolver and onboarding gate (#137)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -41,7 +41,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (public booking):** None — epic ~~#245~~ **done**; ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~, ~~#300~~, ~~#302~~ done. Deferred follow-ups need new issues. See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
-**Current next issue (mobile):** [#136 — POST /rest/mobile/invitations/{token}/redeem](https://github.com/diego-torres/nutriconsultas/issues/136) (**in-progress**). ~~#135~~ done (PR [#324](https://github.com/diego-torres/nutriconsultas/pull/324)).
+**Current next issue (mobile):** [#137 — CurrentPatient resolver + onboarding data gate](https://github.com/diego-torres/nutriconsultas/issues/137) (**in-progress**). ~~#136~~ done (PR [#325](https://github.com/diego-torres/nutriconsultas/pull/325)).
 
 **Current next issue (subscription):** Registered track **complete** (~~#244~~ ✓ on `subscription/244-contact-form-prefill`). Triage open `[Subscription]` GitHub issues. See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
 
@@ -408,8 +408,8 @@ gh pr create ...
 
 | Field | Value |
 |-------|-------|
-| **Next issue** | [#136 — POST /rest/mobile/invitations/{token}/redeem](https://github.com/diego-torres/nutriconsultas/issues/136) |
-| **Status** | **in-progress** — branch `mobile-api/136-invitation-redeem` |
+| **Next issue** | [#137 — CurrentPatient resolver + onboarding data gate](https://github.com/diego-torres/nutriconsultas/issues/137) |
+| **Status** | **in-progress** — branch `mobile-api/137-current-patient-gate` |
 | **Just completed** | [#135 preview](https://github.com/diego-torres/nutriconsultas/issues/135) — PR [#324](https://github.com/diego-torres/nutriconsultas/pull/324) |
 
 ### Upcoming gates
@@ -427,7 +427,7 @@ gh pr create ...
 
 **Patient mobile API on `main`:** Phase 0 + endpoints **#91–#99** done; cross-cutting **#111–#116** done. Onboarding **#132** + token service **#133 done** (PR #229, deployed EC2).
 
-**Next (mobile):** **#136** redeem → #137 resolver.
+**Next (mobile):** **#137** CurrentPatient gate → #138 profile.
 
 **Schema track:** ~~#46~~ Liquibase baseline (PR #196). Changesets **003–007** on `main` (subscription, patient invitation). All new edits → forward changesets only.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -590,7 +590,7 @@ Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 
-**Next:** [#136](https://github.com/diego-torres/nutriconsultas/issues/136) invitation redeem (**in-progress**). ~~#135~~ done (PR [#324](https://github.com/diego-torres/nutriconsultas/pull/324)). ~~#114~~, ~~#116~~, ~~#115~~, ~~#112~~ **done**. Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) — registered track **complete** (~~#244~~ ✓).
+**Next:** [#137](https://github.com/diego-torres/nutriconsultas/issues/137) CurrentPatient gate (**in-progress**). ~~#136~~ done (PR [#325](https://github.com/diego-torres/nutriconsultas/pull/325)). ~~#135~~ done (PR [#324](https://github.com/diego-torres/nutriconsultas/pull/324)). ~~#114~~, ~~#116~~, ~~#115~~, ~~#112~~ **done**. Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) — registered track **complete** (~~#244~~ ✓).
 
 **Schema gate (post-#46):** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline is on `main` (PR #196). All new schema/catalog changes require **incremental Liquibase changesets** — see [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) and [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md). ~~#156~~ Phase C done before baseline.
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) · **Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-22 — ~~#135~~ **done** (PR [#324](https://github.com/diego-torres/nutriconsultas/pull/324)). **in-progress:** [#136 redeem](https://github.com/diego-torres/nutriconsultas/issues/136) (`mobile-api/136-invitation-redeem`).
+**Last updated:** 2026-06-22 — ~~#136~~ **done** (PR [#325](https://github.com/diego-torres/nutriconsultas/pull/325)). **in-progress:** [#137 CurrentPatient gate](https://github.com/diego-torres/nutriconsultas/issues/137) (`mobile-api/137-current-patient-gate`).
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -49,7 +49,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156**, **#46**, **#132**, **#133**, **#134**, and **#135** done on `main`. **in-progress:** #136.
+Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156**, **#46**, **#132**, **#133**, **#134**, **#135**, and **#136** done on `main`. **in-progress:** #137.
 
 ---
 
@@ -138,16 +138,16 @@ Schema-affecting work must respect mobile DTO contracts (§F8). These issues are
 
 ## Phase 2 — Invitation onboarding (P1 · ~~#132~~ ✓ ~~#133~~ ✓ → #134–#141)
 
-Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Active sprint** — preview **#135 done** (PR #324); **in-progress:** #136 redeem.
+Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Active sprint** — redeem **#136 done** (PR #325); **in-progress:** #137 CurrentPatient gate.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | 133 | Invitation token generation & hashing service | https://github.com/diego-torres/nutriconsultas/issues/133 | **done** | ~~132~~ ✓ | Merged PR [#229](https://github.com/diego-torres/nutriconsultas/pull/229): `PatientInvitationTokenService`, human code, SHA-256 hash, optional offline JWS (#140) |
 | 134 | `POST /rest/mobile/invitations` — nutritionist creates patient + invitation | https://github.com/diego-torres/nutriconsultas/issues/134 | **done** | ~~132~~ ✓, ~~133~~ ✓ | Merged PR [#319](https://github.com/diego-torres/nutriconsultas/pull/319) |
 | 135 | `GET /rest/mobile/invitations/{token}/preview` — public rate-limited preview | https://github.com/diego-torres/nutriconsultas/issues/135 | **done** | ~~133~~ ✓ | Merged PR [#324](https://github.com/diego-torres/nutriconsultas/pull/324) |
-| 136 | `POST /rest/mobile/invitations/{token}/redeem` — bind Auth0 sub → patient | https://github.com/diego-torres/nutriconsultas/issues/136 | **in-progress** | ~~132~~ ✓, ~~133~~ ✓, 107 | **Authoritative** redeem gate; patient JWT required |
-| 137 | CurrentPatient resolver + onboarding data gate (403 onboarding required) | https://github.com/diego-torres/nutriconsultas/issues/137 | **NEXT** | ~~132~~ ✓, 107 | Centralizes `sub → Paciente`; 403 until onboarded |
-| 138 | `PATCH` & `GET /rest/mobile/patient/me` — onboarding profile + status→ACTIVE | https://github.com/diego-torres/nutriconsultas/issues/138 | open | ~~132~~ ✓, 137 | Patient completes profile; transitions to `ACTIVE` |
+| 136 | `POST /rest/mobile/invitations/{token}/redeem` — bind Auth0 sub → patient | https://github.com/diego-torres/nutriconsultas/issues/136 | **done** | ~~132~~ ✓, ~~133~~ ✓, 107 | Merged PR [#325](https://github.com/diego-torres/nutriconsultas/pull/325) |
+| 137 | CurrentPatient resolver + onboarding data gate (403 onboarding required) | https://github.com/diego-torres/nutriconsultas/issues/137 | **in-progress** | ~~132~~ ✓, 107 | Centralizes `sub → Paciente`; 403 until onboarded |
+| 138 | `PATCH` & `GET /rest/mobile/patient/me` — onboarding profile + status→ACTIVE | https://github.com/diego-torres/nutriconsultas/issues/138 | **NEXT** | ~~132~~ ✓, 137 | Patient completes profile; transitions to `ACTIVE` |
 | 139 | `POST /rest/mobile/invitations/{id}/revoke` — nutritionist invalidates invite | https://github.com/diego-torres/nutriconsultas/issues/139 | open | ~~132~~ ✓, 134 | Nutritionist JWT |
 | 140 | Auth0 Post-Login Action gate — first-login invitation validation | https://github.com/diego-torres/nutriconsultas/issues/140 | open | ~~133~~ ✓, 136 | **Post-Login** (not Pre-User-Registration — social logins skip PUR); docs + Action script |
 | 141 | Invitation security hardening — rate limits, enumeration protection, no-token logging | https://github.com/diego-torres/nutriconsultas/issues/141 | open | ~~133~~ ✓, 135, 136 | Relates #115; never log raw tokens |
@@ -181,7 +181,7 @@ Each mobile feature consumes these backend endpoints. Two-way linking with the m
 
 **E2E HTTP codes (2026-06-15):**
 - **401** — missing/invalid JWT or wrong `aud` (check mobile `AUTH0_AUDIENCE` = `https://api.nutriconsultas.minutriporcion.com`).
-- **403** — JWT valid, no `Paciente.patientAuthSub` match (#109 linkage required). Localized `ApiResponse` with `error.patient.not.linked` (#111).
+- **403** — JWT valid but patient data blocked: unlinked `sub`, `ONBOARDING` on data endpoints, or `REVOKED`/`INVITED` (#137). Localized `ApiResponse` with `error.patient.onboarding.required`. Legacy controller paths may still return `error.patient.not.linked` (#111).
 - **404** — linkage OK but resource not found (localized `error.resource.not.found`).
 - **400** — validation failure (e.g. blank message body → `error.message.required`).
 - **429** — patient write rate limit exceeded (#113); `Retry-After: 60`; localized `error.rate.limit.exceeded`.

--- a/docs/mobile-api/ALIGNMENT-SPEC.md
+++ b/docs/mobile-api/ALIGNMENT-SPEC.md
@@ -160,7 +160,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 - **Phase 0 DONE:** #107 (PR #117), #109 (PR #142), #110 (DTO envelope).
 - **Endpoints on `main`:** #91–#99 (visits, diet plans + PDF, messages, progress snapshot + measurements time series); #96/#97 messaging with HTTP 201 + Resilience4j 10/min (#113, PR #151).
 - **i18n (#111) DONE** (PR #151): `LocaleContextFilter`, `MobileApiErrorResponses`, localized 403/404/400/429.
-- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). Onboarding **#132–#135 done** (PR #324 for #135). **in-progress:** #136.
+- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). Onboarding **#132–#136 done** (PR #325 for #136). **in-progress:** #137.
 - `deltaPeso`/`deltaImc` are computed-at-query, not stored.
 - Progress `grasa` ambiguity: prefer `bodyComposition.porcentajeGrasaCorporal` (patient-facing %) over `indiceGrasaCorporal`.
 - Template dietas (seed `system:template-dietas`) have 4 ingestas incl. Colación — contract examples show only 3.
@@ -172,7 +172,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 
 ### F8.6 — Invitation onboarding gate (#132–#141)
 - **Prerequisites done on `main`:** #156 Paciente decomposition (PRs #175/#176/#178); #46 Liquibase baseline (PR #196). All new schema → incremental changesets per [`docs/db/LIQUIBASE.md`](../db/LIQUIBASE.md).
-- **Active sprint:** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ **done**; **in-progress:** #136; **NEXT:** #137–#141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
+- **Active sprint:** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ **done**; **in-progress:** #137; **NEXT:** #138–#141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
 - **Orthogonal:** nutritionist subscription invitations (`NutritionistInvitation` in subscription track) — see [`ISSUE-SUBSCRIPTION.md`](../../ISSUE-SUBSCRIPTION.md); do not conflate with patient `Invitation`.
 
 #### F8.6.1 — Token contract (AUTHORITATIVE; verified against `main` #133 code, 2026-06-21)

--- a/docs/mobile-api/MOBILE-E2E-STATUS.md
+++ b/docs/mobile-api/MOBILE-E2E-STATUS.md
@@ -99,7 +99,7 @@ GET /actuator/health                 → 200
 | Code | Meaning |
 |------|---------|
 | **401** | Missing/invalid JWT, wrong issuer, or wrong `aud` |
-| **403** | JWT valid but no linked `Paciente.patientAuthSub` — localized `ApiResponse.message` (`error.patient.not.linked`, #111) |
+| **403** | JWT valid but patient data blocked (#137): unlinked `sub`, `ONBOARDING` on data endpoints, or `REVOKED`/`INVITED` — localized `error.patient.onboarding.required` |
 | **200** | Auth + linkage OK; endpoint implemented |
 | **201** | POST `/messages` success (#97) |
 | **400** | Validation failure (localized message, #111) |

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -12,7 +12,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`MOBILE-E2E-STATUS.md`](MOBILE-E2E-STATUS.md) | Live E2E status, Auth0 setup, HTTP code matrix |
 | [`../api/openapi-mobile.yaml`](../api/openapi-mobile.yaml) | OpenAPI 3.1 export (#112, PR #164); regen: `scripts/export-openapi-mobile.sh` |
 
-**Status (2026-06-22):** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ done (PR [#324](https://github.com/diego-torres/nutriconsultas/pull/324)). **in-progress:** [#136](https://github.com/diego-torres/nutriconsultas/issues/136) redeem.
+**Status (2026-06-22):** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ done (PR [#325](https://github.com/diego-torres/nutriconsultas/pull/325)). **in-progress:** [#137](https://github.com/diego-torres/nutriconsultas/issues/137) CurrentPatient gate.
 
 ## Related registries (same repo)
 

--- a/src/main/java/com/nutriconsultas/mobile/CurrentPatient.java
+++ b/src/main/java/com/nutriconsultas/mobile/CurrentPatient.java
@@ -1,0 +1,19 @@
+package com.nutriconsultas.mobile;
+
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
+
+/**
+ * Resolved mobile patient identity for JWT {@code sub} → {@code patientAuthSub} (#137).
+ */
+public record CurrentPatient(Long pacienteId, String patientAuthSub, PacienteStatus status) {
+
+	public static CurrentPatient from(final PacienteAuthView authView) {
+		return new CurrentPatient(authView.getId(), authView.getPatientAuthSub(), authView.getStatus());
+	}
+
+	public PatientPrincipal toPrincipal() {
+		return new PatientPrincipal(pacienteId, patientAuthSub, status);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/CurrentPatientService.java
+++ b/src/main/java/com/nutriconsultas/mobile/CurrentPatientService.java
@@ -1,0 +1,58 @@
+package com.nutriconsultas.mobile;
+
+import java.util.Optional;
+
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Central {@code sub → Paciente} resolver for the mobile API (#137).
+ */
+@Service
+@Slf4j
+public class CurrentPatientService {
+
+	private final PacienteRepository pacienteRepository;
+
+	public CurrentPatientService(final PacienteRepository pacienteRepository) {
+		this.pacienteRepository = pacienteRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public Optional<CurrentPatient> findByJwt(final Jwt jwt) {
+		if (jwt == null || jwt.getSubject() == null) {
+			return Optional.empty();
+		}
+		return pacienteRepository.findAuthViewByPatientAuthSub(jwt.getSubject()).map(CurrentPatient::from);
+	}
+
+	@Transactional(readOnly = true)
+	public CurrentPatient requireByJwt(final Jwt jwt) {
+		return findByJwt(jwt).orElseThrow(PatientNotLinkedException::new);
+	}
+
+	@Transactional(readOnly = true)
+	public Optional<PacienteAuthView> findAuthViewByJwt(final Jwt jwt) {
+		if (jwt == null || jwt.getSubject() == null) {
+			return Optional.empty();
+		}
+		return pacienteRepository.findAuthViewByPatientAuthSub(jwt.getSubject());
+	}
+
+	@Transactional(readOnly = true)
+	public PatientPrincipal resolvePrincipal(final Jwt jwt) {
+		final CurrentPatient currentPatient = requireByJwt(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Resolved mobile current patient: {}", LogRedaction.redactPaciente(currentPatient.pacienteId()));
+		}
+		return currentPatient.toPrincipal();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/MobileApiErrorResponses.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobileApiErrorResponses.java
@@ -29,6 +29,8 @@ public final class MobileApiErrorResponses {
 
 	public static final String KEY_PATIENT_NOT_LINKED = "error.patient.not.linked";
 
+	public static final String KEY_PATIENT_ONBOARDING_REQUIRED = "error.patient.onboarding.required";
+
 	public static final String KEY_RESOURCE_NOT_FOUND = "error.resource.not.found";
 
 	public static final String KEY_MESSAGE_TOO_LONG = "error.message.too.long";

--- a/src/main/java/com/nutriconsultas/mobile/MobileApiExceptionHandler.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobileApiExceptionHandler.java
@@ -45,6 +45,16 @@ public class MobileApiExceptionHandler {
 			.body(errorResponses.error(MobileApiErrorResponses.KEY_PATIENT_NOT_LINKED));
 	}
 
+	@ExceptionHandler(PatientOnboardingRequiredException.class)
+	public ResponseEntity<ApiResponse<Void>> handlePatientOnboardingRequired(
+			final PatientOnboardingRequiredException ex) {
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile API onboarding required");
+		}
+		return ResponseEntity.status(HttpStatus.FORBIDDEN)
+			.body(errorResponses.error(MobileApiErrorResponses.KEY_PATIENT_ONBOARDING_REQUIRED));
+	}
+
 	@ExceptionHandler(SubscriptionLimitExceededException.class)
 	public ResponseEntity<ApiResponse<Void>> handleSubscriptionLimit(final SubscriptionLimitExceededException ex) {
 		if (log.isDebugEnabled()) {

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientAccessRules.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientAccessRules.java
@@ -1,0 +1,54 @@
+package com.nutriconsultas.mobile;
+
+import java.util.Optional;
+
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
+
+/**
+ * Status-aware access rules for {@code /rest/mobile/patient/**} (#137).
+ */
+public final class MobilePatientAccessRules {
+
+	public static final String PATIENT_API_PREFIX = "/rest/mobile/patient/";
+
+	private static final String ONBOARDING_PROFILE_PATH = "/rest/mobile/patient/me";
+
+	private MobilePatientAccessRules() {
+	}
+
+	public enum Decision {
+
+		ALLOW, ONBOARDING_REQUIRED
+
+	}
+
+	public static Decision evaluatePatientApiAccess(final Optional<PacienteAuthView> authView, final String path) {
+		if (path == null || !path.startsWith(PATIENT_API_PREFIX)) {
+			return Decision.ALLOW;
+		}
+		if (authView.isEmpty()) {
+			return Decision.ONBOARDING_REQUIRED;
+		}
+		return evaluateLinkedPatientAccess(authView.orElseThrow(), path);
+	}
+
+	private static Decision evaluateLinkedPatientAccess(final PacienteAuthView authView, final String path) {
+		final PacienteStatus status = authView.getStatus();
+		if (status == PacienteStatus.REVOKED || status == PacienteStatus.INVITED) {
+			return Decision.ONBOARDING_REQUIRED;
+		}
+		if (status == PacienteStatus.ONBOARDING) {
+			return isOnboardingAllowedPath(path) ? Decision.ALLOW : Decision.ONBOARDING_REQUIRED;
+		}
+		if (status == PacienteStatus.ACTIVE) {
+			return Decision.ALLOW;
+		}
+		return Decision.ONBOARDING_REQUIRED;
+	}
+
+	public static boolean isOnboardingAllowedPath(final String path) {
+		return ONBOARDING_PROFILE_PATH.equals(path) || path.startsWith(ONBOARDING_PROFILE_PATH + "/");
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/PatientAuthService.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientAuthService.java
@@ -4,44 +4,32 @@ import java.util.Optional;
 
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.paciente.projection.PacienteAuthView;
-import com.nutriconsultas.util.LogRedaction;
 
-import lombok.extern.slf4j.Slf4j;
-
+/**
+ * Facade for mobile patient JWT resolution; delegates to {@link CurrentPatientService}
+ * (#137).
+ */
 @Service
-@Slf4j
 public class PatientAuthService {
 
-	private final PacienteRepository pacienteRepository;
+	private final CurrentPatientService currentPatientService;
 
-	public PatientAuthService(final PacienteRepository pacienteRepository) {
-		this.pacienteRepository = pacienteRepository;
+	public PatientAuthService(final CurrentPatientService currentPatientService) {
+		this.currentPatientService = currentPatientService;
 	}
 
-	@Transactional(readOnly = true)
 	public Optional<PacienteAuthView> findAuthViewByJwt(final Jwt jwt) {
-		if (jwt == null || jwt.getSubject() == null) {
-			return Optional.empty();
-		}
-		return pacienteRepository.findAuthViewByPatientAuthSub(jwt.getSubject());
+		return currentPatientService.findAuthViewByJwt(jwt);
 	}
 
-	@Transactional(readOnly = true)
 	public PacienteAuthView requireAuthViewByJwt(final Jwt jwt) {
 		return findAuthViewByJwt(jwt).orElseThrow(PatientNotLinkedException::new);
 	}
 
-	@Transactional(readOnly = true)
 	public PatientPrincipal resolvePrincipal(final Jwt jwt) {
-		final PacienteAuthView authView = requireAuthViewByJwt(jwt);
-		if (log.isDebugEnabled()) {
-			log.debug("Resolved mobile patient principal: {}", LogRedaction.redactPaciente(authView.getId()));
-		}
-		return new PatientPrincipal(authView.getId(), jwt.getSubject());
+		return currentPatientService.resolvePrincipal(jwt);
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/mobile/PatientLinkageFilter.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientLinkageFilter.java
@@ -1,6 +1,7 @@
 package com.nutriconsultas.mobile;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -12,28 +13,29 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.nutriconsultas.mobile.MobilePatientAccessRules.Decision;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Slf4j
 public class PatientLinkageFilter extends OncePerRequestFilter {
 
-	private static final String PATIENT_API_PREFIX = "/rest/mobile/patient/";
-
-	private final PatientAuthService patientAuthService;
+	private final CurrentPatientService currentPatientService;
 
 	private final MobileApiErrorResponses errorResponses;
 
-	public PatientLinkageFilter(final PatientAuthService patientAuthService,
+	public PatientLinkageFilter(final CurrentPatientService currentPatientService,
 			final MobileApiErrorResponses errorResponses) {
-		this.patientAuthService = patientAuthService;
+		this.currentPatientService = currentPatientService;
 		this.errorResponses = errorResponses;
 	}
 
 	@Override
 	protected boolean shouldNotFilter(final HttpServletRequest request) {
 		final String path = request.getRequestURI();
-		return path == null || !path.startsWith(PATIENT_API_PREFIX);
+		return path == null || !path.startsWith(MobilePatientAccessRules.PATIENT_API_PREFIX);
 	}
 
 	@Override
@@ -45,23 +47,25 @@ public class PatientLinkageFilter extends OncePerRequestFilter {
 		}
 
 		final Jwt jwt = jwtAuth.getToken();
-		try {
-			final PatientPrincipal principal = patientAuthService.resolvePrincipal(jwt);
-			jwtAuth.setDetails(principal);
-			filterChain.doFilter(request, response);
-		}
-		catch (PatientNotLinkedException ex) {
+		final String path = request.getRequestURI();
+		final Optional<PacienteAuthView> authView = currentPatientService.findAuthViewByJwt(jwt);
+		final Decision decision = MobilePatientAccessRules.evaluatePatientApiAccess(authView, path);
+		if (decision == Decision.ONBOARDING_REQUIRED) {
 			if (log.isDebugEnabled()) {
-				log.debug("Mobile JWT sub has no linked Paciente.patientAuthSub");
+				log.debug("Mobile patient API blocked by onboarding gate");
 			}
-			writeForbidden(request, response);
+			writeOnboardingRequired(request, response);
+			return;
 		}
+
+		authView.map(CurrentPatient::from).map(CurrentPatient::toPrincipal).ifPresent(jwtAuth::setDetails);
+		filterChain.doFilter(request, response);
 	}
 
-	private void writeForbidden(final HttpServletRequest request, final HttpServletResponse response)
+	private void writeOnboardingRequired(final HttpServletRequest request, final HttpServletResponse response)
 			throws IOException {
 		errorResponses.writeJson(response, HttpServletResponse.SC_FORBIDDEN,
-				errorResponses.error(MobileApiErrorResponses.KEY_PATIENT_NOT_LINKED, request));
+				errorResponses.error(MobileApiErrorResponses.KEY_PATIENT_ONBOARDING_REQUIRED, request));
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/mobile/PatientOnboardingRequiredException.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientOnboardingRequiredException.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.mobile;
+
+/**
+ * Patient JWT is valid but onboarding is incomplete or access is revoked (#137).
+ */
+public final class PatientOnboardingRequiredException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/PatientPrincipal.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientPrincipal.java
@@ -3,6 +3,8 @@ package com.nutriconsultas.mobile;
 import java.io.Serial;
 import java.io.Serializable;
 
+import com.nutriconsultas.paciente.PacienteStatus;
+
 /**
  * Authenticated patient identity for mobile API requests. Contains only non-PHI
  * identifiers.
@@ -16,9 +18,12 @@ public final class PatientPrincipal implements Serializable {
 
 	private final String patientAuthSub;
 
-	public PatientPrincipal(final Long pacienteId, final String patientAuthSub) {
+	private final PacienteStatus status;
+
+	public PatientPrincipal(final Long pacienteId, final String patientAuthSub, final PacienteStatus status) {
 		this.pacienteId = pacienteId;
 		this.patientAuthSub = patientAuthSub;
+		this.status = status;
 	}
 
 	public Long getPacienteId() {
@@ -27,6 +32,10 @@ public final class PatientPrincipal implements Serializable {
 
 	public String getPatientAuthSub() {
 		return patientAuthSub;
+	}
+
+	public PacienteStatus getStatus() {
+		return status;
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
@@ -50,8 +50,8 @@ public interface PacienteRepository extends JpaRepository<Paciente, Long> {
 	List<PacienteListView> findListViewsByUserIdAndSearchTerm(@Param("userId") String userId,
 			@Param("searchTerm") String searchTerm);
 
-	@Query("SELECT p.id AS id, p.patientAuthSub AS patientAuthSub, p.userId AS userId FROM Paciente p "
-			+ "WHERE p.patientAuthSub = :patientAuthSub")
+	@Query("SELECT p.id AS id, p.patientAuthSub AS patientAuthSub, p.userId AS userId, p.status AS status "
+			+ "FROM Paciente p WHERE p.patientAuthSub = :patientAuthSub")
 	Optional<PacienteAuthView> findAuthViewByPatientAuthSub(@Param("patientAuthSub") String patientAuthSub);
 
 	@Query("SELECT p.id AS id, p.name AS name, p.dob AS dob, p.gender AS gender FROM Paciente p "

--- a/src/main/java/com/nutriconsultas/paciente/projection/PacienteAuthView.java
+++ b/src/main/java/com/nutriconsultas/paciente/projection/PacienteAuthView.java
@@ -1,8 +1,10 @@
 package com.nutriconsultas.paciente.projection;
 
+import com.nutriconsultas.paciente.PacienteStatus;
+
 /**
  * Read-only projection for mobile JWT resolution ({@code sub} → {@code patientAuthSub}) —
- * #156 Phase A.
+ * #156 Phase A; status added for onboarding gate (#137).
  */
 public interface PacienteAuthView {
 
@@ -11,5 +13,7 @@ public interface PacienteAuthView {
 	String getPatientAuthSub();
 
 	String getUserId();
+
+	PacienteStatus getStatus();
 
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,4 +1,5 @@
 error.patient.not.linked=Patient account is not linked.
+error.patient.onboarding.required=Complete onboarding to access this resource.
 error.resource.not.found=Resource not found.
 error.message.too.long=Message is too long.
 error.message.required=Message text is required.

--- a/src/main/resources/messages_es_MX.properties
+++ b/src/main/resources/messages_es_MX.properties
@@ -1,4 +1,5 @@
 error.patient.not.linked=La cuenta del paciente no está vinculada.
+error.patient.onboarding.required=Completa el registro para acceder a este recurso.
 error.resource.not.found=Recurso no encontrado.
 error.message.too.long=El mensaje es demasiado largo.
 error.message.required=El texto del mensaje es obligatorio.

--- a/src/test/java/com/nutriconsultas/mobile/CurrentPatientServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/CurrentPatientServiceTest.java
@@ -1,0 +1,71 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
+
+@ExtendWith(MockitoExtension.class)
+class CurrentPatientServiceTest {
+
+	private static final String LINKED_SUB = "auth0|linked-patient";
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@InjectMocks
+	private CurrentPatientService currentPatientService;
+
+	@Test
+	void findByJwt_returnsCurrentPatientWhenLinked() {
+		final PacienteAuthView authView = MobileTestPacienteAuthViews.authView(7L, LINKED_SUB, "nutritionist-sub",
+				PacienteStatus.ACTIVE);
+		when(pacienteRepository.findAuthViewByPatientAuthSub(LINKED_SUB)).thenReturn(Optional.of(authView));
+
+		final Optional<CurrentPatient> result = currentPatientService.findByJwt(jwtWithSub(LINKED_SUB));
+
+		assertThat(result).contains(new CurrentPatient(7L, LINKED_SUB, PacienteStatus.ACTIVE));
+	}
+
+	@Test
+	void requireByJwt_throwsWhenSubIsUnlinked() {
+		when(pacienteRepository.findAuthViewByPatientAuthSub("auth0|unknown")).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> currentPatientService.requireByJwt(jwtWithSub("auth0|unknown")))
+			.isInstanceOf(PatientNotLinkedException.class);
+	}
+
+	@Test
+	void resolvePrincipal_includesStatus() {
+		final PacienteAuthView authView = MobileTestPacienteAuthViews.authView(42L, LINKED_SUB, "nutritionist-sub",
+				PacienteStatus.ONBOARDING);
+		when(pacienteRepository.findAuthViewByPatientAuthSub(LINKED_SUB)).thenReturn(Optional.of(authView));
+
+		final PatientPrincipal principal = currentPatientService.resolvePrincipal(jwtWithSub(LINKED_SUB));
+
+		assertThat(principal.getPacienteId()).isEqualTo(42L);
+		assertThat(principal.getPatientAuthSub()).isEqualTo(LINKED_SUB);
+		assertThat(principal.getStatus()).isEqualTo(PacienteStatus.ONBOARDING);
+	}
+
+	private static Jwt jwtWithSub(final String sub) {
+		return Jwt.withTokenValue("test-token")
+			.header("alg", "none")
+			.subject(sub)
+			.claim("aud", "https://api.nutriconsultas.test/mobile")
+			.build();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobileApiExceptionHandlerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileApiExceptionHandlerTest.java
@@ -69,6 +69,20 @@ class MobileApiExceptionHandlerTest {
 	}
 
 	@Test
+	void handlePatientOnboardingRequiredReturnsLocalized403() {
+		LocaleContextHolder.setLocale(Locale.ENGLISH);
+		when(messageSource.getMessage(MobileApiErrorResponses.KEY_PATIENT_ONBOARDING_REQUIRED, null, Locale.ENGLISH))
+			.thenReturn("Complete onboarding to access this resource.");
+
+		final ResponseEntity<ApiResponse<Void>> response = handler
+			.handlePatientOnboardingRequired(new PatientOnboardingRequiredException());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().message()).isEqualTo("Complete onboarding to access this resource.");
+	}
+
+	@Test
 	void handleResponseStatusNotFoundReturnsLocalized404() {
 		LocaleContextHolder.setLocale(Locale.forLanguageTag("es-MX"));
 		when(messageSource.getMessage(MobileApiErrorResponses.KEY_RESOURCE_NOT_FOUND, null,

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientAccessRulesTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientAccessRulesTest.java
@@ -1,0 +1,67 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.mobile.MobilePatientAccessRules.Decision;
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
+
+class MobilePatientAccessRulesTest {
+
+	private static final String VISITS_PATH = "/rest/mobile/patient/visits";
+
+	private static final String PROFILE_PATH = "/rest/mobile/patient/me";
+
+	@Test
+	void evaluatePatientApiAccess_unlinkedPatientOnDataEndpoint_requiresOnboarding() {
+		final Decision decision = MobilePatientAccessRules.evaluatePatientApiAccess(Optional.empty(), VISITS_PATH);
+
+		assertThat(decision).isEqualTo(Decision.ONBOARDING_REQUIRED);
+	}
+
+	@Test
+	void evaluatePatientApiAccess_onboardingPatientOnProfilePath_allowsAccess() {
+		final PacienteAuthView authView = MobileTestPacienteAuthViews.authView(1L, "auth0|onboarding", "owner",
+				PacienteStatus.ONBOARDING);
+
+		final Decision decision = MobilePatientAccessRules.evaluatePatientApiAccess(Optional.of(authView),
+				PROFILE_PATH);
+
+		assertThat(decision).isEqualTo(Decision.ALLOW);
+	}
+
+	@Test
+	void evaluatePatientApiAccess_onboardingPatientOnDataEndpoint_requiresOnboarding() {
+		final PacienteAuthView authView = MobileTestPacienteAuthViews.authView(1L, "auth0|onboarding", "owner",
+				PacienteStatus.ONBOARDING);
+
+		final Decision decision = MobilePatientAccessRules.evaluatePatientApiAccess(Optional.of(authView), VISITS_PATH);
+
+		assertThat(decision).isEqualTo(Decision.ONBOARDING_REQUIRED);
+	}
+
+	@Test
+	void evaluatePatientApiAccess_revokedPatient_requiresOnboarding() {
+		final PacienteAuthView authView = MobileTestPacienteAuthViews.authView(1L, "auth0|revoked", "owner",
+				PacienteStatus.REVOKED);
+
+		final Decision decision = MobilePatientAccessRules.evaluatePatientApiAccess(Optional.of(authView), VISITS_PATH);
+
+		assertThat(decision).isEqualTo(Decision.ONBOARDING_REQUIRED);
+	}
+
+	@Test
+	void evaluatePatientApiAccess_activePatientOnDataEndpoint_allowsAccess() {
+		final PacienteAuthView authView = MobileTestPacienteAuthViews.authView(1L, "auth0|active", "owner",
+				PacienteStatus.ACTIVE);
+
+		final Decision decision = MobilePatientAccessRules.evaluatePatientApiAccess(Optional.of(authView), VISITS_PATH);
+
+		assertThat(decision).isEqualTo(Decision.ALLOW);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanControllerTest.java
@@ -82,22 +82,7 @@ class MobilePatientDietPlanControllerTest {
 	}
 
 	private static PacienteAuthView authView(final Long id) {
-		return new PacienteAuthView() {
-			@Override
-			public Long getId() {
-				return id;
-			}
-
-			@Override
-			public String getPatientAuthSub() {
-				return PATIENT_SUB;
-			}
-
-			@Override
-			public String getUserId() {
-				return "auth0|nutritionist";
-			}
-		};
+		return MobileTestPacienteAuthViews.authView(id, PATIENT_SUB, "auth0|nutritionist");
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageControllerTest.java
@@ -79,22 +79,7 @@ class MobilePatientMessageControllerTest {
 	}
 
 	private static PacienteAuthView authView(final Long id) {
-		return new PacienteAuthView() {
-			@Override
-			public Long getId() {
-				return id;
-			}
-
-			@Override
-			public String getPatientAuthSub() {
-				return PATIENT_SUB;
-			}
-
-			@Override
-			public String getUserId() {
-				return "auth0|nutritionist-owner";
-			}
-		};
+		return MobileTestPacienteAuthViews.authView(id, PATIENT_SUB, "auth0|nutritionist-owner");
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientMessageServiceTest.java
@@ -150,22 +150,7 @@ class MobilePatientMessageServiceTest {
 	}
 
 	private static PacienteAuthView authView(final Long id, final String userId, final String patientAuthSub) {
-		return new PacienteAuthView() {
-			@Override
-			public Long getId() {
-				return id;
-			}
-
-			@Override
-			public String getPatientAuthSub() {
-				return patientAuthSub;
-			}
-
-			@Override
-			public String getUserId() {
-				return userId;
-			}
-		};
+		return MobileTestPacienteAuthViews.authView(id, patientAuthSub, userId);
 	}
 
 	private static PatientMessage sampleMessage(final Long id, final String body) {

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientProgressControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientProgressControllerTest.java
@@ -73,22 +73,7 @@ class MobilePatientProgressControllerTest {
 	}
 
 	private static PacienteAuthView authView(final Long id) {
-		return new PacienteAuthView() {
-			@Override
-			public Long getId() {
-				return id;
-			}
-
-			@Override
-			public String getPatientAuthSub() {
-				return PATIENT_SUB;
-			}
-
-			@Override
-			public String getUserId() {
-				return "auth0|nutritionist";
-			}
-		};
+		return MobileTestPacienteAuthViews.authView(id, PATIENT_SUB, "auth0|nutritionist");
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitControllerTest.java
@@ -79,22 +79,7 @@ class MobilePatientVisitControllerTest {
 	}
 
 	private static PacienteAuthView authView(final Long id, final String patientAuthSub) {
-		return new PacienteAuthView() {
-			@Override
-			public Long getId() {
-				return id;
-			}
-
-			@Override
-			public String getPatientAuthSub() {
-				return patientAuthSub;
-			}
-
-			@Override
-			public String getUserId() {
-				return "auth0|nutritionist";
-			}
-		};
+		return MobileTestPacienteAuthViews.authView(id, patientAuthSub, "auth0|nutritionist");
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/mobile/MobilePhiLoggingIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePhiLoggingIntegrationTest.java
@@ -88,6 +88,11 @@ class MobilePhiLoggingIntegrationTest {
 			public String getUserId() {
 				return "auth0|nutritionist-owner";
 			}
+
+			@Override
+			public com.nutriconsultas.paciente.PacienteStatus getStatus() {
+				return com.nutriconsultas.paciente.PacienteStatus.ACTIVE;
+			}
 		};
 		final Paciente pacienteRef = new Paciente();
 		pacienteRef.setId(12L);

--- a/src/test/java/com/nutriconsultas/mobile/MobileSecurityIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileSecurityIntegrationTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteStatus;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -28,6 +29,10 @@ import com.nutriconsultas.paciente.PacienteRepository;
 class MobileSecurityIntegrationTest {
 
 	private static final String LINKED_SUB = "auth0|mobile-security-linked";
+
+	private static final String ONBOARDING_SUB = "auth0|mobile-security-onboarding";
+
+	private static final String REVOKED_SUB = "auth0|mobile-security-revoked";
 
 	private static final String UNLINKED_SUB = "auth0|mobile-security-unlinked";
 
@@ -38,11 +43,11 @@ class MobileSecurityIntegrationTest {
 	private PacienteRepository pacienteRepository;
 
 	@BeforeEach
-	void seedLinkedPatient() {
+	void seedPatients() {
 		SecurityContextHolder.clearContext();
-		if (pacienteRepository.findByPatientAuthSub(LINKED_SUB).isEmpty()) {
-			pacienteRepository.saveAndFlush(samplePaciente(LINKED_SUB));
-		}
+		ensurePatient(LINKED_SUB, PacienteStatus.ACTIVE);
+		ensurePatient(ONBOARDING_SUB, PacienteStatus.ONBOARDING);
+		ensurePatient(REVOKED_SUB, PacienteStatus.REVOKED);
 	}
 
 	@AfterEach
@@ -56,19 +61,33 @@ class MobileSecurityIntegrationTest {
 	}
 
 	@Test
-	void patientEndpoint_withUnlinkedJwt_returnsForbidden() throws Exception {
+	void patientEndpoint_withUnlinkedJwt_returnsOnboardingRequired() throws Exception {
 		mockMvc.perform(get("/rest/mobile/patient/visits").with(mobileJwt(UNLINKED_SUB)))
 			.andExpect(status().isForbidden())
-			.andExpect(jsonPath("$.message").value("La cuenta del paciente no está vinculada."))
+			.andExpect(jsonPath("$.message").value("Completa el registro para acceder a este recurso."))
 			.andExpect(jsonPath("$.timestamp").exists());
 	}
 
 	@Test
-	void patientEndpoint_withUnlinkedJwt_returnsEnglishMessageWhenRequested() throws Exception {
+	void patientEndpoint_withUnlinkedJwt_returnsEnglishOnboardingMessageWhenRequested() throws Exception {
 		mockMvc
 			.perform(get("/rest/mobile/patient/visits").with(mobileJwt(UNLINKED_SUB)).header("Accept-Language", "en"))
 			.andExpect(status().isForbidden())
-			.andExpect(jsonPath("$.message").value("Patient account is not linked."));
+			.andExpect(jsonPath("$.message").value("Complete onboarding to access this resource."));
+	}
+
+	@Test
+	void patientEndpoint_withOnboardingJwtOnDataEndpoint_returnsOnboardingRequired() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/visits").with(mobileJwt(ONBOARDING_SUB)))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.message").value("Completa el registro para acceder a este recurso."));
+	}
+
+	@Test
+	void patientEndpoint_withRevokedJwt_returnsOnboardingRequired() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/visits").with(mobileJwt(REVOKED_SUB)))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.message").value("Completa el registro para acceder a este recurso."));
 	}
 
 	@Test
@@ -81,6 +100,20 @@ class MobileSecurityIntegrationTest {
 	@Test
 	void nonPatientMobilePath_doesNotRequirePatientLinkage() throws Exception {
 		mockMvc.perform(get("/rest/mobile/status").with(mobileJwt(UNLINKED_SUB))).andExpect(status().isNotFound());
+	}
+
+	private void ensurePatient(final String patientAuthSub, final PacienteStatus status) {
+		final Paciente existing = pacienteRepository.findByPatientAuthSub(patientAuthSub).orElse(null);
+		if (existing != null) {
+			if (existing.getStatus() != status) {
+				existing.setStatus(status);
+				pacienteRepository.saveAndFlush(existing);
+			}
+			return;
+		}
+		final Paciente paciente = samplePaciente(patientAuthSub);
+		paciente.setStatus(status);
+		pacienteRepository.saveAndFlush(paciente);
 	}
 
 	private static Paciente samplePaciente(final String patientAuthSub) {

--- a/src/test/java/com/nutriconsultas/mobile/MobileTestPacienteAuthViews.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileTestPacienteAuthViews.java
@@ -1,0 +1,40 @@
+package com.nutriconsultas.mobile;
+
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
+
+public final class MobileTestPacienteAuthViews {
+
+	private MobileTestPacienteAuthViews() {
+	}
+
+	public static PacienteAuthView authView(final Long id, final String patientAuthSub, final String userId) {
+		return authView(id, patientAuthSub, userId, PacienteStatus.ACTIVE);
+	}
+
+	public static PacienteAuthView authView(final Long id, final String patientAuthSub, final String userId,
+			final PacienteStatus status) {
+		return new PacienteAuthView() {
+			@Override
+			public Long getId() {
+				return id;
+			}
+
+			@Override
+			public String getPatientAuthSub() {
+				return patientAuthSub;
+			}
+
+			@Override
+			public String getUserId() {
+				return userId;
+			}
+
+			@Override
+			public PacienteStatus getStatus() {
+				return status;
+			}
+		};
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/PatientAuthLinkageServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/PatientAuthLinkageServiceTest.java
@@ -162,6 +162,11 @@ class PatientAuthLinkageServiceTest {
 			public String getUserId() {
 				return entity.getUserId();
 			}
+
+			@Override
+			public com.nutriconsultas.paciente.PacienteStatus getStatus() {
+				return entity.getStatus();
+			}
 		};
 	}
 

--- a/src/test/java/com/nutriconsultas/mobile/PatientAuthServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/PatientAuthServiceTest.java
@@ -13,7 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.jwt.Jwt;
 
-import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteStatus;
 import com.nutriconsultas.paciente.projection.PacienteAuthView;
 
 @ExtendWith(MockitoExtension.class)
@@ -21,18 +21,16 @@ class PatientAuthServiceTest {
 
 	private static final String LINKED_SUB = "auth0|linked-patient";
 
-	private static final String NUTRITIONIST_SUB = "nutritionist-sub";
-
 	@Mock
-	private PacienteRepository pacienteRepository;
+	private CurrentPatientService currentPatientService;
 
 	@InjectMocks
 	private PatientAuthService patientAuthService;
 
 	@Test
 	void findAuthViewByJwt_returnsViewWhenPatientAuthSubMatches() {
-		final PacienteAuthView authView = sampleAuthView(LINKED_SUB, 7L);
-		when(pacienteRepository.findAuthViewByPatientAuthSub(LINKED_SUB)).thenReturn(Optional.of(authView));
+		final PacienteAuthView authView = MobileTestPacienteAuthViews.authView(7L, LINKED_SUB, "nutritionist-sub");
+		when(currentPatientService.findAuthViewByJwt(jwtWithSub(LINKED_SUB))).thenReturn(Optional.of(authView));
 
 		final Optional<PacienteAuthView> result = patientAuthService.findAuthViewByJwt(jwtWithSub(LINKED_SUB));
 
@@ -41,21 +39,20 @@ class PatientAuthServiceTest {
 
 	@Test
 	void requireAuthViewByJwt_throwsWhenSubIsUnlinked() {
-		when(pacienteRepository.findAuthViewByPatientAuthSub("auth0|unknown")).thenReturn(Optional.empty());
+		when(currentPatientService.findAuthViewByJwt(jwtWithSub("auth0|unknown"))).thenReturn(Optional.empty());
 
 		assertThatThrownBy(() -> patientAuthService.requireAuthViewByJwt(jwtWithSub("auth0|unknown")))
 			.isInstanceOf(PatientNotLinkedException.class);
 	}
 
 	@Test
-	void resolvePrincipal_returnsNonPhiIdentifiers() {
-		final PacienteAuthView authView = sampleAuthView(LINKED_SUB, 42L);
-		when(pacienteRepository.findAuthViewByPatientAuthSub(LINKED_SUB)).thenReturn(Optional.of(authView));
+	void resolvePrincipal_delegatesToCurrentPatientService() {
+		final PatientPrincipal principal = new PatientPrincipal(42L, LINKED_SUB, PacienteStatus.ACTIVE);
+		when(currentPatientService.resolvePrincipal(jwtWithSub(LINKED_SUB))).thenReturn(principal);
 
-		final PatientPrincipal principal = patientAuthService.resolvePrincipal(jwtWithSub(LINKED_SUB));
+		final PatientPrincipal result = patientAuthService.resolvePrincipal(jwtWithSub(LINKED_SUB));
 
-		assertThat(principal.getPacienteId()).isEqualTo(42L);
-		assertThat(principal.getPatientAuthSub()).isEqualTo(LINKED_SUB);
+		assertThat(result).isEqualTo(principal);
 	}
 
 	private static Jwt jwtWithSub(final String sub) {
@@ -64,25 +61,6 @@ class PatientAuthServiceTest {
 			.subject(sub)
 			.claim("aud", "https://api.nutriconsultas.test/mobile")
 			.build();
-	}
-
-	private static PacienteAuthView sampleAuthView(final String patientAuthSub, final Long id) {
-		return new PacienteAuthView() {
-			@Override
-			public Long getId() {
-				return id;
-			}
-
-			@Override
-			public String getPatientAuthSub() {
-				return patientAuthSub;
-			}
-
-			@Override
-			public String getUserId() {
-				return NUTRITIONIST_SUB;
-			}
-		};
 	}
 
 }


### PR DESCRIPTION
## Summary
- Add `CurrentPatient` / `CurrentPatientService` to centralize JWT `sub` → `Paciente(patientAuthSub)` resolution with `PacienteStatus`.
- Refactor `PatientLinkageFilter` with `MobilePatientAccessRules`: unlinked, `ONBOARDING` on data endpoints, `REVOKED`, and `INVITED` patients receive **403** with `error.patient.onboarding.required`.
- Extend `PatientPrincipal` and `PacienteAuthView` with status; add localized i18n messages and integration/unit tests.
- Sync mobile API registry: #136 done (PR #325), #137 in-progress → done on merge, #138 NEXT.

Closes #137.

## Test plan
- [x] `./lint.sh` (checkstyle, PMD, SpotBugs, Thymeleaf)
- [x] `MobilePatientAccessRulesTest`, `CurrentPatientServiceTest`, `MobileSecurityIntegrationTest`
- [x] Updated controller/service tests with `PacienteStatus` on auth views
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)