### PR TITLE
feat(dietas): ingesta reorder, PDF layout, and duplicate name validation

### DIFF
--- a/src/main/java/com/nutriconsultas/dieta/DietaController.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaController.java
@@ -212,10 +212,13 @@ public class DietaController extends AbstractAuthorizedController {
 	 */
 	@GetMapping(path = "/admin/dietas/{id}/print")
 	public ResponseEntity<byte[]> printDieta(@PathVariable @NonNull final Long id) {
-		LOGGER.debug("Generating PDF for dieta with id {} (generic, no patient info)", id);
-		// Generate generic PDF without patient information when accessed from diet list
-		final byte[] pdfBytes = dietaPdfService.generatePdf(id, false);
 		final Dieta dieta = dietaService.getDieta(id);
+		if (dieta == null) {
+			return ResponseEntity.notFound().build();
+		}
+		final boolean includePatientInfo = DietaCatalogConstants.isPatientAssignment(dieta);
+		LOGGER.debug("Generating PDF for dieta with id {} (includePatientInfo: {})", id, includePatientInfo);
+		final byte[] pdfBytes = dietaPdfService.generatePdf(id, includePatientInfo);
 		final String fileName = (dieta != null && dieta.getNombre() != null ? dieta.getNombre() : "dieta") + ".pdf";
 		return ResponseEntity.ok()
 			.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + fileName + "\"")

--- a/src/main/java/com/nutriconsultas/dieta/DietaController.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaController.java
@@ -1,7 +1,7 @@
 package com.nutriconsultas.dieta;
 
-import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -20,7 +20,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.nutriconsultas.alimentos.Alimento;
 import com.nutriconsultas.alimentos.AlimentoService;
@@ -134,12 +137,12 @@ public class DietaController extends AbstractAuthorizedController {
 
 		final List<Ingesta> sortedIngestas = dieta.getIngestas()
 			.stream()
-			.sorted(Comparator.comparingLong(Ingesta::getId))
+			.sorted(IngestaComparators.BY_DISPLAY_ORDER)
 			.collect(Collectors.toList());
 		model.addAttribute("ingestas", sortedIngestas);
 
-		final Long minId = sortedIngestas.isEmpty() ? Long.valueOf(0L) : sortedIngestas.get(0).getId();
-		model.addAttribute("minId", minId);
+		final Long activeIngestaId = sortedIngestas.isEmpty() ? Long.valueOf(0L) : sortedIngestas.get(0).getId();
+		model.addAttribute("activeIngestaId", activeIngestaId);
 
 		model.addAttribute("platillos", platilloService.findAll());
 		model.addAttribute("alimentos", alimentoService.findAll());
@@ -228,33 +231,44 @@ public class DietaController extends AbstractAuthorizedController {
 
 	@PostMapping(path = "/admin/dietas/{id}/ingestas/save")
 	public String saveIngesta(@PathVariable @NonNull final Long id, @ModelAttribute final IngestaFormModel ingesta,
-			final Model model, @AuthenticationPrincipal final OidcUser principal) {
+			final Model model, @AuthenticationPrincipal final OidcUser principal,
+			final RedirectAttributes redirectAttributes) {
 		LOGGER.debug("Agregar ingesta {} a dieta con id {}", ingesta, id);
 		model.addAttribute("activeMenu", "dietas");
 
 		final Dieta dieta = loadDietaForMutation(id, principal);
 
-		String result;
-		if (ingesta.getIngestaId() == 0) {
-			LOGGER.debug("nueva ingesta en dieta, agregar");
-			dietaService.addIngesta(id, ingesta.getIngesta());
-			dietaAuthorization.auditSystemDietMutationIfNeeded(principal, dieta, "dietas.ingestas.save");
-			result = "redirect:/admin/dietas/" + id;
-		}
-		else {
-			LOGGER.debug("Ingesta existente, cambiar nombre");
+		try {
 			final Long ingestaId = ingesta.getIngestaId();
-			if (ingestaId == null) {
-				LOGGER.error("Ingesta ID is null, cannot rename");
-				result = "redirect:/admin/dietas/" + id;
+			if (ingestaId == null || ingestaId == 0L) {
+				LOGGER.debug("nueva ingesta en dieta, agregar");
+				dietaService.addIngesta(id, ingesta.getIngesta());
+				dietaAuthorization.auditSystemDietMutationIfNeeded(principal, dieta, "dietas.ingestas.save");
 			}
 			else {
+				LOGGER.debug("Ingesta existente, cambiar nombre");
 				dietaService.renameIngesta(id, ingestaId, ingesta.getIngesta());
 				dietaAuthorization.auditSystemDietMutationIfNeeded(principal, dieta, "dietas.ingestas.save");
-				result = "redirect:/admin/dietas/" + id;
 			}
 		}
-		return result;
+		catch (IllegalArgumentException exception) {
+			redirectAttributes.addFlashAttribute("ingestaError", exception.getMessage());
+		}
+		return "redirect:/admin/dietas/" + id;
+	}
+
+	@PostMapping(path = "/admin/dietas/{id}/ingestas/reorder", consumes = MediaType.APPLICATION_JSON_VALUE)
+	@ResponseBody
+	public ResponseEntity<Map<String, String>> reorderIngestas(@PathVariable @NonNull final Long id,
+			@RequestBody final List<Long> orderedIngestaIds, @AuthenticationPrincipal final OidcUser principal) {
+		loadDietaForMutation(id, principal);
+		try {
+			dietaService.reorderIngestas(id, orderedIngestaIds);
+			return ResponseEntity.ok(Map.of("status", "ok"));
+		}
+		catch (IllegalArgumentException exception) {
+			return ResponseEntity.badRequest().body(Map.of("message", exception.getMessage()));
+		}
 	}
 
 	@PostMapping(path = "/admin/dietas/{id}/ingestas/delete")

--- a/src/main/java/com/nutriconsultas/dieta/DietaPdfService.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaPdfService.java
@@ -5,6 +5,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
@@ -200,6 +203,16 @@ public class DietaPdfService {
 			throw new IllegalArgumentException("Dieta with id " + dietaId + " not found");
 		}
 		return buildPdf(dieta, assignment);
+	}
+
+	public ResponseEntity<byte[]> buildAssignmentPdfResponse(@NonNull final PacienteDieta assignment) {
+		final byte[] pdfBytes = generatePdfForAssignment(assignment);
+		final Dieta dieta = assignment.getDieta();
+		final String fileName = (dieta != null && dieta.getNombre() != null ? dieta.getNombre() : "dieta") + ".pdf";
+		return ResponseEntity.ok()
+			.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + fileName + "\"")
+			.contentType(MediaType.parseMediaType("application/pdf"))
+			.body(pdfBytes);
 	}
 
 	private byte[] buildPdf(final Dieta dieta, final PacienteDieta assignment) {

--- a/src/main/java/com/nutriconsultas/dieta/DietaPdfService.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaPdfService.java
@@ -12,8 +12,11 @@ import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 import org.xhtmlrenderer.pdf.ITextRenderer;
 
+import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
+import com.nutriconsultas.paciente.PacienteDietaStatus;
+import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.profile.NutritionistBrandingHelper;
 import com.nutriconsultas.profile.NutritionistProfile;
 import com.nutriconsultas.profile.NutritionistProfileService;
@@ -86,6 +89,9 @@ public class DietaPdfService {
 	private PacienteDietaRepository pacienteDietaRepository;
 
 	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@Autowired
 	private DietaService dietaService;
 
 	@Autowired
@@ -146,17 +152,31 @@ public class DietaPdfService {
 		}
 
 		// Find patient assignment if exists and if patient info should be included
-		// This determines if we're generating a patient-specific or generic PDF
-		PacienteDieta activeAssignment = null;
-		if (includePatientInfo) {
-			final List<PacienteDieta> assignments = pacienteDietaRepository.findByDietaId(dietaId);
-			activeAssignment = assignments.stream()
-				.filter(a -> a.getStatus() != null && "ACTIVE".equals(a.getStatus().name()))
+		final PacienteDieta activeAssignment = includePatientInfo ? resolveAssignmentForPdf(dieta, dietaId) : null;
+
+		return buildPdf(dieta, activeAssignment);
+	}
+
+	private PacienteDieta resolveAssignmentForPdf(final Dieta dieta, final Long dietaId) {
+		final List<PacienteDieta> assignments = pacienteDietaRepository.findByDietaId(dietaId);
+		final PacienteDieta activeAssignment = assignments.stream()
+			.filter(a -> PacienteDietaStatus.ACTIVE.equals(a.getStatus()))
+			.findFirst()
+			.orElse(null);
+		if (activeAssignment != null) {
+			return activeAssignment;
+		}
+		if (!assignments.isEmpty()) {
+			return assignments.get(0);
+		}
+		if (DietaCatalogConstants.isPatientAssignment(dieta) && dieta.getPacienteId() != null) {
+			return pacienteDietaRepository.findByPacienteId(dieta.getPacienteId())
+				.stream()
+				.filter(a -> a.getDieta() != null && dietaId.equals(a.getDieta().getId()))
 				.findFirst()
 				.orElse(null);
 		}
-
-		return buildPdf(dieta, activeAssignment);
+		return null;
 	}
 
 	/**
@@ -189,7 +209,7 @@ public class DietaPdfService {
 		final Context context = new Context();
 		context.setVariable("dieta", dieta);
 		context.setVariable("pacienteDieta", assignment);
-		context.setVariable("paciente", assignment != null ? assignment.getPaciente() : null);
+		context.setVariable("paciente", resolvePaciente(dieta, assignment));
 
 		// Sort ingestas by id
 		final List<Ingesta> sortedIngestas = dieta.getIngestas()
@@ -232,6 +252,16 @@ public class DietaPdfService {
 
 		// Convert HTML to PDF using Flying Saucer
 		return htmlToPdf(html);
+	}
+
+	private Paciente resolvePaciente(final Dieta dieta, final PacienteDieta assignment) {
+		if (assignment != null && assignment.getPaciente() != null) {
+			return assignment.getPaciente();
+		}
+		if (DietaCatalogConstants.isPatientAssignment(dieta) && dieta.getPacienteId() != null) {
+			return pacienteRepository.findById(dieta.getPacienteId()).orElse(null);
+		}
+		return null;
 	}
 
 	private byte[] htmlToPdf(final String html) {

--- a/src/main/java/com/nutriconsultas/dieta/DietaPdfService.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaPdfService.java
@@ -1,7 +1,6 @@
 package com.nutriconsultas.dieta;
 
 import java.io.ByteArrayOutputStream;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -211,10 +210,10 @@ public class DietaPdfService {
 		context.setVariable("pacienteDieta", assignment);
 		context.setVariable("paciente", resolvePaciente(dieta, assignment));
 
-		// Sort ingestas by id
+		// Sort ingestas by display order
 		final List<Ingesta> sortedIngestas = dieta.getIngestas()
 			.stream()
-			.sorted(Comparator.comparingLong(Ingesta::getId))
+			.sorted(IngestaComparators.BY_DISPLAY_ORDER)
 			.collect(Collectors.toList());
 		context.setVariable("ingestas", sortedIngestas);
 

--- a/src/main/java/com/nutriconsultas/dieta/DietaService.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaService.java
@@ -26,6 +26,8 @@ public interface DietaService {
 
 	void renameIngesta(@NonNull Long id, @NonNull Long ingestaId, String nombreIngesta);
 
+	void reorderIngestas(@NonNull Long id, @NonNull List<Long> orderedIngestaIds);
+
 	void recalculateAlimentoIngestaNutrients(@NonNull AlimentoIngesta alimentoIngesta, @NonNull Integer portions);
 
 	void recalculatePlatilloIngestaNutrients(@NonNull PlatilloIngesta platilloIngesta, @NonNull Integer portions);

--- a/src/main/java/com/nutriconsultas/dieta/DietaServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaServiceImpl.java
@@ -3,6 +3,7 @@ package com.nutriconsultas.dieta;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.NonNull;
@@ -165,34 +166,56 @@ public class DietaServiceImpl implements DietaService {
 	@Override
 	public void addIngesta(@NonNull final Long id, final String nombreIngesta) {
 		log.info("Adding ingesta to dieta with id: " + id);
-		final Dieta dieta = dietaRepository.findById(id).orElse(null);
-		if (dieta != null) {
-			final Ingesta ingesta = new Ingesta();
-			ingesta.setNombre(nombreIngesta);
-			ingesta.setDieta(dieta);
-			dieta.getIngestas().add(ingesta);
-			dietaRepository.save(dieta);
-		}
+		final Dieta dieta = dietaRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("Dieta no encontrada"));
+		IngestaNames.validateForDieta(dieta.getIngestas(), nombreIngesta, null);
+		final Ingesta ingesta = new Ingesta();
+		ingesta.setNombre(nombreIngesta.trim());
+		ingesta.setOrden(nextIngestaOrden(dieta));
+		ingesta.setDieta(dieta);
+		dieta.getIngestas().add(ingesta);
+		dietaRepository.save(dieta);
 	}
 
 	@Override
 	public void renameIngesta(@NonNull final Long id, @NonNull final Long ingestaId, final String nombreIngesta) {
 		log.info("Renaming ingesta in dieta with id: " + id);
-		final Dieta dieta = dietaRepository.findById(id).orElse(null);
-		if (dieta != null) {
-			log.debug("dieta: {}", dieta);
-			dieta.getIngestas().forEach(ingesta -> {
-				if (ingesta.getId() != null && ingesta.getId().equals(ingestaId)) {
-					log.debug("Renaming ingesta with id: {}", id);
-					ingesta.setNombre(nombreIngesta);
-				}
-			});
-			log.debug("Saving dieta with updated ingesta {}", dieta);
-			dietaRepository.save(dieta);
+		final Dieta dieta = dietaRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("Dieta no encontrada"));
+		IngestaNames.validateForDieta(dieta.getIngestas(), nombreIngesta, ingestaId);
+		final Ingesta ingesta = dieta.getIngestas()
+			.stream()
+			.filter(candidate -> ingestaId.equals(candidate.getId()))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("Ingesta no encontrada"));
+		ingesta.setNombre(nombreIngesta.trim());
+		dietaRepository.save(dieta);
+	}
+
+	@Override
+	public void reorderIngestas(@NonNull final Long id, @NonNull final List<Long> orderedIngestaIds) {
+		log.info("Reordering ingestas for dieta with id: {}", id);
+		final Dieta dieta = dietaRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("Dieta no encontrada"));
+		final java.util.Map<Long, Ingesta> ingestasById = dieta.getIngestas()
+			.stream()
+			.collect(java.util.stream.Collectors.toMap(Ingesta::getId, ingesta -> ingesta));
+		if (orderedIngestaIds.size() != ingestasById.size() || !ingestasById.keySet().containsAll(orderedIngestaIds)) {
+			throw new IllegalArgumentException("Lista de ingestas inválida");
 		}
-		else {
-			log.warn("Dieta with id {} not found in an attempt to rename one of its ingestas", id);
+		for (int index = 0; index < orderedIngestaIds.size(); index++) {
+			ingestasById.get(orderedIngestaIds.get(index)).setOrden(index);
 		}
+		dietaRepository.save(dieta);
+	}
+
+	private int nextIngestaOrden(final Dieta dieta) {
+		return dieta.getIngestas()
+			.stream()
+			.map(Ingesta::getOrden)
+			.filter(Objects::nonNull)
+			.max(Integer::compareTo)
+			.orElse(-1) + 1;
 	}
 
 	@Override
@@ -476,9 +499,14 @@ public class DietaServiceImpl implements DietaService {
 		newDieta.setHidratosDeCarbono(originalDieta.getHidratosDeCarbono());
 
 		final List<Ingesta> newIngestas = new ArrayList<>();
-		for (final Ingesta originalIngesta : originalDieta.getIngestas()) {
+		final List<Ingesta> sortedOriginalIngestas = originalDieta.getIngestas()
+			.stream()
+			.sorted(IngestaComparators.BY_DISPLAY_ORDER)
+			.toList();
+		for (final Ingesta originalIngesta : sortedOriginalIngestas) {
 			final Ingesta newIngesta = new Ingesta();
 			newIngesta.setNombre(originalIngesta.getNombre());
+			newIngesta.setOrden(originalIngesta.getOrden());
 			newIngesta.setDieta(newDieta);
 
 			newIngesta.setEnergia(originalIngesta.getEnergia());

--- a/src/main/java/com/nutriconsultas/dieta/DietaTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaTemplateValidator.java
@@ -49,9 +49,9 @@ public class DietaTemplateValidator extends BaseTemplateValidator {
 		variables.put("dieta", mockDieta);
 		variables.put("ingestas", mockIngestas);
 
-		// Add minId for formulario template (minimum ingesta id)
-		final Long minId = mockIngestas.isEmpty() ? Long.valueOf(0L) : mockIngestas.get(0).getId();
-		variables.put("minId", minId);
+		// Add activeIngestaId for formulario template (first ingesta in display order)
+		final Long activeIngestaId = mockIngestas.isEmpty() ? Long.valueOf(0L) : mockIngestas.get(0).getId();
+		variables.put("activeIngestaId", activeIngestaId);
 
 		// Add platillos and alimentos lists for formulario template
 		variables.put("platillos", createMockPlatillosList());
@@ -76,6 +76,7 @@ public class DietaTemplateValidator extends BaseTemplateValidator {
 		final Ingesta mockIngesta = new Ingesta();
 		mockIngesta.setId(1L);
 		mockIngesta.setNombre("Desayuno");
+		mockIngesta.setOrden(0);
 		mockIngesta.setEnergia(0);
 		mockIngesta.setProteina(0.0);
 		mockIngesta.setLipidos(0.0);

--- a/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
@@ -385,7 +385,11 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 	}
 
 	private String getIngestas(final Dieta row) {
-		return row.getIngestas().stream().map(Ingesta::getNombre).collect(Collectors.joining(", "));
+		return row.getIngestas()
+			.stream()
+			.sorted(IngestaComparators.BY_DISPLAY_ORDER)
+			.map(Ingesta::getNombre)
+			.collect(Collectors.joining(", "));
 	}
 
 	private String getDist(final Dieta row) {

--- a/src/main/java/com/nutriconsultas/dieta/Ingesta.java
+++ b/src/main/java/com/nutriconsultas/dieta/Ingesta.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.nutriconsultas.model.AbstractMacroNutrible;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -32,6 +33,9 @@ public class Ingesta extends AbstractMacroNutrible {
 	private Long id;
 
 	private String nombre;
+
+	@Column(nullable = false)
+	private Integer orden = 0;
 
 	public Ingesta(String nombre) {
 		this.nombre = nombre;

--- a/src/main/java/com/nutriconsultas/dieta/IngestaComparators.java
+++ b/src/main/java/com/nutriconsultas/dieta/IngestaComparators.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.dieta;
+
+import java.util.Comparator;
+
+public final class IngestaComparators {
+
+	public static final Comparator<Ingesta> BY_DISPLAY_ORDER = Comparator
+		.comparing(Ingesta::getOrden, Comparator.nullsLast(Comparator.naturalOrder()))
+		.thenComparing(Ingesta::getId, Comparator.nullsLast(Comparator.naturalOrder()));
+
+	private IngestaComparators() {
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/dieta/IngestaNames.java
+++ b/src/main/java/com/nutriconsultas/dieta/IngestaNames.java
@@ -1,0 +1,43 @@
+package com.nutriconsultas.dieta;
+
+import java.util.Collection;
+import java.util.Locale;
+
+public final class IngestaNames {
+
+	private IngestaNames() {
+	}
+
+	public static String normalizeKey(final String nombre) {
+		if (nombre == null) {
+			return "";
+		}
+		return nombre.trim().toLowerCase(Locale.ROOT);
+	}
+
+	public static boolean isBlank(final String nombre) {
+		return nombre == null || nombre.trim().isEmpty();
+	}
+
+	public static boolean hasDuplicateName(final Collection<Ingesta> ingestas, final String nombre,
+			final Long excludeIngestaId) {
+		final String key = normalizeKey(nombre);
+		if (key.isEmpty()) {
+			return false;
+		}
+		return ingestas.stream()
+			.filter(ingesta -> excludeIngestaId == null || !excludeIngestaId.equals(ingesta.getId()))
+			.anyMatch(ingesta -> key.equals(normalizeKey(ingesta.getNombre())));
+	}
+
+	public static void validateForDieta(final Collection<Ingesta> ingestas, final String nombre,
+			final Long excludeIngestaId) {
+		if (isBlank(nombre)) {
+			throw new IllegalArgumentException("El nombre de la ingesta es requerido");
+		}
+		if (hasDuplicateName(ingestas, nombre, excludeIngestaId)) {
+			throw new IllegalArgumentException("Ya existe una ingesta con ese nombre en este plan alimentario");
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/dieta/IngestaNames.java
+++ b/src/main/java/com/nutriconsultas/dieta/IngestaNames.java
@@ -16,16 +16,13 @@ public final class IngestaNames {
 	}
 
 	public static boolean isBlank(final String nombre) {
-		return nombre == null || nombre.trim().isEmpty();
+		return nombre == null || nombre.isBlank();
 	}
 
 	public static boolean hasDuplicateName(final Collection<Ingesta> ingestas, final String nombre,
 			final Long excludeIngestaId) {
 		final String key = normalizeKey(nombre);
-		if (key.isEmpty()) {
-			return false;
-		}
-		return ingestas.stream()
+		return !key.isEmpty() && ingestas.stream()
 			.filter(ingesta -> excludeIngestaId == null || !excludeIngestaId.equals(ingesta.getId()))
 			.anyMatch(ingesta -> key.equals(normalizeKey(ingesta.getNombre())));
 	}

--- a/src/main/java/com/nutriconsultas/mobile/dto/DietPlanDetailDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DietPlanDetailDto.java
@@ -2,13 +2,12 @@ package com.nutriconsultas.mobile.dto;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.nutriconsultas.dieta.Dieta;
-import com.nutriconsultas.dieta.Ingesta;
+import com.nutriconsultas.dieta.IngestaComparators;
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaStatus;
 
@@ -28,7 +27,7 @@ public record DietPlanDetailDto(Long assignmentId, PacienteDietaStatus status, L
 		final Dieta dieta = assignment.getDieta();
 		final List<DietIngestaDto> ingestas = dieta != null && dieta.getIngestas() != null ? dieta.getIngestas()
 			.stream()
-			.sorted(Comparator.comparingLong(Ingesta::getId))
+			.sorted(IngestaComparators.BY_DISPLAY_ORDER)
 			.map(DietIngestaDto::fromEntity)
 			.toList() : List.of();
 		return new DietPlanDetailDto(assignment.getId(), assignment.getStatus(), toLocalDate(assignment.getStartDate()),

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -1038,13 +1038,7 @@ public class PacienteController extends AbstractAuthorizedController {
 		}
 		// Generate PDF with patient information included
 		pacienteDieta.setPaciente(paciente);
-		final byte[] pdfBytes = dietaPdfService.generatePdfForAssignment(pacienteDieta);
-		final com.nutriconsultas.dieta.Dieta dieta = dietaService.getDieta(dietaId);
-		final String fileName = (dieta != null && dieta.getNombre() != null ? dieta.getNombre() : "dieta") + ".pdf";
-		return ResponseEntity.ok()
-			.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + fileName + "\"")
-			.contentType(MediaType.parseMediaType("application/pdf"))
-			.body(pdfBytes);
+		return dietaPdfService.buildAssignmentPdfResponse(pacienteDieta);
 	}
 
 	/**

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -1037,7 +1037,8 @@ public class PacienteController extends AbstractAuthorizedController {
 			return ResponseEntity.notFound().build();
 		}
 		// Generate PDF with patient information included
-		final byte[] pdfBytes = dietaPdfService.generatePdf(dietaId, true);
+		pacienteDieta.setPaciente(paciente);
+		final byte[] pdfBytes = dietaPdfService.generatePdfForAssignment(pacienteDieta);
 		final com.nutriconsultas.dieta.Dieta dieta = dietaService.getDieta(dietaId);
 		final String fileName = (dieta != null && dieta.getNombre() != null ? dieta.getNombre() : "dieta") + ".pdf";
 		return ResponseEntity.ok()

--- a/src/main/java/com/nutriconsultas/validation/template/BaseTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/validation/template/BaseTemplateValidator.java
@@ -34,7 +34,7 @@ public abstract class BaseTemplateValidator implements TemplateValidator {
 		variables.put("alimentos", new ArrayList<>());
 
 		// Common numeric attributes
-		variables.put("minId", 0L);
+		variables.put("activeIngestaId", 0L);
 
 		// Mock #fields object for form validation (used in templates with
 		// th:if="${#fields.hasErrors(...)}")

--- a/src/main/resources/db/changelog/changes/022-ingesta-orden.yaml
+++ b/src/main/resources/db/changelog/changes/022-ingesta-orden.yaml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+  - changeSet:
+      id: 022-ingesta-orden-column
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            columnExists:
+              tableName: ingesta
+              columnName: orden
+      changes:
+        - addColumn:
+            tableName: ingesta
+            columns:
+              - column:
+                  name: orden
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE ingesta i
+              SET orden = (
+                SELECT COUNT(*)
+                FROM ingesta i2
+                WHERE i2.dieta_id = i.dieta_id AND i2.id < i.id
+              );

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -62,3 +62,6 @@ databaseChangeLog:
   - include:
       file: changes/021-seed-high-kcal-dieta-templates.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/022-ingesta-orden.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -53,3 +53,6 @@ databaseChangeLog:
   - include:
       file: changes/019-dieta-paciente-id.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/022-ingesta-orden.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/templates/sbadmin/dietas/formulario.html
+++ b/src/main/resources/templates/sbadmin/dietas/formulario.html
@@ -49,8 +49,47 @@
         min-height: inherit;
         padding-bottom: 0.75rem;
       }
-      .dieta-editor-row .dieta-ingestas-card .tab-content {
+      .dieta-editor-row .dieta-ingestas-card .ingesta-panes {
         flex: 1 1 auto;
+      }
+      .ingesta-pane {
+        display: none;
+      }
+      .ingesta-pane.ingesta-pane--active {
+        display: block;
+      }
+      .ingesta-order-panel {
+        max-height: calc(100vh - 26rem);
+        overflow-y: auto;
+      }
+      .ingesta-order-item {
+        cursor: default;
+        padding: 0.5rem 0.75rem;
+      }
+      .ingesta-order-item.active {
+        background-color: #eaecf4;
+        border-color: #4e73df;
+      }
+      .ingesta-order-item--dragging {
+        opacity: 0.5;
+      }
+      .ingesta-order-item--drop-target {
+        border-top: 2px solid #4e73df;
+      }
+      .ingesta-order-handle {
+        cursor: grab;
+      }
+      .ingesta-order-item--dragging .ingesta-order-handle {
+        cursor: grabbing;
+      }
+      .ingesta-order-select {
+        color: #3a3b45;
+        font-weight: 600;
+        text-decoration: none;
+      }
+      .ingesta-order-select:hover {
+        color: #4e73df;
+        text-decoration: none;
       }
       .dieta-name-toolbar .form-control {
         max-width: 100%;
@@ -294,7 +333,7 @@
               </div>
               <div class="modal-body">
                 <form th:action="@{/admin/dietas/{id}/ingestas/save(id=${dieta != null ? dieta.id : 0})}" method="post">
-                  <input type="hidden" id="ingestaId" name="ingestaId" />
+                  <input type="hidden" id="ingestaId" name="ingestaId" value="0" />
                   <div class="form-group">
                     <label for="nombre">Nombre</label>
                     <input
@@ -823,28 +862,40 @@
                 </form>
                 <div class="card shadow mb-4 dieta-ingestas-card">
                   <div class="card-body">
-                        <ul class="nav nav-tabs" id="ingestaTab" role="tablist">
-                          <li th:each="ingesta : ${ingestas}" class="nav-item">
-                            <a 
-                              th:id="'ingesta-tab-' + ${ingesta.id}" 
-                              th:attr="data-target='#ingesta-' + ${ingesta.id}, 
-                                      aria-controls='ingesta-' + ${ingesta.id}, 
-                                      aria-selected=${ingesta.id == minId ? 'true' : 'false'}"
-                              class="nav-link"
-                              th:classappend="${ingesta.id == minId ? 'active' : ''}" 
-                              data-toggle="tab" 
-                              th:href="'#ingesta-' + ${ingesta.id}" 
-                              role="tab" 
-                              th:text="${ingesta.nombre}"></a>
-                          </li>
-                        </ul>
-                        <!-- tab content per ingesta, should include a grid with platillos -->
-                        <div class="tab-content" id="ingestaTabContent">
-                          <div th:each="ingesta : ${dieta.ingestas}" 
-                            th:id="'ingesta-' + ${ingesta.id}" 
-                            th:classappend="${ingesta.id == minId ? 'tab-pane fade show active' : 'tab-pane fade'}" 
-                            role="tabpanel" 
-                            th:aria-labelledby="'ingesta-tab-' + ${ingesta.id}">
+                    <div id="ingestaErrorMessage" th:if="${ingestaError}" th:text="${ingestaError}" class="d-none"></div>
+                    <div class="ingesta-editor row">
+                      <div class="col-lg-3 col-md-4 mb-3 mb-md-0">
+                        <div
+                          class="list-group ingesta-order-panel"
+                          id="ingestaOrderList"
+                          th:attr="data-dieta-id=${dieta.id},data-can-reorder=${isOwner == null || isOwner}">
+                          <div
+                            th:each="ingesta, iterStat : ${ingestas}"
+                            class="list-group-item ingesta-order-item d-flex align-items-center"
+                            th:classappend="${ingesta.id == activeIngestaId ? 'active' : ''}"
+                            th:attr="data-ingesta-id=${ingesta.id},draggable=${isOwner == null || isOwner ? 'true' : 'false'}">
+                            <span class="ingesta-order-handle text-muted mr-2" title="Arrastrar para reordenar">
+                              <i class="fas fa-grip-vertical"></i>
+                            </span>
+                            <button
+                              type="button"
+                              class="btn btn-link btn-sm ingesta-order-select p-0 text-left flex-grow-1"
+                              th:attr="data-ingesta-id=${ingesta.id}"
+                              th:text="${ingesta.nombre}"></button>
+                          </div>
+                        </div>
+                        <p class="text-muted small mb-0 mt-2" th:if="${isOwner == null || isOwner}">
+                          Arrastra las ingestas para cambiar el orden.
+                        </p>
+                      </div>
+                      <div class="col-lg-9 col-md-8">
+                        <div class="ingesta-panes" id="ingestaPanes">
+                          <div
+                            th:each="ingesta : ${ingestas}"
+                            th:id="'ingesta-' + ${ingesta.id}"
+                            class="ingesta-pane"
+                            th:classappend="${ingesta.id == activeIngestaId ? 'ingesta-pane--active' : ''}"
+                            th:attr="data-ingesta-id=${ingesta.id}">
                             <!-- ingesta action buttons -->
                             <div class="d-flex flex-wrap align-items-center mb-3 mt-3">
                               <button
@@ -1127,9 +1178,12 @@
                             </div>
                             <!-- end ingesta-items-scroll -->
                           </div>
-                          <!-- end tab pane -->
+                          <!-- end ingesta pane -->
                         </div>
-                        <!-- end tab content per ingesta -->
+                        <!-- end ingesta panes -->
+                      </div>
+                    </div>
+                    <!-- end ingesta editor -->
                   </div>
                   <!-- end card body -->
                 </div>
@@ -1206,6 +1260,122 @@
         }
         
         $(document).ready(function () {
+          var ingestaErrorEl = document.getElementById('ingestaErrorMessage');
+          if (ingestaErrorEl) {
+            swal({
+              title: 'No se pudo guardar la ingesta',
+              text: ingestaErrorEl.textContent,
+              type: 'warning',
+              timer: 5000,
+            });
+          }
+
+          function initIngestaOrderList() {
+            var orderList = document.getElementById('ingestaOrderList');
+            if (!orderList) {
+              return;
+            }
+            var canReorder = orderList.getAttribute('data-can-reorder') === 'true';
+            var dietaId = orderList.getAttribute('data-dieta-id');
+            var draggedItem = null;
+            var panesContainer = document.getElementById('ingestaPanes');
+
+            function selectIngesta(ingestaId) {
+              $('#ingestaOrderList .ingesta-order-item').removeClass('active');
+              $('#ingestaOrderList .ingesta-order-item[data-ingesta-id="' + ingestaId + '"]').addClass('active');
+              $('.ingesta-pane').removeClass('ingesta-pane--active');
+              $('#ingesta-' + ingestaId).addClass('ingesta-pane--active');
+            }
+
+            $(document).on('click', '.ingesta-order-select', function () {
+              selectIngesta($(this).data('ingesta-id'));
+            });
+
+            function reorderIngestaPanes() {
+              if (!panesContainer) {
+                return;
+              }
+              Array.from(orderList.querySelectorAll('.ingesta-order-item')).forEach(function (item) {
+                var ingestaId = item.getAttribute('data-ingesta-id');
+                var pane = document.getElementById('ingesta-' + ingestaId);
+                if (pane) {
+                  panesContainer.appendChild(pane);
+                }
+              });
+            }
+
+            function persistIngestaOrder() {
+              var orderedIds = Array.from(orderList.querySelectorAll('.ingesta-order-item')).map(function (item) {
+                return parseInt(item.getAttribute('data-ingesta-id'), 10);
+              });
+              $.ajax({
+                url: '/admin/dietas/' + dietaId + '/ingestas/reorder',
+                type: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify(orderedIds),
+                error: function (error) {
+                  swal({
+                    title: 'Error',
+                    text: error.responseJSON && error.responseJSON.message
+                      ? error.responseJSON.message
+                      : 'No se pudo reordenar las ingestas.',
+                    type: 'error',
+                    timer: 5000,
+                  });
+                  window.location.reload();
+                }
+              });
+            }
+
+            if (!canReorder) {
+              return;
+            }
+
+            orderList.querySelectorAll('.ingesta-order-item').forEach(function (item) {
+              item.addEventListener('dragstart', function (event) {
+                draggedItem = item;
+                item.classList.add('ingesta-order-item--dragging');
+                event.dataTransfer.effectAllowed = 'move';
+              });
+              item.addEventListener('dragend', function () {
+                item.classList.remove('ingesta-order-item--dragging');
+                orderList.querySelectorAll('.ingesta-order-item').forEach(function (element) {
+                  element.classList.remove('ingesta-order-item--drop-target');
+                });
+                draggedItem = null;
+              });
+              item.addEventListener('dragover', function (event) {
+                event.preventDefault();
+                if (!draggedItem || draggedItem === item) {
+                  return;
+                }
+                item.classList.add('ingesta-order-item--drop-target');
+              });
+              item.addEventListener('dragleave', function () {
+                item.classList.remove('ingesta-order-item--drop-target');
+              });
+              item.addEventListener('drop', function (event) {
+                event.preventDefault();
+                item.classList.remove('ingesta-order-item--drop-target');
+                if (!draggedItem || draggedItem === item) {
+                  return;
+                }
+                var items = Array.from(orderList.querySelectorAll('.ingesta-order-item'));
+                var draggedIndex = items.indexOf(draggedItem);
+                var targetIndex = items.indexOf(item);
+                if (draggedIndex < targetIndex) {
+                  orderList.insertBefore(draggedItem, item.nextSibling);
+                } else {
+                  orderList.insertBefore(draggedItem, item);
+                }
+                reorderIngestaPanes();
+                persistIngestaOrder();
+              });
+            });
+          }
+
+          initIngestaOrderList();
+
           // initialize select2 for platillo
           $('#platillo').select2({
             placeholder: 'Selecciona un platillo',

--- a/src/main/resources/templates/sbadmin/dietas/printable.html
+++ b/src/main/resources/templates/sbadmin/dietas/printable.html
@@ -18,7 +18,11 @@
 	   - Shows: patient details, assignment dates, notes (if any), plus all dieta content
 	   - Suitable for patient-specific dietary plans
 	
-	CONDITIONAL RENDERING:
+	PDF LAYOUT (portrait, Flying Saucer):
+	- Compact typography to reduce whitespace
+	- Cover block on its own page (page-break-after); includes patient info when ${paciente != null}
+	- Each ingesta in a single-row table; tr page-break-inside: avoid keeps the block together
+	- No forced page break per ingesta — short ingestas can share a page when they fit
 	- Patient info section: Only shown if ${paciente != null}
 	- Assignment dates: Only shown if ${pacienteDieta != null} and dates exist
 	- Notes: Only shown if ${pacienteDieta != null} and notes exist
@@ -41,129 +45,159 @@
 	<title>Plan de Alimentación - <span th:text="${dieta != null ? dieta.nombre : 'Dieta'}"></span></title>
 	<style>
 		@page {
-			size: A4;
-			margin: 2cm;
+			size: A4 portrait;
+			margin: 1.2cm;
 		}
 		body {
 			font-family: Arial, sans-serif;
-			font-size: 11pt;
-			line-height: 1.4;
+			font-size: 9pt;
+			line-height: 1.25;
 			color: #333;
 		}
+		.cover-page {
+			margin-bottom: 0;
+			page-break-after: always;
+		}
 		.header {
-			border-bottom: 3px solid #4e73df;
-			padding-bottom: 15px;
-			margin-bottom: 20px;
+			border-bottom: 2px solid #4e73df;
+			padding-bottom: 8px;
+			margin-bottom: 10px;
 		}
 		.header h1 {
 			color: #4e73df;
 			margin: 0;
-			font-size: 24pt;
+			font-size: 16pt;
 		}
 		.header p {
-			margin: 5px 0;
+			margin: 2px 0;
 			color: #666;
+			font-size: 8pt;
 		}
 		.patient-info {
 			background-color: #f8f9fc;
-			padding: 15px;
-			border-radius: 5px;
-			margin-bottom: 20px;
+			padding: 8px 10px;
+			border-radius: 4px;
+			margin-bottom: 10px;
 		}
 		.patient-info h2 {
-			margin-top: 0;
+			margin: 0 0 6px 0;
 			color: #4e73df;
-			font-size: 16pt;
+			font-size: 11pt;
 		}
 		.patient-info table {
 			width: 100%;
 			border-collapse: collapse;
 		}
 		.patient-info td {
-			padding: 5px 10px;
+			padding: 2px 6px;
 			border-bottom: 1px solid #e3e6f0;
+			font-size: 8.5pt;
 		}
 		.patient-info td:first-child {
 			font-weight: bold;
-			width: 40%;
+			width: 38%;
 		}
 		.dieta-info {
-			margin-bottom: 20px;
+			margin-bottom: 8px;
 		}
 		.dieta-info h2 {
 			color: #4e73df;
-			font-size: 18pt;
+			font-size: 13pt;
+			margin: 0 0 6px 0;
+		}
+		/* Flying Saucer: single-row table + tr avoid keeps each ingesta intact without forcing a full page */
+		table.ingesta-block {
+			width: 100%;
+			border-collapse: collapse;
 			margin-bottom: 10px;
 		}
-		.ingesta-section {
-			margin-bottom: 30px;
+		table.ingesta-block tr {
+			page-break-inside: avoid;
+		}
+		table.ingesta-block td.ingesta-cell {
+			padding: 0;
+			vertical-align: top;
+		}
+		.ingesta-keep-together {
+			display: block;
 			page-break-inside: avoid;
 		}
 		.ingesta-header {
+			display: block;
 			background-color: #4e73df;
 			color: white;
-			padding: 10px 15px;
-			font-size: 14pt;
+			padding: 6px 10px;
+			font-size: 11pt;
 			font-weight: bold;
-			border-radius: 5px 5px 0 0;
+			border-radius: 4px 4px 0 0;
+			page-break-after: avoid;
 		}
 		.ingesta-content {
+			display: block;
 			border: 1px solid #e3e6f0;
 			border-top: none;
-			padding: 15px;
+			padding: 8px 10px;
 		}
 		.platillo-item, .alimento-item {
-			margin-bottom: 15px;
-			padding-bottom: 15px;
+			display: block;
+			margin-bottom: 8px;
+			padding-bottom: 8px;
 			border-bottom: 1px solid #e3e6f0;
+			page-break-inside: avoid;
 		}
 		.platillo-item:last-child, .alimento-item:last-child {
 			border-bottom: none;
+			margin-bottom: 0;
+			padding-bottom: 0;
 		}
 		.item-name {
 			font-weight: bold;
-			font-size: 12pt;
+			font-size: 9.5pt;
 			color: #2c3e50;
-			margin-bottom: 5px;
+			margin-bottom: 3px;
 		}
 		.item-details {
-			font-size: 10pt;
+			font-size: 8pt;
 			color: #666;
-			margin-left: 15px;
+			margin-left: 10px;
 		}
 		.item-details table {
 			width: 100%;
 			border-collapse: collapse;
-			margin-top: 5px;
+			margin-top: 3px;
 		}
 		.item-details th, .item-details td {
-			padding: 5px;
+			padding: 2px 4px;
 			text-align: left;
 			border-bottom: 1px solid #e3e6f0;
+			font-size: 7.5pt;
 		}
 		.item-details th {
 			background-color: #f8f9fc;
 			font-weight: bold;
 		}
 		.ingrediente-item {
-			margin-left: 20px;
-			font-size: 10pt;
+			margin-left: 12px;
+			font-size: 7.5pt;
 			color: #555;
+			line-height: 1.2;
 		}
 		.nutrition-summary {
 			background-color: #f8f9fc;
-			padding: 10px;
-			border-radius: 5px;
-			margin-top: 10px;
+			padding: 6px 8px;
+			border-radius: 4px;
+			margin-top: 6px;
+			page-break-inside: avoid;
 		}
 		.nutrition-summary table {
 			width: 100%;
 			border-collapse: collapse;
 		}
 		.nutrition-summary th, .nutrition-summary td {
-			padding: 8px;
+			padding: 3px 5px;
 			text-align: left;
 			border-bottom: 1px solid #e3e6f0;
+			font-size: 8pt;
 		}
 		.nutrition-summary th {
 			background-color: #4e73df;
@@ -174,18 +208,27 @@
 			font-weight: bold;
 			background-color: #e3e6f0;
 		}
+		.nutrition-summary--compact {
+			margin-top: 0;
+			margin-bottom: 8px;
+		}
 		.footer {
-			margin-top: 30px;
-			padding-top: 15px;
-			border-top: 2px solid #e3e6f0;
+			margin-top: 12px;
+			padding-top: 8px;
+			border-top: 1px solid #e3e6f0;
 			text-align: center;
 			color: #666;
-			font-size: 9pt;
+			font-size: 7.5pt;
 		}
 		.recommendations {
 			font-style: italic;
 			color: #666;
-			margin-top: 5px;
+			margin-top: 3px;
+			font-size: 7.5pt;
+		}
+		.ingredientes-label {
+			margin: 3px 0;
+			font-size: 8pt;
 		}
 	</style>
 	<style th:replace="~{sbadmin/fragments/pdf-nutritionist-logo :: logoStyles}"></style>
@@ -197,6 +240,7 @@
 		- nutritionistDisplayName: resolved nutritionist name (may be null)
 		- logoBase64: Base64 Data URI string for the clinic logo (may be null)
 	-->
+	<div class="cover-page">
 	<div class="header">
 		<table style="width: 100%; border-collapse: collapse;">
 			<tr>
@@ -252,7 +296,35 @@
 		<h2 th:text="${dieta != null ? dieta.nombre : 'Dieta'}">Dieta</h2>
 	</div>
 
-	<div th:each="ingesta : ${ingestas}" class="ingesta-section">
+	<div class="nutrition-summary nutrition-summary--compact">
+		<table>
+			<tr>
+				<th colspan="2">Resumen Nutricional Total</th>
+			</tr>
+			<tr class="total-row">
+				<td>Energía Total:</td>
+				<td th:text="${totalEnergia != null ? (#numbers.formatDecimal(totalEnergia, 1, 2) + ' kcal') : '0.00 kcal'}"></td>
+			</tr>
+			<tr class="total-row">
+				<td>Proteína Total:</td>
+				<td th:text="${totalProteina != null ? (#numbers.formatDecimal(totalProteina, 1, 2) + ' g') : '0.00 g'}"></td>
+			</tr>
+			<tr class="total-row">
+				<td>Lípidos Total:</td>
+				<td th:text="${totalLipidos != null ? (#numbers.formatDecimal(totalLipidos, 1, 2) + ' g') : '0.00 g'}"></td>
+			</tr>
+			<tr class="total-row">
+				<td>Hidratos de Carbono Total:</td>
+				<td th:text="${totalHidratosDeCarbono != null ? (#numbers.formatDecimal(totalHidratosDeCarbono, 1, 2) + ' g') : '0.00 g'}"></td>
+			</tr>
+		</table>
+	</div>
+	</div>
+
+	<table th:each="ingesta : ${ingestas}" class="ingesta-block">
+		<tr>
+			<td class="ingesta-cell">
+		<div class="ingesta-keep-together">
 		<div class="ingesta-header" th:text="${ingesta.nombre}">Ingesta</div>
 		<div class="ingesta-content">
 			<!-- Platillos -->
@@ -261,7 +333,7 @@
 				<div class="item-details">
 					<div th:if="${platillo.recommendations != null && !platillo.recommendations.isEmpty()}" class="recommendations" th:text="${'Recomendaciones: ' + platillo.recommendations}"></div>
 					<div th:if="${platillo.ingredientes != null && !platillo.ingredientes.isEmpty()}">
-						<p style="margin-top: 5px; margin-bottom: 5px;"><strong>Ingredientes:</strong></p>
+						<p class="ingredientes-label"><strong>Ingredientes:</strong></p>
 						<div th:each="ingrediente : ${platillo.ingredientes}" class="ingrediente-item" th:with="showInGrams=${ingrediente.shouldDisplayWeightInGrams(ingrediente.unidad)}">
 							<span th:text="${(ingrediente.alimento != null && ingrediente.alimento.nombreAlimento != null) ? ingrediente.alimento.nombreAlimento : (ingrediente.description != null ? ingrediente.description : '')}"></span>
 							<!-- Show in grams for g units or very small taza portions; otherwise cooking fractions -->
@@ -309,7 +381,7 @@
 			<div th:each="alimento : ${ingesta.alimentos}" class="alimento-item">
 				<div class="item-name" th:text="${alimento.name + (alimento.portions != null && alimento.portions > 1 ? ' (' + alimento.portions + ' porción' + (alimento.portions > 1 ? 'es' : '') + ')' : '')}">Alimento</div>
 				<div class="item-details" th:if="${alimento.alimento != null && (alimento.alimento.cantSugerida != null || alimento.unidad != null)}">
-					<div style="margin-top: 5px; font-size: 10pt; color: #666;">
+					<div style="margin-top: 3px;">
 						<span th:if="${alimento.alimento.cantSugerida != null}" th:text="${alimento.alimento.getRoundedFractionalCantSugerida()}"></span>
 						<span th:if="${alimento.alimento.cantSugerida != null && alimento.unidad != null}" th:text="${' '}"></span>
 						<span th:if="${alimento.unidad != null}" th:text="${alimento.unidad}"></span>
@@ -318,7 +390,7 @@
 			</div>
 
 			<!-- Resumen nutricional de la ingesta -->
-			<div class="nutrition-summary" style="margin-top: 15px;" th:if="${ingestaTotals != null && ingestaTotals.containsKey(ingesta.id)}" th:with="totals=${ingestaTotals.get(ingesta.id)}">
+			<div class="nutrition-summary" th:if="${ingestaTotals != null && ingestaTotals.containsKey(ingesta.id)}" th:with="totals=${ingestaTotals.get(ingesta.id)}">
 				<table>
 					<tr>
 						<th colspan="2">Resumen Nutricional - <span th:text="${ingesta.nombre}"></span></th>
@@ -342,32 +414,10 @@
 				</table>
 			</div>
 		</div>
-	</div>
-
-	<!-- Resumen nutricional total de la dieta -->
-	<div class="nutrition-summary" style="margin-top: 30px;">
-		<table>
-			<tr>
-				<th colspan="2">Resumen Nutricional Total</th>
-			</tr>
-			<tr class="total-row">
-				<td>Energía Total:</td>
-				<td th:text="${totalEnergia != null ? (#numbers.formatDecimal(totalEnergia, 1, 2) + ' kcal') : '0.00 kcal'}"></td>
-			</tr>
-			<tr class="total-row">
-				<td>Proteína Total:</td>
-				<td th:text="${totalProteina != null ? (#numbers.formatDecimal(totalProteina, 1, 2) + ' g') : '0.00 g'}"></td>
-			</tr>
-			<tr class="total-row">
-				<td>Lípidos Total:</td>
-				<td th:text="${totalLipidos != null ? (#numbers.formatDecimal(totalLipidos, 1, 2) + ' g') : '0.00 g'}"></td>
-			</tr>
-			<tr class="total-row">
-				<td>Hidratos de Carbono Total:</td>
-				<td th:text="${totalHidratosDeCarbono != null ? (#numbers.formatDecimal(totalHidratosDeCarbono, 1, 2) + ' g') : '0.00 g'}"></td>
-			</tr>
-		</table>
-	</div>
+		</div>
+			</td>
+		</tr>
+	</table>
 
 	<div class="footer">
 		<p>Este documento fue generado el <span th:text="${#temporals.format(#temporals.createNow(), 'dd/MM/yyyy HH:mm')}"></span></p>

--- a/src/test/java/com/nutriconsultas/dieta/DietaControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaControllerTest.java
@@ -585,7 +585,7 @@ public class DietaControllerTest {
 		log.info("Starting testPrintDieta");
 
 		final byte[] pdfBytes = "PDF content".getBytes();
-		// When accessed from diet list, patient info should be excluded
+		when(dietaService.getDieta(1L)).thenReturn(dieta);
 		when(dietaPdfService.generatePdf(1L, false)).thenReturn(pdfBytes);
 
 		// Perform GET request
@@ -604,24 +604,31 @@ public class DietaControllerTest {
 
 	@Test
 	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testPrintPatientAssignmentDietaIncludesPatientInfo() throws Exception {
+		dieta.setPacienteId(3L);
+		final byte[] pdfBytes = "PDF content".getBytes();
+		when(dietaService.getDieta(1L)).thenReturn(dieta);
+		when(dietaPdfService.generatePdf(1L, true)).thenReturn(pdfBytes);
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/1/print"))
+			.andExpect(status().isOk())
+			.andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_PDF))
+			.andExpect(MockMvcResultMatchers.content().bytes(pdfBytes));
+
+		verify(dietaPdfService, times(1)).generatePdf(1L, true);
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
 	public void testPrintDietaNotFound() throws Exception {
 		log.info("Starting testPrintDietaNotFound");
 
-		when(dietaPdfService.generatePdf(999L, false))
-			.thenThrow(new IllegalArgumentException("Dieta with id 999 not found"));
+		when(dietaService.getDieta(999L)).thenReturn(null);
 
-		// Perform GET request - exception will be wrapped in ServletException
-		try {
-			mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/999/print"))
-				.andExpect(status().isInternalServerError());
-		}
-		catch (Exception e) {
-			// Expected - exception is thrown during request processing
-			assertThat(e).hasRootCauseInstanceOf(IllegalArgumentException.class);
-		}
+		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/999/print"))
+			.andExpect(status().isNotFound());
 
-		// Verify that service was called with includePatientInfo = false
-		verify(dietaPdfService, times(1)).generatePdf(999L, false);
+		verify(dietaPdfService, never()).generatePdf(999L, false);
 
 		log.info("Finishing testPrintDietaNotFound");
 	}

--- a/src/test/java/com/nutriconsultas/dieta/DietaControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaControllerTest.java
@@ -2,6 +2,8 @@ package com.nutriconsultas.dieta;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -9,6 +11,8 @@ import static org.mockito.Mockito.when;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.ArrayList;
@@ -625,8 +629,7 @@ public class DietaControllerTest {
 
 		when(dietaService.getDieta(999L)).thenReturn(null);
 
-		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/999/print"))
-			.andExpect(status().isNotFound());
+		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/999/print")).andExpect(status().isNotFound());
 
 		verify(dietaPdfService, never()).generatePdf(999L, false);
 
@@ -1042,6 +1045,38 @@ public class DietaControllerTest {
 		mockMvc.perform(MockMvcRequestBuilders.get("/admin/dietas/8").with(oidcLogin(TEST_USER_ID)))
 			.andExpect(status().isOk())
 			.andExpect(MockMvcResultMatchers.model().attribute("isOwner", false));
+	}
+
+	@Test
+	public void testReorderIngestasSuccess() throws Exception {
+		mockMvc
+			.perform(MockMvcRequestBuilders.post("/admin/dietas/1/ingestas/reorder")
+				.with(oidcLogin(TEST_USER_ID))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("[1]"))
+			.andExpect(status().isOk())
+			.andExpect(content().json("{\"status\":\"ok\"}"));
+
+		verify(dietaService).reorderIngestas(eq(1L), eq(List.of(1L)));
+	}
+
+	@Test
+	public void testSaveIngestaDuplicateNameSetsFlashError() throws Exception {
+		doThrow(new IllegalArgumentException("Ya existe una ingesta con ese nombre en este plan alimentario"))
+			.when(dietaService)
+			.addIngesta(eq(1L), eq("Colacion"));
+
+		mockMvc
+			.perform(MockMvcRequestBuilders.post("/admin/dietas/1/ingestas/save")
+				.with(oidcLogin(TEST_USER_ID))
+				.param("ingestaId", "0")
+				.param("ingesta", "Colacion"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/dietas/1"))
+			.andExpect(
+					flash().attribute("ingestaError", "Ya existe una ingesta con ese nombre en este plan alimentario"));
+
+		verify(dietaService).addIngesta(eq(1L), eq("Colacion"));
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/dieta/DietaPdfServiceTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaPdfServiceTest.java
@@ -4,14 +4,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,9 +22,11 @@ import org.springframework.test.context.ActiveProfiles;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
+import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
 import com.nutriconsultas.paciente.PacienteDietaStatus;
+import com.nutriconsultas.paciente.PacienteRepository;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,6 +43,9 @@ public class DietaPdfServiceTest {
 
 	@Mock
 	private PacienteDietaRepository pacienteDietaRepository;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
 
 	@Mock
 	private DietaService dietaService;
@@ -189,6 +197,26 @@ public class DietaPdfServiceTest {
 
 		assertThat(pdfBytes).isNotNull();
 		assertThat(pdfBytes.length).isGreaterThan(0);
+	}
+
+	@Test
+	public void testGeneratePdfForPatientAssignmentDietaLoadsPacienteFromDieta() {
+		dieta.setPacienteId(3L);
+		final Paciente paciente = new Paciente();
+		paciente.setId(3L);
+		paciente.setName("Cesar Torres");
+
+		when(dietaService.getDieta(1L)).thenReturn(dieta);
+		when(pacienteDietaRepository.findByDietaId(1L)).thenReturn(new ArrayList<>());
+		when(pacienteRepository.findById(3L)).thenReturn(Optional.of(paciente));
+		when(templateEngine.process(eq("sbadmin/dietas/printable"), any(Context.class)))
+			.thenReturn("<html><body>Test</body></html>");
+
+		final ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+		dietaPdfService.generatePdf(1L, true);
+
+		verify(templateEngine).process(eq("sbadmin/dietas/printable"), contextCaptor.capture());
+		assertThat(contextCaptor.getValue().getVariable("paciente")).isEqualTo(paciente);
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/dieta/DietaServiceTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaServiceTest.java
@@ -1,6 +1,7 @@
 package com.nutriconsultas.dieta;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -73,6 +74,7 @@ public class DietaServiceTest {
 		ingesta = new Ingesta();
 		ingesta.setId(1L);
 		ingesta.setNombre("Desayuno");
+		ingesta.setOrden(0);
 		ingesta.setDieta(originalDieta);
 		ingesta.setEnergia(500);
 		ingesta.setProteina(25.0);
@@ -530,6 +532,52 @@ public class DietaServiceTest {
 		assertThat(platillo.getIngredientes()).hasSize(1);
 		assertThat(platillo.getProteina()).isEqualTo(4.0);
 		assertThat(platillo.getEnergia()).isEqualTo(90);
+	}
+
+	@Test
+	public void testAddIngestaRejectsDuplicateNameCaseInsensitive() {
+		when(dietaRepository.findById(1L)).thenReturn(Optional.of(originalDieta));
+
+		assertThatThrownBy(() -> dietaService.addIngesta(1L, "desayuno")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Ya existe una ingesta con ese nombre");
+
+		verify(dietaRepository, never()).save(any());
+	}
+
+	@Test
+	public void testAddIngestaAssignsNextOrden() {
+		when(dietaRepository.findById(1L)).thenReturn(Optional.of(originalDieta));
+		when(dietaRepository.save(any(Dieta.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		dietaService.addIngesta(1L, "Colacion");
+
+		assertThat(originalDieta.getIngestas()).hasSize(2);
+		final Ingesta added = originalDieta.getIngestas()
+			.stream()
+			.filter(candidate -> "Colacion".equals(candidate.getNombre()))
+			.findFirst()
+			.orElseThrow();
+		assertThat(added.getOrden()).isEqualTo(1);
+		verify(dietaRepository).save(originalDieta);
+	}
+
+	@Test
+	public void testReorderIngestasUpdatesOrden() {
+		final Ingesta comida = new Ingesta();
+		comida.setId(2L);
+		comida.setNombre("Comida");
+		comida.setOrden(1);
+		comida.setDieta(originalDieta);
+		originalDieta.getIngestas().add(comida);
+
+		when(dietaRepository.findById(1L)).thenReturn(Optional.of(originalDieta));
+		when(dietaRepository.save(any(Dieta.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		dietaService.reorderIngestas(1L, List.of(2L, 1L));
+
+		assertThat(comida.getOrden()).isEqualTo(0);
+		assertThat(ingesta.getOrden()).isEqualTo(1);
+		verify(dietaRepository).save(originalDieta);
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/dieta/IngestaComparatorsTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/IngestaComparatorsTest.java
@@ -1,0 +1,31 @@
+package com.nutriconsultas.dieta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class IngestaComparatorsTest {
+
+	@Test
+	void byDisplayOrderSortsByOrdenThenId() {
+		final Ingesta first = new Ingesta();
+		first.setId(10L);
+		first.setOrden(0);
+		first.setNombre("Desayuno");
+
+		final Ingesta second = new Ingesta();
+		second.setId(5L);
+		second.setOrden(1);
+		second.setNombre("Comida");
+
+		final List<Ingesta> sorted = List.of(second, first)
+			.stream()
+			.sorted(IngestaComparators.BY_DISPLAY_ORDER)
+			.toList();
+
+		assertThat(sorted).containsExactly(first, second);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/dieta/IngestaNamesTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/IngestaNamesTest.java
@@ -1,0 +1,38 @@
+package com.nutriconsultas.dieta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class IngestaNamesTest {
+
+	@Test
+	void hasDuplicateNameIsCaseInsensitive() {
+		final Ingesta existing = new Ingesta();
+		existing.setId(1L);
+		existing.setNombre("Colacion");
+
+		assertThat(IngestaNames.hasDuplicateName(List.of(existing), "colacion", null)).isTrue();
+		assertThat(IngestaNames.hasDuplicateName(List.of(existing), "Colacion 2", null)).isFalse();
+	}
+
+	@Test
+	void validateForDietaRejectsBlankName() {
+		assertThatThrownBy(() -> IngestaNames.validateForDieta(List.of(), "  ", null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("requerido");
+	}
+
+	@Test
+	void validateForDietaAllowsRenameToSameName() {
+		final Ingesta existing = new Ingesta();
+		existing.setId(1L);
+		existing.setNombre("Desayuno");
+
+		IngestaNames.validateForDieta(List.of(existing), "desayuno", 1L);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobileInvitationIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileInvitationIntegrationTest.java
@@ -228,7 +228,8 @@ class MobileInvitationIntegrationTest {
 		final String patientSub = "auth0|patient-redeem-rate-limit";
 
 		for (int attempt = 0; attempt < 2; attempt++) {
-			mockMvc.perform(post("/rest/mobile/invitations/{token}/redeem", bundle.urlToken()).with(mobileJwt(patientSub)))
+			mockMvc
+				.perform(post("/rest/mobile/invitations/{token}/redeem", bundle.urlToken()).with(mobileJwt(patientSub)))
 				.andExpect(status().isOk());
 		}
 

--- a/src/test/java/com/nutriconsultas/mobile/logging/PhiLogTurboFilterTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/logging/PhiLogTurboFilterTest.java
@@ -87,7 +87,8 @@ class PhiLogTurboFilterTest {
 	@Test
 	void deniesStandaloneUrlTokenInPatientInvitationPackage() {
 		filter.start();
-		final Logger invitationLogger = logger("com.nutriconsultas.paciente.invitation.PatientInvitationCreateServiceImpl");
+		final Logger invitationLogger = logger(
+				"com.nutriconsultas.paciente.invitation.PatientInvitationCreateServiceImpl");
 
 		final FilterReply reply = filter.decide(null, invitationLogger, Level.INFO, "token={}",
 				new Object[] { "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG" }, null);

--- a/src/test/java/com/nutriconsultas/paciente/invitation/InvitationPackageLoggingAuditTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/InvitationPackageLoggingAuditTest.java
@@ -17,13 +17,13 @@ import org.junit.jupiter.api.Test;
  */
 class InvitationPackageLoggingAuditTest {
 
-	private static final Path INVITATION_SRC = Path.of("src", "main", "java", "com", "nutriconsultas",
-			"paciente", "invitation");
+	private static final Path INVITATION_SRC = Path.of("src", "main", "java", "com", "nutriconsultas", "paciente",
+			"invitation");
 
 	private static final Pattern LOG_STATEMENT = Pattern.compile("log\\.(info|debug|warn|error|trace)\\(");
 
-	private static final Pattern FORBIDDEN_TOKEN_PLACEHOLDER = Pattern.compile(
-			"log\\.(info|warn|error)\\([^)]*\\b(urlToken|rawUrlToken|humanCode|inviteUrl|tokenHash)\\b");
+	private static final Pattern FORBIDDEN_TOKEN_PLACEHOLDER = Pattern
+		.compile("log\\.(info|warn|error)\\([^)]*\\b(urlToken|rawUrlToken|humanCode|inviteUrl|tokenHash)\\b");
 
 	@Test
 	void invitationPackageHasNoTokenLoggingViolations() throws IOException {


### PR DESCRIPTION
## Summary
- Add persistent `orden` per ingesta with Liquibase migration and sort ingestas by display order in the diet editor, PDF, mobile API, and catalog list.
- Replace ingesta tabs with a draggable sidebar list; reorder is saved via `POST /admin/dietas/{id}/ingestas/reorder`.
- Validate case-insensitive duplicate ingesta names within the same plan and surface errors via SweetAlert.
- Improve patient diet PDF: compact portrait layout, cover page with patient info and totals, and keep ingesta blocks together across pages.

## Test plan
- [x] `./lint.sh` and `mvn pmd:check`
- [x] Unit/controller tests for reorder, duplicate names, and PDF service
- [x] Browser: drag reorder persists after reload; duplicate name shows SweetAlert
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)