### PR TITLE
feat(mobile-api): nutritionist invitation revoke endpoint (#139)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -41,7 +41,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (public booking):** None — epic ~~#245~~ **done**; ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~, ~~#300~~, ~~#302~~ done. Deferred follow-ups need new issues. See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
-**Current next issue (mobile):** [#139 — POST /rest/mobile/invitations/{id}/revoke](https://github.com/diego-torres/nutriconsultas/issues/139) (**NEXT**). ~~#138~~ done (PR [#328](https://github.com/diego-torres/nutriconsultas/pull/328)).
+**Current next issue (mobile):** [#139 — POST /rest/mobile/invitations/{id}/revoke](https://github.com/diego-torres/nutriconsultas/issues/139) (**in-progress**). ~~#138~~ done (PR [#328](https://github.com/diego-torres/nutriconsultas/pull/328)).
 
 **Current next issue (subscription):** Registered track **complete** (~~#244~~ ✓ on `subscription/244-contact-form-prefill`). Triage open `[Subscription]` GitHub issues. See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
 
@@ -409,7 +409,7 @@ gh pr create ...
 | Field | Value |
 |-------|-------|
 | **Next issue** | [#139 — POST /rest/mobile/invitations/{id}/revoke](https://github.com/diego-torres/nutriconsultas/issues/139) |
-| **Status** | **NEXT** — unblocked on `main` |
+| **Status** | **in-progress** — branch `mobile-api/139-invitation-revoke` |
 | **Just completed** | [#135 preview](https://github.com/diego-torres/nutriconsultas/issues/135) — PR [#324](https://github.com/diego-torres/nutriconsultas/pull/324) |
 
 ### Upcoming gates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -590,7 +590,7 @@ Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 
-**Next:** [#139](https://github.com/diego-torres/nutriconsultas/issues/139) invitation revoke (**NEXT**). ~~#138~~ done (PR [#328](https://github.com/diego-torres/nutriconsultas/pull/328)). ~~#137~~ done (PR [#326](https://github.com/diego-torres/nutriconsultas/pull/326)). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) — registered track **complete** (~~#244~~ ✓).
+**Next:** [#139](https://github.com/diego-torres/nutriconsultas/issues/139) invitation revoke (**in-progress**). ~~#138~~ done (PR [#328](https://github.com/diego-torres/nutriconsultas/pull/328)).
 
 **Schema gate (post-#46):** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline is on `main` (PR #196). All new schema/catalog changes require **incremental Liquibase changesets** — see [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) and [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md). ~~#156~~ Phase C done before baseline.
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) · **Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-22 — ~~#138~~ **done** (PR [#328](https://github.com/diego-torres/nutriconsultas/pull/328)). **NEXT:** [#139 invitation revoke](https://github.com/diego-torres/nutriconsultas/issues/139).
+**Last updated:** 2026-06-22 — ~~#138~~ **done** (PR [#328](https://github.com/diego-torres/nutriconsultas/pull/328)). **in-progress:** [#139 invitation revoke](https://github.com/diego-torres/nutriconsultas/issues/139) (`mobile-api/139-invitation-revoke`).
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -49,7 +49,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156**, **#46**, **#132**, **#133**, **#134**, **#135**, **#136**, **#137**, and **#138** done on `main`. **NEXT:** #139.
+Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156**, **#46**, **#132**, **#133**, **#134**, **#135**, **#136**, **#137**, and **#138** done on `main`. **in-progress:** #139.
 
 ---
 
@@ -138,7 +138,7 @@ Schema-affecting work must respect mobile DTO contracts (§F8). These issues are
 
 ## Phase 2 — Invitation onboarding (P1 · ~~#132~~ ✓ ~~#133~~ ✓ → #134–#141)
 
-Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Active sprint** — profile **#138 done** (PR #328); **NEXT:** #139 revoke.
+Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Active sprint** — **in-progress:** #139 invitation revoke.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
@@ -148,8 +148,8 @@ Invite-only patient onboarding replaces manual Afiliación linkage (#109) for ne
 | 136 | `POST /rest/mobile/invitations/{token}/redeem` — bind Auth0 sub → patient | https://github.com/diego-torres/nutriconsultas/issues/136 | **done** | ~~132~~ ✓, ~~133~~ ✓, 107 | Merged PR [#325](https://github.com/diego-torres/nutriconsultas/pull/325) |
 | 137 | CurrentPatient resolver + onboarding data gate (403 onboarding required) | https://github.com/diego-torres/nutriconsultas/issues/137 | **done** | ~~132~~ ✓, 107 | Merged PR [#326](https://github.com/diego-torres/nutriconsultas/pull/326) |
 | 138 | `PATCH` & `GET /rest/mobile/patient/me` — onboarding profile + status→ACTIVE | https://github.com/diego-torres/nutriconsultas/issues/138 | **done** | ~~132~~ ✓, ~~137~~ ✓ | Merged PR [#328](https://github.com/diego-torres/nutriconsultas/pull/328) |
-| 139 | `POST /rest/mobile/invitations/{id}/revoke` — nutritionist invalidates invite | https://github.com/diego-torres/nutriconsultas/issues/139 | **NEXT** | ~~132~~ ✓, 134 | Nutritionist JWT |
-| 140 | Auth0 Post-Login Action gate — first-login invitation validation | https://github.com/diego-torres/nutriconsultas/issues/140 | open | ~~133~~ ✓, 136 | **Post-Login** (not Pre-User-Registration — social logins skip PUR); docs + Action script |
+| 139 | `POST /rest/mobile/invitations/{id}/revoke` — nutritionist invalidates invite | https://github.com/diego-torres/nutriconsultas/issues/139 | **in-progress** | ~~132~~ ✓, 134 | Nutritionist JWT; IDOR → 404 |
+| 140 | Auth0 Post-Login Action gate — first-login invitation validation | https://github.com/diego-torres/nutriconsultas/issues/140 | **NEXT** | ~~133~~ ✓, 136 | **Post-Login** (not Pre-User-Registration — social logins skip PUR); docs + Action script |
 | 141 | Invitation security hardening — rate limits, enumeration protection, no-token logging | https://github.com/diego-torres/nutriconsultas/issues/141 | open | ~~133~~ ✓, 135, 136 | Relates #115; never log raw tokens |
 
 **Suggested build order (after ~~#133~~ ✓):** #134/#135 → #136 → #137 → #138 → #139/#140 → #141.

--- a/docs/api/openapi-mobile.yaml
+++ b/docs/api/openapi-mobile.yaml
@@ -192,6 +192,46 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+  /rest/mobile/invitations/{id}/revoke:
+    post:
+      tags:
+      - Mobile Invitations
+      summary: Revoke patient invitation
+      description: Nutritionist JWT invalidates an outstanding pending invitation;
+        idempotent when already revoked.
+      operationId: revokeInvitation
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: Invitation revoked or already revoked
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRevokedPatientInvitationDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRevokedPatientInvitationDto"
+        "403":
+          description: Subscription limit or entitlement denied
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRevokedPatientInvitationDto"
+        "404":
+          description: Resource not found or not owned by patient
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRevokedPatientInvitationDto"
   /rest/mobile/patient/me:
     get:
       tags:
@@ -789,6 +829,39 @@ components:
           type: string
           format: date-time
           description: Redemption timestamp (ISO-8601 instant)
+    ApiResponseRevokedPatientInvitationDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/RevokedPatientInvitationDto"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    RevokedPatientInvitationDto:
+      type: object
+      description: Revoked patient invitation
+      properties:
+        invitationId:
+          type: integer
+          format: int64
+          description: Invitation row id
+          example: 42
+        pacienteId:
+          type: integer
+          format: int64
+          description: Linked Paciente id
+          example: 1001
+        status:
+          type: string
+          description: Invitation status after revoke
+          enum:
+          - PENDING
+          - REDEEMED
+          - EXPIRED
+          - REVOKED
+          example: REVOKED
     PatchPatientOnboardingProfileRequest:
       type: object
       description: Patch patient onboarding profile

--- a/docs/mobile-api/ALIGNMENT-SPEC.md
+++ b/docs/mobile-api/ALIGNMENT-SPEC.md
@@ -160,7 +160,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 - **Phase 0 DONE:** #107 (PR #117), #109 (PR #142), #110 (DTO envelope).
 - **Endpoints on `main`:** #91–#99 (visits, diet plans + PDF, messages, progress snapshot + measurements time series); #96/#97 messaging with HTTP 201 + Resilience4j 10/min (#113, PR #151).
 - **i18n (#111) DONE** (PR #151): `LocaleContextFilter`, `MobileApiErrorResponses`, localized 403/404/400/429.
-- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). Onboarding **#132–#138 done** (PR #328 for #138). **NEXT:** #139.
+- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). Onboarding **#132–#138 done** (PR #328 for #138). **in-progress:** #139.
 - `deltaPeso`/`deltaImc` are computed-at-query, not stored.
 - Progress `grasa` ambiguity: prefer `bodyComposition.porcentajeGrasaCorporal` (patient-facing %) over `indiceGrasaCorporal`.
 - Template dietas (seed `system:template-dietas`) have 4 ingestas incl. Colación — contract examples show only 3.
@@ -172,7 +172,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 
 ### F8.6 — Invitation onboarding gate (#132–#141)
 - **Prerequisites done on `main`:** #156 Paciente decomposition (PRs #175/#176/#178); #46 Liquibase baseline (PR #196). All new schema → incremental changesets per [`docs/db/LIQUIBASE.md`](../db/LIQUIBASE.md).
-- **Active sprint:** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ ~~#137~~ ~~#138~~ **done**; **NEXT:** #139–#141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
+- **Active sprint:** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ ~~#137~~ ~~#138~~ **done**; **in-progress:** #139; **NEXT:** #140–#141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
 - **Orthogonal:** nutritionist subscription invitations (`NutritionistInvitation` in subscription track) — see [`ISSUE-SUBSCRIPTION.md`](../../ISSUE-SUBSCRIPTION.md); do not conflate with patient `Invitation`.
 
 #### F8.6.1 — Token contract (AUTHORITATIVE; verified against `main` #133 code, 2026-06-21)

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -12,7 +12,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`MOBILE-E2E-STATUS.md`](MOBILE-E2E-STATUS.md) | Live E2E status, Auth0 setup, HTTP code matrix |
 | [`../api/openapi-mobile.yaml`](../api/openapi-mobile.yaml) | OpenAPI 3.1 export (#112, PR #164); regen: `scripts/export-openapi-mobile.sh` |
 
-**Status (2026-06-22):** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ ~~#137~~ ~~#138~~ done (PR [#328](https://github.com/diego-torres/nutriconsultas/pull/328)). **NEXT:** [#139](https://github.com/diego-torres/nutriconsultas/issues/139) invitation revoke.
+**Status (2026-06-22):** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ ~~#137~~ ~~#138~~ done (PR [#328](https://github.com/diego-torres/nutriconsultas/pull/328)). **in-progress:** [#139](https://github.com/diego-torres/nutriconsultas/issues/139) invitation revoke.
 
 ## Related registries (same repo)
 

--- a/src/main/java/com/nutriconsultas/mobile/MobileApiErrorResponses.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobileApiErrorResponses.java
@@ -53,6 +53,8 @@ public final class MobileApiErrorResponses {
 
 	public static final String KEY_INVITATION_PATIENT_STATUS = "error.invitation.patient_status";
 
+	public static final String KEY_INVITATION_REVOKE_NOT_ALLOWED = "error.invitation.revoke_not_allowed";
+
 	private final MessageSource messageSource;
 
 	private final ObjectMapper objectMapper;

--- a/src/main/java/com/nutriconsultas/mobile/MobileApiExceptionHandler.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobileApiExceptionHandler.java
@@ -141,6 +141,26 @@ public class MobileApiExceptionHandler {
 			.body(errorResponses.error(MobileApiErrorResponses.KEY_INVITATION_PATIENT_STATUS));
 	}
 
+	@ExceptionHandler(PatientInvitationRevokeNotFoundException.class)
+	public ResponseEntity<ApiResponse<Void>> handleInvitationRevokeNotFound(
+			final PatientInvitationRevokeNotFoundException ex) {
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile API invitation revoke not found");
+		}
+		return ResponseEntity.status(HttpStatus.NOT_FOUND)
+			.body(errorResponses.error(MobileApiErrorResponses.KEY_INVITATION_UNAVAILABLE));
+	}
+
+	@ExceptionHandler(PatientInvitationRevokeNotAllowedException.class)
+	public ResponseEntity<ApiResponse<Void>> handleInvitationRevokeNotAllowed(
+			final PatientInvitationRevokeNotAllowedException ex) {
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile API invitation revoke not allowed");
+		}
+		return ResponseEntity.status(HttpStatus.CONFLICT)
+			.body(errorResponses.error(MobileApiErrorResponses.KEY_INVITATION_REVOKE_NOT_ALLOWED));
+	}
+
 	@ExceptionHandler(RequestNotPermitted.class)
 	public ResponseEntity<ApiResponse<Void>> handleRateLimitExceeded(final RequestNotPermitted ex) {
 		if (log.isDebugEnabled()) {

--- a/src/main/java/com/nutriconsultas/mobile/MobileInvitationController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobileInvitationController.java
@@ -18,12 +18,15 @@ import com.nutriconsultas.mobile.dto.CreatePatientInvitationRequest;
 import com.nutriconsultas.mobile.dto.CreatedPatientInvitationDto;
 import com.nutriconsultas.mobile.dto.PatientInvitationPreviewDto;
 import com.nutriconsultas.mobile.dto.RedeemedPatientInvitationDto;
+import com.nutriconsultas.mobile.dto.RevokedPatientInvitationDto;
 import com.nutriconsultas.paciente.invitation.CreatedPatientInvitationResult;
 import com.nutriconsultas.paciente.invitation.PatientInvitationCreateService;
 import com.nutriconsultas.paciente.invitation.PatientInvitationPreviewResult;
 import com.nutriconsultas.paciente.invitation.PatientInvitationPreviewService;
 import com.nutriconsultas.paciente.invitation.PatientInvitationRedeemResult;
 import com.nutriconsultas.paciente.invitation.PatientInvitationRedeemService;
+import com.nutriconsultas.paciente.invitation.PatientInvitationRevokeResult;
+import com.nutriconsultas.paciente.invitation.PatientInvitationRevokeService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
@@ -48,16 +51,20 @@ public class MobileInvitationController {
 
 	private final PatientInvitationRedeemRateLimiter patientInvitationRedeemRateLimiter;
 
+	private final PatientInvitationRevokeService patientInvitationRevokeService;
+
 	public MobileInvitationController(final PatientInvitationCreateService patientInvitationCreateService,
 			final PatientInvitationPreviewService patientInvitationPreviewService,
 			final PatientInvitationPreviewRateLimiter patientInvitationPreviewRateLimiter,
 			final PatientInvitationRedeemService patientInvitationRedeemService,
-			final PatientInvitationRedeemRateLimiter patientInvitationRedeemRateLimiter) {
+			final PatientInvitationRedeemRateLimiter patientInvitationRedeemRateLimiter,
+			final PatientInvitationRevokeService patientInvitationRevokeService) {
 		this.patientInvitationCreateService = patientInvitationCreateService;
 		this.patientInvitationPreviewService = patientInvitationPreviewService;
 		this.patientInvitationPreviewRateLimiter = patientInvitationPreviewRateLimiter;
 		this.patientInvitationRedeemService = patientInvitationRedeemService;
 		this.patientInvitationRedeemRateLimiter = patientInvitationRedeemRateLimiter;
+		this.patientInvitationRevokeService = patientInvitationRevokeService;
 	}
 
 	@PostMapping
@@ -113,6 +120,24 @@ public class MobileInvitationController {
 		final PatientInvitationRedeemResult redeemed = patientInvitationRedeemRateLimiter.execute(patientAuthSub,
 				() -> patientInvitationRedeemService.redeem(token, patientAuthSub));
 		return ApiResponse.ok(RedeemedPatientInvitationDto.from(redeemed));
+	}
+
+	@PostMapping("/{id}/revoke")
+	@Operation(summary = "Revoke patient invitation",
+			description = "Nutritionist JWT invalidates an outstanding pending invitation; idempotent when already revoked.")
+	@MobileOpenApiResponses.AuthenticatedNutritionist
+	@MobileOpenApiResponses.NotFoundWhenMissing
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+			description = "Invitation revoked or already revoked")
+	public ApiResponse<RevokedPatientInvitationDto> revokeInvitation(@PathVariable("id") final Long id,
+			@AuthenticationPrincipal final Jwt jwt) {
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile revoke patient invitation request from nutritionist sub present={}",
+					jwt != null && jwt.getSubject() != null);
+		}
+		final String nutritionistUserId = requireSubject(jwt);
+		final PatientInvitationRevokeResult revoked = patientInvitationRevokeService.revoke(id, nutritionistUserId);
+		return ApiResponse.ok(RevokedPatientInvitationDto.from(revoked));
 	}
 
 	private static String requireSubject(final Jwt jwt) {

--- a/src/main/java/com/nutriconsultas/mobile/PatientInvitationRevokeNotAllowedException.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientInvitationRevokeNotAllowedException.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.mobile;
+
+/**
+ * Invitation cannot be revoked in its current status (#139).
+ */
+public final class PatientInvitationRevokeNotAllowedException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/PatientInvitationRevokeNotFoundException.java
+++ b/src/main/java/com/nutriconsultas/mobile/PatientInvitationRevokeNotFoundException.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.mobile;
+
+/**
+ * Invitation not found for the authenticated nutritionist (#139 IDOR protection).
+ */
+public final class PatientInvitationRevokeNotFoundException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/RevokedPatientInvitationDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/RevokedPatientInvitationDto.java
@@ -1,0 +1,22 @@
+package com.nutriconsultas.mobile.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.nutriconsultas.paciente.PatientInvitationStatus;
+import com.nutriconsultas.paciente.invitation.PatientInvitationRevokeResult;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Response after a nutritionist revokes a patient invitation (#139).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Revoked patient invitation")
+public record RevokedPatientInvitationDto(@Schema(description = "Invitation row id", example = "42") Long invitationId,
+		@Schema(description = "Linked Paciente id", example = "1001") Long pacienteId,
+		@Schema(description = "Invitation status after revoke", example = "REVOKED") PatientInvitationStatus status) {
+
+	public static RevokedPatientInvitationDto from(final PatientInvitationRevokeResult result) {
+		return new RevokedPatientInvitationDto(result.invitationId(), result.pacienteId(), result.status());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PatientInvitationRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PatientInvitationRepository.java
@@ -9,6 +9,8 @@ public interface PatientInvitationRepository extends JpaRepository<PatientInvita
 
 	Optional<PatientInvitation> findByTokenHash(String tokenHash);
 
+	Optional<PatientInvitation> findByIdAndNutritionistUserId(Long id, String nutritionistUserId);
+
 	List<PatientInvitation> findByPacienteId(Long pacienteId);
 
 	List<PatientInvitation> findByNutritionistUserIdAndStatus(String nutritionistUserId,

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationRevokeResult.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationRevokeResult.java
@@ -1,0 +1,9 @@
+package com.nutriconsultas.paciente.invitation;
+
+import com.nutriconsultas.paciente.PatientInvitationStatus;
+
+/**
+ * Result after a nutritionist revokes a patient invitation (#139).
+ */
+public record PatientInvitationRevokeResult(Long invitationId, Long pacienteId, PatientInvitationStatus status) {
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationRevokeService.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationRevokeService.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.paciente.invitation;
+
+/**
+ * Nutritionist revokes an outstanding patient invitation (#139).
+ */
+@FunctionalInterface
+public interface PatientInvitationRevokeService {
+
+	PatientInvitationRevokeResult revoke(Long invitationId, String nutritionistUserId);
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationRevokeServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationRevokeServiceImpl.java
@@ -1,0 +1,52 @@
+package com.nutriconsultas.paciente.invitation;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nutriconsultas.mobile.PatientInvitationRevokeNotAllowedException;
+import com.nutriconsultas.mobile.PatientInvitationRevokeNotFoundException;
+import com.nutriconsultas.paciente.PatientInvitation;
+import com.nutriconsultas.paciente.PatientInvitationRepository;
+import com.nutriconsultas.paciente.PatientInvitationStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class PatientInvitationRevokeServiceImpl implements PatientInvitationRevokeService {
+
+	private final PatientInvitationRepository patientInvitationRepository;
+
+	public PatientInvitationRevokeServiceImpl(final PatientInvitationRepository patientInvitationRepository) {
+		this.patientInvitationRepository = patientInvitationRepository;
+	}
+
+	@Override
+	@Transactional
+	public PatientInvitationRevokeResult revoke(final Long invitationId, final String nutritionistUserId) {
+		final PatientInvitation invitation = patientInvitationRepository
+			.findByIdAndNutritionistUserId(invitationId, nutritionistUserId)
+			.orElseThrow(PatientInvitationRevokeNotFoundException::new);
+
+		if (invitation.getStatus() == PatientInvitationStatus.REVOKED) {
+			return toResult(invitation);
+		}
+		if (invitation.getStatus() != PatientInvitationStatus.PENDING) {
+			throw new PatientInvitationRevokeNotAllowedException();
+		}
+
+		invitation.setStatus(PatientInvitationStatus.REVOKED);
+		final PatientInvitation saved = patientInvitationRepository.save(invitation);
+		if (log.isInfoEnabled()) {
+			log.info("Revoked patient invitation: invitationId={}, pacienteId={}", saved.getId(),
+					saved.getPaciente().getId());
+		}
+		return toResult(saved);
+	}
+
+	private static PatientInvitationRevokeResult toResult(final PatientInvitation invitation) {
+		return new PatientInvitationRevokeResult(invitation.getId(), invitation.getPaciente().getId(),
+				invitation.getStatus());
+	}
+
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -11,6 +11,7 @@ error.invitation.invalid=The invitation link is not valid.
 error.invitation.invalid_or_expired=The invitation is invalid or has expired.
 error.invitation.redeem_conflict=This invitation was already redeemed by another account.
 error.invitation.patient_status=The patient is not in pending invitation status.
+error.invitation.revoke_not_allowed=This invitation cannot be revoked.
 error.subscription.patient_limit=Your plan allows up to {0} patients. Upgrade your subscription to add more.
 error.subscription.create_patient_denied=You cannot add patients with your current subscription status.
 error.subscription.nutritionist_limit=Your plan allows up to {0} nutritionists in the clinic.

--- a/src/main/resources/messages_es_MX.properties
+++ b/src/main/resources/messages_es_MX.properties
@@ -11,6 +11,7 @@ error.invitation.invalid=El enlace de invitación no es válido.
 error.invitation.invalid_or_expired=La invitación no es válida o ha expirado.
 error.invitation.redeem_conflict=Esta invitación ya fue canjeada por otra cuenta.
 error.invitation.patient_status=El paciente no está en estado de invitación pendiente.
+error.invitation.revoke_not_allowed=Esta invitación no se puede revocar.
 error.subscription.patient_limit=Tu plan permite hasta {0} pacientes. Actualiza tu suscripción para agregar más.
 error.subscription.create_patient_denied=No puedes agregar pacientes con el estado actual de tu suscripción.
 error.subscription.nutritionist_limit=Tu plan permite hasta {0} nutriólogos en el consultorio.

--- a/src/test/java/com/nutriconsultas/mobile/MobileInvitationControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileInvitationControllerTest.java
@@ -18,13 +18,17 @@ import com.nutriconsultas.mobile.dto.CreatePatientInvitationRequest;
 import com.nutriconsultas.mobile.dto.CreatedPatientInvitationDto;
 import com.nutriconsultas.mobile.dto.PatientInvitationPreviewDto;
 import com.nutriconsultas.mobile.dto.RedeemedPatientInvitationDto;
+import com.nutriconsultas.mobile.dto.RevokedPatientInvitationDto;
 import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.PatientInvitationStatus;
 import com.nutriconsultas.paciente.invitation.CreatedPatientInvitationResult;
 import com.nutriconsultas.paciente.invitation.PatientInvitationCreateService;
 import com.nutriconsultas.paciente.invitation.PatientInvitationPreviewResult;
 import com.nutriconsultas.paciente.invitation.PatientInvitationPreviewService;
 import com.nutriconsultas.paciente.invitation.PatientInvitationRedeemResult;
 import com.nutriconsultas.paciente.invitation.PatientInvitationRedeemService;
+import com.nutriconsultas.paciente.invitation.PatientInvitationRevokeResult;
+import com.nutriconsultas.paciente.invitation.PatientInvitationRevokeService;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -52,6 +56,9 @@ class MobileInvitationControllerTest {
 
 	@Mock
 	private PatientInvitationRedeemRateLimiter patientInvitationRedeemRateLimiter;
+
+	@Mock
+	private PatientInvitationRevokeService patientInvitationRevokeService;
 
 	@Mock
 	private HttpServletRequest httpServletRequest;
@@ -108,6 +115,21 @@ class MobileInvitationControllerTest {
 		assertThat(response.data().pacienteStatus()).isEqualTo(PacienteStatus.ONBOARDING);
 		assertThat(response.data().invitationId()).isEqualTo(1L);
 		verify(patientInvitationRedeemService).redeem("url-token-value", PATIENT_SUB);
+	}
+
+	@Test
+	void revokeInvitation_returnsApiResponseEnvelope() {
+		final PatientInvitationRevokeResult result = new PatientInvitationRevokeResult(7L, 100L,
+				PatientInvitationStatus.REVOKED);
+		final Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject(NUTRITIONIST_SUB).build();
+		when(patientInvitationRevokeService.revoke(7L, NUTRITIONIST_SUB)).thenReturn(result);
+
+		final ApiResponse<RevokedPatientInvitationDto> response = controller.revokeInvitation(7L, jwt);
+
+		assertThat(response.data().invitationId()).isEqualTo(7L);
+		assertThat(response.data().pacienteId()).isEqualTo(100L);
+		assertThat(response.data().status()).isEqualTo(PatientInvitationStatus.REVOKED);
+		verify(patientInvitationRevokeService).revoke(7L, NUTRITIONIST_SUB);
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/mobile/MobileInvitationIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileInvitationIntegrationTest.java
@@ -50,6 +50,8 @@ class MobileInvitationIntegrationTest {
 
 	private static final String NUTRITIONIST_SUB = "auth0|mobile-invitation-nutritionist";
 
+	private static final String OTHER_NUTRITIONIST_SUB = "auth0|mobile-invitation-other-nutritionist";
+
 	@Autowired
 	private MockMvc mockMvc;
 
@@ -252,6 +254,62 @@ class MobileInvitationIntegrationTest {
 		mockMvc.perform(post("/rest/mobile/invitations/{token}/redeem", bundle.urlToken()).with(mobileJwt(patientSub)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.pacienteStatus").value("ONBOARDING"));
+	}
+
+	@Test
+	void revokeInvitation_withNutritionistJwt_revokesPendingInvitation() throws Exception {
+		final PatientInvitationTokenBundle bundle = patientInvitationTokenService.generate();
+		final PatientInvitation invitation = seedPendingInvitation(bundle, NUTRITIONIST_SUB);
+
+		mockMvc
+			.perform(post("/rest/mobile/invitations/{id}/revoke", invitation.getId()).with(mobileJwt(NUTRITIONIST_SUB)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.invitationId").value(invitation.getId()))
+			.andExpect(jsonPath("$.data.pacienteId").value(invitation.getPaciente().getId()))
+			.andExpect(jsonPath("$.data.status").value("REVOKED"));
+
+		final var savedInvitation = patientInvitationRepository.findById(invitation.getId()).orElseThrow();
+		assertThat(savedInvitation.getStatus()).isEqualTo(PatientInvitationStatus.REVOKED);
+
+		mockMvc.perform(get("/rest/mobile/invitations/{token}/preview", bundle.urlToken()))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("La invitación no es válida o ha expirado."));
+	}
+
+	@Test
+	void revokeInvitation_idempotentWhenAlreadyRevoked_returnsOk() throws Exception {
+		final PatientInvitationTokenBundle bundle = patientInvitationTokenService.generate();
+		final PatientInvitation invitation = seedPendingInvitation(bundle, NUTRITIONIST_SUB);
+
+		mockMvc
+			.perform(post("/rest/mobile/invitations/{id}/revoke", invitation.getId()).with(mobileJwt(NUTRITIONIST_SUB)))
+			.andExpect(status().isOk());
+
+		mockMvc
+			.perform(post("/rest/mobile/invitations/{id}/revoke", invitation.getId()).with(mobileJwt(NUTRITIONIST_SUB)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.status").value("REVOKED"));
+	}
+
+	@Test
+	void revokeInvitation_withOtherNutritionist_returnsNotFound() throws Exception {
+		final PatientInvitationTokenBundle bundle = patientInvitationTokenService.generate();
+		final PatientInvitation invitation = seedPendingInvitation(bundle, NUTRITIONIST_SUB);
+
+		mockMvc
+			.perform(post("/rest/mobile/invitations/{id}/revoke", invitation.getId())
+				.with(mobileJwt(OTHER_NUTRITIONIST_SUB)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("La invitación no es válida o ha expirado."));
+	}
+
+	@Test
+	void revokeInvitation_withoutJwt_returnsUnauthorized() throws Exception {
+		final PatientInvitationTokenBundle bundle = patientInvitationTokenService.generate();
+		final PatientInvitation invitation = seedPendingInvitation(bundle, NUTRITIONIST_SUB);
+
+		mockMvc.perform(post("/rest/mobile/invitations/{id}/revoke", invitation.getId()))
+			.andExpect(status().isUnauthorized());
 	}
 
 	private PatientInvitation seedPendingInvitation(final PatientInvitationTokenBundle bundle,

--- a/src/test/java/com/nutriconsultas/mobile/MobileOpenApiIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileOpenApiIntegrationTest.java
@@ -33,7 +33,8 @@ class MobileOpenApiIntegrationTest {
 			"/rest/mobile/patient/diet-plans/{assignmentId}", "/rest/mobile/patient/diet-plans/{assignmentId}/pdf",
 			"/rest/mobile/patient/messages", "/rest/mobile/patient/progress",
 			"/rest/mobile/patient/progress/measurements", "/rest/mobile/patient/me", "/rest/mobile/invitations",
-			"/rest/mobile/invitations/{token}/preview", "/rest/mobile/invitations/{token}/redeem");
+			"/rest/mobile/invitations/{token}/preview", "/rest/mobile/invitations/{token}/redeem",
+			"/rest/mobile/invitations/{id}/revoke");
 
 	@Autowired
 	private MockMvc mockMvc;
@@ -58,6 +59,7 @@ class MobileOpenApiIntegrationTest {
 		assertThat(paths.path("/rest/mobile/patient/messages").has("post")).isTrue();
 		assertThat(paths.path("/rest/mobile/patient/me").has("get")).isTrue();
 		assertThat(paths.path("/rest/mobile/patient/me").has("patch")).isTrue();
+		assertThat(paths.path("/rest/mobile/invitations/{id}/revoke").has("post")).isTrue();
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationRevokeServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationRevokeServiceTest.java
@@ -1,0 +1,102 @@
+package com.nutriconsultas.paciente.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.mobile.PatientInvitationRevokeNotAllowedException;
+import com.nutriconsultas.mobile.PatientInvitationRevokeNotFoundException;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PatientInvitation;
+import com.nutriconsultas.paciente.PatientInvitationRepository;
+import com.nutriconsultas.paciente.PatientInvitationStatus;
+
+@ExtendWith(MockitoExtension.class)
+class PatientInvitationRevokeServiceTest {
+
+	private static final String NUTRITIONIST_SUB = "auth0|nutritionist-owner";
+
+	private static final String OTHER_NUTRITIONIST_SUB = "auth0|other-nutritionist";
+
+	@Mock
+	private PatientInvitationRepository patientInvitationRepository;
+
+	@InjectMocks
+	private PatientInvitationRevokeServiceImpl service;
+
+	@Test
+	void revoke_pendingInvitation_setsRevokedStatus() {
+		final PatientInvitation invitation = sampleInvitation(5L, 9L, PatientInvitationStatus.PENDING);
+		when(patientInvitationRepository.findByIdAndNutritionistUserId(5L, NUTRITIONIST_SUB))
+			.thenReturn(Optional.of(invitation));
+		when(patientInvitationRepository.save(any(PatientInvitation.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		final PatientInvitationRevokeResult result = service.revoke(5L, NUTRITIONIST_SUB);
+
+		final ArgumentCaptor<PatientInvitation> captor = ArgumentCaptor.forClass(PatientInvitation.class);
+		verify(patientInvitationRepository).save(captor.capture());
+		assertThat(captor.getValue().getStatus()).isEqualTo(PatientInvitationStatus.REVOKED);
+		assertThat(result.invitationId()).isEqualTo(5L);
+		assertThat(result.pacienteId()).isEqualTo(9L);
+		assertThat(result.status()).isEqualTo(PatientInvitationStatus.REVOKED);
+	}
+
+	@Test
+	void revoke_alreadyRevoked_isIdempotent() {
+		final PatientInvitation invitation = sampleInvitation(5L, 9L, PatientInvitationStatus.REVOKED);
+		when(patientInvitationRepository.findByIdAndNutritionistUserId(5L, NUTRITIONIST_SUB))
+			.thenReturn(Optional.of(invitation));
+
+		final PatientInvitationRevokeResult result = service.revoke(5L, NUTRITIONIST_SUB);
+
+		assertThat(result.status()).isEqualTo(PatientInvitationStatus.REVOKED);
+	}
+
+	@Test
+	void revoke_wrongNutritionist_throwsNotFound() {
+		when(patientInvitationRepository.findByIdAndNutritionistUserId(5L, OTHER_NUTRITIONIST_SUB))
+			.thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.revoke(5L, OTHER_NUTRITIONIST_SUB))
+			.isInstanceOf(PatientInvitationRevokeNotFoundException.class);
+	}
+
+	@Test
+	void revoke_redeemedInvitation_throwsNotAllowed() {
+		final PatientInvitation invitation = sampleInvitation(5L, 9L, PatientInvitationStatus.REDEEMED);
+		when(patientInvitationRepository.findByIdAndNutritionistUserId(5L, NUTRITIONIST_SUB))
+			.thenReturn(Optional.of(invitation));
+
+		assertThatThrownBy(() -> service.revoke(5L, NUTRITIONIST_SUB))
+			.isInstanceOf(PatientInvitationRevokeNotAllowedException.class);
+	}
+
+	private static PatientInvitation sampleInvitation(final Long id, final Long pacienteId,
+			final PatientInvitationStatus status) {
+		final Paciente paciente = new Paciente();
+		paciente.setId(pacienteId);
+		final PatientInvitation invitation = new PatientInvitation();
+		invitation.setId(id);
+		invitation.setPaciente(paciente);
+		invitation.setNutritionistUserId(NUTRITIONIST_SUB);
+		invitation.setStatus(status);
+		invitation.setTokenHash("a".repeat(64));
+		invitation.setExpiresAt(Instant.now().plus(14, ChronoUnit.DAYS));
+		return invitation;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `POST /rest/mobile/invitations/{id}/revoke` for nutritionist JWT to invalidate pending invitations.
- Tenant-scoped lookup (`findByIdAndNutritionistUserId`); wrong owner → **404** generic unavailable (IDOR-safe).
- Idempotent when already `REVOKED`; `REDEEMED`/`EXPIRED` → **409** `error.invitation.revoke_not_allowed`.
- Regenerate `openapi-mobile.yaml`; sync mobile API registry (#139 in-progress → done on merge, #140 NEXT).

Closes #139.

## Test plan
- [x] `./lint.sh` and `mvn pmd:check -Pci`
- [x] `PatientInvitationRevokeServiceTest`, `MobileInvitationControllerTest`
- [x] `MobileInvitationIntegrationTest` (revoke, preview blocked, idempotent, IDOR 404, 401)
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)