### PR TITLE
feat(mobile-api): human-code invitation preview (#336)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -590,7 +590,7 @@ Issue registry: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Agent workflow
 
 **Done on `main` (2026-06-14):** #107/#109/#110 (JWT + linkage + DTO envelope); endpoints #91–#98; messages #96/#97 with rate limit (#113); localized errors (#111, PR #151); dashboard IMC gauge (#106).
 
-**Next:** Phase 2 invitation onboarding **complete** (~~#141~~). ~~#337~~ web landing **done** (PR [#340](https://github.com/diego-torres/nutriconsultas/pull/340)). ~~#140~~ done ([`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md)).
+**Next:** Phase 2 invitation onboarding **complete** (~~#141~~). ~~#336~~ human-code preview **done**. ~~#337~~ web landing **done** (PR [#340](https://github.com/diego-torres/nutriconsultas/pull/340)). ~~#140~~ done ([`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md)).
 
 **Schema gate (post-#46):** [#46 Liquibase](https://github.com/diego-torres/nutriconsultas/issues/46) baseline is on `main` (PR #196). All new schema/catalog changes require **incremental Liquibase changesets** — see [`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md) and [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md). ~~#156~~ Phase C done before baseline.
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) · **Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-26 — ~~#141~~ **done** (branch `mobile-api/141-invitation-security-hardening`). **Phase 2 invitation onboarding complete.** ~~#337~~ web landing **done**.
+**Last updated:** 2026-06-26 — ~~#336~~ **done** (human-code invitation preview). ~~#141~~ **done**. **Phase 2 invitation onboarding complete.** ~~#337~~ web landing **done**.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -151,6 +151,7 @@ Invite-only patient onboarding replaces manual Afiliación linkage (#109) for ne
 | 139 | `POST /rest/mobile/invitations/{id}/revoke` — nutritionist invalidates invite | https://github.com/diego-torres/nutriconsultas/issues/139 | **done** | ~~132~~ ✓, 134 | Merged PR [#330](https://github.com/diego-torres/nutriconsultas/pull/330) |
 | 140 | Auth0 Post-Login Action gate — first-login invitation validation | https://github.com/diego-torres/nutriconsultas/issues/140 | **done** | ~~133~~ ✓, 136 | Post-Login Action + [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md); Option B social cleanup |
 | 141 | Invitation security hardening — rate limits, enumeration protection, no-token logging | https://github.com/diego-torres/nutriconsultas/issues/141 | **done** | ~~133~~ ✓, 135, 136 | [`INVITATION-SECURITY-AUDIT.md`](docs/mobile-api/INVITATION-SECURITY-AUDIT.md) acceptance audit |
+| 336 | B1 — `GET /rest/mobile/invitations/by-code/{code}/preview` (human-readable code) | https://github.com/diego-torres/nutriconsultas/issues/336 | **done** | ~~135~~ ✓, ~~141~~ ✓ | Public rate-limited preview via `PatientInvitation.humanCode`; Liquibase `023`; defers mobile #68 UX |
 | 337 | B2 — Invitation web landing page `GET /links/i/{token}` | https://github.com/diego-torres/nutriconsultas/issues/337 | **done** | ~~135~~ ✓ | Public Thymeleaf landing (`/links/i/{token}`, `/i/{token}` alias); hero image, human code, store URLs; `buildInviteUrl()` → `/links/i/` |
 
 **Suggested build order (after ~~#133~~ ✓):** #134/#135 → #136 → #137 → #138 → #139/#140 → #141 → #337.

--- a/docs/api/openapi-mobile.yaml
+++ b/docs/api/openapi-mobile.yaml
@@ -661,6 +661,46 @@ paths:
               schema:
                 $ref: "#/components/schemas/ApiResponsePatientInvitationPreviewDto"
       security: []
+  /rest/mobile/invitations/by-code/{code}/preview:
+    get:
+      tags:
+      - Mobile Invitations
+      summary: Preview patient invitation by human code
+      description: "Public, rate-limited preview keyed by human-readable code (e.g.\
+        \ NUTRI-ABCD-EFGH)."
+      operationId: previewInvitationByHumanCode
+      parameters:
+      - name: code
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Invitation preview when code is valid and pending
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientInvitationPreviewDto"
+        "400":
+          description: Malformed invitation token
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientInvitationPreviewDto"
+        "404":
+          description: Invalid or expired invitation
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientInvitationPreviewDto"
+        "429":
+          description: "Rate limit exceeded (Retry-After: 60)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientInvitationPreviewDto"
+      security: []
 components:
   schemas:
     SendPatientMessageRequest:

--- a/docs/db/LIQUIBASE.md
+++ b/docs/db/LIQUIBASE.md
@@ -14,6 +14,7 @@ Nutriconsultas uses [Liquibase](https://www.liquibase.org/) for schema and catal
 | `changes/005-nutritionist-invitation-payment-exempt.yaml` | `payment_exempt` on `nutritionist_invitation` (#184) |
 | `changes/006-subscription-notification-log.yaml` | Lifecycle notification log (#185, PR #215) |
 | `changes/007-patient-invitation-onboarding.yaml` | `PacienteStatus` columns + `patient_invitation` table (#132, PR #214) |
+| `changes/023-patient-invitation-human-code.yaml` | `human_code` on `patient_invitation` (#336) |
 | `changes/008-platillo-ingesta-source-platillo-id.yaml` | `source_platillo_id` on `platillo_ingesta` + catalog backfill (#250) |
 | `data/alimentos-seed.sql` | SMAE alimentos catalog (from `alimentos.sql`) |
 | `data/platillos-seed.sql` | Catalog `platillo` + `ingrediente` rows |

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -14,7 +14,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`../auth0/PATIENT-POST-LOGIN-GATE.md`](../auth0/PATIENT-POST-LOGIN-GATE.md) | Auth0 Post-Login invitation gate (#140) — Action script + deployment |
 | [`../api/openapi-mobile.yaml`](../api/openapi-mobile.yaml) | OpenAPI 3.1 export (#112, PR #164); regen: `scripts/export-openapi-mobile.sh` |
 
-**Status (2026-06-26):** ~~#132~~–~~#141~~ **done** — Phase 2 invitation onboarding complete ([`INVITATION-SECURITY-AUDIT.md`](INVITATION-SECURITY-AUDIT.md)). ~~#337~~ **done** — public web landing at `GET /links/i/{token}` (not-installed fallback).
+**Status (2026-06-26):** ~~#132~~–~~#141~~ **done** — Phase 2 invitation onboarding complete ([`INVITATION-SECURITY-AUDIT.md`](INVITATION-SECURITY-AUDIT.md)). ~~#336~~ **done** — `GET /rest/mobile/invitations/by-code/{code}/preview`. ~~#337~~ **done** — public web landing at `GET /links/i/{token}` (not-installed fallback).
 
 ## Related registries (same repo)
 

--- a/src/main/java/com/nutriconsultas/mobile/MobileInvitationController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobileInvitationController.java
@@ -86,6 +86,24 @@ public class MobileInvitationController {
 		return ApiResponse.ok(CreatedPatientInvitationDto.from(created));
 	}
 
+	@GetMapping("/by-code/{code}/preview")
+	@Operation(summary = "Preview patient invitation by human code",
+			description = "Public, rate-limited preview keyed by human-readable code (e.g. NUTRI-ABCD-EFGH).")
+	@SecurityRequirements
+	@MobileOpenApiResponses.PublicInvitationPreview
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+			description = "Invitation preview when code is valid and pending")
+	public ApiResponse<PatientInvitationPreviewDto> previewInvitationByHumanCode(
+			@PathVariable("code") final String code, final HttpServletRequest httpRequest) {
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile invitation preview by human code request received");
+		}
+		final String clientKey = ClientIpResolver.resolve(httpRequest);
+		final PatientInvitationPreviewResult preview = patientInvitationPreviewRateLimiter.execute(clientKey,
+				() -> patientInvitationPreviewService.previewByHumanCode(code));
+		return ApiResponse.ok(PatientInvitationPreviewDto.from(preview));
+	}
+
 	@GetMapping("/{token}/preview")
 	@Operation(summary = "Preview patient invitation",
 			description = "Public, rate-limited preview returning inviter display name only (no patient PII).")

--- a/src/main/java/com/nutriconsultas/paciente/PatientInvitation.java
+++ b/src/main/java/com/nutriconsultas/paciente/PatientInvitation.java
@@ -36,6 +36,9 @@ public class PatientInvitation {
 	@Column(name = "token_hash", nullable = false, length = 64, unique = true)
 	private String tokenHash;
 
+	@Column(name = "human_code", length = 20, unique = true)
+	private String humanCode;
+
 	@ManyToOne(optional = false, fetch = FetchType.LAZY)
 	@JoinColumn(name = "paciente_id", nullable = false)
 	private Paciente paciente;

--- a/src/main/java/com/nutriconsultas/paciente/PatientInvitationRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PatientInvitationRepository.java
@@ -9,6 +9,8 @@ public interface PatientInvitationRepository extends JpaRepository<PatientInvita
 
 	Optional<PatientInvitation> findByTokenHash(String tokenHash);
 
+	Optional<PatientInvitation> findByHumanCode(String humanCode);
+
 	Optional<PatientInvitation> findByIdAndNutritionistUserId(Long id, String nutritionistUserId);
 
 	List<PatientInvitation> findByPacienteId(Long pacienteId);

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationCreateServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationCreateServiceImpl.java
@@ -73,6 +73,7 @@ public class PatientInvitationCreateServiceImpl implements PatientInvitationCrea
 
 		final PatientInvitation invitation = new PatientInvitation();
 		invitation.setTokenHash(tokenBundle.tokenHash());
+		invitation.setHumanCode(tokenBundle.humanCode());
 		invitation.setPaciente(savedPaciente);
 		invitation.setNutritionistUserId(nutritionistUserId);
 		invitation.setStatus(PatientInvitationStatus.PENDING);

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationHumanCodes.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationHumanCodes.java
@@ -41,10 +41,11 @@ public final class PatientInvitationHumanCodes {
 				return false;
 			}
 		}
-		return payload.charAt(7) == checksum(payload.substring(0, 7).toCharArray());
+		return payload.charAt(7) == checksum(payload.charAt(0), payload.charAt(1), payload.charAt(2), payload.charAt(3),
+				payload.charAt(4), payload.charAt(5), payload.charAt(6));
 	}
 
-	private static char checksum(final char[] payload) {
+	private static char checksum(final char... payload) {
 		int sum = 0;
 		for (int index = 0; index < 7; index++) {
 			sum += ALPHABET.indexOf(payload[index]);

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationHumanCodes.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationHumanCodes.java
@@ -1,0 +1,55 @@
+package com.nutriconsultas.paciente.invitation;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * Validates patient invitation human-readable code shape (#336). Codes follow
+ * {@code PREFIX-XXXX-XXXX} Crockford-style encoding with a checksum digit.
+ */
+public final class PatientInvitationHumanCodes {
+
+	private static final String ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+	private PatientInvitationHumanCodes() {
+	}
+
+	public static String normalize(final String rawCode) {
+		if (rawCode == null) {
+			return null;
+		}
+		return rawCode.trim().toUpperCase(Locale.ROOT);
+	}
+
+	public static boolean isWellFormed(final String rawCode, final String prefix) {
+		final String normalized = normalize(rawCode);
+		if (normalized == null || normalized.isBlank()) {
+			return false;
+		}
+		final String normalizedPrefix = prefix == null || prefix.isBlank() ? "NUTRI" : prefix.trim().toUpperCase();
+		final Pattern pattern = Pattern.compile("^" + Pattern.quote(normalizedPrefix) + "-[0-9A-Z]{4}-[0-9A-Z]{4}$");
+		if (!pattern.matcher(normalized).matches()) {
+			return false;
+		}
+		final int dashIndex = normalized.indexOf('-');
+		final String payload = normalized.substring(dashIndex + 1).replace("-", "");
+		if (payload.length() != 8) {
+			return false;
+		}
+		for (int index = 0; index < 7; index++) {
+			if (ALPHABET.indexOf(payload.charAt(index)) < 0) {
+				return false;
+			}
+		}
+		return payload.charAt(7) == checksum(payload.substring(0, 7).toCharArray());
+	}
+
+	private static char checksum(final char[] payload) {
+		int sum = 0;
+		for (int index = 0; index < 7; index++) {
+			sum += ALPHABET.indexOf(payload[index]);
+		}
+		return ALPHABET.charAt(sum % ALPHABET.length());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationPreviewService.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationPreviewService.java
@@ -1,11 +1,12 @@
 package com.nutriconsultas.paciente.invitation;
 
 /**
- * Public, rate-limited invitation preview for patient onboarding (#135).
+ * Public, rate-limited invitation preview for patient onboarding (#135, #336).
  */
-@FunctionalInterface
 public interface PatientInvitationPreviewService {
 
 	PatientInvitationPreviewResult preview(String rawUrlToken);
+
+	PatientInvitationPreviewResult previewByHumanCode(String humanCode);
 
 }

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationPreviewServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationPreviewServiceImpl.java
@@ -24,10 +24,14 @@ public class PatientInvitationPreviewServiceImpl implements PatientInvitationPre
 
 	private final NutritionistProfileRepository nutritionistProfileRepository;
 
+	private final PatientInvitationProperties invitationProperties;
+
 	public PatientInvitationPreviewServiceImpl(final PatientInvitationRepository patientInvitationRepository,
-			final NutritionistProfileRepository nutritionistProfileRepository) {
+			final NutritionistProfileRepository nutritionistProfileRepository,
+			final PatientInvitationProperties invitationProperties) {
 		this.patientInvitationRepository = patientInvitationRepository;
 		this.nutritionistProfileRepository = nutritionistProfileRepository;
+		this.invitationProperties = invitationProperties;
 	}
 
 	@Override
@@ -41,6 +45,24 @@ public class PatientInvitationPreviewServiceImpl implements PatientInvitationPre
 			.filter(this::isPreviewable)
 			.orElseThrow(PatientInvitationUnavailableException::new);
 
+		return toPreviewResult(invitation);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public PatientInvitationPreviewResult previewByHumanCode(final String humanCode) {
+		if (!PatientInvitationHumanCodes.isWellFormed(humanCode, invitationProperties.getHumanCodePrefix())) {
+			throw new PatientInvitationUnavailableException();
+		}
+		final String normalizedCode = PatientInvitationHumanCodes.normalize(humanCode);
+		final PatientInvitation invitation = patientInvitationRepository.findByHumanCode(normalizedCode)
+			.filter(this::isPreviewable)
+			.orElseThrow(PatientInvitationUnavailableException::new);
+
+		return toPreviewResult(invitation);
+	}
+
+	private PatientInvitationPreviewResult toPreviewResult(final PatientInvitation invitation) {
 		final String inviterDisplayName = nutritionistProfileRepository.findByUserId(invitation.getNutritionistUserId())
 			.map(profile -> NutritionistBrandingHelper.resolveDisplayName(profile, null))
 			.orElse(null);

--- a/src/main/java/com/nutriconsultas/security/MobileSecurityConfig.java
+++ b/src/main/java/com/nutriconsultas/security/MobileSecurityConfig.java
@@ -43,10 +43,13 @@ public class MobileSecurityConfig {
 			.cors(withDefaults())
 			.csrf(csrf -> csrf.disable())
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-			.authorizeHttpRequests(auth -> auth.requestMatchers(HttpMethod.GET, "/rest/mobile/invitations/*/preview")
-				.permitAll()
-				.anyRequest()
-				.authenticated())
+			.authorizeHttpRequests(
+					auth -> auth.requestMatchers(HttpMethod.GET, "/rest/mobile/invitations/by-code/*/preview")
+						.permitAll()
+						.requestMatchers(HttpMethod.GET, "/rest/mobile/invitations/*/preview")
+						.permitAll()
+						.anyRequest()
+						.authenticated())
 			.oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(mobileJwtDecoder)))
 			.addFilterAfter(localeContextFilter, BearerTokenAuthenticationFilter.class)
 			.addFilterAfter(patientLinkageFilter, LocaleContextFilter.class);

--- a/src/main/resources/db/changelog/changes/023-patient-invitation-human-code.yaml
+++ b/src/main/resources/db/changelog/changes/023-patient-invitation-human-code.yaml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: 023-patient-invitation-human-code-column
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            columnExists:
+              tableName: patient_invitation
+              columnName: human_code
+      changes:
+        - addColumn:
+            tableName: patient_invitation
+            columns:
+              - column:
+                  name: human_code
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: true
+                    unique: true
+        - createIndex:
+            indexName: idx_patient_invitation_human_code
+            tableName: patient_invitation
+            columns:
+              - column:
+                  name: human_code

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -65,3 +65,6 @@ databaseChangeLog:
   - include:
       file: changes/022-ingesta-orden.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/023-patient-invitation-human-code.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -56,3 +56,6 @@ databaseChangeLog:
   - include:
       file: changes/022-ingesta-orden.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/023-patient-invitation-human-code.yaml
+      relativeToChangelogFile: true

--- a/src/test/java/com/nutriconsultas/mobile/MobileInvitationControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileInvitationControllerTest.java
@@ -100,6 +100,23 @@ class MobileInvitationControllerTest {
 	}
 
 	@Test
+	void previewInvitationByHumanCode_returnsApiResponseEnvelope() throws Exception {
+		final PatientInvitationPreviewResult preview = new PatientInvitationPreviewResult("Lic. Ana López");
+		when(httpServletRequest.getRemoteAddr()).thenReturn("127.0.0.1");
+		when(patientInvitationPreviewRateLimiter.execute(org.mockito.ArgumentMatchers.eq("127.0.0.1"),
+				org.mockito.ArgumentMatchers.any()))
+			.thenAnswer(invocation -> ((java.util.concurrent.Callable<?>) invocation.getArgument(1)).call());
+		when(patientInvitationPreviewService.previewByHumanCode("NUTRI-WXYZ-1234")).thenReturn(preview);
+
+		final ApiResponse<PatientInvitationPreviewDto> response = controller
+			.previewInvitationByHumanCode("NUTRI-WXYZ-1234", httpServletRequest);
+
+		assertThat(response.data().inviterDisplayName()).isEqualTo("Lic. Ana López");
+		assertThat(response.timestamp()).isNotNull();
+		verify(patientInvitationPreviewService).previewByHumanCode("NUTRI-WXYZ-1234");
+	}
+
+	@Test
 	void redeemInvitation_returnsApiResponseEnvelope() throws Exception {
 		final PatientInvitationRedeemResult result = new PatientInvitationRedeemResult(100L, PacienteStatus.ONBOARDING,
 				1L, Instant.parse("2026-06-01T12:00:00Z"));

--- a/src/test/java/com/nutriconsultas/mobile/MobileInvitationIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileInvitationIntegrationTest.java
@@ -197,6 +197,50 @@ class MobileInvitationIntegrationTest {
 	}
 
 	@Test
+	void previewInvitationByHumanCode_withoutJwt_returnsInviterDisplayName() throws Exception {
+		final PatientInvitationTokenBundle bundle = patientInvitationTokenService.generate();
+		seedPendingInvitation(bundle, NUTRITIONIST_SUB);
+		seedNutritionistProfile(NUTRITIONIST_SUB, "Lic. Human Code Nutri");
+
+		mockMvc.perform(get("/rest/mobile/invitations/by-code/{code}/preview", bundle.humanCode()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.inviterDisplayName").value("Lic. Human Code Nutri"))
+			.andExpect(jsonPath("$.timestamp").exists());
+	}
+
+	@Test
+	void previewInvitationByHumanCode_withUnknownCode_returnsGenericNotFound() throws Exception {
+		final PatientInvitationTokenBundle bundle = patientInvitationTokenService.generate();
+
+		mockMvc.perform(get("/rest/mobile/invitations/by-code/{code}/preview", bundle.humanCode()))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("La invitación no es válida o ha expirado."));
+	}
+
+	@Test
+	void previewInvitationByHumanCode_withMalformedCode_returnsGenericNotFound() throws Exception {
+		mockMvc.perform(get("/rest/mobile/invitations/by-code/{code}/preview", "not-a-code"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("La invitación no es válida o ha expirado."));
+	}
+
+	@Test
+	void previewInvitationByHumanCode_whenRateLimited_returns429WithRetryAfter() throws Exception {
+		final PatientInvitationTokenBundle bundle = patientInvitationTokenService.generate();
+		seedPendingInvitation(bundle, NUTRITIONIST_SUB);
+
+		for (int attempt = 0; attempt < 2; attempt++) {
+			mockMvc.perform(get("/rest/mobile/invitations/by-code/{code}/preview", bundle.humanCode()))
+				.andExpect(status().isOk());
+		}
+
+		mockMvc.perform(get("/rest/mobile/invitations/by-code/{code}/preview", bundle.humanCode()))
+			.andExpect(status().isTooManyRequests())
+			.andExpect(header().string("Retry-After", "60"))
+			.andExpect(jsonPath("$.message").value("Demasiadas solicitudes. Inténtalo de nuevo en un minuto."));
+	}
+
+	@Test
 	void redeemInvitation_withUnknownToken_returnsGenericNotFound() throws Exception {
 		final PatientInvitationTokenBundle bundle = patientInvitationTokenService.generate();
 
@@ -370,6 +414,7 @@ class MobileInvitationIntegrationTest {
 
 		final PatientInvitation invitation = new PatientInvitation();
 		invitation.setTokenHash(bundle.tokenHash());
+		invitation.setHumanCode(bundle.humanCode());
 		invitation.setPaciente(savedPaciente);
 		invitation.setNutritionistUserId(nutritionistUserId);
 		invitation.setStatus(PatientInvitationStatus.PENDING);
@@ -379,6 +424,13 @@ class MobileInvitationIntegrationTest {
 	}
 
 	private void seedNutritionistProfile(final String nutritionistUserId, final String displayName) {
+		final var existing = nutritionistProfileRepository.findByUserId(nutritionistUserId);
+		if (existing.isPresent()) {
+			final NutritionistProfile profile = existing.get();
+			profile.setDisplayName(displayName);
+			nutritionistProfileRepository.saveAndFlush(profile);
+			return;
+		}
 		final NutritionistProfile profile = new NutritionistProfile();
 		profile.setUserId(nutritionistUserId);
 		profile.setPublicBookingId(UUID.randomUUID().toString());

--- a/src/test/java/com/nutriconsultas/mobile/MobileOpenApiIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileOpenApiIntegrationTest.java
@@ -33,8 +33,8 @@ class MobileOpenApiIntegrationTest {
 			"/rest/mobile/patient/diet-plans/{assignmentId}", "/rest/mobile/patient/diet-plans/{assignmentId}/pdf",
 			"/rest/mobile/patient/messages", "/rest/mobile/patient/progress",
 			"/rest/mobile/patient/progress/measurements", "/rest/mobile/patient/me", "/rest/mobile/invitations",
-			"/rest/mobile/invitations/{token}/preview", "/rest/mobile/invitations/{token}/redeem",
-			"/rest/mobile/invitations/{id}/revoke");
+			"/rest/mobile/invitations/{token}/preview", "/rest/mobile/invitations/by-code/{code}/preview",
+			"/rest/mobile/invitations/{token}/redeem", "/rest/mobile/invitations/{id}/revoke");
 
 	@Autowired
 	private MockMvc mockMvc;

--- a/src/test/java/com/nutriconsultas/paciente/PatientInvitationRepositoryTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PatientInvitationRepositoryTest.java
@@ -22,6 +22,8 @@ class PatientInvitationRepositoryTest {
 
 	private static final String TOKEN_HASH = "a".repeat(64);
 
+	private static final String HUMAN_CODE = "NUTRI-ABCD-EFGH";
+
 	@Autowired
 	private PacienteRepository pacienteRepository;
 
@@ -35,6 +37,14 @@ class PatientInvitationRepositoryTest {
 		patientInvitationRepository.saveAndFlush(invitation);
 
 		assertThat(patientInvitationRepository.findByTokenHash(TOKEN_HASH)).isPresent();
+	}
+
+	@Test
+	void findByHumanCode_returnsInvitationWhenPresent() {
+		final Paciente paciente = pacienteRepository.save(invitedPaciente());
+		patientInvitationRepository.saveAndFlush(sampleInvitation(paciente));
+
+		assertThat(patientInvitationRepository.findByHumanCode(HUMAN_CODE)).isPresent();
 	}
 
 	@Test
@@ -79,6 +89,7 @@ class PatientInvitationRepositoryTest {
 		invitation.setPaciente(paciente);
 		invitation.setNutritionistUserId(NUTRITIONIST_SUB);
 		invitation.setTokenHash(TOKEN_HASH);
+		invitation.setHumanCode(HUMAN_CODE);
 		invitation.setStatus(PatientInvitationStatus.PENDING);
 		invitation.setExpiresAt(Instant.now().plus(14, ChronoUnit.DAYS));
 		invitation.setMaxUses(1);

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationCreateServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationCreateServiceTest.java
@@ -103,6 +103,7 @@ class PatientInvitationCreateServiceTest {
 		final ArgumentCaptor<PatientInvitation> invitationCaptor = ArgumentCaptor.forClass(PatientInvitation.class);
 		verify(patientInvitationRepository).save(invitationCaptor.capture());
 		assertThat(invitationCaptor.getValue().getTokenHash()).isEqualTo("abc123hash");
+		assertThat(invitationCaptor.getValue().getHumanCode()).isEqualTo("NUTRI-ABCD-EFGH");
 		assertThat(invitationCaptor.getValue().getStatus()).isEqualTo(PatientInvitationStatus.PENDING);
 		assertThat(invitationCaptor.getValue().getNutritionistUserId()).isEqualTo(NUTRITIONIST_SUB);
 

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationHumanCodesTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationHumanCodesTest.java
@@ -1,0 +1,28 @@
+package com.nutriconsultas.paciente.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PatientInvitationHumanCodesTest {
+
+	@Test
+	void isWellFormed_acceptsValidGeneratedCode() {
+		final PatientInvitationTokenService service = new PatientInvitationTokenServiceImpl(
+				new PatientInvitationProperties());
+		final PatientInvitationTokenBundle bundle = service.generate();
+
+		assertThat(PatientInvitationHumanCodes.isWellFormed(bundle.humanCode(), "NUTRI")).isTrue();
+		assertThat(PatientInvitationHumanCodes.normalize("  nutri-abcd-efgh  ")).isEqualTo("NUTRI-ABCD-EFGH");
+	}
+
+	@Test
+	void isWellFormed_rejectsMalformedOrChecksumMismatch() {
+		assertThat(PatientInvitationHumanCodes.isWellFormed(null, "NUTRI")).isFalse();
+		assertThat(PatientInvitationHumanCodes.isWellFormed("", "NUTRI")).isFalse();
+		assertThat(PatientInvitationHumanCodes.isWellFormed("NUTRI-ABCD", "NUTRI")).isFalse();
+		assertThat(PatientInvitationHumanCodes.isWellFormed("NUTRI-ABCD-EFG1", "NUTRI")).isFalse();
+		assertThat(PatientInvitationHumanCodes.isWellFormed("WRONG-ABCD-EFGH", "NUTRI")).isFalse();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationLandingServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationLandingServiceTest.java
@@ -48,7 +48,7 @@ class PatientInvitationLandingServiceTest {
 		invitationProperties.setBaseUrl("https://minutriporcion.com");
 		tokenService = new PatientInvitationTokenServiceImpl(invitationProperties);
 		final PatientInvitationPreviewService previewService = new PatientInvitationPreviewServiceImpl(
-				patientInvitationRepository, nutritionistProfileRepository);
+				patientInvitationRepository, nutritionistProfileRepository, invitationProperties);
 		service = new PatientInvitationLandingServiceImpl(previewService, patientInvitationPreviewRateLimiter,
 				invitationProperties);
 		when(patientInvitationPreviewRateLimiter.execute(any(), any())).thenAnswer(invocation -> {

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationPreviewServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationPreviewServiceTest.java
@@ -42,7 +42,8 @@ class PatientInvitationPreviewServiceTest {
 	@BeforeEach
 	void setUp() {
 		tokenService = new PatientInvitationTokenServiceImpl(new PatientInvitationProperties());
-		service = new PatientInvitationPreviewServiceImpl(patientInvitationRepository, nutritionistProfileRepository);
+		service = new PatientInvitationPreviewServiceImpl(patientInvitationRepository, nutritionistProfileRepository,
+				new PatientInvitationProperties());
 	}
 
 	@Test
@@ -111,6 +112,48 @@ class PatientInvitationPreviewServiceTest {
 			.isExactlyInstanceOf(PatientInvitationUnavailableException.class);
 		assertThatThrownBy(() -> service.preview(expiredToken))
 			.isExactlyInstanceOf(PatientInvitationUnavailableException.class);
+	}
+
+	@Test
+	void previewByHumanCode_withValidPendingInvitation_returnsInviterDisplayName() {
+		final PatientInvitationTokenBundle bundle = tokenService.generate();
+		final PatientInvitation invitation = pendingInvitation(bundle.tokenHash());
+		invitation.setHumanCode(bundle.humanCode());
+		when(patientInvitationRepository.findByHumanCode(bundle.humanCode())).thenReturn(Optional.of(invitation));
+		final NutritionistProfile profile = new NutritionistProfile();
+		profile.setDisplayName("Lic. Ana López");
+		when(nutritionistProfileRepository.findByUserId(NUTRITIONIST_SUB)).thenReturn(Optional.of(profile));
+
+		final PatientInvitationPreviewResult result = service.previewByHumanCode(bundle.humanCode());
+
+		assertThat(result.inviterDisplayName()).isEqualTo("Lic. Ana López");
+	}
+
+	@Test
+	void previewByHumanCode_withUnknownCode_throwsUnavailable() {
+		final PatientInvitationTokenBundle bundle = tokenService.generate();
+		when(patientInvitationRepository.findByHumanCode(bundle.humanCode())).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.previewByHumanCode(bundle.humanCode()))
+			.isInstanceOf(PatientInvitationUnavailableException.class);
+	}
+
+	@Test
+	void previewByHumanCode_withMalformedCode_throwsUnavailable() {
+		assertThatThrownBy(() -> service.previewByHumanCode("not-a-code"))
+			.isInstanceOf(PatientInvitationUnavailableException.class);
+	}
+
+	@Test
+	void previewByHumanCode_withExpiredInvitation_throwsUnavailable() {
+		final PatientInvitationTokenBundle bundle = tokenService.generate();
+		final PatientInvitation invitation = pendingInvitation(bundle.tokenHash());
+		invitation.setHumanCode(bundle.humanCode());
+		invitation.setExpiresAt(Instant.now().minus(1, ChronoUnit.HOURS));
+		when(patientInvitationRepository.findByHumanCode(bundle.humanCode())).thenReturn(Optional.of(invitation));
+
+		assertThatThrownBy(() -> service.previewByHumanCode(bundle.humanCode()))
+			.isInstanceOf(PatientInvitationUnavailableException.class);
 	}
 
 	private PatientInvitation pendingInvitation(final String tokenHash) {


### PR DESCRIPTION
## Summary
- Adds public `GET /rest/mobile/invitations/by-code/{code}/preview` keyed by human-readable code (`NUTRI-XXXX-XXXX`), mirroring token preview (#135) with the same rate limiter and `PatientInvitationPreviewDto` response.
- Persists `human_code` on new invitations (Liquibase `023`) for indexed lookup; validates format/checksum before DB access; malformed/unknown codes return generic 404.
- Updates OpenAPI export, security permit-all rule, and tracking docs (`ISSUE.md`, `AGENTS.md`, `LIQUIBASE.md`).

Closes #336

## Test plan
- [x] `mvn verify` (checkstyle, PMD, SpotBugs, unit + integration tests)
- [x] `MobileInvitationIntegrationTest` — happy path, 404, 429 for by-code preview
- [x] `PatientInvitationPreviewServiceTest` + `PatientInvitationHumanCodesTest`
- [x] OpenAPI documents new path


Made with [Cursor](https://cursor.com)