### PR TITLE
feat(mobile-api): expose nutritionist display name in onboarding profile

### DIFF
--- a/docs/api/openapi-mobile.yaml
+++ b/docs/api/openapi-mobile.yaml
@@ -1032,6 +1032,10 @@ components:
           type: boolean
           description: True when all required onboarding fields are present
           example: false
+        nutritionistDisplayName:
+          type: string
+          description: Assigned nutritionist display name from profile
+          example: Lic. Ana López
         assignedDietPlan:
           $ref: "#/components/schemas/AssignedDietPlanReferenceDto"
           description: "Primary active diet assignment, when present"

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientOnboardingService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientOnboardingService.java
@@ -21,6 +21,8 @@ import com.nutriconsultas.paciente.PacienteDietaRepository;
 import com.nutriconsultas.paciente.PacienteDietaStatus;
 import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.profile.NutritionistBrandingHelper;
+import com.nutriconsultas.profile.NutritionistProfileRepository;
 import com.nutriconsultas.util.LogRedaction;
 
 import lombok.extern.slf4j.Slf4j;
@@ -33,10 +35,14 @@ public class MobilePatientOnboardingService {
 
 	private final PacienteDietaRepository pacienteDietaRepository;
 
+	private final NutritionistProfileRepository nutritionistProfileRepository;
+
 	public MobilePatientOnboardingService(final PacienteRepository pacienteRepository,
-			final PacienteDietaRepository pacienteDietaRepository) {
+			final PacienteDietaRepository pacienteDietaRepository,
+			final NutritionistProfileRepository nutritionistProfileRepository) {
 		this.pacienteRepository = pacienteRepository;
 		this.pacienteDietaRepository = pacienteDietaRepository;
+		this.nutritionistProfileRepository = nutritionistProfileRepository;
 	}
 
 	@Transactional(readOnly = true)
@@ -46,10 +52,11 @@ public class MobilePatientOnboardingService {
 				PacienteDietaStatus.ACTIVE);
 		final AssignedDietPlanReferenceDto assignedDietPlan = PatientOnboardingProfileDto
 			.resolvePrimaryAssignment(activeAssignments);
+		final String nutritionistDisplayName = resolveNutritionistDisplayName(paciente);
 		if (log.isDebugEnabled()) {
 			log.debug("Loaded mobile onboarding profile for patient {}", LogRedaction.redactPaciente(pacienteId));
 		}
-		return PatientOnboardingProfileDto.fromEntity(paciente, assignedDietPlan);
+		return PatientOnboardingProfileDto.fromEntity(paciente, assignedDietPlan, nutritionistDisplayName);
 	}
 
 	@Transactional
