### PR TITLE
infra: wire Auth0 patient auth broker env into Terraform and SSM

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -158,6 +158,26 @@ bash infrastructure/scripts/ssm-update-stripe-keys.sh
 
 Full runbook: [`docs/subscription/STRIPE-OPS.md`](../docs/subscription/STRIPE-OPS.md). Webhook URL: `https://minutriporcion.com/rest/subscription/payment/webhook`.
 
+**Patient mobile auth broker** — required for `POST /rest/mobile/auth/signup` and `/login` (Flutter email/password registration). Without these, production returns HTTP 503 *El registro no está disponible por ahora*.
+
+| Variable | Purpose |
+|----------|---------|
+| `AUTH0_MOBILE_NATIVE_CLIENT_ID` | Native app client id (`/dbconnections/signup`) |
+| `AUTH0_PATIENT_BROKER_CLIENT_ID` | Confidential Auth0 app (password-realm grant) |
+| `AUTH0_PATIENT_BROKER_CLIENT_SECRET` | Broker client secret |
+| `AUTH0_PATIENT_BROKER_DOMAIN` | Auth0 tenant URL (defaults to `AUTH_ISSUER`) |
+| `AUTH0_PATIENT_BROKER_CONNECTION` | Database connection (default `Username-Password-Authentication`) |
+
+Set in gitignored `terraform.tfvars` (`auth0_mobile_native_client_id`, `auth0_patient_broker_*`) for new instances, or on a running host:
+
+```bash
+export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+set -a && source .env && set +a
+bash infrastructure/scripts/ssm-update-patient-broker.sh
+```
+
+Verify: signup probe should **not** return HTTP 503 (400/403/409 is OK for a dummy email).
+
 **Invitation email (#209)** — nutritionist invite delivery (SES prod / console local):
 
 | Variable | Purpose |

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -258,6 +258,13 @@ resource "aws_instance" "app" {
         auth0_mgmt_client_id_b64     = base64encode(var.auth0_mgmt_client_id)
         auth0_mgmt_client_secret_b64 = base64encode(var.auth0_mgmt_client_secret)
         auth0_mgmt_domain_b64        = base64encode(var.auth0_mgmt_domain != "" ? var.auth0_mgmt_domain : var.auth_issuer)
+        auth0_mobile_native_client_id_b64     = base64encode(var.auth0_mobile_native_client_id)
+        auth0_patient_broker_client_id_b64    = base64encode(var.auth0_patient_broker_client_id)
+        auth0_patient_broker_client_secret_b64 = base64encode(var.auth0_patient_broker_client_secret)
+        auth0_patient_broker_domain_b64 = base64encode(
+          var.auth0_patient_broker_domain != "" ? var.auth0_patient_broker_domain : var.auth_issuer
+        )
+        auth0_patient_broker_connection_b64 = base64encode(var.auth0_patient_broker_connection)
         payment_provider_b64         = base64encode(var.payment_provider)
         stripe_secret_key_b64        = base64encode(var.stripe_secret_key)
         stripe_webhook_secret_b64    = base64encode(var.stripe_webhook_secret)

--- a/infrastructure/scripts/ssm-update-patient-broker.sh
+++ b/infrastructure/scripts/ssm-update-patient-broker.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Update patient mobile Auth0 broker env vars in /opt/nutriconsultas/app.env, then restart.
+#
+# Usage:
+#   export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+#   export AUTH0_MOBILE_NATIVE_CLIENT_ID='CmZd...'
+#   export AUTH0_PATIENT_BROKER_CLIENT_ID='...'
+#   export AUTH0_PATIENT_BROKER_CLIENT_SECRET='...'
+#   export AUTH0_PATIENT_BROKER_DOMAIN='https://your-tenant.auth0.com/'   # optional
+#   export AUTH0_PATIENT_BROKER_CONNECTION='Username-Password-Authentication'  # optional
+#   ./ssm-update-patient-broker.sh [project]
+#
+# Or source repo root `.env`:
+#   set -a && source ../.env && set +a && ./ssm-update-patient-broker.sh
+#
+# See docs/auth0-mobile-setup.md (mobile repo) and .env.example (broker section).
+set -euo pipefail
+
+PROJECT="${1:-nutriconsultas}"
+P="/${PROJECT}/deploy"
+: "${AWS_REGION:-${AWS_DEFAULT_REGION:?Set AWS_DEFAULT_REGION (or use configure)}}"
+: "${AUTH0_MOBILE_NATIVE_CLIENT_ID:?Set AUTH0_MOBILE_NATIVE_CLIENT_ID}"
+: "${AUTH0_PATIENT_BROKER_CLIENT_ID:?Set AUTH0_PATIENT_BROKER_CLIENT_ID}"
+: "${AUTH0_PATIENT_BROKER_CLIENT_SECRET:?Set AUTH0_PATIENT_BROKER_CLIENT_SECRET}"
+
+AUTH0_PATIENT_BROKER_DOMAIN="${AUTH0_PATIENT_BROKER_DOMAIN:-${AUTH_ISSUER:-}}"
+AUTH0_PATIENT_BROKER_CONNECTION="${AUTH0_PATIENT_BROKER_CONNECTION:-Username-Password-Authentication}"
+
+if [ -z "$AUTH0_PATIENT_BROKER_DOMAIN" ]; then
+  echo "Error: set AUTH0_PATIENT_BROKER_DOMAIN or AUTH_ISSUER." >&2
+  exit 1
+fi
+
+INSTANCE_ID="$(aws ssm get-parameter --name "$P/app_instance_id" --query "Parameter.Value" --output text)"
+
+b64() { printf '%s' "$1" | base64 | tr -d '\n'; }
+
+PARAMS="$(jq -n \
+  --arg native "$(b64 "$AUTH0_MOBILE_NATIVE_CLIENT_ID")" \
+  --arg brokerId "$(b64 "$AUTH0_PATIENT_BROKER_CLIENT_ID")" \
+  --arg brokerSecret "$(b64 "$AUTH0_PATIENT_BROKER_CLIENT_SECRET")" \
+  --arg brokerDomain "$(b64 "$AUTH0_PATIENT_BROKER_DOMAIN")" \
+  --arg brokerConn "$(b64 "$AUTH0_PATIENT_BROKER_CONNECTION")" \
+  'def upsert($key; $valB64):
+     [
+       "set -euo pipefail",
+       "ENV_FILE=/opt/nutriconsultas/app.env",
+       "touch \"$ENV_FILE\"",
+       ("grep -v \"^" + $key + "=\" \"$ENV_FILE\" > \"${ENV_FILE}.tmp\" || true"),
+       ("echo -n " + $key + "= >> \"${ENV_FILE}.tmp\""),
+       ("printf %s \"" + $valB64 + "\" | base64 -d >> \"${ENV_FILE}.tmp\""),
+       "echo >> \"${ENV_FILE}.tmp\"",
+       "mv \"${ENV_FILE}.tmp\" \"$ENV_FILE\""
+     ];
+   upsert("AUTH0_MOBILE_NATIVE_CLIENT_ID"; $native)
+   + upsert("AUTH0_PATIENT_BROKER_CLIENT_ID"; $brokerId)
+   + upsert("AUTH0_PATIENT_BROKER_CLIENT_SECRET"; $brokerSecret)
+   + upsert("AUTH0_PATIENT_BROKER_DOMAIN"; $brokerDomain)
+   + upsert("AUTH0_PATIENT_BROKER_CONNECTION"; $brokerConn)
+   + [
+       "chmod 640 \"$ENV_FILE\"",
+       "chown root:nutri \"$ENV_FILE\"",
+       "systemctl restart nutriconsultas",
+       "for i in $(seq 1 60); do",
+       "  if curl -sf http://127.0.0.1:3000/actuator/health >/dev/null 2>&1; then break; fi",
+       "  sleep 2",
+       "done",
+       "curl -sf http://127.0.0.1:3000/actuator/health >/dev/null",
+       "systemctl is-active --quiet nutriconsultas",
+       "echo \"=== broker env audit ===\"",
+       "for k in AUTH0_MOBILE_NATIVE_CLIENT_ID AUTH0_PATIENT_BROKER_CLIENT_ID AUTH0_PATIENT_BROKER_CLIENT_SECRET AUTH0_PATIENT_BROKER_DOMAIN AUTH0_PATIENT_BROKER_CONNECTION; do",
+       "  v=$(grep -E \"^${k}=\" \"$ENV_FILE\" | cut -d= -f2- || true)",
+       "  if [ -z \"$v\" ]; then echo \"${k}=EMPTY\"; else echo \"${k}=SET(len=${#v})\"; fi",
+       "done",
+       "echo \"=== signup probe ===\"",
+       "curl -sS -o /tmp/signup-probe.json -w \"HTTP %{http_code}\\n\" -X POST http://127.0.0.1:3000/rest/mobile/auth/signup -H \"Content-Type: application/json\" -d \"{\\\"email\\\":\\\"broker-probe@example.com\\\",\\\"password\\\":\\\"TestPass123!\\\",\\\"displayName\\\":\\\"Probe\\\"}\"",
+       "head -c 200 /tmp/signup-probe.json; echo"
+     ] | { commands: . }')"
+
+COMMAND_ID="$(aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunShellScript" \
+  --timeout-seconds 180 \
+  --parameters "$PARAMS" \
+  --query 'Command.CommandId' \
+  --output text)"
+
+echo "SSM command: $COMMAND_ID (instance $INSTANCE_ID)"
+aws ssm wait command-executed --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID"
+STATUS="$(aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" --query Status --output text)"
+STDOUT="$(aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" --query StandardOutputContent --output text)"
+if [ "$STATUS" != "Success" ]; then
+  aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+    --query '[Status,StandardErrorContent]' --output text >&2
+  exit 1
+fi
+echo "$STDOUT"
+echo "Patient auth broker env updated and nutriconsultas restarted."

