### PR TITLE
fix(mobile-api): use derived queries for progress timeline date filters

### DIFF
--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressService.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -103,9 +104,9 @@ public class MobilePatientProgressService {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
 		}
 		final int safeMaxRows = resolveMaxRows(maxRows);
-		final long totalMatching = bodyMetricRecordRepository.countPatientTimeline(pacienteId, fromDate, toDate);
-		final List<BodyMetricRecord> records = bodyMetricRecordRepository.findPatientTimeline(pacienteId, fromDate,
-				toDate, PageRequest.of(0, safeMaxRows));
+		final Pageable page = PageRequest.of(0, safeMaxRows);
+		final long totalMatching = countPatientTimelineRecords(pacienteId, fromDate, toDate);
+		final List<BodyMetricRecord> records = findPatientTimelineRecords(pacienteId, fromDate, toDate, page);
 		final Map<Long, ProgressCircumferenceDto> circumferencesBySourceId = loadCircumferencesForRecords(pacienteId,
 				records);
 		final List<ProgressMeasurementPointDto> points = records.stream()
@@ -116,6 +117,36 @@ public class MobilePatientProgressService {
 					totalMatching > safeMaxRows, LogRedaction.redactPaciente(pacienteId));
 		}
 		return new ProgressMeasurementsDto(points, points.size(), totalMatching > safeMaxRows);