@@ -111,6 +118,16 @@ public class MobilePatientOnboardingService {
 
 	private static Date toDate(final LocalDate dob) {
 		return Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant());
+	}
+
+	private String resolveNutritionistDisplayName(final Paciente paciente) {
+		final String nutritionistUserId = paciente.getUserId();
+		if (nutritionistUserId == null || nutritionistUserId.isBlank()) {
+			return null;
+		}
+		return nutritionistProfileRepository.findByUserId(nutritionistUserId)
+			.map(profile -> NutritionistBrandingHelper.resolveDisplayName(profile, null))
+			.orElse(null);
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/mobile/dto/PatientOnboardingProfileDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/PatientOnboardingProfileDto.java
@@ -31,14 +31,16 @@ public record PatientOnboardingProfileDto(@Schema(description = "Paciente id", e
 		@Schema(description = "Clinic-facing identifier", example = "P-CLINIC-001") String assignedId,
 		@Schema(description = "True when all required onboarding fields are present",
 				example = "false") boolean profileComplete,
+		@Schema(description = "Assigned nutritionist display name from profile",
+				example = "Lic. Ana López") String nutritionistDisplayName,
 		@Schema(description = "Primary active diet assignment, when present") AssignedDietPlanReferenceDto assignedDietPlan) {
 
 	public static PatientOnboardingProfileDto fromEntity(final Paciente paciente,
-			final AssignedDietPlanReferenceDto assignedDietPlan) {
+			final AssignedDietPlanReferenceDto assignedDietPlan, final String nutritionistDisplayName) {
 		return new PatientOnboardingProfileDto(paciente.getId(), paciente.getStatus(), paciente.getName(),
 				paciente.getDisplayName(), toLocalDate(paciente.getDob()), paciente.getGender(), paciente.getEmail(),
 				paciente.getPhone(), paciente.getAvatarId(), paciente.getAssignedId(),
-				PatientOnboardingCompleteness.isComplete(paciente), assignedDietPlan);
+				PatientOnboardingCompleteness.isComplete(paciente), nutritionistDisplayName, assignedDietPlan);
 	}
 
 	public static AssignedDietPlanReferenceDto toAssignedDietPlanReference(final PacienteDieta assignment) {

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientOnboardingControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientOnboardingControllerTest.java
@@ -41,7 +41,7 @@ class MobilePatientOnboardingControllerTest {
 				MobileTestPacienteAuthViews.authView(12L, PATIENT_SUB, "nutritionist-sub", PacienteStatus.ONBOARDING));
 		final PatientOnboardingProfileDto profile = new PatientOnboardingProfileDto(12L, PacienteStatus.ONBOARDING,
 				"María López", "María", LocalDate.of(1990, 5, 15), "F", "maria@example.com", null, null, "P-001", false,
-				null);
+				"Lic. Ana López", null);
 		when(mobilePatientOnboardingService.getProfile(12L)).thenReturn(profile);
 
 		final ApiResponse<PatientOnboardingProfileDto> response = controller.getProfile(jwt);
@@ -59,7 +59,7 @@ class MobilePatientOnboardingControllerTest {
 				null, null, null, PacienteAvatarCatalog.DEFAULT_FEMALE_ID);
 		final PatientOnboardingProfileDto profile = new PatientOnboardingProfileDto(12L, PacienteStatus.ACTIVE,
 				"María López", "María", LocalDate.of(1990, 5, 15), "F", "maria@example.com", null,
-				PacienteAvatarCatalog.DEFAULT_FEMALE_ID, "P-001", true, null);
+				PacienteAvatarCatalog.DEFAULT_FEMALE_ID, "P-001", true, "Lic. Ana López", null);
 		when(mobilePatientOnboardingService.updateProfile(12L, request)).thenReturn(profile);
 
 		final ApiResponse<PatientOnboardingProfileDto> response = controller.updateProfile(jwt, request);

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientOnboardingIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientOnboardingIntegrationTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,8 @@ import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteAvatarCatalog;
 import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.profile.NutritionistProfile;
+import com.nutriconsultas.profile.NutritionistProfileRepository;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -37,6 +40,9 @@ class MobilePatientOnboardingIntegrationTest {
 	@Autowired
 	private PacienteRepository pacienteRepository;
 
+	@Autowired
+	private NutritionistProfileRepository nutritionistProfileRepository;
+
 	@BeforeEach
 	void seedOnboardingPatient() {
 		final Paciente existing = pacienteRepository.findByPatientAuthSub(ONBOARDING_SUB).orElse(null);
@@ -45,7 +51,9 @@ class MobilePatientOnboardingIntegrationTest {
 			existing.setAvatarId(null);
 			existing.setName("María López");
 			existing.setDisplayName("María");
+			existing.setUserId("nutritionist-sub");
 			pacienteRepository.saveAndFlush(existing);
+			seedNutritionistProfile("nutritionist-sub", "Lic. Ana López");
 			return;
 		}
 		final Paciente paciente = new Paciente();
@@ -59,6 +67,7 @@ class MobilePatientOnboardingIntegrationTest {
 		final LocalDate dob = LocalDate.of(1990, 5, 15);
 		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
 		pacienteRepository.saveAndFlush(paciente);
+		seedNutritionistProfile("nutritionist-sub", "Lic. Ana López");
 	}
 
 	@Test
@@ -67,7 +76,8 @@ class MobilePatientOnboardingIntegrationTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.status").value("ONBOARDING"))
 			.andExpect(jsonPath("$.data.profileComplete").value(false))
-			.andExpect(jsonPath("$.data.name").value("María López"));
+			.andExpect(jsonPath("$.data.name").value("María López"))
+			.andExpect(jsonPath("$.data.nutritionistDisplayName").value("Lic. Ana López"));
 	}
 
 	@Test
@@ -94,6 +104,21 @@ class MobilePatientOnboardingIntegrationTest {
 				.content("{\"avatarId\":\"invalid-avatar\"}"))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.message").value("Selecciona un avatar válido."));
+	}
+
+	private void seedNutritionistProfile(final String nutritionistUserId, final String displayName) {
+		final var existing = nutritionistProfileRepository.findByUserId(nutritionistUserId);
+		if (existing.isPresent()) {
+			final NutritionistProfile profile = existing.get();
+			profile.setDisplayName(displayName);
+			nutritionistProfileRepository.saveAndFlush(profile);
+			return;
+		}
+		final NutritionistProfile profile = new NutritionistProfile();
+		profile.setUserId(nutritionistUserId);
+		profile.setPublicBookingId(UUID.randomUUID().toString());
+		profile.setDisplayName(displayName);
+		nutritionistProfileRepository.saveAndFlush(profile);
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientOnboardingServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientOnboardingServiceTest.java
@@ -26,6 +26,8 @@ import com.nutriconsultas.paciente.PacienteAvatarCatalog;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
 import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.profile.NutritionistProfile;
+import com.nutriconsultas.profile.NutritionistProfileRepository;
 
 @ExtendWith(MockitoExtension.class)
 class MobilePatientOnboardingServiceTest {
@@ -35,6 +37,9 @@ class MobilePatientOnboardingServiceTest {
 
 	@Mock
 	private PacienteDietaRepository pacienteDietaRepository;
+
+	@Mock
+	private NutritionistProfileRepository nutritionistProfileRepository;
 
 	@InjectMocks
 	private MobilePatientOnboardingService service;
@@ -75,6 +80,23 @@ class MobilePatientOnboardingServiceTest {
 		when(pacienteRepository.findById(9L)).thenReturn(Optional.of(paciente));
 
 		assertThatThrownBy(() -> service.getProfile(9L)).isInstanceOf(PatientOnboardingRequiredException.class);
+	}
+
+	@Test
+	void getProfile_includesNutritionistDisplayName() {
+		final Paciente paciente = sampleOnboardingPaciente(9L);
+		when(pacienteRepository.findById(9L)).thenReturn(Optional.of(paciente));
+		when(pacienteDietaRepository.findByPacienteIdAndStatus(9L,
+				com.nutriconsultas.paciente.PacienteDietaStatus.ACTIVE))
+			.thenReturn(List.of());
+		final NutritionistProfile profile = new NutritionistProfile();
+		profile.setUserId("nutritionist-sub");
+		profile.setDisplayName("Lic. Ana López");
+		when(nutritionistProfileRepository.findByUserId("nutritionist-sub")).thenReturn(Optional.of(profile));
+
+		final PatientOnboardingProfileDto result = service.getProfile(9L);
+
+		assertThat(result.nutritionistDisplayName()).isEqualTo("Lic. Ana López");
 	}
 
 	private static Paciente sampleOnboardingPaciente(final Long id) {


### PR DESCRIPTION
## Summary
- Add `nutritionistDisplayName` to `PatientOnboardingProfileDto` so mobile onboarding can show the assigned nutritionist's name
- Resolve display name from the patient's `userId` via `NutritionistProfileRepository` and `NutritionistBrandingHelper`
- Update OpenAPI spec and add unit/integration test coverage

## Test plan
- [x] `./lint.sh` passes (checkstyle, spotbugs, PMD, Thymeleaf)
- [x] `mvn pmd:check` passes
- [x] `mvn test -Dtest='MobilePatientOnboarding*'` passes
- [x] Verify `GET /rest/mobile/patient/onboarding/profile` returns `nutritionistDisplayName` when nutritionist profile exists


Made with [Cursor](https://cursor.com)