--- a/infrastructure/templates/app.user_data.sh
+++ b/infrastructure/templates/app.user_data.sh
@@ -64,6 +64,21 @@ install -d -o root -g nutri -m 750 /opt/nutriconsultas
   echo -n "AUTH0_MGMT_DOMAIN="
   printf '%s' '${auth0_mgmt_domain_b64}' | base64 -d
   echo
+  echo -n "AUTH0_MOBILE_NATIVE_CLIENT_ID="
+  printf '%s' '${auth0_mobile_native_client_id_b64}' | base64 -d
+  echo
+  echo -n "AUTH0_PATIENT_BROKER_CLIENT_ID="
+  printf '%s' '${auth0_patient_broker_client_id_b64}' | base64 -d
+  echo
+  echo -n "AUTH0_PATIENT_BROKER_CLIENT_SECRET="
+  printf '%s' '${auth0_patient_broker_client_secret_b64}' | base64 -d
+  echo
+  echo -n "AUTH0_PATIENT_BROKER_DOMAIN="
+  printf '%s' '${auth0_patient_broker_domain_b64}' | base64 -d
+  echo
+  echo -n "AUTH0_PATIENT_BROKER_CONNECTION="
+  printf '%s' '${auth0_patient_broker_connection_b64}' | base64 -d
+  echo
   echo -n "PAYMENT_PROVIDER="
   printf '%s' '${payment_provider_b64}' | base64 -d
   echo

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -29,6 +29,12 @@ ebs_root_volume_size_gb = 30
 # auth0_mgmt_client_id     = "from-auth0-m2m-app"   # M2M app with read:users on Management API (#109)
 # auth0_mgmt_client_secret = "from-auth0-m2m-app"
 # auth0_mgmt_domain        = ""   # optional; defaults to auth_issuer when empty
