### PR TITLE
feat(mobile-api): invitation preview auth routing hints (#349)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -41,7 +41,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (public booking):** None — epic ~~#245~~ **done**; ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~, ~~#300~~, ~~#302~~ done. Deferred follow-ups need new issues. See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
-**Current next issue (mobile):** Phase 2 invitation onboarding **complete** (~~#141~~). Next mobile work requires new issues.
+**Current next issue (mobile):** [#349 — Invitation preview auth routing hints](https://github.com/diego-torres/nutriconsultas/issues/349) (`in-progress`). Open follow-ups: #352, #353, #354.
 
 **Current next issue (subscription):** Registered track **complete** (~~#244~~ ✓ on `subscription/244-contact-form-prefill`). Triage open `[Subscription]` GitHub issues. See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) · **Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-27 — `POST /rest/mobile/invitations/reconcile` (post-login JWT email linkage; PR #345). ~~#336~~ **done**. ~~#141~~ **done**. **Phase 2 invitation onboarding complete.** ~~#337~~ web landing **done**. Mobile F9 (#62–#67) + reconcile in `PostAuthCoordinator`.
+**Last updated:** 2026-06-30 — #349 invitation preview auth routing hints (`mobile-api/349-invitation-preview-auth-routing`). ~~#336~~ **done**. ~~#141~~ **done**. **Phase 2 invitation onboarding complete.** ~~#337~~ web landing **done**.
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -153,8 +153,9 @@ Invite-only patient onboarding replaces manual Afiliación linkage (#109) for ne
 | 141 | Invitation security hardening — rate limits, enumeration protection, no-token logging | https://github.com/diego-torres/nutriconsultas/issues/141 | **done** | ~~133~~ ✓, 135, 136 | [`INVITATION-SECURITY-AUDIT.md`](docs/mobile-api/INVITATION-SECURITY-AUDIT.md) acceptance audit |
 | 336 | B1 — `GET /rest/mobile/invitations/by-code/{code}/preview` (human-readable code) | https://github.com/diego-torres/nutriconsultas/issues/336 | **done** | ~~135~~ ✓, ~~141~~ ✓ | Public rate-limited preview via `PatientInvitation.humanCode`; mobile #62–#63 shipped |
 | 337 | B2 — Invitation web landing page `GET /links/i/{token}` | https://github.com/diego-torres/nutriconsultas/issues/337 | **done** | ~~135~~ ✓ | Public Thymeleaf landing (`/links/i/{token}`, `/i/{token}` alias); hero image, human code, store URLs; `buildInviteUrl()` → `/links/i/` |
+| 349 | Invitation preview auth routing hints (signup vs login) | https://github.com/diego-torres/nutriconsultas/issues/349 | **in-progress** | ~~135~~ ✓, ~~141~~ ✓ | `patientStatus`, `mobileAppLinked`, `authPath`, masked `emailHint` on both preview endpoints; blocks mobile #99 |
 
-**Suggested build order (after ~~#133~~ ✓):** #134/#135 → #136 → #137 → #138 → #139/#140 → #141 → #337.
+**Suggested build order (after ~~#133~~ ✓):** #134/#135 → #136 → #137 → #138 → #139/#140 → #141 → #337 → #349.
 
 ---
 

--- a/docs/api/openapi-mobile.yaml
+++ b/docs/api/openapi-mobile.yaml
@@ -1474,6 +1474,30 @@ components:
           type: string
           description: Nutritionist display name from profile
           example: Lic. Ana López
+        patientStatus:
+          type: string
+          description: Patient lifecycle status
+          enum:
+          - INVITED
+          - ONBOARDING
+          - ACTIVE
+          - REVOKED
+          example: INVITED
+        mobileAppLinked:
+          type: boolean
+          description: Whether the patient record is linked to a mobile Auth0 account
+          example: false
+        authPath:
+          type: string
+          description: Suggested Auth0 flow for the mobile app
+          enum:
+          - CREATE_ACCOUNT
+          - SIGN_IN
+          example: CREATE_ACCOUNT
+        emailHint:
+          type: string
+          description: Masked email for optional pre-fill (never the full address)
+          example: p***@example.com
   securitySchemes:
     bearer-jwt:
       type: http

--- a/docs/mobile-api/ALIGNMENT-SPEC.md
+++ b/docs/mobile-api/ALIGNMENT-SPEC.md
@@ -205,6 +205,20 @@ Source: `util/InvitationTokenHasher`, `paciente/invitation/PatientInvitationHuma
 | 422 | patient not in `INVITED` status at redeem | status guard |
 | 429 | rate limit on `preview`/`redeem` | reuse #113 Resilience4j (`Retry-After`) |
 
+#### F8.6.5 — Invitation preview auth routing (#349)
+
+Both `GET /rest/mobile/invitations/{token}/preview` and `GET /rest/mobile/invitations/by-code/{code}/preview` return:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `inviterDisplayName` | string | Nutritionist display name (existing) |
+| `patientStatus` | `INVITED` \| `ONBOARDING` \| `ACTIVE` \| `REVOKED` | From `Paciente.status` |
+| `mobileAppLinked` | boolean | `true` when `Paciente.patientAuthSub` is set |
+| `authPath` | `CREATE_ACCOUNT` \| `SIGN_IN` | `INVITED` + unlinked → `CREATE_ACCOUNT`; otherwise `SIGN_IN` |
+| `emailHint` | string (optional) | Masked email (`p***@example.com`) for optional pre-fill — never full address |
+
+No full email, patient name, or token values in response or logs.
+
 #### F8.6.4 — DoD controls every #134–#141 PR must satisfy (drift guard)
 
 These exit criteria live in the workflow but were not per-row in [`ISSUE.md`](../../ISSUE.md); enforce them here:

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -14,7 +14,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`../auth0/PATIENT-POST-LOGIN-GATE.md`](../auth0/PATIENT-POST-LOGIN-GATE.md) | Auth0 Post-Login invitation gate (#140) — Action script + deployment |
 | [`../api/openapi-mobile.yaml`](../api/openapi-mobile.yaml) | OpenAPI 3.1 export (#112, PR #164); regen: `scripts/export-openapi-mobile.sh` |
 
-**Status (2026-06-26):** ~~#132~~–~~#141~~ **done** — Phase 2 invitation onboarding complete ([`INVITATION-SECURITY-AUDIT.md`](INVITATION-SECURITY-AUDIT.md)). ~~#336~~ **done** — `GET /rest/mobile/invitations/by-code/{code}/preview`. ~~#337~~ **done** — public web landing at `GET /links/i/{token}` (not-installed fallback).
+**Status (2026-06-30):** ~~#349~~ **in-progress** — invitation preview auth routing hints. ~~#132~~–~~#141~~ **done** — Phase 2 invitation onboarding complete ([`INVITATION-SECURITY-AUDIT.md`](INVITATION-SECURITY-AUDIT.md)). ~~#336~~ **done** — `GET /rest/mobile/invitations/by-code/{code}/preview`. ~~#337~~ **done** — public web landing at `GET /links/i/{token}` (not-installed fallback).
 
 ## Related registries (same repo)
 

--- a/src/main/java/com/nutriconsultas/mobile/dto/PatientInvitationPreviewDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/PatientInvitationPreviewDto.java
@@ -2,20 +2,32 @@ package com.nutriconsultas.mobile.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.paciente.invitation.InvitationAuthPath;
 import com.nutriconsultas.paciente.invitation.PatientInvitationPreviewResult;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
- * Public invitation preview (#135). Inviter branding only — no patient PII.
+ * Public invitation preview (#135, #349). Inviter branding plus non-PII auth routing
+ * hints.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Public invitation preview")
-public record PatientInvitationPreviewDto(@Schema(description = "Nutritionist display name from profile",
-		example = "Lic. Ana López") String inviterDisplayName) {
+public record PatientInvitationPreviewDto(
+		@Schema(description = "Nutritionist display name from profile",
+				example = "Lic. Ana López") String inviterDisplayName,
+		@Schema(description = "Patient lifecycle status", example = "INVITED") PacienteStatus patientStatus,
+		@Schema(description = "Whether the patient record is linked to a mobile Auth0 account",
+				example = "false") Boolean mobileAppLinked,
+		@Schema(description = "Suggested Auth0 flow for the mobile app",
+				example = "CREATE_ACCOUNT") InvitationAuthPath authPath,
+		@Schema(description = "Masked email for optional pre-fill (never the full address)",
+				example = "p***@example.com") String emailHint) {
 
 	public static PatientInvitationPreviewDto from(final PatientInvitationPreviewResult result) {
-		return new PatientInvitationPreviewDto(result.inviterDisplayName());
+		return new PatientInvitationPreviewDto(result.inviterDisplayName(), result.patientStatus(),
+				result.mobileAppLinked(), result.authPath(), result.emailHint());
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/paciente/invitation/InvitationAuthPath.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/InvitationAuthPath.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.paciente.invitation;
+
+/**
+ * Mobile Auth0 flow hint for invitation preview (#349).
+ */
+public enum InvitationAuthPath {
+
+	CREATE_ACCOUNT, SIGN_IN
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationAuthRouting.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationAuthRouting.java
@@ -1,0 +1,33 @@
+package com.nutriconsultas.paciente.invitation;
+
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteStatus;
+import com.nutriconsultas.util.EmailMasking;
+
+/**
+ * Resolves invitation preview auth routing hints for the mobile app (#349).
+ */
+public final class PatientInvitationAuthRouting {
+
+	private PatientInvitationAuthRouting() {
+	}
+
+	public static boolean isMobileAppLinked(final Paciente paciente) {
+		return paciente != null && StringUtils.hasText(paciente.getPatientAuthSub());
+	}
+
+	public static InvitationAuthPath resolveAuthPath(final PacienteStatus status, final boolean mobileAppLinked) {
+		if (status == PacienteStatus.INVITED && !mobileAppLinked) {
+			return InvitationAuthPath.CREATE_ACCOUNT;
+		}
+		return InvitationAuthPath.SIGN_IN;
+	}
+
+	public static String resolveEmailHint(final Paciente paciente) {
+		final String recipientEmail = PatientMobileInvitationUiSupport.resolveRecipientEmail(paciente);
+		return EmailMasking.maskForHint(recipientEmail);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationPreviewResult.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationPreviewResult.java
@@ -1,9 +1,12 @@
 package com.nutriconsultas.paciente.invitation;
 
+import com.nutriconsultas.paciente.PacienteStatus;
+
 /**
- * Public invitation preview payload (#135). Contains inviter branding only — no patient
- * PII.
+ * Public invitation preview payload (#135, #349). Inviter branding plus non-PII auth
+ * routing hints — no full email or patient name.
  */
-public record PatientInvitationPreviewResult(String inviterDisplayName) {
+public record PatientInvitationPreviewResult(String inviterDisplayName, PacienteStatus patientStatus,
+		boolean mobileAppLinked, InvitationAuthPath authPath, String emailHint) {
 
 }

--- a/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationPreviewServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/invitation/PatientInvitationPreviewServiceImpl.java
@@ -7,6 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.nutriconsultas.mobile.PatientInvitationInvalidTokenException;
 import com.nutriconsultas.mobile.PatientInvitationUnavailableException;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteStatus;
 import com.nutriconsultas.paciente.PatientInvitation;
 import com.nutriconsultas.paciente.PatientInvitationRepository;
 import com.nutriconsultas.paciente.PatientInvitationStatus;
@@ -66,12 +68,19 @@ public class PatientInvitationPreviewServiceImpl implements PatientInvitationPre
 		final String inviterDisplayName = nutritionistProfileRepository.findByUserId(invitation.getNutritionistUserId())
 			.map(profile -> NutritionistBrandingHelper.resolveDisplayName(profile, null))
 			.orElse(null);
+		final Paciente paciente = invitation.getPaciente();
+		final PacienteStatus patientStatus = paciente.getStatus();
+		final boolean mobileAppLinked = PatientInvitationAuthRouting.isMobileAppLinked(paciente);
+		final InvitationAuthPath authPath = PatientInvitationAuthRouting.resolveAuthPath(patientStatus,
+				mobileAppLinked);
+		final String emailHint = PatientInvitationAuthRouting.resolveEmailHint(paciente);
 
 		if (log.isDebugEnabled()) {
 			log.debug("Patient invitation preview resolved for invitationId={}", invitation.getId());
 		}
 
-		return new PatientInvitationPreviewResult(inviterDisplayName);
+		return new PatientInvitationPreviewResult(inviterDisplayName, patientStatus, mobileAppLinked, authPath,
+				emailHint);
 	}
 
 	private boolean isPreviewable(final PatientInvitation invitation) {

--- a/src/main/java/com/nutriconsultas/util/EmailMasking.java
+++ b/src/main/java/com/nutriconsultas/util/EmailMasking.java
@@ -1,0 +1,29 @@
+package com.nutriconsultas.util;
+
+/**
+ * Masks email addresses for non-log API hints (#349). Never exposes the full local part.
+ */
+public final class EmailMasking {
+
+	private EmailMasking() {
+	}
+
+	/**
+	 * Returns a masked email suitable for optional mobile pre-fill hints (e.g.
+	 * {@code p***@example.com}).
+	 * @param email raw email address
+	 * @return masked email, or {@code null} when blank or malformed
+	 */
+	public static String maskForHint(final String email) {
+		if (email == null || email.isBlank()) {
+			return null;
+		}
+		final String normalized = email.trim().toLowerCase();
+		final int atIndex = normalized.indexOf('@');
+		if (atIndex <= 0 || atIndex == normalized.length() - 1) {
+			return null;
+		}
+		return normalized.charAt(0) + "***@" + normalized.substring(atIndex + 1);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobileInvitationControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileInvitationControllerTest.java
@@ -22,6 +22,7 @@ import com.nutriconsultas.mobile.dto.RevokedPatientInvitationDto;
 import com.nutriconsultas.paciente.PacienteStatus;
 import com.nutriconsultas.paciente.PatientInvitationStatus;
 import com.nutriconsultas.paciente.invitation.CreatedPatientInvitationResult;
+import com.nutriconsultas.paciente.invitation.InvitationAuthPath;
 import com.nutriconsultas.paciente.invitation.PatientInvitationCreateService;
 import com.nutriconsultas.paciente.invitation.PatientInvitationPreviewResult;
 import com.nutriconsultas.paciente.invitation.PatientInvitationPreviewService;
@@ -84,7 +85,8 @@ class MobileInvitationControllerTest {
 
 	@Test
 	void previewInvitation_returnsApiResponseEnvelope() throws Exception {
-		final PatientInvitationPreviewResult preview = new PatientInvitationPreviewResult("Lic. Ana López");
+		final PatientInvitationPreviewResult preview = new PatientInvitationPreviewResult("Lic. Ana López",
+				PacienteStatus.INVITED, false, InvitationAuthPath.CREATE_ACCOUNT, "l***@example.com");
 		when(httpServletRequest.getRemoteAddr()).thenReturn("127.0.0.1");
 		when(patientInvitationPreviewRateLimiter.execute(org.mockito.ArgumentMatchers.eq("127.0.0.1"),
 				org.mockito.ArgumentMatchers.any()))
@@ -101,7 +103,8 @@ class MobileInvitationControllerTest {
 
 	@Test
 	void previewInvitationByHumanCode_returnsApiResponseEnvelope() throws Exception {
-		final PatientInvitationPreviewResult preview = new PatientInvitationPreviewResult("Lic. Ana López");
+		final PatientInvitationPreviewResult preview = new PatientInvitationPreviewResult("Lic. Ana López",
+				PacienteStatus.INVITED, false, InvitationAuthPath.CREATE_ACCOUNT, "l***@example.com");
 		when(httpServletRequest.getRemoteAddr()).thenReturn("127.0.0.1");
 		when(patientInvitationPreviewRateLimiter.execute(org.mockito.ArgumentMatchers.eq("127.0.0.1"),
 				org.mockito.ArgumentMatchers.any()))

--- a/src/test/java/com/nutriconsultas/mobile/MobileInvitationIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileInvitationIntegrationTest.java
@@ -153,7 +153,29 @@ class MobileInvitationIntegrationTest {
 		mockMvc.perform(get("/rest/mobile/invitations/{token}/preview", bundle.urlToken()))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.inviterDisplayName").value("Lic. Preview Nutri"))
+			.andExpect(jsonPath("$.data.patientStatus").value("INVITED"))
+			.andExpect(jsonPath("$.data.mobileAppLinked").value(false))
+			.andExpect(jsonPath("$.data.authPath").value("CREATE_ACCOUNT"))
+			.andExpect(jsonPath("$.data.emailHint").exists())
 			.andExpect(jsonPath("$.timestamp").exists());
+	}
+
+	@Test
+	void previewInvitation_withLinkedOnboardingPatient_returnsSignInAuthPath() throws Exception {
+		final PatientInvitationTokenBundle bundle = patientInvitationTokenService.generate();
+		final String email = "onboarding.linked." + UUID.randomUUID() + "@example.com";
+		final PatientInvitation invitation = seedPendingInvitation(bundle, NUTRITIONIST_SUB, email);
+		final Paciente paciente = invitation.getPaciente();
+		paciente.setStatus(PacienteStatus.ONBOARDING);
+		paciente.setPatientAuthSub("auth0|preview-onboarding-linked");
+		pacienteRepository.saveAndFlush(paciente);
+		seedNutritionistProfile(NUTRITIONIST_SUB, "Lic. Preview Nutri");
+
+		mockMvc.perform(get("/rest/mobile/invitations/{token}/preview", bundle.urlToken()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.patientStatus").value("ONBOARDING"))
+			.andExpect(jsonPath("$.data.mobileAppLinked").value(true))
+			.andExpect(jsonPath("$.data.authPath").value("SIGN_IN"));
 	}
 
 	@Test
@@ -209,6 +231,9 @@ class MobileInvitationIntegrationTest {
 		mockMvc.perform(get("/rest/mobile/invitations/by-code/{code}/preview", bundle.humanCode()))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.inviterDisplayName").value("Lic. Human Code Nutri"))
+			.andExpect(jsonPath("$.data.patientStatus").value("INVITED"))
+			.andExpect(jsonPath("$.data.mobileAppLinked").value(false))
+			.andExpect(jsonPath("$.data.authPath").value("CREATE_ACCOUNT"))
 			.andExpect(jsonPath("$.timestamp").exists());
 	}
 

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationAuthRoutingTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationAuthRoutingTest.java
@@ -1,0 +1,40 @@
+package com.nutriconsultas.paciente.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteStatus;
+
+class PatientInvitationAuthRoutingTest {
+
+	@Test
+	void resolveAuthPath_withInvitedUnlinkedPatient_returnsCreateAccount() {
+		assertThat(PatientInvitationAuthRouting.resolveAuthPath(PacienteStatus.INVITED, false))
+			.isEqualTo(InvitationAuthPath.CREATE_ACCOUNT);
+	}
+
+	@Test
+	void resolveAuthPath_withLinkedOrOnboardingOrActive_returnsSignIn() {
+		assertThat(PatientInvitationAuthRouting.resolveAuthPath(PacienteStatus.INVITED, true))
+			.isEqualTo(InvitationAuthPath.SIGN_IN);
+		assertThat(PatientInvitationAuthRouting.resolveAuthPath(PacienteStatus.ONBOARDING, true))
+			.isEqualTo(InvitationAuthPath.SIGN_IN);
+		assertThat(PatientInvitationAuthRouting.resolveAuthPath(PacienteStatus.ACTIVE, true))
+			.isEqualTo(InvitationAuthPath.SIGN_IN);
+		assertThat(PatientInvitationAuthRouting.resolveAuthPath(PacienteStatus.REVOKED, false))
+			.isEqualTo(InvitationAuthPath.SIGN_IN);
+	}
+
+	@Test
+	void isMobileAppLinked_reflectsPatientAuthSubPresence() {
+		final Paciente linked = new Paciente();
+		linked.setPatientAuthSub("auth0|patient");
+		assertThat(PatientInvitationAuthRouting.isMobileAppLinked(linked)).isTrue();
+
+		final Paciente unlinked = new Paciente();
+		assertThat(PatientInvitationAuthRouting.isMobileAppLinked(unlinked)).isFalse();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationPreviewServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationPreviewServiceTest.java
@@ -17,9 +17,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.nutriconsultas.mobile.PatientInvitationInvalidTokenException;
 import com.nutriconsultas.mobile.PatientInvitationUnavailableException;
 import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteStatus;
 import com.nutriconsultas.paciente.PatientInvitation;
 import com.nutriconsultas.paciente.PatientInvitationRepository;
 import com.nutriconsultas.paciente.PatientInvitationStatus;
+import com.nutriconsultas.paciente.invitation.InvitationAuthPath;
 import com.nutriconsultas.profile.NutritionistProfile;
 import com.nutriconsultas.profile.NutritionistProfileRepository;
 import com.nutriconsultas.util.InvitationTokenHasher;
@@ -58,6 +60,59 @@ class PatientInvitationPreviewServiceTest {
 		final PatientInvitationPreviewResult result = service.preview(bundle.urlToken());
 
 		assertThat(result.inviterDisplayName()).isEqualTo("Lic. Ana López");
+		assertThat(result.patientStatus()).isEqualTo(PacienteStatus.INVITED);
+		assertThat(result.mobileAppLinked()).isFalse();
+		assertThat(result.authPath()).isEqualTo(InvitationAuthPath.CREATE_ACCOUNT);
+		assertThat(result.emailHint()).isNull();
+	}
+
+	@Test
+	void preview_withInvitedUnlinkedPatient_returnsCreateAccountAuthPath() {
+		final PatientInvitationTokenBundle bundle = tokenService.generate();
+		final PatientInvitation invitation = pendingInvitation(bundle.tokenHash());
+		invitation.getPaciente().setEmail("patient@example.com");
+		when(patientInvitationRepository.findByTokenHash(bundle.tokenHash())).thenReturn(Optional.of(invitation));
+		when(nutritionistProfileRepository.findByUserId(NUTRITIONIST_SUB)).thenReturn(Optional.empty());
+
+		final PatientInvitationPreviewResult result = service.preview(bundle.urlToken());
+
+		assertThat(result.authPath()).isEqualTo(InvitationAuthPath.CREATE_ACCOUNT);
+		assertThat(result.mobileAppLinked()).isFalse();
+		assertThat(result.emailHint()).isEqualTo("p***@example.com");
+	}
+
+	@Test
+	void preview_withOnboardingLinkedPatient_returnsSignInAuthPath() {
+		final PatientInvitationTokenBundle bundle = tokenService.generate();
+		final PatientInvitation invitation = pendingInvitation(bundle.tokenHash());
+		final Paciente paciente = invitation.getPaciente();
+		paciente.setStatus(PacienteStatus.ONBOARDING);
+		paciente.setPatientAuthSub("auth0|linked-patient");
+		paciente.setEmail("linked@example.com");
+		when(patientInvitationRepository.findByTokenHash(bundle.tokenHash())).thenReturn(Optional.of(invitation));
+		when(nutritionistProfileRepository.findByUserId(NUTRITIONIST_SUB)).thenReturn(Optional.empty());
+
+		final PatientInvitationPreviewResult result = service.preview(bundle.urlToken());
+
+		assertThat(result.patientStatus()).isEqualTo(PacienteStatus.ONBOARDING);
+		assertThat(result.mobileAppLinked()).isTrue();
+		assertThat(result.authPath()).isEqualTo(InvitationAuthPath.SIGN_IN);
+		assertThat(result.emailHint()).isEqualTo("l***@example.com");
+	}
+
+	@Test
+	void previewByHumanCode_withInvitedUnlinkedPatient_returnsCreateAccountAuthPath() {
+		final PatientInvitationTokenBundle bundle = tokenService.generate();
+		final PatientInvitation invitation = pendingInvitation(bundle.tokenHash());
+		invitation.setHumanCode(bundle.humanCode());
+		invitation.getPaciente().setEmailHint("hint@example.com");
+		when(patientInvitationRepository.findByHumanCode(bundle.humanCode())).thenReturn(Optional.of(invitation));
+		when(nutritionistProfileRepository.findByUserId(NUTRITIONIST_SUB)).thenReturn(Optional.empty());
+
+		final PatientInvitationPreviewResult result = service.previewByHumanCode(bundle.humanCode());
+
+		assertThat(result.authPath()).isEqualTo(InvitationAuthPath.CREATE_ACCOUNT);
+		assertThat(result.emailHint()).isEqualTo("h***@example.com");
 	}
 
 	@Test
@@ -159,6 +214,7 @@ class PatientInvitationPreviewServiceTest {
 	private PatientInvitation pendingInvitation(final String tokenHash) {
 		final Paciente paciente = new Paciente();
 		paciente.setId(100L);
+		paciente.setStatus(PacienteStatus.INVITED);
 		final PatientInvitation invitation = new PatientInvitation();
 		invitation.setId(1L);
 		invitation.setTokenHash(tokenHash);

--- a/src/test/java/com/nutriconsultas/util/EmailMaskingTest.java
+++ b/src/test/java/com/nutriconsultas/util/EmailMaskingTest.java
@@ -1,0 +1,26 @@
+package com.nutriconsultas.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class EmailMaskingTest {
+
+	@Test
+	void maskForHint_withValidEmail_returnsMaskedLocalPart() {
+		assertThat(EmailMasking.maskForHint("Patient@Example.com")).isEqualTo("p***@example.com");
+	}
+
+	@Test
+	void maskForHint_withBlankEmail_returnsNull() {
+		assertThat(EmailMasking.maskForHint(null)).isNull();
+		assertThat(EmailMasking.maskForHint("  ")).isNull();
+	}
+
+	@Test
+	void maskForHint_withMalformedEmail_returnsNull() {
+		assertThat(EmailMasking.maskForHint("not-an-email")).isNull();
+		assertThat(EmailMasking.maskForHint("@example.com")).isNull();
+	}
+
+}


### PR DESCRIPTION
## Summary
- Extends both invitation preview endpoints with `patientStatus`, `mobileAppLinked`, `authPath`, and masked `emailHint` so the mobile app can route patients to signup vs login
- Adds `InvitationAuthPath`, `PatientInvitationAuthRouting`, and `EmailMasking` utilities; updates OpenAPI and ALIGNMENT-SPEC §F8.6.5

## Test plan
- [x] `./lint.sh` pre-commit checkstyle passed on commit
- [x] `mvn test -Dtest=PatientInvitationPreviewServiceTest,PatientInvitationAuthRoutingTest,EmailMaskingTest,MobileInvitationControllerTest,MobileInvitationIntegrationTest` — 54 tests green
- [ ] CI green on PR
- [ ] Preview returns `CREATE_ACCOUNT` for `INVITED` + unlinked patient
- [ ] Preview returns `SIGN_IN` for linked/onboarding patient
- [ ] No full email in response or logs

Closes #349

Made with [Cursor](https://cursor.com)