### PR TITLE
feat(mobile-api): patient onboarding profile GET/PATCH /patient/me (#138)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -41,7 +41,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (public booking):** None — epic ~~#245~~ **done**; ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~, ~~#300~~, ~~#302~~ done. Deferred follow-ups need new issues. See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
-**Current next issue (mobile):** [#138 — GET/PATCH /rest/mobile/patient/me](https://github.com/diego-torres/nutriconsultas/issues/138) (**NEXT**). ~~#137~~ done (PR [#326](https://github.com/diego-torres/nutriconsultas/pull/326)).
+**Current next issue (mobile):** [#138 — GET/PATCH /rest/mobile/patient/me](https://github.com/diego-torres/nutriconsultas/issues/138) (**in-progress**). ~~#137~~ done (PR [#326](https://github.com/diego-torres/nutriconsultas/pull/326)).
 
 **Current next issue (subscription):** Registered track **complete** (~~#244~~ ✓ on `subscription/244-contact-form-prefill`). Triage open `[Subscription]` GitHub issues. See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
 
@@ -409,7 +409,7 @@ gh pr create ...
 | Field | Value |
 |-------|-------|
 | **Next issue** | [#138 — GET/PATCH /rest/mobile/patient/me](https://github.com/diego-torres/nutriconsultas/issues/138) |
-| **Status** | **NEXT** — unblocked on `main` |
+| **Status** | **in-progress** — branch `mobile-api/138-patient-onboarding-profile` |
 | **Just completed** | [#135 preview](https://github.com/diego-torres/nutriconsultas/issues/135) — PR [#324](https://github.com/diego-torres/nutriconsultas/pull/324) |
 
 ### Upcoming gates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -590,7 +590,7 @@ Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 
-**Next:** [#138](https://github.com/diego-torres/nutriconsultas/issues/138) onboarding profile (**NEXT**). ~~#137~~ done (PR [#326](https://github.com/diego-torres/nutriconsultas/pull/326)). ~~#136~~ done (PR [#325](https://github.com/diego-torres/nutriconsultas/pull/325)). ~~#135~~ done (PR [#324](https://github.com/diego-torres/nutriconsultas/pull/324)). ~~#114~~, ~~#116~~, ~~#115~~, ~~#112~~ **done**. Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) — registered track **complete** (~~#244~~ ✓).
+**Next:** [#138](https://github.com/diego-torres/nutriconsultas/issues/138) onboarding profile (**in-progress**). ~~#137~~ done (PR [#326](https://github.com/diego-torres/nutriconsultas/pull/326)).
 
 **Schema gate (post-#46):** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline is on `main` (PR #196). All new schema/catalog changes require **incremental Liquibase changesets** — see [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) and [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md). ~~#156~~ Phase C done before baseline.
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) · **Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-22 — ~~#137~~ **done** (PR [#326](https://github.com/diego-torres/nutriconsultas/pull/326)). **NEXT:** [#138 patient profile](https://github.com/diego-torres/nutriconsultas/issues/138).
+**Last updated:** 2026-06-22 — ~~#137~~ **done** (PR [#326](https://github.com/diego-torres/nutriconsultas/pull/326)). **in-progress:** [#138 patient profile](https://github.com/diego-torres/nutriconsultas/issues/138) (`mobile-api/138-patient-onboarding-profile`).
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -49,7 +49,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156**, **#46**, **#132**, **#133**, **#134**, **#135**, **#136**, and **#137** done on `main`. **NEXT:** #138.
+Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156**, **#46**, **#132**, **#133**, **#134**, **#135**, **#136**, and **#137** done on `main`. **in-progress:** #138.
 
 ---
 
@@ -138,7 +138,7 @@ Schema-affecting work must respect mobile DTO contracts (§F8). These issues are
 
 ## Phase 2 — Invitation onboarding (P1 · ~~#132~~ ✓ ~~#133~~ ✓ → #134–#141)
 
-Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Active sprint** — CurrentPatient gate **#137 done** (PR #326); **NEXT:** #138 profile.
+Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Active sprint** — **in-progress:** #138 onboarding profile (GET/PATCH `/rest/mobile/patient/me`).
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
@@ -147,8 +147,8 @@ Invite-only patient onboarding replaces manual Afiliación linkage (#109) for ne
 | 135 | `GET /rest/mobile/invitations/{token}/preview` — public rate-limited preview | https://github.com/diego-torres/nutriconsultas/issues/135 | **done** | ~~133~~ ✓ | Merged PR [#324](https://github.com/diego-torres/nutriconsultas/pull/324) |
 | 136 | `POST /rest/mobile/invitations/{token}/redeem` — bind Auth0 sub → patient | https://github.com/diego-torres/nutriconsultas/issues/136 | **done** | ~~132~~ ✓, ~~133~~ ✓, 107 | Merged PR [#325](https://github.com/diego-torres/nutriconsultas/pull/325) |
 | 137 | CurrentPatient resolver + onboarding data gate (403 onboarding required) | https://github.com/diego-torres/nutriconsultas/issues/137 | **done** | ~~132~~ ✓, 107 | Merged PR [#326](https://github.com/diego-torres/nutriconsultas/pull/326) |
-| 138 | `PATCH` & `GET /rest/mobile/patient/me` — onboarding profile + status→ACTIVE | https://github.com/diego-torres/nutriconsultas/issues/138 | **NEXT** | ~~132~~ ✓, ~~137~~ ✓ | Patient completes profile; transitions to `ACTIVE` |
-| 139 | `POST /rest/mobile/invitations/{id}/revoke` — nutritionist invalidates invite | https://github.com/diego-torres/nutriconsultas/issues/139 | open | ~~132~~ ✓, 134 | Nutritionist JWT |
+| 138 | `PATCH` & `GET /rest/mobile/patient/me` — onboarding profile + status→ACTIVE | https://github.com/diego-torres/nutriconsultas/issues/138 | **in-progress** | ~~132~~ ✓, ~~137~~ ✓ | Patient completes profile; transitions to `ACTIVE` |
+| 139 | `POST /rest/mobile/invitations/{id}/revoke` — nutritionist invalidates invite | https://github.com/diego-torres/nutriconsultas/issues/139 | **NEXT** | ~~132~~ ✓, 134 | Nutritionist JWT |
 | 140 | Auth0 Post-Login Action gate — first-login invitation validation | https://github.com/diego-torres/nutriconsultas/issues/140 | open | ~~133~~ ✓, 136 | **Post-Login** (not Pre-User-Registration — social logins skip PUR); docs + Action script |
 | 141 | Invitation security hardening — rate limits, enumeration protection, no-token logging | https://github.com/diego-torres/nutriconsultas/issues/141 | open | ~~133~~ ✓, 135, 136 | Relates #115; never log raw tokens |
 

--- a/docs/api/openapi-mobile.yaml
+++ b/docs/api/openapi-mobile.yaml
@@ -192,6 +192,77 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+  /rest/mobile/patient/me:
+    get:
+      tags:
+      - Mobile
+      summary: Get onboarding profile
+      description: Returns patient bootstrap profile and optional assigned diet plan
+        reference.
+      operationId: getProfile
+      responses:
+        "200":
+          description: Onboarding profile
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientOnboardingProfileDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientOnboardingProfileDto"
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientOnboardingProfileDto"
+    patch:
+      tags:
+      - Mobile
+      summary: Update onboarding profile
+      description: Patches onboarding fields; transitions status to ACTIVE when all
+        required fields are present.
+      operationId: updateProfile
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PatchPatientOnboardingProfileRequest"
+        required: true
+      responses:
+        "200":
+          description: Updated onboarding profile
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientOnboardingProfileDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientOnboardingProfileDto"
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientOnboardingProfileDto"
+        "400":
+          description: Validation failed
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientOnboardingProfileDto"
+        "429":
+          description: "Rate limit exceeded (Retry-After: 60)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientOnboardingProfileDto"
   /rest/mobile/patient/visits:
     get:
       tags:
@@ -718,6 +789,139 @@ components:
           type: string
           format: date-time
           description: Redemption timestamp (ISO-8601 instant)
+    PatchPatientOnboardingProfileRequest:
+      type: object
+      description: Patch patient onboarding profile
+      properties:
+        name:
+          type: string
+          description: Legal/clinical name
+          example: María López
+          maxLength: 100
+          minLength: 0
+        displayName:
+          type: string
+          description: Display name for mobile UI
+          example: María
+          maxLength: 100
+          minLength: 0
+        dob:
+          type: string
+          format: date
+          description: Date of birth (ISO-8601 date)
+          example: 1990-05-15
+        gender:
+          type: string
+          description: Gender (M/F)
+          example: F
+          pattern: "(?i)^[MF]$"
+        email:
+          type: string
+          description: Contact email
+          example: maria@example.com
+          maxLength: 100
+          minLength: 0
+        phone:
+          type: string
+          description: Contact phone
+          example: "+525512345678"
+          maxLength: 25
+          minLength: 0
+        avatarId:
+          type: string
+          description: Avatar id from catalog
+          example: avatar_6
+          maxLength: 32
+          minLength: 0
+    ApiResponsePatientOnboardingProfileDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/PatientOnboardingProfileDto"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    AssignedDietPlanReferenceDto:
+      type: object
+      description: Assigned diet plan reference
+      properties:
+        assignmentId:
+          type: integer
+          format: int64
+          description: PacienteDieta assignment id
+          example: 55
+        status:
+          type: string
+          description: Assignment status
+          enum:
+          - ACTIVE
+          - COMPLETED
+          - CANCELLED
+          example: ACTIVE
+        dietaName:
+          type: string
+          description: Diet display name
+          example: Plan hipocalórico
+    PatientOnboardingProfileDto:
+      type: object
+      description: Patient onboarding profile
+      properties:
+        pacienteId:
+          type: integer
+          format: int64
+          description: Paciente id
+          example: 1001
+        status:
+          type: string
+          description: Lifecycle status
+          enum:
+          - INVITED
+          - ONBOARDING
+          - ACTIVE
+          - REVOKED
+          example: ONBOARDING
+        name:
+          type: string
+          description: Legal/clinical name
+          example: María López
+        displayName:
+          type: string
+          description: Display name for mobile UI
+          example: María
+        dob:
+          type: string
+          format: date
+          description: Date of birth (ISO-8601 date)
+          example: 1990-05-15
+        gender:
+          type: string
+          description: Gender (M/F)
+          example: F
+        email:
+          type: string
+          description: Contact email
+          example: maria@example.com
+        phone:
+          type: string
+          description: Contact phone
+          example: "+525512345678"
+        avatarId:
+          type: string
+          description: Selected avatar id
+          example: avatar_6
+        assignedId:
+          type: string
+          description: Clinic-facing identifier
+          example: P-CLINIC-001
+        profileComplete:
+          type: boolean
+          description: True when all required onboarding fields are present
+          example: false
+        assignedDietPlan:
+          $ref: "#/components/schemas/AssignedDietPlanReferenceDto"
+          description: "Primary active diet assignment, when present"
     ApiResponsePagedResponseVisitSummaryDto:
       type: object
       properties:

--- a/docs/mobile-api/ALIGNMENT-SPEC.md
+++ b/docs/mobile-api/ALIGNMENT-SPEC.md
@@ -160,7 +160,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 - **Phase 0 DONE:** #107 (PR #117), #109 (PR #142), #110 (DTO envelope).
 - **Endpoints on `main`:** #91–#99 (visits, diet plans + PDF, messages, progress snapshot + measurements time series); #96/#97 messaging with HTTP 201 + Resilience4j 10/min (#113, PR #151).
 - **i18n (#111) DONE** (PR #151): `LocaleContextFilter`, `MobileApiErrorResponses`, localized 403/404/400/429.
-- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). Onboarding **#132–#137 done** (PR #326 for #137). **NEXT:** #138.
+- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). Onboarding **#132–#137 done** (PR #326 for #137). **in-progress:** #138.
 - `deltaPeso`/`deltaImc` are computed-at-query, not stored.
 - Progress `grasa` ambiguity: prefer `bodyComposition.porcentajeGrasaCorporal` (patient-facing %) over `indiceGrasaCorporal`.
 - Template dietas (seed `system:template-dietas`) have 4 ingestas incl. Colación — contract examples show only 3.
@@ -172,7 +172,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 
 ### F8.6 — Invitation onboarding gate (#132–#141)
 - **Prerequisites done on `main`:** #156 Paciente decomposition (PRs #175/#176/#178); #46 Liquibase baseline (PR #196). All new schema → incremental changesets per [`docs/db/LIQUIBASE.md`](../db/LIQUIBASE.md).
-- **Active sprint:** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ ~~#137~~ **done**; **NEXT:** #138–#141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
+- **Active sprint:** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ ~~#137~~ **done**; **in-progress:** #138; **NEXT:** #139–#141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
 - **Orthogonal:** nutritionist subscription invitations (`NutritionistInvitation` in subscription track) — see [`ISSUE-SUBSCRIPTION.md`](../../ISSUE-SUBSCRIPTION.md); do not conflate with patient `Invitation`.
 
 #### F8.6.1 — Token contract (AUTHORITATIVE; verified against `main` #133 code, 2026-06-21)

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -12,7 +12,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`MOBILE-E2E-STATUS.md`](MOBILE-E2E-STATUS.md) | Live E2E status, Auth0 setup, HTTP code matrix |
 | [`../api/openapi-mobile.yaml`](../api/openapi-mobile.yaml) | OpenAPI 3.1 export (#112, PR #164); regen: `scripts/export-openapi-mobile.sh` |
 
-**Status (2026-06-22):** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ ~~#137~~ done (PR [#326](https://github.com/diego-torres/nutriconsultas/pull/326)). **NEXT:** [#138](https://github.com/diego-torres/nutriconsultas/issues/138) onboarding profile.
+**Status (2026-06-22):** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ ~~#137~~ done (PR [#326](https://github.com/diego-torres/nutriconsultas/pull/326)). **in-progress:** [#138](https://github.com/diego-torres/nutriconsultas/issues/138) onboarding profile.
 
 ## Related registries (same repo)
 

--- a/src/main/java/com/nutriconsultas/mobile/MobileApiErrorResponses.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobileApiErrorResponses.java
@@ -31,6 +31,8 @@ public final class MobileApiErrorResponses {
 
 	public static final String KEY_PATIENT_ONBOARDING_REQUIRED = "error.patient.onboarding.required";
 
+	public static final String KEY_PATIENT_ONBOARDING_INVALID_AVATAR = "error.patient.onboarding.invalid_avatar";
+
 	public static final String KEY_RESOURCE_NOT_FOUND = "error.resource.not.found";
 
 	public static final String KEY_MESSAGE_TOO_LONG = "error.message.too.long";

--- a/src/main/java/com/nutriconsultas/mobile/MobileApiExceptionHandler.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobileApiExceptionHandler.java
@@ -55,6 +55,16 @@ public class MobileApiExceptionHandler {
 			.body(errorResponses.error(MobileApiErrorResponses.KEY_PATIENT_ONBOARDING_REQUIRED));
 	}
 
+	@ExceptionHandler(PatientOnboardingInvalidAvatarException.class)
+	public ResponseEntity<ApiResponse<Void>> handlePatientOnboardingInvalidAvatar(
+			final PatientOnboardingInvalidAvatarException ex) {
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile API onboarding invalid avatar");
+		}
+		return ResponseEntity.badRequest()
+			.body(errorResponses.error(MobileApiErrorResponses.KEY_PATIENT_ONBOARDING_INVALID_AVATAR));
+	}
+
 	@ExceptionHandler(SubscriptionLimitExceededException.class)
 	public ResponseEntity<ApiResponse<Void>> handleSubscriptionLimit(final SubscriptionLimitExceededException ex) {
 		if (log.isDebugEnabled()) {

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientOnboardingController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientOnboardingController.java
@@ -1,0 +1,65 @@
+package com.nutriconsultas.mobile;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nutriconsultas.mobile.config.MobileOpenApiResponses;
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.PatchPatientOnboardingProfileRequest;
+import com.nutriconsultas.mobile.dto.PatientOnboardingProfileDto;
+import com.nutriconsultas.util.LogRedaction;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/mobile/patient/me")
+@Tag(name = "Mobile", description = "Patient mobile API")
+@Slf4j
+public class MobilePatientOnboardingController extends AbstractMobilePatientController {
+
+	private final MobilePatientOnboardingService mobilePatientOnboardingService;
+
+	public MobilePatientOnboardingController(final PatientAuthService patientAuthService,
+			final MobilePatientOnboardingService mobilePatientOnboardingService) {
+		super(patientAuthService);
+		this.mobilePatientOnboardingService = mobilePatientOnboardingService;
+	}
+
+	@GetMapping
+	@Operation(summary = "Get onboarding profile",
+			description = "Returns patient bootstrap profile and optional assigned diet plan reference.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Onboarding profile")
+	public ApiResponse<PatientOnboardingProfileDto> getProfile(@AuthenticationPrincipal final Jwt jwt) {
+		final Long pacienteId = getAuthenticatedPacienteId(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile onboarding profile request for patient {}", LogRedaction.redactPaciente(pacienteId));
+		}
+		return ApiResponse.ok(mobilePatientOnboardingService.getProfile(pacienteId));
+	}
+
+	@PatchMapping
+	@Operation(summary = "Update onboarding profile",
+			description = "Patches onboarding fields; transitions status to ACTIVE when all required fields are present.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	@MobileOpenApiResponses.WriteEndpoint
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+			description = "Updated onboarding profile")
+	public ApiResponse<PatientOnboardingProfileDto> updateProfile(@AuthenticationPrincipal final Jwt jwt,
+			@Valid @RequestBody final PatchPatientOnboardingProfileRequest request) {
+		final Long pacienteId = getAuthenticatedPacienteId(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile onboarding profile patch for patient {}", LogRedaction.redactPaciente(pacienteId));
+		}
+		return ApiResponse.ok(mobilePatientOnboardingService.updateProfile(pacienteId, request));
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientOnboardingService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientOnboardingService.java
@@ -1,0 +1,116 @@
+package com.nutriconsultas.mobile;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nutriconsultas.mobile.dto.AssignedDietPlanReferenceDto;
+import com.nutriconsultas.mobile.dto.PatchPatientOnboardingProfileRequest;
+import com.nutriconsultas.mobile.dto.PatientOnboardingProfileDto;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteAvatarCatalog;
+import com.nutriconsultas.paciente.PacienteDieta;
+import com.nutriconsultas.paciente.PacienteDietaRepository;
+import com.nutriconsultas.paciente.PacienteDietaStatus;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class MobilePatientOnboardingService {
+
+	private final PacienteRepository pacienteRepository;
+
+	private final PacienteDietaRepository pacienteDietaRepository;
+
+	public MobilePatientOnboardingService(final PacienteRepository pacienteRepository,
+			final PacienteDietaRepository pacienteDietaRepository) {
+		this.pacienteRepository = pacienteRepository;
+		this.pacienteDietaRepository = pacienteDietaRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public PatientOnboardingProfileDto getProfile(final Long pacienteId) {
+		final Paciente paciente = requireOnboardingEligiblePatient(pacienteId);
+		final List<PacienteDieta> activeAssignments = pacienteDietaRepository.findByPacienteIdAndStatus(pacienteId,
+				PacienteDietaStatus.ACTIVE);
+		final AssignedDietPlanReferenceDto assignedDietPlan = PatientOnboardingProfileDto
+			.resolvePrimaryAssignment(activeAssignments);
+		if (log.isDebugEnabled()) {
+			log.debug("Loaded mobile onboarding profile for patient {}", LogRedaction.redactPaciente(pacienteId));
+		}
+		return PatientOnboardingProfileDto.fromEntity(paciente, assignedDietPlan);
+	}
+
+	@Transactional
+	public PatientOnboardingProfileDto updateProfile(final Long pacienteId,
+			final PatchPatientOnboardingProfileRequest request) {
+		final Paciente paciente = requireOnboardingEligiblePatient(pacienteId);
+		applyPatch(paciente, request);
+		maybeActivate(paciente);
+		final Paciente saved = pacienteRepository.save(paciente);
+		if (log.isInfoEnabled()) {
+			log.info("Updated mobile onboarding profile for patient {} status={}",
+					LogRedaction.redactPaciente(pacienteId), saved.getStatus());
+		}
+		return getProfile(saved.getId());
+	}
+
+	private Paciente requireOnboardingEligiblePatient(final Long pacienteId) {
+		final Paciente paciente = pacienteRepository.findById(pacienteId)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+		if (paciente.getStatus() != PacienteStatus.ONBOARDING && paciente.getStatus() != PacienteStatus.ACTIVE) {
+			throw new PatientOnboardingRequiredException();
+		}
+		return paciente;
+	}
+
+	private void applyPatch(final Paciente paciente, final PatchPatientOnboardingProfileRequest request) {
+		if (request.name() != null) {
+			paciente.setName(request.name().trim());
+		}
+		if (request.displayName() != null) {
+			paciente.setDisplayName(request.displayName().trim());
+		}
+		if (request.dob() != null) {
+			paciente.setDob(toDate(request.dob()));
+		}
+		if (request.gender() != null) {
+			paciente.setGender(request.gender().trim().toUpperCase(Locale.ROOT));
+		}
+		if (request.email() != null) {
+			paciente.setEmail(request.email().trim().toLowerCase(Locale.ROOT));
+		}
+		if (request.phone() != null) {
+			paciente.setPhone(request.phone().trim());
+		}
+		if (request.avatarId() != null) {
+			final String avatarId = request.avatarId().trim();
+			if (!PacienteAvatarCatalog.isValid(avatarId)) {
+				throw new PatientOnboardingInvalidAvatarException();
+			}
+			paciente.setAvatarId(avatarId);
+		}
+	}
+
+	private void maybeActivate(final Paciente paciente) {
+		if (paciente.getStatus() == PacienteStatus.ONBOARDING && PatientOnboardingCompleteness.isComplete(paciente)) {
+			paciente.setStatus(PacienteStatus.ACTIVE);
+		}
+	}
+
+	private static Date toDate(final LocalDate dob) {
+		return Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/PatientOnboardingCompleteness.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientOnboardingCompleteness.java
@@ -1,0 +1,33 @@
+package com.nutriconsultas.mobile;
+
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteAvatarCatalog;
+
+/**
+ * Required-field checks for mobile onboarding profile completion (#138).
+ */
+public final class PatientOnboardingCompleteness {
+
+	private PatientOnboardingCompleteness() {
+	}
+
+	public static boolean isComplete(final Paciente paciente) {
+		if (paciente == null) {
+			return false;
+		}
+		return StringUtils.hasText(paciente.getName()) && paciente.getDob() != null
+				&& isValidGender(paciente.getGender()) && StringUtils.hasText(paciente.getDisplayName())
+				&& PacienteAvatarCatalog.isValid(paciente.getAvatarId());
+	}
+
+	private static boolean isValidGender(final String gender) {
+		if (!StringUtils.hasText(gender)) {
+			return false;
+		}
+		final String normalized = gender.trim().toUpperCase();
+		return "M".equals(normalized) || "F".equals(normalized);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/PatientOnboardingInvalidAvatarException.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientOnboardingInvalidAvatarException.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.mobile;
+
+/**
+ * Invalid avatar id in onboarding profile patch (#138).
+ */
+public final class PatientOnboardingInvalidAvatarException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/AssignedDietPlanReferenceDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/AssignedDietPlanReferenceDto.java
@@ -1,0 +1,17 @@
+package com.nutriconsultas.mobile.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.nutriconsultas.paciente.PacienteDietaStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Lightweight assigned diet plan pointer for onboarding bootstrap (#138).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Assigned diet plan reference")
+public record AssignedDietPlanReferenceDto(
+		@Schema(description = "PacienteDieta assignment id", example = "55") Long assignmentId,
+		@Schema(description = "Assignment status", example = "ACTIVE") PacienteDietaStatus status,
+		@Schema(description = "Diet display name", example = "Plan hipocalórico") String dietaName) {
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/PatchPatientOnboardingProfileRequest.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/PatchPatientOnboardingProfileRequest.java
@@ -1,0 +1,23 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.time.LocalDate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Partial onboarding profile update for {@code PATCH /rest/mobile/patient/me} (#138).
+ */
+@Schema(description = "Patch patient onboarding profile")
+public record PatchPatientOnboardingProfileRequest(
+		@Size(max = 100) @Schema(description = "Legal/clinical name", example = "María López") String name,
+		@Size(max = 100) @Schema(description = "Display name for mobile UI", example = "María") String displayName,
+		@Schema(description = "Date of birth (ISO-8601 date)", example = "1990-05-15") LocalDate dob,
+		@Pattern(regexp = "(?i)^[MF]$", message = "must be M or F") @Schema(description = "Gender (M/F)",
+				example = "F") String gender,
+		@Email @Size(max = 100) @Schema(description = "Contact email", example = "maria@example.com") String email,
+		@Size(max = 25) @Schema(description = "Contact phone", example = "+525512345678") String phone,
+		@Size(max = 32) @Schema(description = "Avatar id from catalog", example = "avatar_6") String avatarId) {
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/PatientOnboardingProfileDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/PatientOnboardingProfileDto.java
@@ -1,0 +1,70 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.nutriconsultas.mobile.PatientOnboardingCompleteness;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteDieta;
+import com.nutriconsultas.paciente.PacienteDietaStatus;
+import com.nutriconsultas.paciente.PacienteStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Patient onboarding bootstrap profile for {@code GET /rest/mobile/patient/me} (#138).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Patient onboarding profile")
+public record PatientOnboardingProfileDto(@Schema(description = "Paciente id", example = "1001") Long pacienteId,
+		@Schema(description = "Lifecycle status", example = "ONBOARDING") PacienteStatus status,
+		@Schema(description = "Legal/clinical name", example = "María López") String name,
+		@Schema(description = "Display name for mobile UI", example = "María") String displayName,
+		@Schema(description = "Date of birth (ISO-8601 date)", example = "1990-05-15") LocalDate dob,
+		@Schema(description = "Gender (M/F)", example = "F") String gender,
+		@Schema(description = "Contact email", example = "maria@example.com") String email,
+		@Schema(description = "Contact phone", example = "+525512345678") String phone,
+		@Schema(description = "Selected avatar id", example = "avatar_6") String avatarId,
+		@Schema(description = "Clinic-facing identifier", example = "P-CLINIC-001") String assignedId,
+		@Schema(description = "True when all required onboarding fields are present",
+				example = "false") boolean profileComplete,
+		@Schema(description = "Primary active diet assignment, when present") AssignedDietPlanReferenceDto assignedDietPlan) {
+
+	public static PatientOnboardingProfileDto fromEntity(final Paciente paciente,
+			final AssignedDietPlanReferenceDto assignedDietPlan) {
+		return new PatientOnboardingProfileDto(paciente.getId(), paciente.getStatus(), paciente.getName(),
+				paciente.getDisplayName(), toLocalDate(paciente.getDob()), paciente.getGender(), paciente.getEmail(),
+				paciente.getPhone(), paciente.getAvatarId(), paciente.getAssignedId(),
+				PatientOnboardingCompleteness.isComplete(paciente), assignedDietPlan);
+	}
+
+	public static AssignedDietPlanReferenceDto toAssignedDietPlanReference(final PacienteDieta assignment) {
+		if (assignment == null) {
+			return null;
+		}
+		final String dietaName = assignment.getDieta() != null ? assignment.getDieta().getNombre() : null;
+		return new AssignedDietPlanReferenceDto(assignment.getId(), assignment.getStatus(), dietaName);
+	}
+
+	public static AssignedDietPlanReferenceDto resolvePrimaryAssignment(final List<PacienteDieta> assignments) {
+		return assignments.stream()
+			.filter(assignment -> assignment.getStatus() == PacienteDietaStatus.ACTIVE)
+			.findFirst()
+			.map(PatientOnboardingProfileDto::toAssignedDietPlanReference)
+			.orElse(null);
+	}
+
+	private static LocalDate toLocalDate(final Date date) {
+		if (date == null) {
+			return null;
+		}
+		if (date instanceof java.sql.Date sqlDate) {
+			return sqlDate.toLocalDate();
+		}
+		return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+	}
+
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,5 +1,6 @@
 error.patient.not.linked=Patient account is not linked.
 error.patient.onboarding.required=Complete onboarding to access this resource.
+error.patient.onboarding.invalid_avatar=Select a valid avatar.
 error.resource.not.found=Resource not found.
 error.message.too.long=Message is too long.
 error.message.required=Message text is required.

--- a/src/main/resources/messages_es_MX.properties
+++ b/src/main/resources/messages_es_MX.properties
@@ -1,5 +1,6 @@
 error.patient.not.linked=La cuenta del paciente no está vinculada.
 error.patient.onboarding.required=Completa el registro para acceder a este recurso.
+error.patient.onboarding.invalid_avatar=Selecciona un avatar válido.
 error.resource.not.found=Recurso no encontrado.
 error.message.too.long=El mensaje es demasiado largo.
 error.message.required=El texto del mensaje es obligatorio.

--- a/src/test/java/com/nutriconsultas/mobile/MobileOpenApiIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileOpenApiIntegrationTest.java
@@ -32,7 +32,7 @@ class MobileOpenApiIntegrationTest {
 			"/rest/mobile/patient/visits/{visitId}", "/rest/mobile/patient/diet-plans",
 			"/rest/mobile/patient/diet-plans/{assignmentId}", "/rest/mobile/patient/diet-plans/{assignmentId}/pdf",
 			"/rest/mobile/patient/messages", "/rest/mobile/patient/progress",
-			"/rest/mobile/patient/progress/measurements", "/rest/mobile/invitations",
+			"/rest/mobile/patient/progress/measurements", "/rest/mobile/patient/me", "/rest/mobile/invitations",
 			"/rest/mobile/invitations/{token}/preview", "/rest/mobile/invitations/{token}/redeem");
 
 	@Autowired
@@ -56,6 +56,8 @@ class MobileOpenApiIntegrationTest {
 		}
 		assertThat(paths.path("/rest/mobile/patient/messages").has("get")).isTrue();
 		assertThat(paths.path("/rest/mobile/patient/messages").has("post")).isTrue();
+		assertThat(paths.path("/rest/mobile/patient/me").has("get")).isTrue();
+		assertThat(paths.path("/rest/mobile/patient/me").has("patch")).isTrue();
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientOnboardingControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientOnboardingControllerTest.java
@@ -1,0 +1,75 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.PatchPatientOnboardingProfileRequest;
+import com.nutriconsultas.mobile.dto.PatientOnboardingProfileDto;
+import com.nutriconsultas.paciente.PacienteAvatarCatalog;
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
+
+@ExtendWith(MockitoExtension.class)
+class MobilePatientOnboardingControllerTest {
+
+	private static final String PATIENT_SUB = "auth0|onboarding-patient";
+
+	@InjectMocks
+	private MobilePatientOnboardingController controller;
+
+	@Mock
+	private PatientAuthService patientAuthService;
+
+	@Mock
+	private MobilePatientOnboardingService mobilePatientOnboardingService;
+
+	@Test
+	void getProfile_returnsEnvelope() {
+		final Jwt jwt = jwtWithSub(PATIENT_SUB);
+		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(
+				MobileTestPacienteAuthViews.authView(12L, PATIENT_SUB, "nutritionist-sub", PacienteStatus.ONBOARDING));
+		final PatientOnboardingProfileDto profile = new PatientOnboardingProfileDto(12L, PacienteStatus.ONBOARDING,
+				"María López", "María", LocalDate.of(1990, 5, 15), "F", "maria@example.com", null, null, "P-001", false,
+				null);
+		when(mobilePatientOnboardingService.getProfile(12L)).thenReturn(profile);
+
+		final ApiResponse<PatientOnboardingProfileDto> response = controller.getProfile(jwt);
+
+		assertThat(response.data()).isEqualTo(profile);
+		verify(mobilePatientOnboardingService).getProfile(12L);
+	}
+
+	@Test
+	void updateProfile_delegatesToService() {
+		final Jwt jwt = jwtWithSub(PATIENT_SUB);
+		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(
+				MobileTestPacienteAuthViews.authView(12L, PATIENT_SUB, "nutritionist-sub", PacienteStatus.ONBOARDING));
+		final PatchPatientOnboardingProfileRequest request = new PatchPatientOnboardingProfileRequest(null, null, null,
+				null, null, null, PacienteAvatarCatalog.DEFAULT_FEMALE_ID);
+		final PatientOnboardingProfileDto profile = new PatientOnboardingProfileDto(12L, PacienteStatus.ACTIVE,
+				"María López", "María", LocalDate.of(1990, 5, 15), "F", "maria@example.com", null,
+				PacienteAvatarCatalog.DEFAULT_FEMALE_ID, "P-001", true, null);
+		when(mobilePatientOnboardingService.updateProfile(12L, request)).thenReturn(profile);
+
+		final ApiResponse<PatientOnboardingProfileDto> response = controller.updateProfile(jwt, request);
+
+		assertThat(response.data().status()).isEqualTo(PacienteStatus.ACTIVE);
+		verify(mobilePatientOnboardingService).updateProfile(12L, request);
+	}
+
+	private static Jwt jwtWithSub(final String subject) {
+		return Jwt.withTokenValue("token").header("alg", "none").subject(subject).build();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientOnboardingIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientOnboardingIntegrationTest.java
@@ -1,0 +1,99 @@
+package com.nutriconsultas.mobile;
+
+import static com.nutriconsultas.mobile.MobileIntegrationTestJwt.mobileJwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteAvatarCatalog;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteStatus;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MobilePatientOnboardingIntegrationTest {
+
+	private static final String ONBOARDING_SUB = "auth0|mobile-onboarding-profile";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@BeforeEach
+	void seedOnboardingPatient() {
+		final Paciente existing = pacienteRepository.findByPatientAuthSub(ONBOARDING_SUB).orElse(null);
+		if (existing != null) {
+			existing.setStatus(PacienteStatus.ONBOARDING);
+			existing.setAvatarId(null);
+			existing.setName("María López");
+			existing.setDisplayName("María");
+			pacienteRepository.saveAndFlush(existing);
+			return;
+		}
+		final Paciente paciente = new Paciente();
+		paciente.setName("María López");
+		paciente.setDisplayName("María");
+		paciente.setUserId("nutritionist-sub");
+		paciente.setPatientAuthSub(ONBOARDING_SUB);
+		paciente.setStatus(PacienteStatus.ONBOARDING);
+		paciente.setGender("F");
+		paciente.setEmail("maria.onboarding@example.com");
+		final LocalDate dob = LocalDate.of(1990, 5, 15);
+		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		pacienteRepository.saveAndFlush(paciente);
+	}
+
+	@Test
+	void getProfile_withOnboardingJwt_returnsProfile() throws Exception {
+		mockMvc.perform(get("/rest/mobile/patient/me").with(mobileJwt(ONBOARDING_SUB)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.status").value("ONBOARDING"))
+			.andExpect(jsonPath("$.data.profileComplete").value(false))
+			.andExpect(jsonPath("$.data.name").value("María López"));
+	}
+
+	@Test
+	void patchProfile_withAvatar_transitionsToActive() throws Exception {
+		mockMvc
+			.perform(patch("/rest/mobile/patient/me").with(mobileJwt(ONBOARDING_SUB))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"avatarId\":\"" + PacienteAvatarCatalog.DEFAULT_FEMALE_ID + "\"}"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.status").value("ACTIVE"))
+			.andExpect(jsonPath("$.data.profileComplete").value(true))
+			.andExpect(jsonPath("$.data.avatarId").value(PacienteAvatarCatalog.DEFAULT_FEMALE_ID));
+
+		mockMvc.perform(get("/rest/mobile/patient/visits").with(mobileJwt(ONBOARDING_SUB)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content").isArray());
+	}
+
+	@Test
+	void patchProfile_withInvalidAvatar_returnsBadRequest() throws Exception {
+		mockMvc
+			.perform(patch("/rest/mobile/patient/me").with(mobileJwt(ONBOARDING_SUB))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"avatarId\":\"invalid-avatar\"}"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("Selecciona un avatar válido."));
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientOnboardingServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientOnboardingServiceTest.java
@@ -1,0 +1,93 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.mobile.dto.PatchPatientOnboardingProfileRequest;
+import com.nutriconsultas.mobile.dto.PatientOnboardingProfileDto;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteAvatarCatalog;
+import com.nutriconsultas.paciente.PacienteDietaRepository;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteStatus;
+
+@ExtendWith(MockitoExtension.class)
+class MobilePatientOnboardingServiceTest {
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Mock
+	private PacienteDietaRepository pacienteDietaRepository;
+
+	@InjectMocks
+	private MobilePatientOnboardingService service;
+
+	@Test
+	void updateProfile_transitionsToActiveWhenComplete() {
+		final Paciente paciente = sampleOnboardingPaciente(9L);
+		when(pacienteRepository.findById(9L)).thenReturn(Optional.of(paciente));
+		when(pacienteRepository.save(any(Paciente.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		when(pacienteDietaRepository.findByPacienteIdAndStatus(9L,
+				com.nutriconsultas.paciente.PacienteDietaStatus.ACTIVE))
+			.thenReturn(List.of());
+
+		final PatientOnboardingProfileDto updated = service.updateProfile(9L, new PatchPatientOnboardingProfileRequest(
+				null, null, null, null, null, null, PacienteAvatarCatalog.DEFAULT_FEMALE_ID));
+
+		final ArgumentCaptor<Paciente> captor = ArgumentCaptor.forClass(Paciente.class);
+		verify(pacienteRepository).save(captor.capture());
+		assertThat(captor.getValue().getStatus()).isEqualTo(PacienteStatus.ACTIVE);
+		assertThat(updated.status()).isEqualTo(PacienteStatus.ACTIVE);
+		assertThat(updated.profileComplete()).isTrue();
+	}
+
+	@Test
+	void updateProfile_rejectsInvalidAvatar() {
+		final Paciente paciente = sampleOnboardingPaciente(9L);
+		when(pacienteRepository.findById(9L)).thenReturn(Optional.of(paciente));
+
+		assertThatThrownBy(() -> service.updateProfile(9L,
+				new PatchPatientOnboardingProfileRequest(null, null, null, null, null, null, "not-an-avatar")))
+			.isInstanceOf(PatientOnboardingInvalidAvatarException.class);
+	}
+
+	@Test
+	void getProfile_rejectsInvitedStatus() {
+		final Paciente paciente = sampleOnboardingPaciente(9L);
+		paciente.setStatus(PacienteStatus.INVITED);
+		when(pacienteRepository.findById(9L)).thenReturn(Optional.of(paciente));
+
+		assertThatThrownBy(() -> service.getProfile(9L)).isInstanceOf(PatientOnboardingRequiredException.class);
+	}
+
+	private static Paciente sampleOnboardingPaciente(final Long id) {
+		final Paciente paciente = new Paciente();
+		paciente.setId(id);
+		paciente.setName("María López");
+		paciente.setDisplayName("María");
+		paciente.setGender("F");
+		paciente.setStatus(PacienteStatus.ONBOARDING);
+		paciente.setUserId("nutritionist-sub");
+		final LocalDate dob = LocalDate.of(1990, 5, 15);
+		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		return paciente;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/PatientOnboardingCompletenessTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/PatientOnboardingCompletenessTest.java
@@ -1,0 +1,45 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteAvatarCatalog;
+import com.nutriconsultas.paciente.PacienteStatus;
+
+class PatientOnboardingCompletenessTest {
+
+	@Test
+	void isComplete_returnsFalseWhenAvatarMissing() {
+		final Paciente paciente = samplePaciente(PacienteStatus.ONBOARDING);
+		paciente.setAvatarId(null);
+
+		assertThat(PatientOnboardingCompleteness.isComplete(paciente)).isFalse();
+	}
+
+	@Test
+	void isComplete_returnsTrueWhenRequiredFieldsPresent() {
+		final Paciente paciente = samplePaciente(PacienteStatus.ONBOARDING);
+		paciente.setAvatarId(PacienteAvatarCatalog.DEFAULT_FEMALE_ID);
+
+		assertThat(PatientOnboardingCompleteness.isComplete(paciente)).isTrue();
+	}
+
+	private static Paciente samplePaciente(final PacienteStatus status) {
+		final Paciente paciente = new Paciente();
+		paciente.setName("María López");
+		paciente.setDisplayName("María");
+		paciente.setGender("F");
+		paciente.setStatus(status);
+		paciente.setUserId("nutritionist-sub");
+		final LocalDate dob = LocalDate.of(1990, 5, 15);
+		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		return paciente;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `GET` and `PATCH /rest/mobile/patient/me` for patient onboarding bootstrap and profile updates.
- Transition `ONBOARDING` → `ACTIVE` when required fields are complete (name, displayName, dob, gender, valid avatarId).
- Return optional active assigned diet plan reference; localized invalid-avatar validation.
- Regenerate `openapi-mobile.yaml`; sync mobile API registry (#138 in-progress → done on merge, #139 NEXT).

Closes #138.

## Test plan
- [x] `./lint.sh` and `mvn pmd:check -Pci`
- [x] `PatientOnboardingCompletenessTest`, `MobilePatientOnboardingServiceTest`, `MobilePatientOnboardingControllerTest`
- [x] `MobilePatientOnboardingIntegrationTest` (profile GET, PATCH→ACTIVE unlocks visits, invalid avatar 400)
- [x] `MobileOpenApiIntegrationTest` documents `/rest/mobile/patient/me`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)