### PR TITLE
feat(mobile-api): Auth0 Post-Login invitation gate (#140)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -41,7 +41,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (public booking):** None — epic ~~#245~~ **done**; ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~, ~~#300~~, ~~#302~~ done. Deferred follow-ups need new issues. See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
-**Current next issue (mobile):** [#140 — Auth0 Post-Login Action gate](https://github.com/diego-torres/nutriconsultas/issues/140) (**NEXT**). ~~#139~~ done (PR [#330](https://github.com/diego-torres/nutriconsultas/pull/330)).
+**Current next issue (mobile):** [#141 — Invitation security hardening](https://github.com/diego-torres/nutriconsultas/issues/141) (**NEXT**). ~~#140~~ done ([`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md)).
 
 **Current next issue (subscription):** Registered track **complete** (~~#244~~ ✓ on `subscription/244-contact-form-prefill`). Triage open `[Subscription]` GitHub issues. See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
 
@@ -408,9 +408,9 @@ gh pr create ...
 
 | Field | Value |
 |-------|-------|
-| **Next issue** | [#140 — Auth0 Post-Login Action gate](https://github.com/diego-torres/nutriconsultas/issues/140) |
+| **Next issue** | [#141 — Invitation security hardening](https://github.com/diego-torres/nutriconsultas/issues/141) |
 | **Status** | **NEXT** — unblocked on `main` |
-| **Just completed** | [#135 preview](https://github.com/diego-torres/nutriconsultas/issues/135) — PR [#324](https://github.com/diego-torres/nutriconsultas/pull/324) |
+| **Just completed** | [#140 — Auth0 Post-Login Action gate](https://github.com/diego-torres/nutriconsultas/issues/140) — [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md) |
 
 ### Upcoming gates
 
@@ -427,7 +427,7 @@ gh pr create ...
 
 **Patient mobile API on `main`:** Phase 0 + endpoints **#91–#99** done; cross-cutting **#111–#116** done. Onboarding **#132** + token service **#133 done** (PR #229, deployed EC2).
 
-**Next (mobile):** **#140** Auth0 Post-Login → #141 hardening.
+**Next (mobile):** **#141** invitation hardening.
 
 **Schema track:** ~~#46~~ Liquibase baseline (PR #196). Changesets **003–007** on `main` (subscription, patient invitation). All new edits → forward changesets only.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -590,7 +590,7 @@ Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 
-**Next:** [#140](https://github.com/diego-torres/nutriconsultas/issues/140) Auth0 Post-Login gate (**NEXT**). ~~#139~~ done (PR [#330](https://github.com/diego-torres/nutriconsultas/pull/330)). ~~#138~~ done (PR [#328](https://github.com/diego-torres/nutriconsultas/pull/328)).
+**Next:** [#141](https://github.com/diego-torres/nutriconsultas/issues/141) invitation hardening (**NEXT**). ~~#140~~ done (Post-Login Action — [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md)). ~~#139~~ done (PR [#330](https://github.com/diego-torres/nutriconsultas/pull/330)).
 
 **Schema gate (post-#46):** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline is on `main` (PR #196). All new schema/catalog changes require **incremental Liquibase changesets** — see [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) and [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md). ~~#156~~ Phase C done before baseline.
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) · **Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-22 — ~~#139~~ **done** (PR [#330](https://github.com/diego-torres/nutriconsultas/pull/330)). **NEXT:** [#140 Auth0 Post-Login gate](https://github.com/diego-torres/nutriconsultas/issues/140).
+**Last updated:** 2026-06-22 — ~~#140~~ **done** (branch `mobile-api/140-auth0-post-login-gate`). **NEXT:** [#141 Invitation hardening](https://github.com/diego-torres/nutriconsultas/issues/141).
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -49,7 +49,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156**, **#46**, **#132**, **#133**, **#134**, **#135**, **#136**, **#137**, **#138**, and **#139** done on `main`. **NEXT:** #140.
+Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156**, **#46**, **#132**, **#133**, **#134**, **#135**, **#136**, **#137**, **#138**, **#139**, and **#140** done on `main`. **NEXT:** #141.
 
 ---
 
@@ -138,7 +138,7 @@ Schema-affecting work must respect mobile DTO contracts (§F8). These issues are
 
 ## Phase 2 — Invitation onboarding (P1 · ~~#132~~ ✓ ~~#133~~ ✓ → #134–#141)
 
-Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Active sprint** — revoke **#139 done** (PR #330); **NEXT:** #140 Auth0 Post-Login gate.
+Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Active sprint** — Post-Login gate **#140 done**; **NEXT:** #141 hardening.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
@@ -149,8 +149,8 @@ Invite-only patient onboarding replaces manual Afiliación linkage (#109) for ne
 | 137 | CurrentPatient resolver + onboarding data gate (403 onboarding required) | https://github.com/diego-torres/nutriconsultas/issues/137 | **done** | ~~132~~ ✓, 107 | Merged PR [#326](https://github.com/diego-torres/nutriconsultas/pull/326) |
 | 138 | `PATCH` & `GET /rest/mobile/patient/me` — onboarding profile + status→ACTIVE | https://github.com/diego-torres/nutriconsultas/issues/138 | **done** | ~~132~~ ✓, ~~137~~ ✓ | Merged PR [#328](https://github.com/diego-torres/nutriconsultas/pull/328) |
 | 139 | `POST /rest/mobile/invitations/{id}/revoke` — nutritionist invalidates invite | https://github.com/diego-torres/nutriconsultas/issues/139 | **done** | ~~132~~ ✓, 134 | Merged PR [#330](https://github.com/diego-torres/nutriconsultas/pull/330) |
-| 140 | Auth0 Post-Login Action gate — first-login invitation validation | https://github.com/diego-torres/nutriconsultas/issues/140 | **NEXT** | ~~133~~ ✓, 136 | **Post-Login** (not Pre-User-Registration — social logins skip PUR); docs + Action script |
-| 141 | Invitation security hardening — rate limits, enumeration protection, no-token logging | https://github.com/diego-torres/nutriconsultas/issues/141 | open | ~~133~~ ✓, 135, 136 | Relates #115; never log raw tokens |
+| 140 | Auth0 Post-Login Action gate — first-login invitation validation | https://github.com/diego-torres/nutriconsultas/issues/140 | **done** | ~~133~~ ✓, 136 | Post-Login Action + [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md); Option B social cleanup |
+| 141 | Invitation security hardening — rate limits, enumeration protection, no-token logging | https://github.com/diego-torres/nutriconsultas/issues/141 | **NEXT** | ~~133~~ ✓, 135, 136 | Relates #115; never log raw tokens |
 
 **Suggested build order (after ~~#133~~ ✓):** #134/#135 → #136 → #137 → #138 → #139/#140 → #141.
 

--- a/docs/auth0/PATIENT-POST-LOGIN-GATE.md
+++ b/docs/auth0/PATIENT-POST-LOGIN-GATE.md
@@ -1,0 +1,184 @@
+# Auth0 Post-Login Action — patient invitation gate (#140)
+
+Invite-only patient onboarding requires a valid invitation on **first login**. Social connections (Google, Apple) skip Auth0 **Pre-User-Registration**, so the gate **must** be a **Post-Login Action**.
+
+**Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](../mobile-api/ALIGNMENT-SPEC.md) §F8.6.2.
+
+---
+
+## Why Post-Login (not Pre-User-Registration)
+
+| Trigger | Google / Apple social | Username-Password |
+|---------|----------------------|-------------------|
+| Pre-User-Registration | Does **not** run | Runs |
+| Post-Login | Runs | Runs |
+
+A Pre-User-Registration Action would **not** protect social sign-up paths.
+
+---
+
+## End-to-end flow
+
+```mermaid
+sequenceDiagram
+  participant P as Patient app
+  participant A as Auth0
+  participant Act as Post-Login Action
+  participant API as nutriconsultas API
+
+  P->>P: Open deep link /i/{urlToken}
+  P->>A: authorize(custom: invitation_token=urlToken)
+  A->>Act: onExecutePostLogin (logins_count=1)
+  alt offline JWS in invitation_token
+    Act->>Act: verify HS256 JWS (shared secret)
+  else raw URL token
+    Act->>API: GET /rest/mobile/invitations/{token}/preview
+    API-->>Act: 200 or 404
+  end
+  Act->>A: setAppMetadata invited=true OR access.deny
+  A-->>P: tokens (or login blocked)
+  P->>API: POST /rest/mobile/invitations/{token}/redeem (#136)
+  P->>API: PATCH /rest/mobile/patient/me (#138)
+```
+
+1. Nutritionist creates invite (#134) → deep link with **raw URL token** (43-char base64url).
+2. Patient app stores token from deep link.
+3. On Auth0 `authorize`, pass custom query param **`invitation_token`** (see [mobile #64](https://github.com/Escanor4323/nutriconsultas-mobile/issues/64)).
+4. Post-Login Action validates on `logins_count === 1`, stamps `app_metadata.invited = true` on success.
+5. Backend **redeem** (#136) and **onboarding gate** (#137) remain authoritative regardless of Auth0 outcome.
+
+---
+
+## Action script
+
+Source: [`docs/auth0/actions/patient-invitation-gate.js`](actions/patient-invitation-gate.js)
+
+### Logic summary
+
+| Condition | Behavior |
+|-----------|----------|
+| `app_metadata.invited === true` | Allow (skip gate) |
+| `logins_count !== 1` | Allow (legacy / returning users; not first login) |
+| `logins_count === 1` | Require valid `invitation_token` |
+| Valid token | `api.user.setAppMetadata('invited', true)` |
+| Invalid / missing token | `api.access.deny('invitation_required', …)` |
+
+### Validation modes (either/or)
+
+| Mode | When | How |
+|------|------|-----|
+| **Offline JWS** | `invitation_token` matches compact JWS shape **and** `PATIENT_INVITATION_JWS_SECRET` is set | HS256 verify; payload `patientId`, `tokenHash`, `exp` per §F8.6.2 |
+| **Preview API** | Raw URL token (default mobile path) **and** `API_BASE_URL` secret set | `GET {API_BASE_URL}/rest/mobile/invitations/{token}/preview` → HTTP 200 |
+
+**Recommendation:** configure **both** secrets in production. Mobile passes the **raw URL token** from the deep link; preview catches revocation/expiry. Nutritionist tooling may pass **offline JWS** from create response when testing without API round-trip.
+
+Offline JWS does **not** replace DB redeem (#136) for single-use enforcement.
+
+---
+
+## Deployment checklist
+
+### 1. Backend secrets (already on app host)
+
+| Env var | Purpose |
+|---------|---------|
+| `PATIENT_INVITATION_JWS_SECRET` | Same value as Auth0 Action secret; enables `offlineJws` on create (#134) |
+| `PATIENT_INVITATION_BASE_URL` | Deep link host (e.g. `https://minutriporcion.com`) |
+
+### 2. Auth0 Action secrets
+
+In Dashboard → Actions → *patient-invitation-gate* → Settings → Secrets:
+
+| Secret name | Example | Required |
+|-------------|---------|----------|
+| `PATIENT_INVITATION_JWS_SECRET` | (same as backend) | Optional; required for JWS path |
+| `API_BASE_URL` | `https://minutriporcion.com` | **Required** for raw-token mobile path |
+
+### 3. Create and attach Action
+
+1. Auth0 Dashboard → **Actions** → **Library** → **Build Custom** → **Post Login**.
+2. Name: `patient-invitation-gate`.
+3. Paste [`patient-invitation-gate.js`](actions/patient-invitation-gate.js).
+4. Add secrets above.
+5. **Deploy**.
+6. **Actions** → **Flows** → **Login** → drag action into flow → **Apply**.
+
+### 4. Mobile app (`invitation_token` custom param)
+
+Pass on Auth0 authorize (React Native / Expo example):
+
+```javascript
+await authorize({
+  scope: 'openid profile email offline_access',
+  audience: 'https://api.nutriconsultas.minutriporcion.com',
+  additionalParameters: {
+    invitation_token: storedUrlTokenFromDeepLink,
+  },
+});
+```
+
+Auth0 forwards custom authorize params to `event.request.query` in Post-Login Actions.
+
+### 5. Disable public signup (nutritionist web)
+
+See [`docs/subscription/AUTH0-ROLE-SYNC.md`](../subscription/AUTH0-ROLE-SYNC.md) — patient native app uses social + invitation gate; nutritionist signup remains invitation-based separately.
+
+---
+
+## Denied social users — cleanup strategy (Option B)
+
+**Decision (2026-06-22, #140):** **Option B — leave blocked & harmless.**
+
+| Option | Description | Chosen |
+|--------|-------------|--------|
+| A | Scheduled Management API job deletes users where `invited != true` and `logins_count <= 1` | No |
+| B | Orphan Auth0 users remain; backend gates are authoritative | **Yes** |
+
+**Rationale:**
+
+- Denied first login still **creates** the Auth0 user (social providers). A second login attempt has `logins_count > 1` and **passes** this Action (only first login is gated).
+- Those users **cannot redeem** (#136) without a valid token and **cannot access patient APIs** (#137: 403 onboarding required).
+- No PHI is exposed; no Management API cron or delete permissions required.
+- Optional future hardening: Pre-Login Action or Option A job — track separately if tenant hygiene becomes a concern.
+
+---
+
+## Secret rotation
+
+Rotating `PATIENT_INVITATION_JWS_SECRET` invalidates outstanding **offline JWS** tokens only. DB-backed invitations and raw URL tokens remain valid until expiry/revoke. Re-issue invites or rely on preview path after rotation.
+
+---
+
+## Testing
+
+### Local JWS interop (Java ↔ Action script)
+
+```bash
+mvn test -Dtest=PatientInvitationGateScriptInteropTest
+```
+
+Runs `scripts/test-patient-invitation-gate.cjs` against JWS tokens signed by `PatientInvitationJws` (Java).
+
+### Manual Auth0 test
+
+1. Create invite via nutritionist JWT (`POST /rest/mobile/invitations`).
+2. Copy URL token from `inviteUrl`.
+3. Auth0 authorize with `invitation_token` = URL token.
+4. First login → success, `app_metadata.invited: true` in user profile.
+5. Repeat without token → `access.denied` on first login.
+
+### E2E status doc
+
+Update [`docs/mobile-api/MOBILE-E2E-STATUS.md`](../mobile-api/MOBILE-E2E-STATUS.md) after tenant deployment.
+
+---
+
+## Related issues
+
+| # | Topic |
+|---|-------|
+| 133 | Offline JWS signing (Java) |
+| 135 | Preview endpoint (Action fallback validation) |
+| 136 | Redeem gate (authoritative) |
+| 137 | Onboarding API gate |
+| 141 | Rate limits, enumeration hardening |

--- a/docs/auth0/actions/patient-invitation-gate.js
+++ b/docs/auth0/actions/patient-invitation-gate.js
@@ -1,0 +1,132 @@
+/**
+ * Auth0 Post-Login Action — patient invitation gate (#140).
+ *
+ * Deploy: Auth0 Dashboard → Actions → Library → Build Custom → Post Login.
+ * Paste this file, add secrets (see docs/auth0/PATIENT-POST-LOGIN-GATE.md), attach to Login flow.
+ *
+ * Runtime: Node 18 (Auth0 Actions). Uses crypto + fetch (preview fallback).
+ */
+'use strict';
+
+const crypto = require('crypto');
+
+const COMPACT_JWS_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+const DENY_CODE = 'invitation_required';
+
+const DENY_MESSAGE = 'Se requiere una invitación válida para registrarse.';
+
+/**
+ * Verifies HS256 offline JWS issued by PatientInvitationJws (Java #133).
+ * Returns patientId on success, null otherwise. Does not check single-use (DB redeem #136).
+ */
+function verifyOfflineJws(secret, compactJws) {
+	if (!secret || !compactJws) {
+		return null;
+	}
+	const parts = compactJws.split('.');
+	if (parts.length !== 3) {
+		return null;
+	}
+	let header;
+	try {
+		header = JSON.parse(Buffer.from(parts[0], 'base64url').toString('utf8'));
+	}
+	catch (error) {
+		return null;
+	}
+	if (header.alg !== 'HS256') {
+		return null;
+	}
+	const signingInput = parts[0] + '.' + parts[1];
+	const expected = crypto.createHmac('sha256', secret).update(signingInput).digest();
+	let actual;
+	try {
+		actual = Buffer.from(parts[2], 'base64url');
+	}
+	catch (error) {
+		return null;
+	}
+	if (expected.length !== actual.length || !crypto.timingSafeEqual(expected, actual)) {
+		return null;
+	}
+	let payload;
+	try {
+		payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+	}
+	catch (error) {
+		return null;
+	}
+	const now = Math.floor(Date.now() / 1000);
+	if (!payload.exp || payload.exp <= now) {
+		return null;
+	}
+	if (!payload.patientId || payload.patientId < 1) {
+		return null;
+	}
+	return payload.patientId;
+}
+
+function isCompactJws(value) {
+	return typeof value === 'string' && COMPACT_JWS_PATTERN.test(value);
+}
+
+/**
+ * Validates raw URL token against public preview endpoint (#135). Authoritative for
+ * revocation/expiry at login time; rate-limited server-side.
+ */
+async function validateViaPreview(apiBaseUrl, rawUrlToken) {
+	if (!apiBaseUrl || !rawUrlToken) {
+		return false;
+	}
+	const base = apiBaseUrl.replace(/\/$/, '');
+	const url = base + '/rest/mobile/invitations/' + encodeURIComponent(rawUrlToken) + '/preview';
+	const response = await fetch(url, {
+		method: 'GET',
+		headers: { Accept: 'application/json' },
+	});
+	return response.ok;
+}
+
+async function validateInvitationToken(event) {
+	const token = event.request?.query?.invitation_token;
+	if (!token || typeof token !== 'string' || token.trim() === '') {
+		return false;
+	}
+	const trimmed = token.trim();
+	const jwsSecret = event.secrets?.PATIENT_INVITATION_JWS_SECRET;
+	if (isCompactJws(trimmed) && jwsSecret) {
+		return verifyOfflineJws(jwsSecret, trimmed) !== null;
+	}
+	const apiBaseUrl = event.secrets?.API_BASE_URL;
+	if (apiBaseUrl) {
+		return validateViaPreview(apiBaseUrl, trimmed);
+	}
+	return false;
+}
+
+/**
+ * @param {Event} event
+ * @param {PostLoginAPI} api
+ */
+exports.onExecutePostLogin = async (event, api) => {
+	if (event.user.app_metadata?.invited === true) {
+		return;
+	}
+	const loginsCount = event.stats?.logins_count ?? 0;
+	if (loginsCount !== 1) {
+		return;
+	}
+	const valid = await validateInvitationToken(event);
+	if (!valid) {
+		api.access.deny(DENY_CODE, DENY_MESSAGE);
+		return;
+	}
+	api.user.setAppMetadata('invited', true);
+};
+
+// Exported for Node interop tests (scripts/test-patient-invitation-gate.mjs).
+if (typeof module !== 'undefined') {
+	module.exports.verifyOfflineJws = verifyOfflineJws;
+	module.exports.isCompactJws = isCompactJws;
+}

--- a/docs/mobile-api/ALIGNMENT-SPEC.md
+++ b/docs/mobile-api/ALIGNMENT-SPEC.md
@@ -160,7 +160,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 - **Phase 0 DONE:** #107 (PR #117), #109 (PR #142), #110 (DTO envelope).
 - **Endpoints on `main`:** #91–#99 (visits, diet plans + PDF, messages, progress snapshot + measurements time series); #96/#97 messaging with HTTP 201 + Resilience4j 10/min (#113, PR #151).
 - **i18n (#111) DONE** (PR #151): `LocaleContextFilter`, `MobileApiErrorResponses`, localized 403/404/400/429.
-- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). Onboarding **#132–#139 done** (PR #330 for #139). **NEXT:** #140.
+- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). Onboarding **#132–#139 done** (PR #330 for #139). **#140** Post-Login Action script + docs in [`docs/auth0/`](../auth0/PATIENT-POST-LOGIN-GATE.md). **NEXT:** #141.
 - `deltaPeso`/`deltaImc` are computed-at-query, not stored.
 - Progress `grasa` ambiguity: prefer `bodyComposition.porcentajeGrasaCorporal` (patient-facing %) over `indiceGrasaCorporal`.
 - Template dietas (seed `system:template-dietas`) have 4 ingestas incl. Colación — contract examples show only 3.
@@ -172,7 +172,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 
 ### F8.6 — Invitation onboarding gate (#132–#141)
 - **Prerequisites done on `main`:** #156 Paciente decomposition (PRs #175/#176/#178); #46 Liquibase baseline (PR #196). All new schema → incremental changesets per [`docs/db/LIQUIBASE.md`](../db/LIQUIBASE.md).
-- **Active sprint:** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ ~~#137~~ ~~#138~~ ~~#139~~ **done**; **NEXT:** #140–#141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
+- **Active sprint:** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ ~~#137~~ ~~#138~~ ~~#139~~ ~~#140~~ **done**; **NEXT:** #141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
 - **Orthogonal:** nutritionist subscription invitations (`NutritionistInvitation` in subscription track) — see [`ISSUE-SUBSCRIPTION.md`](../../ISSUE-SUBSCRIPTION.md); do not conflate with patient `Invitation`.
 
 #### F8.6.1 — Token contract (AUTHORITATIVE; verified against `main` #133 code, 2026-06-21)
@@ -213,7 +213,7 @@ These exit criteria live in the workflow but were not per-row in [`ISSUE.md`](..
 - **Liquibase same-PR** — #134 (create `Paciente`+`Invitation`), #136 (`patientAuthSub`+status), #138 (profile fields) ship their changeset in the same PR; no `ddl-auto=update`.
 - **OpenAPI regen** — every endpoint PR (#134+) regenerates [`openapi-mobile.yaml`](../api/openapi-mobile.yaml) (#112).
 - **`REVOKED` gating** — `CurrentPatient` resolver (#137) must return 403 for `PacienteStatus.REVOKED`, not only for non-onboarded states.
-- **#140 social cleanup decision** — #140 is not done until the social-user cleanup strategy (scheduled Management-API delete vs. leave-blocked) is chosen and documented under `docs/`.
+- **#140 social cleanup decision** — **Option B (leave blocked & harmless)** documented in [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](../auth0/PATIENT-POST-LOGIN-GATE.md); backend redeem (#136) + onboarding gate (#137) remain authoritative.
 
 ### F8.5 — Design source of truth
 Canonical visual design: `mobile/.claude/MiNutriporcion-2/` (light editorial palette per JSX + 01-p-dashboard.png; the dark welcome/login screenshots are an OLD iteration — ignore).

--- a/docs/mobile-api/MOBILE-E2E-STATUS.md
+++ b/docs/mobile-api/MOBILE-E2E-STATUS.md
@@ -22,6 +22,7 @@ This document summarizes what the backend team verified after Auth0 CLI authenti
 | Visits / diet-plans / messages / progress API | ✅ Deployed on `main` (incl. #99 via PR #153) | Expect **200** (POST messages **201**) after login + linkage |
 | Localized error envelope (#111) | ✅ Deployed | 403/404/400/429 return `ApiResponse` with localized `message` |
 | Message rate limit (#113) | ✅ Deployed | POST messages: 10/min per `patientAuthSub`; **429** + `Retry-After: 60` |
+| Patient invitation Post-Login gate (#140) | 📋 Script ready | Deploy Action from [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](../auth0/PATIENT-POST-LOGIN-GATE.md); mobile must pass `invitation_token` on authorize ([mobile #64](https://github.com/Escanor4323/nutriconsultas-mobile/issues/64)) |
 
 ---
 

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -10,9 +10,10 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`mobile-api-roadmap-v2.md`](mobile-api-roadmap-v2.md) | Per-endpoint (#91–#99) request/response JSON and field mappings |
 | [`PHI-LOGGING-AUDIT.md`](PHI-LOGGING-AUDIT.md) | Completed PHI logging audit for `/rest/mobile/**` (#115, PR #168) |
 | [`MOBILE-E2E-STATUS.md`](MOBILE-E2E-STATUS.md) | Live E2E status, Auth0 setup, HTTP code matrix |
+| [`../auth0/PATIENT-POST-LOGIN-GATE.md`](../auth0/PATIENT-POST-LOGIN-GATE.md) | Auth0 Post-Login invitation gate (#140) — Action script + deployment |
 | [`../api/openapi-mobile.yaml`](../api/openapi-mobile.yaml) | OpenAPI 3.1 export (#112, PR #164); regen: `scripts/export-openapi-mobile.sh` |
 
-**Status (2026-06-22):** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ ~~#137~~ ~~#138~~ ~~#139~~ done (PR [#330](https://github.com/diego-torres/nutriconsultas/pull/330)). **NEXT:** [#140](https://github.com/diego-torres/nutriconsultas/issues/140) Auth0 Post-Login gate.
+**Status (2026-06-22):** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ ~~#137~~ ~~#138~~ ~~#139~~ ~~#140~~ done ([`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](../auth0/PATIENT-POST-LOGIN-GATE.md)). **NEXT:** [#141](https://github.com/diego-torres/nutriconsultas/issues/141) invitation hardening.
 
 ## Related registries (same repo)
 

--- a/scripts/test-patient-invitation-gate.cjs
+++ b/scripts/test-patient-invitation-gate.cjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Interop tests for docs/auth0/actions/patient-invitation-gate.js (#140).
+ * Verifies Node HS256 logic matches PatientInvitationJws (Java #133).
+ *
+ * Usage:
+ *   node scripts/test-patient-invitation-gate.cjs verify <secret> <compact-jws>
+ * Prints patientId or "null", exits 0.
+ */
+const path = require('path');
+
+const gate = require(path.join(__dirname, '../docs/auth0/actions/patient-invitation-gate.js'));
+
+const [, , command, secret, jws] = process.argv;
+
+if (command === 'verify') {
+	const result = gate.verifyOfflineJws(secret, jws);
+	process.stdout.write(result === null ? 'null' : String(result));
+	process.exit(0);
+}
+
+console.error('Usage: node scripts/test-patient-invitation-gate.cjs verify <secret> <jws>');
+process.exit(1);

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationGateScriptInteropTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationGateScriptInteropTest.java
@@ -1,0 +1,67 @@
+package com.nutriconsultas.paciente.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import com.nutriconsultas.util.InvitationTokenHasher;
+
+/**
+ * Ensures the Auth0 Post-Login Action script (#140) verifies JWS tokens signed by
+ * {@link PatientInvitationJws} (Java #133).
+ */
+class PatientInvitationGateScriptInteropTest {
+
+	private static final String SECRET = "test-jws-secret-at-least-32-chars-long";
+
+	static boolean isNodeAvailable() {
+		try {
+			final Process process = new ProcessBuilder("node", "--version").start();
+			return process.waitFor(5, TimeUnit.SECONDS) && process.exitValue() == 0;
+		}
+		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			return false;
+		}
+		catch (Exception ex) {
+			return false;
+		}
+	}
+
+	@Test
+	@EnabledIf("isNodeAvailable")
+	void auth0ActionScript_verifiesJavaSignedJws() throws Exception {
+		final String tokenHash = InvitationTokenHasher.hashToken("sample-url-token");
+		final Instant expiresAt = Instant.now().plus(7, ChronoUnit.DAYS);
+		final String validJws = PatientInvitationJws.sign(SECRET, 42L, tokenHash, expiresAt);
+		final String expiredJws = PatientInvitationJws.sign(SECRET, 1L, tokenHash,
+				Instant.now().minus(1, ChronoUnit.SECONDS));
+		final String tamperedJws = validJws.substring(0, validJws.lastIndexOf('.') + 1) + "bad-signature";
+
+		final Path script = Path.of("scripts/test-patient-invitation-gate.cjs").toAbsolutePath();
+
+		assertThat(verifyViaNode(script, SECRET, validJws)).isEqualTo("42");
+		assertThat(verifyViaNode(script, SECRET, expiredJws)).isEqualTo("null");
+		assertThat(verifyViaNode(script, SECRET, tamperedJws)).isEqualTo("null");
+	}
+
+	private static String verifyViaNode(final Path script, final String secret, final String compactJws)
+			throws Exception {
+		final Process process = new ProcessBuilder("node", script.toString(), "verify", secret, compactJws)
+			.directory(Path.of("").toAbsolutePath().toFile())
+			.redirectErrorStream(true)
+			.start();
+		final boolean finished = process.waitFor(30, TimeUnit.SECONDS);
+		assertThat(finished).as("node interop script timed out").isTrue();
+		assertThat(process.exitValue()).as("node interop script failed").isZero();
+		return new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add Auth0 Post-Login Action script (`docs/auth0/actions/patient-invitation-gate.js`) gating first login on a valid invitation token (offline HS256 JWS or preview API fallback).
- Document deployment runbook, mobile `invitation_token` authorize param, and Option B social-user cleanup strategy.
- Add Java/Node JWS interop test (`PatientInvitationGateScriptInteropTest`).
- Registry sync: #140 done, NEXT → #141.

## Test plan
- [x] `./lint.sh`
- [x] `mvn pmd:check -Pci`
- [x] `mvn test -Dtest=PatientInvitationGateScriptInteropTest`
- [ ] Deploy Action to Auth0 tenant (manual follow-up)
- [ ] Mobile passes `invitation_token` on authorize (nutriconsultas-mobile#64)


Made with [Cursor](https://cursor.com)