+	}
+
+	private long countPatientTimelineRecords(final Long pacienteId, final Date from, final Date to) {
+		if (from == null && to == null) {
+			return bodyMetricRecordRepository.countByPacienteId(pacienteId);
+		}
+		if (from != null && to != null) {
+			return bodyMetricRecordRepository.countByPacienteIdAndRecordedAtBetween(pacienteId, from, to);
+		}
+		if (from != null) {
+			return bodyMetricRecordRepository.countByPacienteIdAndRecordedAtGreaterThanEqual(pacienteId, from);
+		}
+		return bodyMetricRecordRepository.countByPacienteIdAndRecordedAtLessThanEqual(pacienteId, to);
+	}
+
+	private List<BodyMetricRecord> findPatientTimelineRecords(final Long pacienteId, final Date from, final Date to,
+			final Pageable pageable) {
+		if (from == null && to == null) {
+			return bodyMetricRecordRepository.findByPacienteIdOrderByRecordedAtAscIdAsc(pacienteId, pageable);
+		}
+		if (from != null && to != null) {
+			return bodyMetricRecordRepository.findByPacienteIdAndRecordedAtBetweenOrderByRecordedAtAscIdAsc(pacienteId,
+					from, to, pageable);
+		}
+		if (from != null) {
+			return bodyMetricRecordRepository
+				.findByPacienteIdAndRecordedAtGreaterThanEqualOrderByRecordedAtAscIdAsc(pacienteId, from, pageable);
+		}
+		return bodyMetricRecordRepository.findByPacienteIdAndRecordedAtLessThanEqualOrderByRecordedAtAscIdAsc(pacienteId,
+				to, pageable);
 	}
 
 	private static int resolveMaxRows(final Integer maxRows) {

--- a/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordRepository.java
@@ -6,8 +6,6 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -27,14 +25,23 @@ public interface BodyMetricRecordRepository extends JpaRepository<BodyMetricReco
 
 	void deleteBySourceAndSourceId(BodyMetricSource source, Long sourceId);
 
-	@Query("SELECT b FROM BodyMetricRecord b WHERE b.paciente.id = :pacienteId "
-			+ "AND (:from IS NULL OR b.recordedAt >= :from) AND (:to IS NULL OR b.recordedAt <= :to) "
-			+ "ORDER BY b.recordedAt ASC, b.id ASC")
-	List<BodyMetricRecord> findPatientTimeline(@Param("pacienteId") Long pacienteId, @Param("from") Date from,
-			@Param("to") Date to, Pageable pageable);
+	long countByPacienteId(Long pacienteId);
 
-	@Query("SELECT COUNT(b) FROM BodyMetricRecord b WHERE b.paciente.id = :pacienteId "
-			+ "AND (:from IS NULL OR b.recordedAt >= :from) AND (:to IS NULL OR b.recordedAt <= :to)")
-	long countPatientTimeline(@Param("pacienteId") Long pacienteId, @Param("from") Date from, @Param("to") Date to);
+	long countByPacienteIdAndRecordedAtGreaterThanEqual(Long pacienteId, Date from);
+
+	long countByPacienteIdAndRecordedAtLessThanEqual(Long pacienteId, Date to);
+
+	long countByPacienteIdAndRecordedAtBetween(Long pacienteId, Date from, Date to);
+
+	List<BodyMetricRecord> findByPacienteIdOrderByRecordedAtAscIdAsc(Long pacienteId, Pageable pageable);
+
+	List<BodyMetricRecord> findByPacienteIdAndRecordedAtGreaterThanEqualOrderByRecordedAtAscIdAsc(Long pacienteId,
+			Date from, Pageable pageable);
+
+	List<BodyMetricRecord> findByPacienteIdAndRecordedAtLessThanEqualOrderByRecordedAtAscIdAsc(Long pacienteId,
+			Date to, Pageable pageable);
+
+	List<BodyMetricRecord> findByPacienteIdAndRecordedAtBetweenOrderByRecordedAtAscIdAsc(Long pacienteId, Date from,
+			Date to, Pageable pageable);
 
 }

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientProgressServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientProgressServiceTest.java
@@ -118,8 +118,8 @@ class MobilePatientProgressServiceTest {
 		measurement.getCircumferences().setWaistCircumference(82.0);
 		measurement.getCircumferences().setHipCircumference(98.0);
 
-		when(bodyMetricRecordRepository.countPatientTimeline(eq(5L), isNull(), isNull())).thenReturn(2L);
-		when(bodyMetricRecordRepository.findPatientTimeline(eq(5L), isNull(), isNull(), any(Pageable.class)))
+		when(bodyMetricRecordRepository.countByPacienteId(5L)).thenReturn(2L);
+		when(bodyMetricRecordRepository.findByPacienteIdOrderByRecordedAtAscIdAsc(eq(5L), any(Pageable.class)))
 			.thenReturn(List.of(older, latest));
 		when(anthropometricMeasurementRepository.findByPacienteIdAndIdIn(5L, List.of(1L, 2L)))
 			.thenReturn(List.of(measurement));
@@ -136,8 +136,8 @@ class MobilePatientProgressServiceTest {
 
 	@Test
 	void listMeasurements_truncatesBeyondMaxRowsCap() {
-		when(bodyMetricRecordRepository.countPatientTimeline(eq(5L), isNull(), isNull())).thenReturn(400L);
-		when(bodyMetricRecordRepository.findPatientTimeline(eq(5L), isNull(), isNull(), any(Pageable.class)))
+		when(bodyMetricRecordRepository.countByPacienteId(5L)).thenReturn(400L);
+		when(bodyMetricRecordRepository.findByPacienteIdOrderByRecordedAtAscIdAsc(eq(5L), any(Pageable.class)))
 			.thenReturn(List.of(metricRecord(1L, 70.0, 1.70, 24.2, NivelPeso.NORMAL, null, 22.0,
 					Date.from(Instant.parse("2026-06-01T10:00:00Z")))));
 		when(anthropometricMeasurementRepository.findByPacienteIdAndIdIn(eq(5L), any())).thenReturn(List.of());


### PR DESCRIPTION
## Summary
- Replace `BodyMetricRecordRepository` JPQL timeline queries that used nullable `:from`/`:to` parameters with Spring Data derived count/find methods.
- Dispatch timeline fetch and count in `MobilePatientProgressService` based on which date bounds are present, avoiding unreliable SQL `NULL` comparisons.
- Update `MobilePatientProgressServiceTest` mocks for the new repository methods.

## Test plan
- [x] `./lint.sh`
- [x] `mvn pmd:check`
- [x] Pre-commit checkstyle on staged files
- [x] `MobilePatientProgressServiceTest` (via full lint/test suite)


Made with [Cursor](https://cursor.com)