### PR TITLE
docs(registry): advance AGENT-WORKFLOW.md backend state past #135–#141

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -57,7 +57,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | **API surface** | All mobile endpoints live under `/rest/mobile/patient/` as plain JSON (not DataTables-shaped like the admin `*RestController`s). |
 | **Identity (security-critical)** | JWT `sub` → **`Paciente.patientAuthSub`** (#107 ✓ PR #117). **Never `Paciente.userId`** — that is the NUTRITIONIST's Auth0 sub / tenant owner (ALIGNMENT-SPEC §F2). `PatientLinkageFilter` returns **403** if no linked `Paciente`. |
 | **Ownership / IDOR** | Return only the authenticated patient's rows. On an ownership miss prefer **404** (not 403) so existence isn't leaked (esp. #92). Never return cross-tenant data. |
-| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **Cross-cutting done** (#111–#116). **#156**, **#46**, **#132**, **#133**, **#134** done. **NEXT:** #135 invitation preview. Requires `AUTH_AUDIENCE` env var. |
+| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **Cross-cutting done** (#111–#116). **#156**, **#46**, **#132–#141** done. **Phase 2 invitation onboarding complete.** Next mobile work requires new issues. Requires `AUTH_AUDIENCE` env var. |
 | **DTO envelope** | `ApiResponse<T>`; lists in `PagedResponse<T>` or `CursorPagedResponse<T>` (messages); ISO-8601 date strings. See #110. |
 | **Schema ground truth** | ALIGNMENT-SPEC §F8 field-name map (`nombre→dietaName`, `energia→totalKcal`, `lipidos→totalGrasas`, `hidratosDeCarbono→totalCarbohidratos`, `Ingesta.nombre→tipo`); enums `EventStatus`/`PacienteDietaStatus` (no INACTIVE)/`NivelPeso`. Serialization aliases only — **no DB schema changes** for field renames. |
 | **PHI & logging** | No patient names/emails/DOB in unstructured logs. `LogRedaction` + `PhiLogTurboFilter`; CI runs `scripts/audit-logging.sh` and `scripts/audit-mobile-logging.sh` (#115 done). |
@@ -107,7 +107,7 @@ flowchart LR
    - **#113 (rate limit)** should land with or before **#97** (write endpoint).
    - **#114 (nutritionist reply) is web-only** — do not expose it under `/rest/mobile/**`.
    - **#46 (Liquibase)** ✓ — all schema/catalog changes are incremental changesets (see [Liquibase section](#liquibase--entity-schema-and-catalog-data)).
-   - **#134 (create invitation)** ✓ — merged PR #319. **NEXT:** #135 public preview endpoint.
+   - **Phase 2 invitation onboarding** ✓ — #134–#141 all merged (PRs #319, #324–#333). **Phase 2 complete.** No NEXT in the mobile track — new issues required for additional work.
    - If a dependency is still `open`, complete it first or document the blocker in the plan (Phase 2) and stop.
 5. **Update local registry** when remote state drifted (issue closed on GitHub but still `open` here, or vice versa). `ISSUE.md` must match GitHub before proceeding.
 

--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -421,11 +421,11 @@ gh pr create ...
 | Endpoints | ~~#91–#99~~ ✓ | **Done** (PR #153) |
 | Cross-cutting | ~~#111~~ ✓, ~~#112~~ ✓ (OpenAPI), ~~#115~~ ✓ (PHI audit) | **Done** |
 | Hardening / additive | ~~#113~~ ✓, ~~#116~~ ✓ (`senderDisplayName`), ~~#114~~ ✓ (nutritionist reply) | **Done** |
-| Schema / Liquibase | ~~**#46**~~ ✓ (PR #196) → ~~**#132**~~ ✓ (PR #214) → ~~**#133**~~ ✓ (PR #229) → **#134–#141** | **#134 NEXT** — incremental changesets per [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) |
+| Schema / Liquibase | ~~**#46**~~ ✓ (PR #196) → ~~**#132**~~ ✓ (PR #214) → ~~**#133–#141**~~ ✓ (PRs #229, #319, #324–#333) | **Done** — forward changesets per [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) |
 
-### Status snapshot (2026-06-19)
+### Status snapshot (2026-06-23)
 
-**Patient mobile API on `main`:** Phase 0 + endpoints **#91–#99** done; cross-cutting **#111–#116** done. Onboarding **#132** + token service **#133 done** (PR #229, deployed EC2).
+**Patient mobile API on `main`:** Phase 0 + endpoints **#91–#99** done; cross-cutting **#111–#116** done. Phase 2 invitation onboarding **#132–#141 complete** (PRs #214, #229, #319, #324–#333).
 
 **Next (mobile):** Phase 2 invitation onboarding **complete** (~~#141~~).
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -10,7 +10,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
-> **GitHub sync note (2026-06-19):** **#133** closed (PR #229). **NEXT:** #134. ~~#97~~, ~~#111~~ closed on GitHub (PRs #147, #151).
+> **GitHub sync note (2026-06-23):** Phase 2 invitation onboarding **#134–#141 complete** (PRs #319, #324–#333). ~~#133~~ closed (PR #229). ~~#97~~, ~~#111~~ closed (PRs #147, #151).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ registro de consultorio de nutrición
 
 **Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
-**On `main` (2026-06-22):** Mobile **NEXT:** #136. Subscription **registered track complete** (~~#244~~ ✓ on `subscription/244-contact-form-prefill`; ~~#314~~ ~~#188~~ ~~#186~~ ~~#220~~ ~~#207~~ ~~#208~~ ~~#209~~ done). Nutritionist web: all registered epics **complete** (#221–#242, #271–#272). Public booking: epic ~~#245~~ **done** (v1); ~~#246~~–~~#302~~ shipped.
+**On `main` (2026-06-23):** Mobile **Phase 2 invitation onboarding complete** (~~#141~~). Subscription **registered track complete** (~~#244~~ ✓ on `subscription/244-contact-form-prefill`; ~~#314~~ ~~#188~~ ~~#186~~ ~~#220~~ ~~#207~~ ~~#208~~ ~~#209~~ done). Nutritionist web: all registered epics **complete** (#221–#242, #271–#272). Public booking: epic ~~#245~~ **done** (v1); ~~#246~~–~~#302~~ shipped.
 
 ## AWS (production infrastructure)
 

--- a/docs/mobile-api/MOBILE-E2E-STATUS.md
+++ b/docs/mobile-api/MOBILE-E2E-STATUS.md
@@ -218,4 +218,4 @@ Optional backend script (requires access token from the app):
 
 ---
 
-*Updated 2026-06-19: ~~#133~~ token service on `main` (PR #229, EC2); **NEXT:** #134 create invitation.*
+*Updated 2026-06-23: Phase 2 invitation onboarding **#132–#141 complete** on `main` (PRs #319, #324–#333).*

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -40,7 +40,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`../../ISSUE-NUTRITIONIST-WEB.md`](../../ISSUE-NUTRITIONIST-WEB.md) | Patient MPX epic (#221–#223) |
 | [`../paciente/PATIENT-MPX-PLAN.md`](../paciente/PATIENT-MPX-PLAN.md) | Export/import plan |
 
-**Nutritionist web NEXT:** [#271](https://github.com/diego-torres/nutriconsultas/issues/271)–[#272](https://github.com/diego-torres/nutriconsultas/issues/272) system catalog create. ~~#285~~ done (`issue-285-platillo-inline-cantidad`, 340a318). ~~#281~~ done (`issue-281-ingesta-platillo-ingredient-edit`). ~~#280~~ done (PR [#284](https://github.com/diego-torres/nutriconsultas/pull/284)). ~~#238~~ done (PR [#279](https://github.com/diego-torres/nutriconsultas/pull/279)). ~~#237~~ done (PR [#278](https://github.com/diego-torres/nutriconsultas/pull/278)). ~~#236~~ done (PR [#274](https://github.com/diego-torres/nutriconsultas/pull/274)). ~~#259~~ done (PR [#270](https://github.com/diego-torres/nutriconsultas/pull/270)); platillo ownership ~~#257–#258~~ done; diet catalog ~~#232–#235~~ done; ~~#221–#223~~ MPX epic done.
+**Nutritionist web NEXT:** None — all registered epics complete (~~#271~~–~~#272~~ system catalog create; ~~#285~~ done; ~~#281~~ done; ~~#280~~ done; ~~#238~~ done; ~~#237~~ done; ~~#236~~ done; ~~#259~~ done; platillo ownership ~~#257–#258~~ done; diet catalog ~~#232–#235~~ done; ~~#221–#223~~ MPX epic done).
 
 **Subscription NEXT:** Registered track **complete** (~~#244~~ ✓ on `subscription/244-contact-form-prefill`; ~~#314~~ ~~#188~~ ~~#186~~ ~~#220~~ ~~#207~~ ~~#208~~ ~~#209~~ ~~#211~~ ~~#210~~ ~~#187~~ ~~#190~~ on `main`).
 

--- a/docs/mobile-api/mobile-api-roadmap-v2.md
+++ b/docs/mobile-api/mobile-api-roadmap-v2.md
@@ -14,7 +14,7 @@
 
 > **State verification (2026-06-11):**
 >
-> - **Backend schema (2026-06-19):** Phase 0 **done** (#107, #109, #110). **All endpoints #91–#99 on `main`**. Cross-cutting **#111–#116 done**. Onboarding **#132** + **#133 done** (PRs #214, #229). **NEXT:** #134. #106 dashboard IMC gauge **done**.
+> - **Backend schema (2026-06-23):** Phase 0 **done** (#107, #109, #110). **All endpoints #91–#99 on `main`**. Cross-cutting **#111–#116 done**. Phase 2 invitation onboarding **#132–#141 done** (PRs #214, #229, #319, #324–#333). #106 dashboard IMC gauge **done**.
 > - **DTO field-name map (authoritative — ALIGNMENT-SPEC §F8):** `Dieta.nombre→dietaName`, `energia→totalKcal`, `proteina→totalProteina`, `lipidos→totalGrasas`, `hidratosDeCarbono→totalCarbohidratos`; `Ingesta.nombre→tipo`; `PlatilloIngesta.name/portions/energia→nombre/porciones/kcal`, `hidratosDeCarbono→carbohidratos`, `lipidos→grasas` (same for `AlimentoIngesta`). Enums: `EventStatus = SCHEDULED/COMPLETED/CANCELLED`; `PacienteDietaStatus = ACTIVE/COMPLETED/CANCELLED` (no INACTIVE); `NivelPeso = BAJO/NORMAL/ALTO/SOBREPESO` (translate to `imcLabel` server-side). `deltaPeso`/`deltaImc` are computed, not stored.
 > - **Mobile redesign branch state (style/editorial-redesign):** Auth dedup complete — `AuthFlowController` + login/signup/welcome screens canonical; PR #48's `AuthController`/`LoginView` retired (commit 3427612); `flutter analyze` clean, 146/146 tests pass. Canonical design source: `.claude/MiNutriporcion-2/` (light editorial palette; dark welcome/login PNGs are OLD, ignore). Mobile issues #13/#21/#31 done; #32/#33 in flight on branch.
 


### PR DESCRIPTION
## Summary
- Fixes two stale `NEXT: #135 invitation preview` references in `AGENT-WORKFLOW.md` that were left behind after PRs #324–#333 shipped Phase 2 complete (#135–#141).
- Updates the "Backend state" product context table row and the Phase 1 triage example to reflect Phase 2 invitation onboarding is complete and no NEXT exists in the mobile track.
- `ISSUE.md` and `ISSUE-SUBSCRIPTION.md` are already current on `main` (registry-advance PRs #327/#329/#331 handled those; #207/#208 correctly marked done).

## Test plan
- [ ] Confirm `AGENT-WORKFLOW.md` no longer references `NEXT: #135` in the product context table or triage example.
- [ ] Confirm `ISSUE.md` #135–#141 rows all show `done` (already correct on main, no change needed).
- [ ] No code changes — docs only, CI should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)