+# Patient mobile auth broker (POST /rest/mobile/auth/signup|login):
+# auth0_mobile_native_client_id      = "CmZd..."   # minutriporcion-native; same as Flutter AUTH0_CLIENT_ID
+# auth0_patient_broker_client_id     = "confidential-app-client-id"
+# auth0_patient_broker_client_secret = "confidential-app-client-secret"
+# auth0_patient_broker_domain        = ""   # optional; defaults to auth_issuer
+# auth0_patient_broker_connection    = "Username-Password-Authentication"
 # aws_bucket             = "your-s3-bucket"   # Terraform creates this bucket; import if it already exists
 # aws_key                = "AKIA..."
 # aws_secret             = "..."

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -114,6 +114,41 @@ variable "auth0_mgmt_domain" {
   sensitive   = false
 }
 
+variable "auth0_mobile_native_client_id" {
+  type        = string
+  description = "Auth0 Native app client ID for patient mobile signup (/dbconnections/signup). AUTH0_MOBILE_NATIVE_CLIENT_ID."
+  default     = ""
+  sensitive   = true
+}
+
+variable "auth0_patient_broker_client_id" {
+  type        = string
+  description = "Confidential Auth0 app client ID for server-side password-realm login. AUTH0_PATIENT_BROKER_CLIENT_ID."
+  default     = ""
+  sensitive   = true
+}
+
+variable "auth0_patient_broker_client_secret" {
+  type        = string
+  description = "Confidential Auth0 app client secret for patient auth broker. AUTH0_PATIENT_BROKER_CLIENT_SECRET."
+  default     = ""
+  sensitive   = true
+}
+
+variable "auth0_patient_broker_domain" {
+  type        = string
+  description = "Auth0 tenant domain for patient broker (AUTH0_PATIENT_BROKER_DOMAIN). Defaults to auth_issuer when empty."
+  default     = ""
+  sensitive   = false
+}
+
+variable "auth0_patient_broker_connection" {
+  type        = string
+  description = "Auth0 database connection name for patient signup/login. AUTH0_PATIENT_BROKER_CONNECTION."
+  default     = "Username-Password-Authentication"
+  sensitive   = false
+}
+
 variable "aws_bucket" {
   type        = string
   description = "S3 bucket name for application uploads (amazon.s3.bucket). Terraform creates this bucket (see s3-app-uploads.tf). If it already exists, run: terraform import aws_s3_bucket.app_uploads NAME"


### PR DESCRIPTION
## Summary
- Add Terraform variables and EC2 user-data wiring for `AUTH0_MOBILE_NATIVE_CLIENT_ID` and patient auth broker credentials (`AUTH0_PATIENT_BROKER_*`).
- Add `ssm-update-patient-broker.sh` to update broker env vars on running production hosts without a full instance rebuild.
- Document the patient mobile auth broker runbook in `infrastructure/README.md` and placeholder entries in `terraform.tfvars.example`.

## Secrets review
- No real credentials committed; only placeholders in `terraform.tfvars.example` and env-var-based SSM script (same pattern as Stripe keys script).
- `terraform.tfvars` and `.env` remain gitignored.

## Test plan
- [ ] Review Terraform plan in a safe environment with real `terraform.tfvars` (not committed).
- [ ] On a running host: `set -a && source .env && set +a && bash infrastructure/scripts/ssm-update-patient-broker.sh` and confirm signup probe does not return HTTP 503.
- [ ] New instance bootstrap: verify `/opt/nutriconsultas/app.env` contains all five broker variables after apply.


Made with [Cursor](https://cursor.com)