### PR TITLE
feat(mobile-api): invitation security hardening (#141)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -41,7 +41,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (public booking):** None — epic ~~#245~~ **done**; ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~, ~~#300~~, ~~#302~~ done. Deferred follow-ups need new issues. See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
-**Current next issue (mobile):** [#141 — Invitation security hardening](https://github.com/diego-torres/nutriconsultas/issues/141) (**NEXT**). ~~#140~~ done ([`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md)).
+**Current next issue (mobile):** Phase 2 invitation onboarding **complete** (~~#141~~). Next mobile work requires new issues.
 
 **Current next issue (subscription):** Registered track **complete** (~~#244~~ ✓ on `subscription/244-contact-form-prefill`). Triage open `[Subscription]` GitHub issues. See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
 
@@ -408,9 +408,9 @@ gh pr create ...
 
 | Field | Value |
 |-------|-------|
-| **Next issue** | [#141 — Invitation security hardening](https://github.com/diego-torres/nutriconsultas/issues/141) |
-| **Status** | **NEXT** — unblocked on `main` |
-| **Just completed** | [#140 — Auth0 Post-Login Action gate](https://github.com/diego-torres/nutriconsultas/issues/140) — [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md) |
+| **Next issue** | None — Phase 2 invitation onboarding **complete** (~~#141~~) |
+| **Status** | **Complete** — new issues needed for next mobile sprint |
+| **Just completed** | [#141 — Invitation security hardening](https://github.com/diego-torres/nutriconsultas/issues/141) — [`INVITATION-SECURITY-AUDIT.md`](docs/mobile-api/INVITATION-SECURITY-AUDIT.md) |
 
 ### Upcoming gates
 
@@ -427,7 +427,7 @@ gh pr create ...
 
 **Patient mobile API on `main`:** Phase 0 + endpoints **#91–#99** done; cross-cutting **#111–#116** done. Onboarding **#132** + token service **#133 done** (PR #229, deployed EC2).
 
-**Next (mobile):** **#141** invitation hardening.
+**Next (mobile):** Phase 2 invitation onboarding **complete** (~~#141~~).
 
 **Schema track:** ~~#46~~ Liquibase baseline (PR #196). Changesets **003–007** on `main` (subscription, patient invitation). All new edits → forward changesets only.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -590,7 +590,7 @@ Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 
-**Next:** [#141](https://github.com/diego-torres/nutriconsultas/issues/141) invitation hardening (**NEXT**). ~~#140~~ done (Post-Login Action — [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md)). ~~#139~~ done (PR [#330](https://github.com/diego-torres/nutriconsultas/pull/330)).
+**Next:** Phase 2 invitation onboarding **complete** (~~#141~~). ~~#140~~ done ([`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md)).
 
 **Schema gate (post-#46):** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline is on `main` (PR #196). All new schema/catalog changes require **incremental Liquibase changesets** — see [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) and [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md). ~~#156~~ Phase C done before baseline.
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) · **Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-22 — ~~#140~~ **done** (branch `mobile-api/140-auth0-post-login-gate`). **NEXT:** [#141 Invitation hardening](https://github.com/diego-torres/nutriconsultas/issues/141).
+**Last updated:** 2026-06-22 — ~~#141~~ **done** (branch `mobile-api/141-invitation-security-hardening`). **Phase 2 invitation onboarding complete.**
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -49,7 +49,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 | `done` | Merged to `main` |
 | `deferred` | Intentionally paused — decision pending |
 
-Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156**, **#46**, **#132**, **#133**, **#134**, **#135**, **#136**, **#137**, **#138**, **#139**, and **#140** done on `main`. **NEXT:** #141.
+Phase 0 (#107, #109, #110) is **done**. Endpoints **#91–#99 are done** on `main`. Cross-cutting **#111–#116** done. **#156**, **#46**, **#132–#141** done on `main`. **Phase 2 invitation onboarding complete.**
 
 ---
 
@@ -138,7 +138,7 @@ Schema-affecting work must respect mobile DTO contracts (§F8). These issues are
 
 ## Phase 2 — Invitation onboarding (P1 · ~~#132~~ ✓ ~~#133~~ ✓ → #134–#141)
 
-Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Active sprint** — Post-Login gate **#140 done**; **NEXT:** #141 hardening.
+Invite-only patient onboarding replaces manual Afiliación linkage (#109) for new patients. **Phase 2 complete** — #141 hardening done.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
@@ -150,7 +150,7 @@ Invite-only patient onboarding replaces manual Afiliación linkage (#109) for ne
 | 138 | `PATCH` & `GET /rest/mobile/patient/me` — onboarding profile + status→ACTIVE | https://github.com/diego-torres/nutriconsultas/issues/138 | **done** | ~~132~~ ✓, ~~137~~ ✓ | Merged PR [#328](https://github.com/diego-torres/nutriconsultas/pull/328) |
 | 139 | `POST /rest/mobile/invitations/{id}/revoke` — nutritionist invalidates invite | https://github.com/diego-torres/nutriconsultas/issues/139 | **done** | ~~132~~ ✓, 134 | Merged PR [#330](https://github.com/diego-torres/nutriconsultas/pull/330) |
 | 140 | Auth0 Post-Login Action gate — first-login invitation validation | https://github.com/diego-torres/nutriconsultas/issues/140 | **done** | ~~133~~ ✓, 136 | Post-Login Action + [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md); Option B social cleanup |
-| 141 | Invitation security hardening — rate limits, enumeration protection, no-token logging | https://github.com/diego-torres/nutriconsultas/issues/141 | **NEXT** | ~~133~~ ✓, 135, 136 | Relates #115; never log raw tokens |
+| 141 | Invitation security hardening — rate limits, enumeration protection, no-token logging | https://github.com/diego-torres/nutriconsultas/issues/141 | **done** | ~~133~~ ✓, 135, 136 | [`INVITATION-SECURITY-AUDIT.md`](docs/mobile-api/INVITATION-SECURITY-AUDIT.md) acceptance audit |
 
 **Suggested build order (after ~~#133~~ ✓):** #134/#135 → #136 → #137 → #138 → #139/#140 → #141.
 

--- a/docs/auth0/PATIENT-POST-LOGIN-GATE.md
+++ b/docs/auth0/PATIENT-POST-LOGIN-GATE.md
@@ -149,6 +149,14 @@ Rotating `PATIENT_INVITATION_JWS_SECRET` invalidates outstanding **offline JWS**
 
 ---
 
+## Logging policy (#141)
+
+- **Never** log `invitation_token`, raw URL tokens, human codes, or offline JWS in Action code, custom log streams, or `console.*`.
+- The Action does not emit token values; rely on deny/allow outcomes only.
+- Preview API fallback passes the token in the request URL — restrict Auth0 platform log access and retention.
+
+---
+
 ## Testing
 
 ### Local JWS interop (Java ↔ Action script)

--- a/docs/mobile-api/ALIGNMENT-SPEC.md
+++ b/docs/mobile-api/ALIGNMENT-SPEC.md
@@ -160,7 +160,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 - **Phase 0 DONE:** #107 (PR #117), #109 (PR #142), #110 (DTO envelope).
 - **Endpoints on `main`:** #91–#99 (visits, diet plans + PDF, messages, progress snapshot + measurements time series); #96/#97 messaging with HTTP 201 + Resilience4j 10/min (#113, PR #151).
 - **i18n (#111) DONE** (PR #151): `LocaleContextFilter`, `MobileApiErrorResponses`, localized 403/404/400/429.
-- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). Onboarding **#132–#139 done** (PR #330 for #139). **#140** Post-Login Action script + docs in [`docs/auth0/`](../auth0/PATIENT-POST-LOGIN-GATE.md). **NEXT:** #141.
+- **Cross-cutting:** ~~#116~~ `senderDisplayName` **done** (PR #173). ~~#114~~ nutritionist reply **done**. ~~#115~~ PHI audit **done** (PR #168). ~~#112~~ OpenAPI **done** (PR #164). Onboarding **#132–#141 done** — Phase 2 complete ([`INVITATION-SECURITY-AUDIT.md`](INVITATION-SECURITY-AUDIT.md)).
 - `deltaPeso`/`deltaImc` are computed-at-query, not stored.
 - Progress `grasa` ambiguity: prefer `bodyComposition.porcentajeGrasaCorporal` (patient-facing %) over `indiceGrasaCorporal`.
 - Template dietas (seed `system:template-dietas`) have 4 ingestas incl. Colación — contract examples show only 3.
@@ -172,7 +172,7 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 
 ### F8.6 — Invitation onboarding gate (#132–#141)
 - **Prerequisites done on `main`:** #156 Paciente decomposition (PRs #175/#176/#178); #46 Liquibase baseline (PR #196). All new schema → incremental changesets per [`docs/db/LIQUIBASE.md`](../db/LIQUIBASE.md).
-- **Active sprint:** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ ~~#137~~ ~~#138~~ ~~#139~~ ~~#140~~ **done**; **NEXT:** #141 per [`ISSUE.md`](../../ISSUE.md) Phase 2.
+- **Active sprint:** ~~#132~~–~~#141~~ **done** — Phase 2 invitation onboarding complete per [`ISSUE.md`](../../ISSUE.md).
 - **Orthogonal:** nutritionist subscription invitations (`NutritionistInvitation` in subscription track) — see [`ISSUE-SUBSCRIPTION.md`](../../ISSUE-SUBSCRIPTION.md); do not conflate with patient `Invitation`.
 
 #### F8.6.1 — Token contract (AUTHORITATIVE; verified against `main` #133 code, 2026-06-21)

--- a/docs/mobile-api/INVITATION-SECURITY-AUDIT.md
+++ b/docs/mobile-api/INVITATION-SECURITY-AUDIT.md
@@ -1,0 +1,118 @@
+# Invitation security audit (#141)
+
+Cross-cutting acceptance audit for patient invitation onboarding security controls. Canonical error codes: [`ALIGNMENT-SPEC.md`](ALIGNMENT-SPEC.md) §F8.6.3–4.
+
+**Audit date:** 2026-06-22  
+**Scope:** #134 create, #135 preview, #136 redeem, #139 revoke, #140 Auth0 Post-Login gate
+
+---
+
+## Control matrix
+
+| Control | Requirement | Status | Evidence |
+|---------|-------------|--------|----------|
+| Rate limit preview | Resilience4j, IP-scoped (#135) | ✅ | `PatientInvitationPreviewRateLimiter`, `application.properties` |
+| Rate limit redeem | Resilience4j, sub-scoped (#136) | ✅ | `PatientInvitationRedeemRateLimiter` |
+| Enumeration protection | Generic 404 for absent/expired/revoked | ✅ | `PatientInvitationUnavailableException`, `PatientInvitationRevokeNotFoundException` |
+| Malformed token | 400, distinct message | ✅ | `PatientInvitationInvalidTokenException` |
+| TTL server-side | `expiresAt` checked in service layer | ✅ | `isRedeemablePending`, preview service |
+| No raw token logging | App + invitation package | ✅ | `PhiLogTurboFilter`, `InvitationPackageLoggingAuditTest` |
+| Auth0 Action logging | No token in Action code | ✅ | `patient-invitation-gate.js` (no `console.log`) |
+| JWT + redeem gate | Data access requires linked `sub` + redeem | ✅ | #136 redeem, #137 `PatientLinkageFilter` |
+
+---
+
+## F8.6.3 error-code compliance
+
+| HTTP | Condition | Implementation | Test |
+|------|-----------|----------------|------|
+| 400 | Malformed token | `PatientInvitationInvalidTokenException` | `MobileInvitationIntegrationTest` preview malformed; `PatientInvitationRedeemServiceTest` |
+| 404 | Absent / expired / revoked (generic) | `PatientInvitationUnavailableException` | Preview unknown vs expired; redeem unknown vs expired; revoke IDOR |
+| 409 | Redeem by different `sub` | `PatientInvitationRedeemConflictException` | `MobileInvitationIntegrationTest` |
+| 422 | Patient not `INVITED` at redeem | `PatientInvitationPatientStatusException` | `PatientInvitationRedeemServiceTest` |
+| 429 | Rate limit preview/redeem | `RequestNotPermitted` → handler | Preview + redeem integration tests |
+
+---
+
+## Rate limiting
+
+| Endpoint | Limiter key | Prod limit | Test limit |
+|----------|-------------|------------|------------|
+| `GET …/preview` | Client IP (`ClientIpResolver`) | 10/min | 2/min |
+| `POST …/redeem` | `patientAuthSub` | 10/min | 2/min |
+
+Configuration: `resilience4j.ratelimiter.instances.patientInvitationPreview` / `patientInvitationRedeem` in `application.properties` and `application-test.properties`.
+
+429 response: localized `error.rate.limit.exceeded`, `Retry-After: 60` (`MobileApiExceptionHandler`).
+
+---
+
+## Enumeration protection
+
+**Rule:** Never distinguish whether a token exists, expired, or was revoked — single generic 404 message (`error.invitation.invalid_or_expired`).
+
+| Flow | Service | Notes |
+|------|---------|-------|
+| Preview | `PatientInvitationPreviewServiceImpl` | Revoked/expired/unknown → same exception |
+| Redeem | `PatientInvitationRedeemServiceImpl` | Absent hash → `Unavailable`; non-pending → `Unavailable` |
+| Revoke IDOR | `PatientInvitationRevokeServiceImpl` | Wrong nutritionist → `RevokeNotFound` (same 404 message) |
+
+**Intentional 409:** Second `sub` redeeming an already-redeemed invite reveals prior redemption (F8.6.3).
+
+---
+
+## Token logging defense
+
+### Runtime (`PhiLogTurboFilter`)
+
+Protects loggers under `com.nutriconsultas.mobile` and `com.nutriconsultas.paciente.invitation` at INFO+:
+
+- Email addresses
+- Raw Auth0 `sub` (unless `REDACTED`)
+- Human codes (`NUTRI-XXXX-XXXX`)
+- Invite URL path tokens (`/i/{token}`)
+- Standalone 43-char base64url URL tokens (#141)
+
+### Static audits
+
+| Gate | Command / test |
+|------|----------------|
+| Mobile package | `bash scripts/audit-mobile-logging.sh` |
+| Invitation package | Same script (extended #141) |
+| JUnit | `MobilePackageLoggingAuditTest`, `InvitationPackageLoggingAuditTest` |
+
+### Service logging
+
+Controllers and invitation services log only non-sensitive IDs (`invitationId`, `pacienteId`) at INFO.
+
+---
+
+## Auth0 Post-Login gate (#140)
+
+- Action script does not log `invitation_token`.
+- Preview fallback sends token in URL path to backend — **platform access logs** may capture URLs; operational teams must restrict Auth0 log retention/access.
+- Documented in [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](../auth0/PATIENT-POST-LOGIN-GATE.md).
+
+---
+
+## Residual risks
+
+| Risk | Mitigation |
+|------|------------|
+| Preview rate limit keyed on `X-Forwarded-For` | Trust proxy chain on production load balancer |
+| 409 on redeem conflict | Acceptable per F8.6.3; does not leak token validity |
+| Offline JWS cannot see DB revocation at Auth0 login | Preview path validates live state; redeem is authoritative |
+| Standalone 43-char TurboFilter pattern | Low false-positive risk; only invitation package + mobile loggers |
+
+---
+
+## Sign-off criteria (#141)
+
+- [x] Rate limits on preview and redeem with integration tests
+- [x] Enumeration tests for preview and redeem (unknown vs expired)
+- [x] IDOR tests for revoke (#139)
+- [x] PHI/token logging audits (TurboFilter + static)
+- [x] Auth0 Action no-token policy documented
+- [x] This audit doc published
+
+**Phase 2 invitation onboarding track:** complete after #141 merges.

--- a/docs/mobile-api/PHI-LOGGING-AUDIT.md
+++ b/docs/mobile-api/PHI-LOGGING-AUDIT.md
@@ -6,7 +6,7 @@ Audit completed **2026-06-15**; merged to `main` via [PR #168](https://github.co
 
 - No patient names, emails, phone numbers, DOB, measurements, message bodies, or raw Auth0 `sub` values in unstructured logs at **INFO** or above.
 - Use `com.nutriconsultas.util.LogRedaction` for all patient-related identifiers in log statements.
-- Defense in depth: `PhiLogTurboFilter` (configured in `logback-spring.xml`) denies INFO+ mobile log lines that match email or unredacted Auth0 sub patterns. Static audit + checklist cover names/DOB/measures; TurboFilter does not yet mask those patterns (follow-up optional).
+- Defense in depth: `PhiLogTurboFilter` (configured in `logback-spring.xml`) denies INFO+ mobile and `paciente.invitation` log lines that match email, unredacted Auth0 sub, human invitation codes, invite URL tokens, or standalone 43-char URL tokens (#141).
 
 ## Checklist
 
@@ -24,8 +24,8 @@ Audit completed **2026-06-15**; merged to `main` via [PR #168](https://github.co
 | Gate | Command |
 |------|---------|
 | Repo-wide logging audit | `bash scripts/audit-logging.sh` |
-| Mobile package audit (#115) | `bash scripts/audit-mobile-logging.sh` |
-| Automated tests | `MobilePackageLoggingAuditTest`, `MobilePhiLoggingIntegrationTest`, `PhiLogTurboFilterTest` |
+| Mobile package audit (#115 / #141) | `bash scripts/audit-mobile-logging.sh` |
+| Automated tests | `MobilePackageLoggingAuditTest`, `InvitationPackageLoggingAuditTest`, `MobilePhiLoggingIntegrationTest`, `PhiLogTurboFilterTest` |
 
 ## Safe logging examples
 
@@ -40,4 +40,4 @@ log.info("Linked mobile Auth0 account for patient {} sub={}",
 
 - `docs/LOGGING_SECURITY.md` — project-wide logging security guide
 - `README_LOGGING_SECURITY.md` — quick reference
-- Issue [#141](https://github.com/diego-torres/nutriconsultas/issues/141) — invitation token logging (future; never log raw tokens)
+- Issue [#141](https://github.com/diego-torres/nutriconsultas/issues/141) — invitation token logging **done**; see [`INVITATION-SECURITY-AUDIT.md`](INVITATION-SECURITY-AUDIT.md)

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -9,11 +9,12 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`ALIGNMENT-SPEC.md`](ALIGNMENT-SPEC.md) | Source-of-truth contract — §F7 audience, §F8 schema/enum map, verified gaps, invitation gate §F8.6 |
 | [`mobile-api-roadmap-v2.md`](mobile-api-roadmap-v2.md) | Per-endpoint (#91–#99) request/response JSON and field mappings |
 | [`PHI-LOGGING-AUDIT.md`](PHI-LOGGING-AUDIT.md) | Completed PHI logging audit for `/rest/mobile/**` (#115, PR #168) |
+| [`INVITATION-SECURITY-AUDIT.md`](INVITATION-SECURITY-AUDIT.md) | #141 acceptance audit — rate limits, enumeration, no-token logging |
 | [`MOBILE-E2E-STATUS.md`](MOBILE-E2E-STATUS.md) | Live E2E status, Auth0 setup, HTTP code matrix |
 | [`../auth0/PATIENT-POST-LOGIN-GATE.md`](../auth0/PATIENT-POST-LOGIN-GATE.md) | Auth0 Post-Login invitation gate (#140) — Action script + deployment |
 | [`../api/openapi-mobile.yaml`](../api/openapi-mobile.yaml) | OpenAPI 3.1 export (#112, PR #164); regen: `scripts/export-openapi-mobile.sh` |
 
-**Status (2026-06-22):** ~~#132~~ ~~#133~~ ~~#134~~ ~~#135~~ ~~#136~~ ~~#137~~ ~~#138~~ ~~#139~~ ~~#140~~ done ([`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](../auth0/PATIENT-POST-LOGIN-GATE.md)). **NEXT:** [#141](https://github.com/diego-torres/nutriconsultas/issues/141) invitation hardening.
+**Status (2026-06-22):** ~~#132~~–~~#141~~ **done** — Phase 2 invitation onboarding complete ([`INVITATION-SECURITY-AUDIT.md`](INVITATION-SECURITY-AUDIT.md)).
 
 ## Related registries (same repo)
 

--- a/scripts/audit-mobile-logging.sh
+++ b/scripts/audit-mobile-logging.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Strict PHI logging audit for the patient mobile API package (#115).
-# Scans only src/main/java/com/nutriconsultas/mobile for unsafe log patterns.
+# Strict PHI logging audit for the patient mobile API package (#115) and patient
+# invitation package (#141). Scans mobile + paciente.invitation for unsafe log patterns.
 
 set -euo pipefail
 
@@ -15,21 +15,78 @@ VIOLATIONS=0
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MOBILE_SRC="$PROJECT_ROOT/src/main/java/com/nutriconsultas/mobile"
+INVITATION_SRC="$PROJECT_ROOT/src/main/java/com/nutriconsultas/paciente/invitation"
 
 echo -e "${BLUE}========================================${NC}"
-echo -e "${BLUE}Mobile API PHI Logging Audit (#115)${NC}"
+echo -e "${BLUE}Mobile API PHI Logging Audit (#115 / #141)${NC}"
 echo -e "${BLUE}========================================${NC}"
 echo ""
 
-if [ ! -d "$MOBILE_SRC" ]; then
-  echo -e "${RED}✗ Mobile source directory not found: $MOBILE_SRC${NC}"
-  exit 1
-fi
+scan_directory() {
+  local label="$1"
+  local src_dir="$2"
 
-JAVA_FILES=$(find "$MOBILE_SRC" -name "*.java" -type f | sort)
-FILE_COUNT=$(echo "$JAVA_FILES" | wc -l | tr -d ' ')
-echo -e "${YELLOW}Scanning ${FILE_COUNT} mobile Java file(s)...${NC}"
-echo ""
+  if [ ! -d "$src_dir" ]; then
+    echo -e "${RED}✗ ${label} source directory not found: $src_dir${NC}"
+    exit 1
+  fi
+
+  local java_files
+  java_files=$(find "$src_dir" -name "*.java" -type f | sort)
+  local file_count
+  file_count=$(echo "$java_files" | wc -l | tr -d ' ')
+  echo -e "${YELLOW}Scanning ${file_count} ${label} Java file(s)...${NC}"
+  echo ""
+
+  while IFS= read -r file; do
+    if [[ "$file" == *"PhiLogTurboFilter.java" ]]; then
+      continue
+    fi
+
+    line_number=0
+    while IFS= read -r line; do
+      line_number=$((line_number + 1))
+
+      if [[ "$line" =~ ^[[:space:]]*// ]] || [[ "$line" =~ ^[[:space:]]*\* ]]; then
+        continue
+      fi
+
+      if echo "$line" | grep -qE 'log\.(info|debug|warn|error|trace)\('; then
+        if echo "$line" | grep -qE '\b(body|getBody\(\)|request\.body\(\))\b' \
+            && ! echo "$line" | grep -q 'LogRedaction'; then
+          report_violation "$file" "$line_number" "$line" "Message body must never appear in log statements"
+        fi
+
+        if echo "$line" | grep -qE 'log\.(info|warn|error)\(' \
+            && echo "$line" | grep -qE '\b(getEmail|getNombre|getTelefono|getDireccion|getFechaNacimiento)\b' \
+            && ! echo "$line" | grep -q 'LogRedaction'; then
+          report_violation "$file" "$line_number" "$line" "PHI accessor must not be logged at INFO+ without LogRedaction"
+        fi
+
+        if echo "$line" | grep -qE 'log\.(info|warn|error)\(' \
+            && echo "$line" | grep -qE '\bpatientAuthSub\b' \
+            && ! echo "$line" | grep -q 'LogRedaction\.redactUserId'; then
+          report_violation "$file" "$line_number" "$line" "Auth0 sub must use LogRedaction.redactUserId at INFO+"
+        fi
+
+        if echo "$line" | grep -qE 'log\.(info|debug|warn|error|trace)\([^)]*\{[^}]*\b(paciente|Paciente)\b[^}]*\}' \
+            && ! echo "$line" | grep -q 'LogRedaction'; then
+          report_violation "$file" "$line_number" "$line" "Paciente entity must be logged via LogRedaction"
+        fi
+
+        if echo "$line" | grep -qE 'log\.(info|debug|warn|error|trace)\([^)]*\{[^}]*\b(PatientMessage|CalendarEvent|ClinicalExam|AnthropometricMeasurement|PacienteDieta)\b[^}]*\}' \
+            && ! echo "$line" | grep -q 'LogRedaction'; then
+          report_violation "$file" "$line_number" "$line" "Patient-related entity must be logged via LogRedaction"
+        fi
+
+        if echo "$line" | grep -qE 'log\.(info|warn|error)\(' \
+            && echo "$line" | grep -qE '\b(urlToken|rawUrlToken|humanCode|inviteUrl)\b'; then
+          report_violation "$file" "$line_number" "$line" "Raw invitation token material must never be logged (#141)"
+        fi
+      fi
+    done < "$file"
+  done <<< "$java_files"
+}
 
 report_violation() {
   local file="$1"
@@ -43,56 +100,15 @@ report_violation() {
   VIOLATIONS=$((VIOLATIONS + 1))
 }
 
-while IFS= read -r file; do
-  if [[ "$file" == *"PhiLogTurboFilter.java" ]]; then
-    continue
-  fi
-
-  line_number=0
-  while IFS= read -r line; do
-    line_number=$((line_number + 1))
-
-    if [[ "$line" =~ ^[[:space:]]*// ]] || [[ "$line" =~ ^[[:space:]]*\* ]]; then
-      continue
-    fi
-
-    if echo "$line" | grep -qE 'log\.(info|debug|warn|error|trace)\('; then
-      if echo "$line" | grep -qE '\b(body|getBody\(\)|request\.body\(\))\b' \
-          && ! echo "$line" | grep -q 'LogRedaction'; then
-        report_violation "$file" "$line_number" "$line" "Message body must never appear in log statements"
-      fi
-
-      if echo "$line" | grep -qE 'log\.(info|warn|error)\(' \
-          && echo "$line" | grep -qE '\b(getEmail|getNombre|getTelefono|getDireccion|getFechaNacimiento)\b' \
-          && ! echo "$line" | grep -q 'LogRedaction'; then
-        report_violation "$file" "$line_number" "$line" "PHI accessor must not be logged at INFO+ without LogRedaction"
-      fi
-
-      if echo "$line" | grep -qE 'log\.(info|warn|error)\(' \
-          && echo "$line" | grep -qE '\bpatientAuthSub\b' \
-          && ! echo "$line" | grep -q 'LogRedaction\.redactUserId'; then
-        report_violation "$file" "$line_number" "$line" "Auth0 sub must use LogRedaction.redactUserId at INFO+"
-      fi
-
-      if echo "$line" | grep -qE 'log\.(info|debug|warn|error|trace)\([^)]*\{[^}]*\b(paciente|Paciente)\b[^}]*\}' \
-          && ! echo "$line" | grep -q 'LogRedaction'; then
-        report_violation "$file" "$line_number" "$line" "Paciente entity must be logged via LogRedaction"
-      fi
-
-      if echo "$line" | grep -qE 'log\.(info|debug|warn|error|trace)\([^)]*\{[^}]*\b(PatientMessage|CalendarEvent|ClinicalExam|AnthropometricMeasurement|PacienteDieta)\b[^}]*\}' \
-          && ! echo "$line" | grep -q 'LogRedaction'; then
-        report_violation "$file" "$line_number" "$line" "Patient-related entity must be logged via LogRedaction"
-      fi
-    fi
-  done < "$file"
-done <<< "$JAVA_FILES"
+scan_directory "mobile" "$MOBILE_SRC"
+scan_directory "patient invitation" "$INVITATION_SRC"
 
 echo -e "${BLUE}========================================${NC}"
 echo -e "${BLUE}Audit Summary${NC}"
 echo -e "${BLUE}========================================${NC}"
 
 if [ "$VIOLATIONS" -eq 0 ]; then
-  echo -e "${GREEN}✓ No mobile PHI logging violations found${NC}"
+  echo -e "${GREEN}✓ No mobile/invitation PHI logging violations found${NC}"
   exit 0
 fi
 

--- a/src/main/java/com/nutriconsultas/mobile/logging/PhiLogTurboFilter.java
+++ b/src/main/java/com/nutriconsultas/mobile/logging/PhiLogTurboFilter.java
@@ -29,6 +29,8 @@ public final class PhiLogTurboFilter extends TurboFilter {
 
 	private static final Pattern INVITE_URL_TOKEN = Pattern.compile("/i/[A-Za-z0-9_-]{40,50}\\b");
 
+	private static final Pattern STANDALONE_URL_TOKEN = Pattern.compile("\\b[A-Za-z0-9_-]{43}\\b");
+
 	@Override
 	public FilterReply decide(final Marker marker, final Logger logger, final Level level, final String format,
 			final Object[] params, final Throwable throwable) {
@@ -52,6 +54,9 @@ public final class PhiLogTurboFilter extends TurboFilter {
 			return FilterReply.DENY;
 		}
 		if (INVITE_URL_TOKEN.matcher(message).find()) {
+			return FilterReply.DENY;
+		}
+		if (STANDALONE_URL_TOKEN.matcher(message).find()) {
 			return FilterReply.DENY;
 		}
 		return FilterReply.NEUTRAL;

--- a/src/test/java/com/nutriconsultas/mobile/MobileInvitationIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileInvitationIntegrationTest.java
@@ -81,6 +81,8 @@ class MobileInvitationIntegrationTest {
 		rateLimiterRegistry.remove(PatientInvitationPreviewRateLimiter.PATIENT_INVITATION_PREVIEW + ":127.0.0.1");
 		rateLimiterRegistry
 			.remove(PatientInvitationRedeemRateLimiter.PATIENT_INVITATION_REDEEM + ":auth0|patient-redeem-integration");
+		rateLimiterRegistry
+			.remove(PatientInvitationRedeemRateLimiter.PATIENT_INVITATION_REDEEM + ":auth0|patient-redeem-rate-limit");
 	}
 
 	@Test
@@ -189,6 +191,48 @@ class MobileInvitationIntegrationTest {
 		}
 
 		mockMvc.perform(get("/rest/mobile/invitations/{token}/preview", bundle.urlToken()))
+			.andExpect(status().isTooManyRequests())
+			.andExpect(header().string("Retry-After", "60"))
+			.andExpect(jsonPath("$.message").value("Demasiadas solicitudes. Inténtalo de nuevo en un minuto."));
+	}
+
+	@Test
+	void redeemInvitation_withUnknownToken_returnsGenericNotFound() throws Exception {
+		final PatientInvitationTokenBundle bundle = patientInvitationTokenService.generate();
+
+		mockMvc
+			.perform(post("/rest/mobile/invitations/{token}/redeem", bundle.urlToken())
+				.with(mobileJwt("auth0|patient-redeem-unknown")))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("La invitación no es válida o ha expirado."));
+	}
+
+	@Test
+	void redeemInvitation_withExpiredToken_returnsSameMessageAsUnknown() throws Exception {
+		final PatientInvitationTokenBundle bundle = patientInvitationTokenService.generate();
+		final PatientInvitation invitation = seedPendingInvitation(bundle, NUTRITIONIST_SUB);
+		invitation.setExpiresAt(Instant.now().minus(1, ChronoUnit.HOURS));
+		patientInvitationRepository.saveAndFlush(invitation);
+
+		mockMvc
+			.perform(post("/rest/mobile/invitations/{token}/redeem", bundle.urlToken())
+				.with(mobileJwt("auth0|patient-redeem-expired")))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("La invitación no es válida o ha expirado."));
+	}
+
+	@Test
+	void redeemInvitation_whenRateLimited_returns429WithRetryAfter() throws Exception {
+		final PatientInvitationTokenBundle bundle = patientInvitationTokenService.generate();
+		seedPendingInvitation(bundle, NUTRITIONIST_SUB);
+		final String patientSub = "auth0|patient-redeem-rate-limit";
+
+		for (int attempt = 0; attempt < 2; attempt++) {
+			mockMvc.perform(post("/rest/mobile/invitations/{token}/redeem", bundle.urlToken()).with(mobileJwt(patientSub)))
+				.andExpect(status().isOk());
+		}
+
+		mockMvc.perform(post("/rest/mobile/invitations/{token}/redeem", bundle.urlToken()).with(mobileJwt(patientSub)))
 			.andExpect(status().isTooManyRequests())
 			.andExpect(header().string("Retry-After", "60"))
 			.andExpect(jsonPath("$.message").value("Demasiadas solicitudes. Inténtalo de nuevo en un minuto."));

--- a/src/test/java/com/nutriconsultas/mobile/logging/PhiLogTurboFilterTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/logging/PhiLogTurboFilterTest.java
@@ -85,11 +85,12 @@ class PhiLogTurboFilterTest {
 	}
 
 	@Test
-	void deniesInviteUrlTokenInMobilePackage() {
+	void deniesStandaloneUrlTokenInPatientInvitationPackage() {
 		filter.start();
+		final Logger invitationLogger = logger("com.nutriconsultas.paciente.invitation.PatientInvitationCreateServiceImpl");
 
-		final FilterReply reply = filter.decide(null, mobileLogger, Level.INFO, "url={}",
-				new Object[] { "https://links.test/i/abcdefghijklmnopqrstuvwxyz0123456789ABCDE" }, null);
+		final FilterReply reply = filter.decide(null, invitationLogger, Level.INFO, "token={}",
+				new Object[] { "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG" }, null);
 
 		assertThat(reply).isEqualTo(FilterReply.DENY);
 	}

--- a/src/test/java/com/nutriconsultas/paciente/invitation/InvitationPackageLoggingAuditTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/InvitationPackageLoggingAuditTest.java
@@ -1,0 +1,62 @@
+package com.nutriconsultas.paciente.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Static audit for invitation token logging safety (#141).
+ */
+class InvitationPackageLoggingAuditTest {
+
+	private static final Path INVITATION_SRC = Path.of("src", "main", "java", "com", "nutriconsultas",
+			"paciente", "invitation");
+
+	private static final Pattern LOG_STATEMENT = Pattern.compile("log\\.(info|debug|warn|error|trace)\\(");
+
+	private static final Pattern FORBIDDEN_TOKEN_PLACEHOLDER = Pattern.compile(
+			"log\\.(info|warn|error)\\([^)]*\\b(urlToken|rawUrlToken|humanCode|inviteUrl|tokenHash)\\b");
+
+	@Test
+	void invitationPackageHasNoTokenLoggingViolations() throws IOException {
+		assertThat(Files.isDirectory(INVITATION_SRC)).as("invitation source directory").isTrue();
+
+		final List<String> violations = new ArrayList<>();
+		try (Stream<Path> paths = Files.walk(INVITATION_SRC)) {
+			paths.filter(path -> path.toString().endsWith(".java")).forEach(path -> scanFile(path, violations));
+		}
+
+		assertThat(violations).as("invitation token logging violations:\n%s", String.join("\n", violations)).isEmpty();
+	}
+
+	private static void scanFile(final Path file, final List<String> violations) {
+		try {
+			final List<String> lines = Files.readAllLines(file);
+			for (int index = 0; index < lines.size(); index++) {
+				final String line = lines.get(index).trim();
+				if (line.startsWith("//") || line.startsWith("*")) {
+					continue;
+				}
+				if (!LOG_STATEMENT.matcher(line).find()) {
+					continue;
+				}
+				final String location = file + ":" + (index + 1);
+				if (FORBIDDEN_TOKEN_PLACEHOLDER.matcher(line).find()) {
+					violations.add(location + " — raw invitation token material must never be logged");
+				}
+			}
+		}
+		catch (IOException ex) {
+			violations.add(file + " — could not read file: " + ex.getMessage());
+		}
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationRedeemServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationRedeemServiceTest.java
@@ -143,6 +143,17 @@ class PatientInvitationRedeemServiceTest {
 	}
 
 	@Test
+	void redeem_withRevokedInvitation_throwsUnavailable() {
+		final PatientInvitationTokenBundle bundle = tokenService.generate();
+		final PatientInvitation invitation = pendingInvitation(bundle.tokenHash(), invitedPaciente(100L));
+		invitation.setStatus(PatientInvitationStatus.REVOKED);
+		when(patientInvitationRepository.findByTokenHash(bundle.tokenHash())).thenReturn(Optional.of(invitation));
+
+		assertThatThrownBy(() -> service.redeem(bundle.urlToken(), PATIENT_SUB))
+			.isInstanceOf(PatientInvitationUnavailableException.class);
+	}
+
+	@Test
 	void redeem_withMalformedToken_throwsInvalid() {
 		assertThatThrownBy(() -> service.redeem("bad-token", PATIENT_SUB))
 			.isInstanceOf(PatientInvitationInvalidTokenException.class);


### PR DESCRIPTION
## Summary
- Publish acceptance audit (`INVITATION-SECURITY-AUDIT.md`) confirming rate limits, enumeration protection, and no-token logging across #134–#140.
- Extend `PhiLogTurboFilter` to redact standalone 43-char URL tokens; add `InvitationPackageLoggingAuditTest` and extend `audit-mobile-logging.sh`.
- Add redeem rate-limit and enumeration integration tests; revoked-invitation unit test.
- Registry sync: #141 done — **Phase 2 invitation onboarding complete**.

## Test plan
- [x] `./lint.sh`
- [x] `mvn pmd:check -Pci`
- [x] `MobileInvitationIntegrationTest`, `PhiLogTurboFilterTest`, `InvitationPackageLoggingAuditTest`
- [x] `bash scripts/audit-mobile-logging.sh`


Made with [Cursor](https://cursor.com)