### PR TITLE
[Nutritionist Web] Patient grid + profile — send mobile app invitation (#341)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -604,6 +604,8 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 **Bug ~~#250~~** (2026-06-19): diet ingesta platillo name links to wrong catalog platillo — **done** (PR [#256](https://github.com/diego-torres/nutriconsultas/pull/256)).
 
+**Epic ~~#341~~** (2026-06-26): nutritionist web mobile app invitation — ~~#341~~ **done** (branch `issue-341-web-mobile-invitation`, 38f358e): session REST `/rest/pacientes/{id}/mobile-invitation`, patient grid **App móvil** column, Afiliación send/resend/revoke. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+
 ## Public booking (tracking)
 
 Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic ~~**#245**~~ **done** (v1 shipped, 2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)); ~~#248~~ **done** (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)); ~~#297~~ **done** (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)); ~~#300~~ **done** (PR [#301](https://github.com/diego-torres/nutriconsultas/pull/301)); ~~#302~~ **done** (PR [#303](https://github.com/diego-torres/nutriconsultas/pull/303)). Track complete; deferred follow-ups (verification, SMTP) need new issues.

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-21 — ~~#242~~ **done** (branch `issue-242-anthropometric-field-edit`). ~~#241~~ **done** (PR [#291](https://github.com/diego-torres/nutriconsultas/pull/291)). Patient UX epic **complete** (#241–#242). ~~#272~~ **done** (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)). ~~#271~~ **done** (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)).
+**Last updated:** 2026-06-26 — ~~#341~~ **done** (branch `issue-341-web-mobile-invitation`, 38f358e). ~~#242~~ **done** (branch `issue-242-anthropometric-field-edit`). ~~#241~~ **done** (PR [#291](https://github.com/diego-torres/nutriconsultas/pull/291)). Patient UX epic **complete** (#241–#242). ~~#272~~ **done** (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)). ~~#271~~ **done** (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)).
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -196,7 +196,7 @@ Nutritionist sends patient mobile onboarding invitations from the **patient grid
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| **341** | Patient grid + profile — send mobile app invitation | https://github.com/diego-torres/nutriconsultas/issues/341 | **in-progress** | #134, #336 | Branch `issue-341-web-mobile-invitation`; `PatientMobileInvitationService`; SweetAlert |
+| **341** | Patient grid + profile — send mobile app invitation | https://github.com/diego-torres/nutriconsultas/issues/341 | **done** | #134, #336 | Branch `issue-341-web-mobile-invitation` (38f358e); grid badge + afiliación send/resend/revoke; SweetAlert |
 
 ---
 

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -190,6 +190,16 @@ Inline **cantidad** editing on the catalog platillo form (`/admin/platillos/{id}
 
 ---
 
+## Epic — Web mobile app invitation (#341)
+
+Nutritionist sends patient mobile onboarding invitations from the **patient grid** and **Afiliación** profile without a mobile JWT.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| **341** | Patient grid + profile — send mobile app invitation | https://github.com/diego-torres/nutriconsultas/issues/341 | **in-progress** | #134, #336 | Branch `issue-341-web-mobile-invitation`; `PatientMobileInvitationService`; SweetAlert |
+
+---
+
 ## Bugs
 
 | # | Title | URL | State | Depends on | Notes |
@@ -215,6 +225,7 @@ Inline **cantidad** editing on the catalog platillo form (`/admin/platillos/{id}
 | #109 Mobile linkage | Delete clears `patientAuthSub`; not stored in `.mpx` |
 | ~~#220~~ Retention purge | Platform admin purge of **revoked** nutritionists — ~~#220~~ PR [#313](https://github.com/diego-torres/nutriconsultas/pull/313); orthogonal to nutritionist-initiated patient delete |
 | #132 Patient invitations | Onboarding `Paciente.status` — import creates `ACTIVE` patient unless product specifies otherwise |
+| **#341** Web mobile invite UI | Session REST `/rest/pacientes/{id}/mobile-invitation`; grid badge + afiliación send/resend/revoke (#341) |
 | #183 Platform admin | System diet edit (#232), create (#272); system platillo edit (#257), create (#271) |
 | #187 Branded PDF | Logo profile (#236) and PDF sizing (#237) |
 | #198 Diet templates | System diets seeded; editable (#232) and creatable (#272) by admin |

--- a/src/main/java/com/nutriconsultas/paciente/PacienteComparators.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteComparators.java
@@ -41,6 +41,11 @@ public final class PacienteComparators {
 			.comparing(PacienteListView::getResponsibleName, Comparator.nullsLast(Comparator.naturalOrder())));
 		MAP.put(new ComparatorKey("responsible", Direction.desc), Comparator
 			.comparing(PacienteListView::getResponsibleName, Comparator.nullsLast(Comparator.reverseOrder())));
+
+		MAP.put(new ComparatorKey("mobileApp", Direction.asc),
+				Comparator.comparing(PacienteListView::getStatus, Comparator.nullsLast(Comparator.naturalOrder())));
+		MAP.put(new ComparatorKey("mobileApp", Direction.desc),
+				Comparator.comparing(PacienteListView::getStatus, Comparator.nullsLast(Comparator.reverseOrder())));
 	}
 
 	public static Comparator<PacienteListView> getComparator(String name, Direction dir) {

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -115,6 +115,9 @@ public class PacienteController extends AbstractAuthorizedController {
 	@Autowired
 	private PacienteMpxImportService pacienteMpxImportService;
 
+	@Autowired
+	private com.nutriconsultas.paciente.invitation.PatientMobileInvitationService patientMobileInvitationService;
+
 	/**
 	 * Gets the user ID from the OAuth2 principal.
 	 * @param principal the OAuth2 principal
@@ -337,6 +340,7 @@ public class PacienteController extends AbstractAuthorizedController {
 		model.addAttribute("paciente", paciente);
 		model.addAttribute("mobileAuth",
 				PatientMobileAuthStatus.of(paciente.getPatientAuthSub(), auth0UserLookup.isConfigured()));
+		model.addAttribute("mobileInvitation", patientMobileInvitationService.getStatus(id, userId));
 		return "sbadmin/pacientes/afiliacion";
 	}
 

--- a/src/main/java/com/nutriconsultas/paciente/PacienteMobileInvitationRestController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteMobileInvitationRestController.java
@@ -1,0 +1,130 @@
+package com.nutriconsultas.paciente;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nutriconsultas.paciente.invitation.IssuedPatientMobileInvitationResult;
+import com.nutriconsultas.paciente.invitation.PatientInvitationRevokeResult;
+import com.nutriconsultas.paciente.invitation.PatientMobileInvitationNotAllowedException;
+import com.nutriconsultas.paciente.invitation.PatientMobileInvitationService;
+import com.nutriconsultas.paciente.invitation.PatientMobileInvitationStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/pacientes/{pacienteId}/mobile-invitation")
+@Slf4j
+public class PacienteMobileInvitationRestController {
+
+	private final PatientMobileInvitationService patientMobileInvitationService;
+
+	public PacienteMobileInvitationRestController(final PatientMobileInvitationService patientMobileInvitationService) {
+		this.patientMobileInvitationService = patientMobileInvitationService;
+	}
+
+	@GetMapping
+	public ResponseEntity<Map<String, Object>> getStatus(@PathVariable @NonNull final Long pacienteId,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = requireUserId(principal);
+		try {
+			final PatientMobileInvitationStatus status = patientMobileInvitationService.getStatus(pacienteId, userId);
+			final Map<String, Object> body = new LinkedHashMap<>(status.toMap());
+			body.put("success", true);
+			return ResponseEntity.ok(body);
+		}
+		catch (IllegalArgumentException ex) {
+			return notFound(ex.getMessage());
+		}
+	}
+
+	@PostMapping
+	public ResponseEntity<Map<String, Object>> sendInvitation(@PathVariable @NonNull final Long pacienteId,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = requireUserId(principal);
+		try {
+			final IssuedPatientMobileInvitationResult issued = patientMobileInvitationService.sendInvitation(pacienteId,
+					userId);
+			final Map<String, Object> body = new LinkedHashMap<>();
+			body.put("success", true);
+			body.put("invitationId", issued.invitationId());
+			body.put("pacienteId", issued.pacienteId());
+			body.put("humanCode", issued.humanCode());
+			body.put("expiresAt", issued.expiresAt().toString());
+			body.put("recipientEmailRedacted", issued.recipientEmailRedacted());
+			body.put("message", "Invitación enviada correctamente.");
+			return ResponseEntity.status(HttpStatus.CREATED).body(body);
+		}
+		catch (IllegalArgumentException ex) {
+			return notFound(ex.getMessage());
+		}
+		catch (PatientMobileInvitationNotAllowedException ex) {
+			return badRequest(ex.getMessageKey(), resolveNotAllowedMessage(ex.getMessageKey()));
+		}
+	}
+
+	@DeleteMapping
+	public ResponseEntity<Map<String, Object>> revokeInvitation(@PathVariable @NonNull final Long pacienteId,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = requireUserId(principal);
+		try {
+			final PatientInvitationRevokeResult revoked = patientMobileInvitationService
+				.revokePendingInvitation(pacienteId, userId);
+			final Map<String, Object> body = new LinkedHashMap<>();
+			body.put("success", true);
+			body.put("invitationId", revoked.invitationId());
+			body.put("pacienteId", revoked.pacienteId());
+			body.put("status", revoked.status().name());
+			body.put("message", "Invitación revocada.");
+			return ResponseEntity.ok(body);
+		}
+		catch (IllegalArgumentException ex) {
+			return notFound(ex.getMessage());
+		}
+		catch (PatientMobileInvitationNotAllowedException ex) {
+			return badRequest(ex.getMessageKey(), resolveNotAllowedMessage(ex.getMessageKey()));
+		}
+	}
+
+	private static String requireUserId(final OidcUser principal) {
+		if (principal == null || !StringUtils.hasText(principal.getSubject())) {
+			throw new IllegalStateException("Not authenticated");
+		}
+		return principal.getSubject();
+	}
+
+	private static ResponseEntity<Map<String, Object>> notFound(final String message) {
+		return ResponseEntity.status(HttpStatus.NOT_FOUND)
+			.body(Map.of("success", false, "error", message != null ? message : "Paciente no encontrado"));
+	}
+
+	private static ResponseEntity<Map<String, Object>> badRequest(final String code, final String message) {
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(Map.of("success", false, "error", code, "message", message));
+	}
+
+	private static String resolveNotAllowedMessage(final String code) {
+		return switch (code) {
+			case "NO_EMAIL" -> "El paciente debe tener un correo registrado para enviar la invitación.";
+			case "NO_PENDING_INVITATION" -> "No hay una invitación pendiente para revocar.";
+			case "LINKED" -> "El paciente ya está vinculado a la app móvil.";
+			case "ONBOARDING" -> "El paciente se está registrando en la app.";
+			case "REVOKED" -> "El acceso del paciente está revocado.";
+			case "PENDING" -> "Ya existe una invitación pendiente.";
+			default -> "No se puede enviar la invitación en el estado actual del paciente.";
+		};
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
@@ -20,7 +20,8 @@ import com.nutriconsultas.paciente.projection.PacienteListView;
 public interface PacienteRepository extends JpaRepository<Paciente, Long> {
 
 	String LIST_VIEW_SELECT = "SELECT p.id AS id, p.name AS name, p.email AS email, p.phone AS phone, "
-			+ "p.dob AS dob, p.gender AS gender, p.responsibleName AS responsibleName ";
+			+ "p.dob AS dob, p.gender AS gender, p.responsibleName AS responsibleName, "
+			+ "p.status AS status, p.patientAuthSub AS patientAuthSub ";
 
 	List<Paciente> findByUserId(String userId);
 

--- a/src/main/java/com/nutriconsultas/paciente/PacienteRestController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteRestController.java
@@ -36,6 +36,7 @@ import com.nutriconsultas.dataTables.paging.Direction;
 import com.nutriconsultas.dataTables.paging.Order;
 import com.nutriconsultas.dataTables.paging.PageArray;
 import com.nutriconsultas.dataTables.paging.PagingRequest;
+import com.nutriconsultas.paciente.invitation.PatientMobileInvitationUiSupport;
 import com.nutriconsultas.paciente.projection.PacienteListView;
 import com.nutriconsultas.util.LogRedaction;
 
@@ -62,6 +63,7 @@ public class PacienteRestController extends AbstractGridController<PacienteListV
 		COLUMN_TO_FIELD_MAP.put("phone", "phone");
 		COLUMN_TO_FIELD_MAP.put("gender", "gender");
 		COLUMN_TO_FIELD_MAP.put("responsible", "responsibleName");
+		COLUMN_TO_FIELD_MAP.put("mobileApp", "status");
 	}
 
 	/**
@@ -184,11 +186,21 @@ public class PacienteRestController extends AbstractGridController<PacienteListV
 				row.getEmail(), //
 				row.getPhone(), //
 				row.getGender(), //
-				row.getResponsibleName(), buildPacienteActions(row.getId()));
+				row.getResponsibleName(), //
+				PatientMobileInvitationUiSupport.gridBadgeHtml(row.getStatus(), row.getPatientAuthSub()),
+				buildPacienteActions(row));
 	}
 
-	private String buildPacienteActions(final Long pacienteId) {
-		return "<button type='button' class='btn action-btn btn-outline-primary btn-sm paciente-export-btn' "
+	private String buildPacienteActions(final PacienteListView row) {
+		final Long pacienteId = row.getId();
+		final String inviteButton = PatientMobileInvitationUiSupport.canInviteFromGrid(row.getStatus(), row
+			.getPatientAuthSub(), PatientMobileInvitationUiSupport.resolveRecipientEmailFromListRow(row))
+					? "<button type='button' class='btn action-btn btn-outline-success btn-sm paciente-mobile-invite-btn' "
+							+ "data-id='" + pacienteId
+							+ "' title='Invitar a la app'><i class='fas fa-mobile-alt'></i></button> "
+					: "";
+		return inviteButton
+				+ "<button type='button' class='btn action-btn btn-outline-primary btn-sm paciente-export-btn' "
 				+ "data-id='" + pacienteId + "' title='Exportar registro'><i class='fas fa-download'></i></button> "
 				+ "<button type='button' class='btn action-btn btn-danger btn-sm paciente-delete-btn' data-id='"
 				+ pacienteId + "' title='Eliminar paciente'><i class='fas fa-trash'></i></button>";
@@ -226,7 +238,7 @@ public class PacienteRestController extends AbstractGridController<PacienteListV
 	@Override
 	protected List<Column> getColumns() {
 		log.debug("getting Paciente columns.");
-		return Stream.of("nombre", "dob", "email", "phone", "gender", "responsible", "acciones")
+		return Stream.of("nombre", "dob", "email", "phone", "gender", "responsible", "mobileApp", "acciones")
 			.map(Column::new)
 			.collect(Collectors.toList());
 	}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
@@ -16,6 +16,7 @@ import com.nutriconsultas.clinical.exam.ClinicalExam;
 import com.nutriconsultas.dieta.Dieta;
 import com.nutriconsultas.validation.template.BaseTemplateValidator;
 import com.nutriconsultas.mobile.PatientMobileAuthStatus;
+import com.nutriconsultas.paciente.invitation.PatientMobileInvitationStatus;
 
 /**
  * Validator for paciente (patient) templates. Provides mock variables for patient
@@ -35,6 +36,8 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 		final Paciente paciente = createMockPaciente();
 		variables.put("paciente", paciente);
 		variables.put("mobileAuth", PatientMobileAuthStatus.of(null, false));
+		variables.put("mobileInvitation", new PatientMobileInvitationStatus("NONE", "Sin app", true, false, false, null,
+				null, null, "j***@example.com"));
 		variables.put("avatarImageUrl", PacienteAvatarCatalog.resolveImagePath(paciente));
 		variables.put("selectedAvatarId", PacienteAvatarCatalog.resolveSelectedId(paciente));
 		variables.put("avatarOptions", PacienteAvatarCatalog.allOptions());

--- a/src/main/java/com/nutriconsultas/paciente/PatientInvitationRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PatientInvitationRepository.java
@@ -15,6 +15,8 @@ public interface PatientInvitationRepository extends JpaRepository<PatientInvita
 
 	List<PatientInvitation> findByPacienteId(Long pacienteId);
 
+	List<PatientInvitation> findByPacienteIdAndStatus(Long pacienteId, PatientInvitationStatus status);
+
 	List<PatientInvitation> findByNutritionistUserIdAndStatus(String nutritionistUserId,
 			PatientInvitationStatus status);
 

--- a/src/main/java/com/nutriconsultas/paciente/invitation/IssuedPatientMobileInvitationResult.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/IssuedPatientMobileInvitationResult.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.paciente.invitation;
+
+import java.time.Instant;
+
+/**
+ * Web-safe result after sending a patient mobile invitation (#341). Does not include raw
+ * URL token.
+ */
+public record IssuedPatientMobileInvitationResult(Long invitationId, Long pacienteId, String humanCode,
+		Instant expiresAt, String recipientEmailRedacted) {
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientMobileInvitationNotAllowedException.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientMobileInvitationNotAllowedException.java
@@ -1,0 +1,19 @@
+package com.nutriconsultas.paciente.invitation;
+
+/**
+ * Patient is not eligible for mobile invitation actions (#341).
+ */
+public final class PatientMobileInvitationNotAllowedException extends RuntimeException {
+
+	private final String messageKey;
+
+	public PatientMobileInvitationNotAllowedException(final String messageKey) {
+		super(messageKey);
+		this.messageKey = messageKey;
+	}
+
+	public String getMessageKey() {
+		return messageKey;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientMobileInvitationNotAllowedException.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientMobileInvitationNotAllowedException.java
@@ -5,6 +5,8 @@ package com.nutriconsultas.paciente.invitation;
  */
 public final class PatientMobileInvitationNotAllowedException extends RuntimeException {
 
+	private static final long serialVersionUID = 1L;
+
 	private final String messageKey;
 
 	public PatientMobileInvitationNotAllowedException(final String messageKey) {

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientMobileInvitationService.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientMobileInvitationService.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.paciente.invitation;
+
+public interface PatientMobileInvitationService {
+
+	PatientMobileInvitationStatus getStatus(Long pacienteId, String nutritionistUserId);
+
+	IssuedPatientMobileInvitationResult sendInvitation(Long pacienteId, String nutritionistUserId);
+
+	PatientInvitationRevokeResult revokePendingInvitation(Long pacienteId, String nutritionistUserId);
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientMobileInvitationServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientMobileInvitationServiceImpl.java
@@ -1,0 +1,177 @@
+package com.nutriconsultas.paciente.invitation;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Locale;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.PatientInvitation;
+import com.nutriconsultas.paciente.PatientInvitationRepository;
+import com.nutriconsultas.paciente.PatientInvitationStatus;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class PatientMobileInvitationServiceImpl implements PatientMobileInvitationService {
+
+	private final PacienteRepository pacienteRepository;
+
+	private final PatientInvitationRepository patientInvitationRepository;
+
+	private final PatientInvitationTokenService patientInvitationTokenService;
+
+	private final PatientInvitationProperties invitationProperties;
+
+	private final PatientInvitationEmailSender patientInvitationEmailSender;
+
+	private final PatientInvitationRevokeService patientInvitationRevokeService;
+
+	public PatientMobileInvitationServiceImpl(final PacienteRepository pacienteRepository,
+			final PatientInvitationRepository patientInvitationRepository,
+			final PatientInvitationTokenService patientInvitationTokenService,
+			final PatientInvitationProperties invitationProperties,
+			final PatientInvitationEmailSender patientInvitationEmailSender,
+			final PatientInvitationRevokeService patientInvitationRevokeService) {
+		this.pacienteRepository = pacienteRepository;
+		this.patientInvitationRepository = patientInvitationRepository;
+		this.patientInvitationTokenService = patientInvitationTokenService;
+		this.invitationProperties = invitationProperties;
+		this.patientInvitationEmailSender = patientInvitationEmailSender;
+		this.patientInvitationRevokeService = patientInvitationRevokeService;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public PatientMobileInvitationStatus getStatus(final Long pacienteId, final String nutritionistUserId) {
+		final Paciente paciente = requireOwnedPaciente(pacienteId, nutritionistUserId);
+		return PatientMobileInvitationUiSupport.resolve(paciente, findActivePendingInvitation(pacienteId).orElse(null));
+	}
+
+	@Override
+	@Transactional
+	public IssuedPatientMobileInvitationResult sendInvitation(final Long pacienteId, final String nutritionistUserId) {
+		final Paciente paciente = requireOwnedPaciente(pacienteId, nutritionistUserId);
+		final PatientMobileInvitationStatus current = PatientMobileInvitationUiSupport.resolve(paciente,
+				findActivePendingInvitation(pacienteId).orElse(null));
+		if (!current.canSend() && !current.canResend()) {
+			throw new PatientMobileInvitationNotAllowedException(current.stateCode());
+		}
+		final String recipientEmail = requireRecipientEmail(paciente);
+		revokeExpiredPendingInvitations(pacienteId);
+		findActivePendingInvitation(pacienteId)
+			.ifPresent(pending -> patientInvitationRevokeService.revoke(pending.getId(), nutritionistUserId));
+
+		ensureInviteMetadata(paciente);
+		if (paciente.getStatus() == PacienteStatus.ACTIVE) {
+			paciente.setStatus(PacienteStatus.INVITED);
+		}
+		pacienteRepository.save(paciente);
+
+		final PatientInvitationTokenBundle tokenBundle = patientInvitationTokenService.generate();
+		final Instant expiresAt = Instant.now().plus(invitationProperties.getExpiryDays(), ChronoUnit.DAYS);
+		final PatientInvitation invitation = new PatientInvitation();
+		invitation.setTokenHash(tokenBundle.tokenHash());
+		invitation.setHumanCode(tokenBundle.humanCode());
+		invitation.setPaciente(paciente);
+		invitation.setNutritionistUserId(nutritionistUserId);
+		invitation.setStatus(PatientInvitationStatus.PENDING);
+		invitation.setExpiresAt(expiresAt);
+		invitation.setMaxUses(1);
+		final PatientInvitation savedInvitation = patientInvitationRepository.save(invitation);
+
+		final String inviteUrl = invitationProperties.buildInviteUrl(tokenBundle.urlToken());
+		patientInvitationEmailSender.sendPatientInvitation(recipientEmail, tokenBundle.humanCode(), inviteUrl);
+
+		if (log.isInfoEnabled()) {
+			log.info("Issued patient mobile invitation from web: invitationId={}, pacienteId={}",
+					savedInvitation.getId(), paciente.getId());
+		}
+
+		return new IssuedPatientMobileInvitationResult(savedInvitation.getId(), paciente.getId(),
+				tokenBundle.humanCode(), expiresAt, LogRedaction.redactEmail(recipientEmail));
+	}
+
+	@Override
+	@Transactional
+	public PatientInvitationRevokeResult revokePendingInvitation(final Long pacienteId,
+			final String nutritionistUserId) {
+		final Paciente paciente = requireOwnedPaciente(pacienteId, nutritionistUserId);
+		final PatientInvitation pending = findActivePendingInvitation(pacienteId)
+			.orElseThrow(() -> new PatientMobileInvitationNotAllowedException("NO_PENDING_INVITATION"));
+		final PatientMobileInvitationStatus current = PatientMobileInvitationUiSupport.resolve(paciente, pending);
+		if (!current.canRevoke()) {
+			throw new PatientMobileInvitationNotAllowedException(current.stateCode());
+		}
+		return patientInvitationRevokeService.revoke(pending.getId(), nutritionistUserId);
+	}
+
+	private Paciente requireOwnedPaciente(final Long pacienteId, final String nutritionistUserId) {
+		if (!StringUtils.hasText(nutritionistUserId)) {
+			throw new IllegalArgumentException("nutritionistUserId is required");
+		}
+		return pacienteRepository.findByIdAndUserId(pacienteId, nutritionistUserId)
+			.orElseThrow(() -> new IllegalArgumentException("Paciente no encontrado"));
+	}
+
+	private java.util.Optional<PatientInvitation> findActivePendingInvitation(final Long pacienteId) {
+		final Instant now = Instant.now();
+		return patientInvitationRepository.findByPacienteIdAndStatus(pacienteId, PatientInvitationStatus.PENDING)
+			.stream()
+			.filter(invitation -> !invitation.getExpiresAt().isBefore(now))
+			.findFirst();
+	}
+
+	private void revokeExpiredPendingInvitations(final Long pacienteId) {
+		final Instant now = Instant.now();
+		final List<PatientInvitation> expired = patientInvitationRepository
+			.findByPacienteIdAndStatus(pacienteId, PatientInvitationStatus.PENDING)
+			.stream()
+			.filter(invitation -> invitation.getExpiresAt().isBefore(now))
+			.toList();
+		for (final PatientInvitation invitation : expired) {
+			invitation.setStatus(PatientInvitationStatus.REVOKED);
+			patientInvitationRepository.save(invitation);
+		}
+	}
+
+	private static String requireRecipientEmail(final Paciente paciente) {
+		final String email = PatientMobileInvitationUiSupport.resolveRecipientEmail(paciente);
+		if (!StringUtils.hasText(email)) {
+			throw new PatientMobileInvitationNotAllowedException("NO_EMAIL");
+		}
+		return email;
+	}
+
+	private void ensureInviteMetadata(final Paciente paciente) {
+		if (!StringUtils.hasText(paciente.getAssignedId())) {
+			String candidate = PatientAssignedIdGenerator.generate();
+			while (pacienteRepository.existsByAssignedId(candidate)) {
+				candidate = PatientAssignedIdGenerator.generate();
+			}
+			paciente.setAssignedId(candidate);
+		}
+		final String email = PatientMobileInvitationUiSupport.resolveRecipientEmail(paciente);
+		if (StringUtils.hasText(email)) {
+			paciente.setEmail(email);
+			if (!StringUtils.hasText(paciente.getEmailHint())) {
+				paciente.setEmailHint(email);
+			}
+		}
+		if (!StringUtils.hasText(paciente.getDisplayName()) && StringUtils.hasText(paciente.getName())) {
+			paciente.setDisplayName(paciente.getName().trim());
+		}
+		if (StringUtils.hasText(paciente.getGender())) {
+			paciente.setGender(paciente.getGender().trim().toUpperCase(Locale.ROOT));
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientMobileInvitationStatus.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientMobileInvitationStatus.java
@@ -1,0 +1,36 @@
+package com.nutriconsultas.paciente.invitation;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Web-safe mobile invitation state for nutritionist UI (#341).
+ */
+public record PatientMobileInvitationStatus(String stateCode, String stateLabel, boolean canSend, boolean canResend,
+		boolean canRevoke, Long pendingInvitationId, String humanCode, Instant expiresAt,
+		String recipientEmailRedacted) {
+
+	public Map<String, Object> toMap() {
+		final Map<String, Object> map = new LinkedHashMap<>();
+		map.put("stateCode", stateCode);
+		map.put("stateLabel", stateLabel);
+		map.put("canSend", canSend);
+		map.put("canResend", canResend);
+		map.put("canRevoke", canRevoke);
+		if (pendingInvitationId != null) {
+			map.put("pendingInvitationId", pendingInvitationId);
+		}
+		if (humanCode != null) {
+			map.put("humanCode", humanCode);
+		}
+		if (expiresAt != null) {
+			map.put("expiresAt", expiresAt.toString());
+		}
+		if (recipientEmailRedacted != null) {
+			map.put("recipientEmailRedacted", recipientEmailRedacted);
+		}
+		return map;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientMobileInvitationUiSupport.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientMobileInvitationUiSupport.java
@@ -1,0 +1,106 @@
+package com.nutriconsultas.paciente.invitation;
+
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.PatientInvitation;
+import com.nutriconsultas.paciente.projection.PacienteListView;
+import com.nutriconsultas.util.LogRedaction;
+
+/**
+ * Resolves nutritionist-web mobile invitation UI state (#341).
+ */
+public final class PatientMobileInvitationUiSupport {
+
+	private PatientMobileInvitationUiSupport() {
+	}
+
+	public static PatientMobileInvitationStatus resolve(final Paciente paciente,
+			final PatientInvitation pendingInvitation) {
+		if (paciente.getStatus() == PacienteStatus.REVOKED) {
+			return status("REVOKED", "Acceso revocado", false, false, false, null, null, null, null);
+		}
+		if (StringUtils.hasText(paciente.getPatientAuthSub())) {
+			if (paciente.getStatus() == PacienteStatus.ONBOARDING) {
+				return status("ONBOARDING", "Registrándose en la app", false, false, false, null, null, null, null);
+			}
+			return status("LINKED", "Vinculado a la app", false, false, false, null, null, null, null);
+		}
+		if (paciente.getStatus() == PacienteStatus.INVITED && pendingInvitation != null) {
+			return status("PENDING", "Invitación pendiente", false, true, true, pendingInvitation.getId(),
+					pendingInvitation.getHumanCode(), pendingInvitation.getExpiresAt(), redactRecipientEmail(paciente));
+		}
+		if (!StringUtils.hasText(resolveRecipientEmail(paciente))) {
+			return status("NO_EMAIL", "Sin correo registrado", false, false, false, null, null, null, null);
+		}
+		return status("NONE", "Sin app", true, false, false, null, null, null, redactRecipientEmail(paciente));
+	}
+
+	public static String resolveRecipientEmail(final Paciente paciente) {
+		if (StringUtils.hasText(paciente.getEmail())) {
+			return paciente.getEmail().trim().toLowerCase();
+		}
+		if (StringUtils.hasText(paciente.getEmailHint())) {
+			return paciente.getEmailHint().trim().toLowerCase();
+		}
+		return null;
+	}
+
+	public static String resolveRecipientEmailFromListRow(final PacienteListView row) {
+		if (row == null) {
+			return null;
+		}
+		if (StringUtils.hasText(row.getEmail())) {
+			return row.getEmail().trim().toLowerCase();
+		}
+		return null;
+	}
+
+	public static String gridBadgeHtml(final PacienteStatus status, final String patientAuthSub) {
+		if (status == PacienteStatus.REVOKED) {
+			return badge("badge-dark", "Revocado");
+		}
+		if (StringUtils.hasText(patientAuthSub)) {
+			if (status == PacienteStatus.ONBOARDING) {
+				return badge("badge-info", "En onboarding");
+			}
+			return badge("badge-success", "Vinculado");
+		}
+		if (status == PacienteStatus.INVITED) {
+			return badge("badge-warning", "Invitación pendiente");
+		}
+		return badge("badge-secondary", "Sin app");
+	}
+
+	public static boolean canInviteFromGrid(final PacienteStatus status, final String patientAuthSub,
+			final String email) {
+		if (status == PacienteStatus.REVOKED || StringUtils.hasText(patientAuthSub)) {
+			return false;
+		}
+		if (status == PacienteStatus.ONBOARDING) {
+			return false;
+		}
+		if (status == PacienteStatus.INVITED) {
+			return StringUtils.hasText(email);
+		}
+		return status == PacienteStatus.ACTIVE && StringUtils.hasText(email);
+	}
+
+	private static PatientMobileInvitationStatus status(final String stateCode, final String stateLabel,
+			final boolean canSend, final boolean canResend, final boolean canRevoke, final Long pendingInvitationId,
+			final String humanCode, final java.time.Instant expiresAt, final String recipientEmailRedacted) {
+		return new PatientMobileInvitationStatus(stateCode, stateLabel, canSend, canResend, canRevoke,
+				pendingInvitationId, humanCode, expiresAt, recipientEmailRedacted);
+	}
+
+	private static String redactRecipientEmail(final Paciente paciente) {
+		final String email = resolveRecipientEmail(paciente);
+		return email != null ? LogRedaction.redactEmail(email) : null;
+	}
+
+	private static String badge(final String cssClass, final String label) {
+		return "<span class='badge " + cssClass + "'>" + label + "</span>";
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/projection/PacienteListView.java
+++ b/src/main/java/com/nutriconsultas/paciente/projection/PacienteListView.java
@@ -2,6 +2,8 @@ package com.nutriconsultas.paciente.projection;
 
 import java.util.Date;
 
+import com.nutriconsultas.paciente.PacienteStatus;
+
 /**
  * Read-only projection for patient grid and search — excludes heavy TEXT and
  * energy-preference columns (#156 Phase A).
@@ -21,5 +23,9 @@ public interface PacienteListView {
 	String getGender();
 
 	String getResponsibleName();
+
+	PacienteStatus getStatus();
+
+	String getPatientAuthSub();
 
 }

--- a/src/main/resources/static/sbadmin/js/paciente-mobile-invitation.js
+++ b/src/main/resources/static/sbadmin/js/paciente-mobile-invitation.js
@@ -1,0 +1,243 @@
+'use strict';
+
+/**
+ * Send / resend / revoke mobile app invitations from patient grid and profile (#341).
+ */
+(function ($) {
+  if (!$) {
+    return;
+  }
+
+  function invitationUrl(pacienteId) {
+    return '/rest/pacientes/' + pacienteId + '/mobile-invitation';
+  }
+
+  function errorMessage(xhr, fallback) {
+    if (xhr.responseJSON) {
+      if (xhr.responseJSON.message) {
+        return xhr.responseJSON.message;
+      }
+      if (xhr.responseJSON.error && typeof xhr.responseJSON.error === 'string') {
+        return xhr.responseJSON.error;
+      }
+    }
+    return fallback;
+  }
+
+  function confirmSend(isResend, recipientEmailRedacted, callback) {
+    var title = isResend ? 'Reenviar invitación' : 'Invitar a la app móvil';
+    var text = isResend
+      ? 'Se revocará la invitación anterior y se enviará un nuevo correo al paciente.'
+      : 'Se enviará un correo al paciente con un enlace para registrarse en la app móvil.';
+    if (recipientEmailRedacted) {
+      text += ' Destinatario: ' + recipientEmailRedacted + '.';
+    }
+    swal({
+      title: title,
+      text: text,
+      type: 'warning',
+      showCancelButton: true,
+      confirmButtonText: isResend ? 'Reenviar' : 'Enviar invitación',
+      cancelButtonText: 'Cancelar',
+      closeOnConfirm: false,
+      showLoaderOnConfirm: true
+    }, function (isConfirm) {
+      if (isConfirm) {
+        callback();
+      }
+    });
+  }
+
+  function confirmRevoke(callback) {
+    swal({
+      title: 'Revocar invitación',
+      text: 'El enlace de invitación dejará de ser válido. ¿Continuar?',
+      type: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#d33',
+      confirmButtonText: 'Revocar',
+      cancelButtonText: 'Cancelar',
+      closeOnConfirm: false,
+      showLoaderOnConfirm: true
+    }, function (isConfirm) {
+      if (isConfirm) {
+        callback();
+      }
+    });
+  }
+
+  function showSuccess(title, text, onClose) {
+    swal({
+      title: title,
+      text: text,
+      type: 'success',
+      timer: 2500,
+      showConfirmButton: false
+    });
+    if (onClose) {
+      setTimeout(onClose, 2600);
+    }
+  }
+
+  function showError(message) {
+    swal({
+      title: 'No se pudo completar',
+      text: message,
+      type: 'error',
+      timer: 5000
+    });
+  }
+
+  function postInvitation(pacienteId, options) {
+    $.ajax({
+      url: invitationUrl(pacienteId),
+      type: 'POST',
+      success: function (data) {
+        var codeText = data.humanCode ? ' Código: ' + data.humanCode + '.' : '';
+        showSuccess('Invitación enviada', (data.message || 'Correo enviado correctamente.') + codeText,
+          options && options.onChanged);
+      },
+      error: function (xhr) {
+        if (typeof swal.enableButtons === 'function') {
+          swal.enableButtons();
+        }
+        showError(errorMessage(xhr, 'Error al enviar la invitación.'));
+      }
+    });
+  }
+
+  function deleteInvitation(pacienteId, options) {
+    $.ajax({
+      url: invitationUrl(pacienteId),
+      type: 'DELETE',
+      success: function (data) {
+        showSuccess('Invitación revocada', data.message || 'La invitación fue revocada.', options && options.onChanged);
+      },
+      error: function (xhr) {
+        if (typeof swal.enableButtons === 'function') {
+          swal.enableButtons();
+        }
+        showError(errorMessage(xhr, 'Error al revocar la invitación.'));
+      }
+    });
+  }
+
+  function sendFromGrid(pacienteId, options) {
+    confirmSend(false, null, function () {
+      postInvitation(pacienteId, options);
+    });
+  }
+
+  function bindGrid(options) {
+    $(document).on('click', '.paciente-mobile-invite-btn', function (event) {
+      event.preventDefault();
+      var pacienteId = $(this).data('id');
+      if (pacienteId) {
+        sendFromGrid(pacienteId, options);
+      }
+    });
+  }
+
+  function refreshProfileUi(data) {
+    var badgeEl = document.getElementById('mobile-invitation-status-badge');
+    var detailsEl = document.getElementById('mobile-invitation-details');
+    var sendBtn = document.getElementById('mobile-invitation-send-btn');
+    var resendBtn = document.getElementById('mobile-invitation-resend-btn');
+    var revokeBtn = document.getElementById('mobile-invitation-revoke-btn');
+    if (!badgeEl) {
+      return;
+    }
+    badgeEl.textContent = data.stateLabel || '';
+    badgeEl.className = 'badge ' + profileBadgeClass(data.stateCode);
+    if (detailsEl) {
+      var parts = [];
+      if (data.humanCode) {
+        parts.push('Código: ' + data.humanCode);
+      }
+      if (data.expiresAt) {
+        parts.push('Vence: ' + data.expiresAt.replace('T', ' ').replace('Z', ' UTC'));
+      }
+      if (data.recipientEmailRedacted) {
+        parts.push('Correo: ' + data.recipientEmailRedacted);
+      }
+      detailsEl.textContent = parts.join(' · ');
+      detailsEl.classList.toggle('d-none', parts.length === 0);
+    }
+    if (sendBtn) {
+      sendBtn.classList.toggle('d-none', !data.canSend);
+    }
+    if (resendBtn) {
+      resendBtn.classList.toggle('d-none', !data.canResend);
+    }
+    if (revokeBtn) {
+      revokeBtn.classList.toggle('d-none', !data.canRevoke);
+    }
+  }
+
+  function profileBadgeClass(stateCode) {
+    switch (stateCode) {
+      case 'LINKED':
+        return 'badge-success';
+      case 'ONBOARDING':
+        return 'badge-info';
+      case 'PENDING':
+        return 'badge-warning';
+      case 'REVOKED':
+        return 'badge-dark';
+      case 'NO_EMAIL':
+        return 'badge-secondary';
+      default:
+        return 'badge-secondary';
+    }
+  }
+
+  function reloadProfileStatus(pacienteId) {
+    return $.getJSON(invitationUrl(pacienteId)).done(function (data) {
+      if (data && data.success) {
+        refreshProfileUi(data);
+      }
+    });
+  }
+
+  function bindProfile(pacienteId) {
+    var sendBtn = document.getElementById('mobile-invitation-send-btn');
+    var resendBtn = document.getElementById('mobile-invitation-resend-btn');
+    var revokeBtn = document.getElementById('mobile-invitation-revoke-btn');
+    var options = {
+      onChanged: function () {
+        reloadProfileStatus(pacienteId);
+      }
+    };
+
+    if (sendBtn) {
+      sendBtn.addEventListener('click', function () {
+        var recipient = sendBtn.getAttribute('data-recipient') || '';
+        confirmSend(false, recipient, function () {
+          postInvitation(pacienteId, options);
+        });
+      });
+    }
+    if (resendBtn) {
+      resendBtn.addEventListener('click', function () {
+        var recipient = resendBtn.getAttribute('data-recipient') || '';
+        confirmSend(true, recipient, function () {
+          postInvitation(pacienteId, options);
+        });
+      });
+    }
+    if (revokeBtn) {
+      revokeBtn.addEventListener('click', function () {
+        confirmRevoke(function () {
+          deleteInvitation(pacienteId, options);
+        });
+      });
+    }
+  }
+
+  window.PacienteMobileInvitation = {
+    bindGrid: bindGrid,
+    bindProfile: bindProfile,
+    sendInvitation: postInvitation,
+    revokeInvitation: deleteInvitation
+  };
+})(window.jQuery);

--- a/src/main/resources/templates/sbadmin/pacientes/afiliacion.html
+++ b/src/main/resources/templates/sbadmin/pacientes/afiliacion.html
@@ -101,6 +101,44 @@
                     </form>
                   </div>
 
+                  <!-- Mobile app invitation (#341) -->
+                  <div class="info-form p-5 border-top" th:if="${paciente != null and paciente.id != null}">
+                    <h5 class="text-gray-800 mb-3">Invitación a la app móvil</h5>
+                    <p class="text-muted small">
+                      Envíe un correo al paciente para que se registre en la app móvil de Minutriporcion.
+                    </p>
+                    <div class="mb-3">
+                      <span class="font-weight-bold">Estado:</span>
+                      <span id="mobile-invitation-status-badge" class="badge badge-secondary"
+                        th:text="${mobileInvitation != null ? mobileInvitation.stateLabel : 'Sin app'}">Sin app</span>
+                    </div>
+                    <p id="mobile-invitation-details" class="text-muted small"
+                      th:classappend="${mobileInvitation == null or (mobileInvitation.humanCode == null and mobileInvitation.expiresAt == null and mobileInvitation.recipientEmailRedacted == null)} ? ' d-none' : ''">
+                      <span th:if="${mobileInvitation != null and mobileInvitation.humanCode != null}"
+                        th:text="'Código: ' + ${mobileInvitation.humanCode}"></span>
+                      <span th:if="${mobileInvitation != null and mobileInvitation.expiresAt != null}"
+                        th:text="' · Vence: ' + ${mobileInvitation.expiresAt}"></span>
+                      <span th:if="${mobileInvitation != null and mobileInvitation.recipientEmailRedacted != null}"
+                        th:text="' · Correo: ' + ${mobileInvitation.recipientEmailRedacted}"></span>
+                    </p>
+                    <div class="mb-3">
+                      <button type="button" class="btn btn-success btn-sm" id="mobile-invitation-send-btn"
+                        th:classappend="${mobileInvitation == null or !mobileInvitation.canSend} ? ' d-none' : ''"
+                        th:attr="data-recipient=${mobileInvitation != null ? mobileInvitation.recipientEmailRedacted : ''}">
+                        Enviar invitación
+                      </button>
+                      <button type="button" class="btn btn-outline-success btn-sm" id="mobile-invitation-resend-btn"
+                        th:classappend="${mobileInvitation == null or !mobileInvitation.canResend} ? ' d-none' : ''"
+                        th:attr="data-recipient=${mobileInvitation != null ? mobileInvitation.recipientEmailRedacted : ''}">
+                        Reenviar invitación
+                      </button>
+                      <button type="button" class="btn btn-outline-danger btn-sm" id="mobile-invitation-revoke-btn"
+                        th:classappend="${mobileInvitation == null or !mobileInvitation.canRevoke} ? ' d-none' : ''">
+                        Revocar invitación
+                      </button>
+                    </div>
+                  </div>
+
                   <!-- Mobile app Auth0 linkage (#109) -->
                   <div class="info-form p-5 border-top" th:if="${paciente != null and paciente.id != null}">
                     <h5 class="text-gray-800 mb-3">App móvil del paciente</h5>
@@ -175,6 +213,7 @@
     <!-- Custom scripts for all pages-->
     <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
     <script th:src="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.js}"></script>
+    <script th:src="@{/sbadmin/js/paciente-mobile-invitation.js}"></script>
 
     <script th:inline="javascript">
       (function () {
@@ -302,6 +341,10 @@
               });
             });
           });
+        }
+
+        if (window.PacienteMobileInvitation) {
+          PacienteMobileInvitation.bindProfile(pacienteId);
         }
       })();
     </script>

--- a/src/main/resources/templates/sbadmin/pacientes/listado.html
+++ b/src/main/resources/templates/sbadmin/pacientes/listado.html
@@ -90,6 +90,7 @@
                         <th>Tel&eacute;fono</th>
                         <th>Género</th>
                         <th>Responsable</th>
+                        <th>App móvil</th>
                         <th>Acciones</th>
                       </tr>
                     </thead>
@@ -125,6 +126,7 @@
     <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
     <script th:src="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.js}"></script>
     <script th:src="@{/sbadmin/js/paciente-mpx-actions.js}"></script>
+    <script th:src="@{/sbadmin/js/paciente-mobile-invitation.js}"></script>
     <script lang="javascript">
       'use strict';
       (function ($) {
@@ -172,6 +174,14 @@
         if (window.PacienteMpxActions) {
           PacienteMpxActions.bind({
             onDeleted: function () {
+              $('#mainGrid').DataTable().ajax.reload(null, false);
+            }
+          });
+        }
+
+        if (window.PacienteMobileInvitation) {
+          PacienteMobileInvitation.bindGrid({
+            onChanged: function () {
               $('#mainGrid').DataTable().ajax.reload(null, false);
             }
           });

--- a/src/test/java/com/nutriconsultas/paciente/PacienteMobileInvitationRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteMobileInvitationRestControllerTest.java
@@ -1,0 +1,103 @@
+package com.nutriconsultas.paciente;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import com.nutriconsultas.paciente.invitation.IssuedPatientMobileInvitationResult;
+import com.nutriconsultas.paciente.invitation.PatientInvitationRevokeResult;
+import com.nutriconsultas.paciente.invitation.PatientMobileInvitationNotAllowedException;
+import com.nutriconsultas.paciente.invitation.PatientMobileInvitationService;
+import com.nutriconsultas.paciente.invitation.PatientMobileInvitationStatus;
+
+@ExtendWith(MockitoExtension.class)
+class PacienteMobileInvitationRestControllerTest {
+
+	private static final String NUTRITIONIST_SUB = "auth0|nutritionist-web-invite";
+
+	@InjectMocks
+	private PacienteMobileInvitationRestController controller;
+
+	@Mock
+	private PatientMobileInvitationService patientMobileInvitationService;
+
+	@Test
+	void getStatus_returnsInvitationState() {
+		final PatientMobileInvitationStatus status = new PatientMobileInvitationStatus("NONE", "Sin app", true, false,
+				false, null, null, null, "j***@example.com");
+		when(patientMobileInvitationService.getStatus(eq(1L), eq(NUTRITIONIST_SUB))).thenReturn(status);
+
+		final ResponseEntity<Map<String, Object>> response = controller.getStatus(1L, principal());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("success", true)
+			.containsEntry("stateCode", "NONE")
+			.containsEntry("canSend", true);
+	}
+
+	@Test
+	void sendInvitation_returnsCreated() {
+		final Instant expiresAt = Instant.now().plus(7, ChronoUnit.DAYS);
+		when(patientMobileInvitationService.sendInvitation(eq(2L), eq(NUTRITIONIST_SUB))).thenReturn(
+				new IssuedPatientMobileInvitationResult(10L, 2L, "NUTRI-ABCD-EFGH", expiresAt, "j***@example.com"));
+
+		final ResponseEntity<Map<String, Object>> response = controller.sendInvitation(2L, principal());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+		assertThat(response.getBody()).containsEntry("success", true).containsEntry("humanCode", "NUTRI-ABCD-EFGH");
+	}
+
+	@Test
+	void sendInvitation_returnsBadRequestWhenNotAllowed() {
+		when(patientMobileInvitationService.sendInvitation(eq(3L), eq(NUTRITIONIST_SUB)))
+			.thenThrow(new PatientMobileInvitationNotAllowedException("NO_EMAIL"));
+
+		final ResponseEntity<Map<String, Object>> response = controller.sendInvitation(3L, principal());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+		assertThat(response.getBody()).containsEntry("error", "NO_EMAIL");
+	}
+
+	@Test
+	void revokeInvitation_delegatesToService() {
+		when(patientMobileInvitationService.revokePendingInvitation(eq(4L), eq(NUTRITIONIST_SUB)))
+			.thenReturn(new PatientInvitationRevokeResult(99L, 4L, PatientInvitationStatus.REVOKED));
+
+		final ResponseEntity<Map<String, Object>> response = controller.revokeInvitation(4L, principal());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("success", true).containsEntry("invitationId", 99L);
+		verify(patientMobileInvitationService).revokePendingInvitation(4L, NUTRITIONIST_SUB);
+	}
+
+	private static OidcUser principal() {
+		final Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject(NUTRITIONIST_SUB).build();
+		final OidcIdToken idToken = new OidcIdToken("token", jwt.getIssuedAt(), jwt.getExpiresAt(),
+				Map.of("sub", NUTRITIONIST_SUB));
+		return new DefaultOidcUser(null, idToken);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/PacienteProjectionRepositoryTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteProjectionRepositoryTest.java
@@ -48,6 +48,8 @@ class PacienteProjectionRepositoryTest {
 		assertThat(view.getPhone()).isEqualTo("5551234");
 		assertThat(view.getGender()).isEqualTo("F");
 		assertThat(view.getResponsibleName()).isEqualTo("Tutor Test");
+		assertThat(view.getStatus()).isEqualTo(PacienteStatus.ACTIVE);
+		assertThat(view.getPatientAuthSub()).isEqualTo(PATIENT_SUB);
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/paciente/PacienteRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteRestControllerTest.java
@@ -258,7 +258,7 @@ public class PacienteRestControllerTest {
 
 		// Assert
 		assertThat(result).isNotNull();
-		assertThat(result.size()).isEqualTo(7);
+		assertThat(result.size()).isEqualTo(8);
 		assertThat(result.get(0)).contains("Juan Perez");
 		assertThat(result.get(0)).contains("/admin/pacientes/1");
 		assertThat(result.get(1)).isNotEmpty(); // Date formatted
@@ -266,8 +266,9 @@ public class PacienteRestControllerTest {
 		assertThat(result.get(3)).isEqualTo("1234567890");
 		assertThat(result.get(4)).isEqualTo("M");
 		assertThat(result.get(5)).isEqualTo("Maria Perez");
-		assertThat(result.get(6)).contains("paciente-export-btn");
-		assertThat(result.get(6)).contains("paciente-delete-btn");
+		assertThat(result.get(6)).contains("badge");
+		assertThat(result.get(7)).contains("paciente-export-btn");
+		assertThat(result.get(7)).contains("paciente-delete-btn");
 		log.info("finished testToStringList");
 	}
 
@@ -289,13 +290,13 @@ public class PacienteRestControllerTest {
 
 		// Assert
 		assertThat(result).isNotNull();
-		assertThat(result.size()).isEqualTo(7);
+		assertThat(result.size()).isEqualTo(8);
 		assertThat(result.get(1)).isEmpty(); // Null date
 		assertThat(result.get(2)).isNull(); // Null email
 		assertThat(result.get(3)).isNull(); // Null phone
 		assertThat(result.get(4)).isNull(); // Null gender
 		assertThat(result.get(5)).isNull(); // Null responsibleName
-		assertThat(result.get(6)).contains("paciente-delete-btn");
+		assertThat(result.get(7)).contains("paciente-delete-btn");
 		log.info("finished testToStringListWithNullValues");
 	}
 
@@ -307,14 +308,15 @@ public class PacienteRestControllerTest {
 
 		// Assert
 		assertThat(result).isNotNull();
-		assertThat(result.size()).isEqualTo(7);
+		assertThat(result.size()).isEqualTo(8);
 		assertThat(result.get(0).getData()).isEqualTo("nombre");
 		assertThat(result.get(1).getData()).isEqualTo("dob");
 		assertThat(result.get(2).getData()).isEqualTo("email");
 		assertThat(result.get(3).getData()).isEqualTo("phone");
 		assertThat(result.get(4).getData()).isEqualTo("gender");
 		assertThat(result.get(5).getData()).isEqualTo("responsible");
-		assertThat(result.get(6).getData()).isEqualTo("acciones");
+		assertThat(result.get(6).getData()).isEqualTo("mobileApp");
+		assertThat(result.get(7).getData()).isEqualTo("acciones");
 		log.info("finished testGetColumns");
 	}
 
@@ -524,6 +526,16 @@ public class PacienteRestControllerTest {
 			@Override
 			public String getResponsibleName() {
 				return paciente.getResponsibleName();
+			}
+
+			@Override
+			public PacienteStatus getStatus() {
+				return paciente.getStatus();
+			}
+
+			@Override
+			public String getPatientAuthSub() {
+				return paciente.getPatientAuthSub();
 			}
 		};
 	}

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientMobileInvitationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientMobileInvitationServiceTest.java
@@ -1,0 +1,147 @@
+package com.nutriconsultas.paciente.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.PatientInvitation;
+import com.nutriconsultas.paciente.PatientInvitationRepository;
+import com.nutriconsultas.paciente.PatientInvitationStatus;
+
+@ExtendWith(MockitoExtension.class)
+class PatientMobileInvitationServiceTest {
+
+	private static final String NUTRITIONIST_SUB = "auth0|nutritionist-web-invite";
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Mock
+	private PatientInvitationRepository patientInvitationRepository;
+
+	@Mock
+	private PatientInvitationTokenService patientInvitationTokenService;
+
+	@Mock
+	private PatientInvitationEmailSender patientInvitationEmailSender;
+
+	@Mock
+	private PatientInvitationRevokeService patientInvitationRevokeService;
+
+	private PatientInvitationProperties invitationProperties;
+
+	private PatientMobileInvitationServiceImpl service;
+
+	@BeforeEach
+	void setUp() {
+		invitationProperties = new PatientInvitationProperties();
+		invitationProperties.setBaseUrl("https://links.test.example");
+		service = new PatientMobileInvitationServiceImpl(pacienteRepository, patientInvitationRepository,
+				patientInvitationTokenService, invitationProperties, patientInvitationEmailSender,
+				patientInvitationRevokeService);
+	}
+
+	@Test
+	void getStatus_returnsNoneForActivePatientWithoutAuth() {
+		final Paciente paciente = activePaciente(1L, "patient@test.com");
+		when(pacienteRepository.findByIdAndUserId(1L, NUTRITIONIST_SUB)).thenReturn(Optional.of(paciente));
+		when(patientInvitationRepository.findByPacienteIdAndStatus(1L, PatientInvitationStatus.PENDING))
+			.thenReturn(List.of());
+
+		final PatientMobileInvitationStatus status = service.getStatus(1L, NUTRITIONIST_SUB);
+
+		assertThat(status.stateCode()).isEqualTo("NONE");
+		assertThat(status.canSend()).isTrue();
+	}
+
+	@Test
+	void sendInvitation_transitionsActiveToInvitedAndEmailsPatient() {
+		final Paciente paciente = activePaciente(2L, "invite@test.com");
+		when(pacienteRepository.findByIdAndUserId(2L, NUTRITIONIST_SUB)).thenReturn(Optional.of(paciente));
+		when(patientInvitationRepository.findByPacienteIdAndStatus(2L, PatientInvitationStatus.PENDING))
+			.thenReturn(List.of());
+		when(patientInvitationTokenService.generate())
+			.thenReturn(new PatientInvitationTokenBundle("url-token", "NUTRI-WEB-TEST", "hash123"));
+		when(pacienteRepository.existsByAssignedId(any())).thenReturn(false);
+		when(pacienteRepository.save(any(Paciente.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		when(patientInvitationRepository.save(any(PatientInvitation.class))).thenAnswer(invocation -> {
+			final PatientInvitation invitation = invocation.getArgument(0);
+			invitation.setId(77L);
+			return invitation;
+		});
+
+		final IssuedPatientMobileInvitationResult issued = service.sendInvitation(2L, NUTRITIONIST_SUB);
+
+		assertThat(issued.invitationId()).isEqualTo(77L);
+		assertThat(issued.humanCode()).isEqualTo("NUTRI-WEB-TEST");
+
+		final ArgumentCaptor<Paciente> pacienteCaptor = ArgumentCaptor.forClass(Paciente.class);
+		verify(pacienteRepository).save(pacienteCaptor.capture());
+		assertThat(pacienteCaptor.getValue().getStatus()).isEqualTo(PacienteStatus.INVITED);
+
+		verify(patientInvitationEmailSender).sendPatientInvitation(eq("invite@test.com"), eq("NUTRI-WEB-TEST"),
+				eq("https://links.test.example/links/i/url-token"));
+	}
+
+	@Test
+	void sendInvitation_rejectsPatientWithoutEmail() {
+		final Paciente paciente = activePaciente(3L, null);
+		when(pacienteRepository.findByIdAndUserId(3L, NUTRITIONIST_SUB)).thenReturn(Optional.of(paciente));
+		when(patientInvitationRepository.findByPacienteIdAndStatus(3L, PatientInvitationStatus.PENDING))
+			.thenReturn(List.of());
+
+		assertThatThrownBy(() -> service.sendInvitation(3L, NUTRITIONIST_SUB))
+			.isInstanceOf(PatientMobileInvitationNotAllowedException.class)
+			.extracting(ex -> ((PatientMobileInvitationNotAllowedException) ex).getMessageKey())
+			.isEqualTo("NO_EMAIL");
+	}
+
+	@Test
+	void revokePendingInvitation_delegatesToRevokeService() {
+		final Paciente paciente = activePaciente(4L, "pending@test.com");
+		paciente.setStatus(PacienteStatus.INVITED);
+		final PatientInvitation pending = new PatientInvitation();
+		pending.setId(88L);
+		pending.setStatus(PatientInvitationStatus.PENDING);
+		pending.setExpiresAt(Instant.now().plus(3, ChronoUnit.DAYS));
+		when(pacienteRepository.findByIdAndUserId(4L, NUTRITIONIST_SUB)).thenReturn(Optional.of(paciente));
+		when(patientInvitationRepository.findByPacienteIdAndStatus(4L, PatientInvitationStatus.PENDING))
+			.thenReturn(List.of(pending));
+		when(patientInvitationRevokeService.revoke(88L, NUTRITIONIST_SUB))
+			.thenReturn(new PatientInvitationRevokeResult(88L, 4L, PatientInvitationStatus.REVOKED));
+
+		final PatientInvitationRevokeResult result = service.revokePendingInvitation(4L, NUTRITIONIST_SUB);
+
+		assertThat(result.invitationId()).isEqualTo(88L);
+		verify(patientInvitationRevokeService).revoke(88L, NUTRITIONIST_SUB);
+	}
+
+	private static Paciente activePaciente(final Long id, final String email) {
+		final Paciente paciente = new Paciente();
+		paciente.setId(id);
+		paciente.setUserId(NUTRITIONIST_SUB);
+		paciente.setName("Paciente Test");
+		paciente.setEmail(email);
+		paciente.setStatus(PacienteStatus.ACTIVE);
+		return paciente;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/search/SearchServiceTest.java
+++ b/src/test/java/com/nutriconsultas/search/SearchServiceTest.java
@@ -26,6 +26,7 @@ import com.nutriconsultas.clinical.exam.ClinicalExam;
 import com.nutriconsultas.clinical.exam.ClinicalExamRepository;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteStatus;
 import com.nutriconsultas.paciente.projection.PacienteListView;
 import com.nutriconsultas.platillos.Platillo;
 import com.nutriconsultas.platillos.PlatilloRepository;
@@ -269,6 +270,16 @@ public class SearchServiceTest {
 			@Override
 			public String getResponsibleName() {
 				return entity.getResponsibleName();
+			}
+
+			@Override
+			public PacienteStatus getStatus() {
+				return entity.getStatus();
+			}
+
+			@Override
+			public String getPatientAuthSub() {
+				return entity.getPatientAuthSub();
 			}
 		};
 	}


### PR DESCRIPTION
## Summary

- Adds session-authenticated REST for existing patients: `GET/POST/DELETE /rest/pacientes/{pacienteId}/mobile-invitation` (send, resend, revoke) with multi-tenant ownership and Spanish error messages.
- Patient grid: new **App móvil** status column and invite action button; Afiliación profile section for send/resend/revoke with human code and expiry display.
- Reuses invitation token/email infrastructure from #134/#336; transitions `ACTIVE` → `INVITED` on first invite without subscription cap checks for existing roster patients.
- SweetAlert confirmations on grid and profile; unit/controller tests and template validator updates.

Closes #341

## Test plan

- [x] `mvn verify` / `./lint.sh` pass locally
- [x] Grid shows App móvil badge and invite button for eligible patients
- [x] Afiliación: NO_EMAIL / LINKED / PENDING states render correctly
- [x] Send invitation → success SweetAlert, human code shown, status becomes Invitación pendiente
- [x] Resend/revoke buttons appear for pending invitations
- [x] Linked patient (Esperanza) shows Vinculado with no invite actions
- [x] `PatientMobileInvitationServiceTest`, `PacienteMobileInvitationRestControllerTest`, grid/projection tests updated


Made with [Cursor](https://cursor.com)