### PR TITLE
feat(mobile-api): diet platillo DTO macros and detail endpoint (#354, #352)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -41,7 +41,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (public booking):** None — epic ~~#245~~ **done**; ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~, ~~#300~~, ~~#302~~ done. Deferred follow-ups need new issues. See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
-**Current next issue (mobile):** [#349 — Invitation preview auth routing hints](https://github.com/diego-torres/nutriconsultas/issues/349) (`in-progress`). Open follow-ups: #352, #353, #354.
+**Current next issue (mobile):** [#352 — Patient platillo detail endpoint](https://github.com/diego-torres/nutriconsultas/issues/352) (`in-progress`). ~~#354~~ **done**. Open follow-up: #353.
 
 **Current next issue (subscription):** Registered track **complete** (~~#244~~ ✓ on `subscription/244-contact-form-prefill`). Triage open `[Subscription]` GitHub issues. See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) · **Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-30 — #349 invitation preview auth routing hints (`mobile-api/349-invitation-preview-auth-routing`). ~~#336~~ **done**. ~~#141~~ **done**. **Phase 2 invitation onboarding complete.** ~~#337~~ web landing **done**.
+**Last updated:** 2026-06-30 — #352 platillo detail endpoint (`mobile-api/354-diet-platillo-dto-macros`). ~~#354~~ **in-progress**. ~~#349~~ **done** (PR [#356](https://github.com/diego-torres/nutriconsultas/pull/356)).
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -153,9 +153,21 @@ Invite-only patient onboarding replaces manual Afiliación linkage (#109) for ne
 | 141 | Invitation security hardening — rate limits, enumeration protection, no-token logging | https://github.com/diego-torres/nutriconsultas/issues/141 | **done** | ~~133~~ ✓, 135, 136 | [`INVITATION-SECURITY-AUDIT.md`](docs/mobile-api/INVITATION-SECURITY-AUDIT.md) acceptance audit |
 | 336 | B1 — `GET /rest/mobile/invitations/by-code/{code}/preview` (human-readable code) | https://github.com/diego-torres/nutriconsultas/issues/336 | **done** | ~~135~~ ✓, ~~141~~ ✓ | Public rate-limited preview via `PatientInvitation.humanCode`; mobile #62–#63 shipped |
 | 337 | B2 — Invitation web landing page `GET /links/i/{token}` | https://github.com/diego-torres/nutriconsultas/issues/337 | **done** | ~~135~~ ✓ | Public Thymeleaf landing (`/links/i/{token}`, `/i/{token}` alias); hero image, human code, store URLs; `buildInviteUrl()` → `/links/i/` |
-| 349 | Invitation preview auth routing hints (signup vs login) | https://github.com/diego-torres/nutriconsultas/issues/349 | **in-progress** | ~~135~~ ✓, ~~141~~ ✓ | `patientStatus`, `mobileAppLinked`, `authPath`, masked `emailHint` on both preview endpoints; blocks mobile #99 |
+| 349 | Invitation preview auth routing hints (signup vs login) | https://github.com/diego-torres/nutriconsultas/issues/349 | **done** | ~~135~~ ✓, ~~141~~ ✓ | Merged PR [#356](https://github.com/diego-torres/nutriconsultas/pull/356): `patientStatus`, `mobileAppLinked`, `authPath`, masked `emailHint` on both preview endpoints |
 
-**Suggested build order (after ~~#133~~ ✓):** #134/#135 → #136 → #137 → #138 → #139/#140 → #141 → #337 → #349.
+**Suggested build order (after ~~#133~~ ✓):** … → ~~#349~~ ✓ → ~~#354~~ ✓ → #352 → #353.
+
+---
+
+## Phase 3 — Diet plan mobile enhancements (P1)
+
+Extended diet plan DTOs and endpoints for mobile home/diet detail flows.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| 354 | Extend `DietPlatilloDto` with id and per-dish macros | https://github.com/diego-torres/nutriconsultas/issues/354 | **done** | ~~94~~ ✓ | `id`, `proteina`, `carbohidratos`, `grasas` on platillos; optional macros on `DietAlimentoDto`; OpenAPI updated |
+| 352 | Patient platillo detail endpoint (ingredients, prep, nutrition) | https://github.com/diego-torres/nutriconsultas/issues/352 | **in-progress** | ~~94~~ ✓, ~~354~~ ✓ | `GET /rest/mobile/patient/diet-plans/{assignmentId}/platillos/{platilloIngestaId}` |
+| 353 | Grocery list for patient diet plan | https://github.com/diego-torres/nutriconsultas/issues/353 | open | ~~94~~ ✓ | `GET /rest/mobile/patient/diet-plans/{assignmentId}/grocery-list` |
 
 ---
 

--- a/docs/api/openapi-mobile.yaml
+++ b/docs/api/openapi-mobile.yaml
@@ -580,6 +580,54 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/ApiResponseDietPlanDetailDto"
+  /rest/mobile/patient/diet-plans/{assignmentId}/platillos/{platilloIngestaId}:
+    get:
+      tags:
+      - Mobile
+      summary: Get platillo detail
+      description: Returns ingredients, preparation, and nutrition for a platillo in
+        the patient's assignment.
+      operationId: getPlatilloDetail
+      parameters:
+      - name: assignmentId
+        in: path
+        description: PacienteDieta assignment identifier
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: platilloIngestaId
+        in: path
+        description: PlatilloIngesta identifier within the assignment
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: Platillo detail with ingredients and nutrition facts
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseDietPlatilloDetailDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseDietPlatilloDetailDto"
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseDietPlatilloDetailDto"
+        "404":
+          description: Resource not found or not owned by patient
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseDietPlatilloDetailDto"
   /rest/mobile/patient/diet-plans/{assignmentId}/pdf:
     get:
       tags:
@@ -1378,6 +1426,15 @@ components:
           format: int32
         unidad:
           type: string
+        proteina:
+          type: number
+          format: double
+        carbohidratos:
+          type: number
+          format: double
+        grasas:
+          type: number
+          format: double
     DietIngestaDto:
       type: object
       properties:
@@ -1444,6 +1501,10 @@ components:
     DietPlatilloDto:
       type: object
       properties:
+        id:
+          type: integer
+          format: int64
+          description: PlatilloIngesta id for detail deep links (#354)
         nombre:
           type: string
         porciones:
@@ -1452,10 +1513,85 @@ components:
         kcal:
           type: integer
           format: int32
+        proteina:
+          type: number
+          format: double
+        carbohidratos:
+          type: number
+          format: double
+        grasas:
+          type: number
+          format: double
         recommendations:
           type: string
         imageUrl:
           type: string
+    ApiResponseDietPlatilloDetailDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/DietPlatilloDetailDto"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    DietPlatilloDetailDto:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        nombre:
+          type: string
+        porciones:
+          type: integer
+          format: int32
+        imageUrl:
+          type: string
+        description:
+          type: string
+          description: Preparation instructions (from PlatilloIngesta.recommendations)
+        videoUrl:
+          type: string
+        pdfUrl:
+          type: string
+        ingredientes:
+          type: array
+          items:
+            $ref: "#/components/schemas/DietPlatilloIngredientDto"
+        nutritionFacts:
+          $ref: "#/components/schemas/DietPlatilloNutritionFactsDto"
+    DietPlatilloIngredientDto:
+      type: object
+      properties:
+        nombre:
+          type: string
+        cantidad:
+          type: string
+        unidad:
+          type: string
+    DietPlatilloNutritionFactsDto:
+      type: object
+      properties:
+        kcal:
+          type: integer
+          format: int32
+        proteina:
+          type: number
+          format: double
+        carbohidratos:
+          type: number
+          format: double
+        grasas:
+          type: number
+          format: double
+        fibra:
+          type: number
+          format: double
+        sodio:
+          type: number
+          format: double
     ApiResponsePatientInvitationPreviewDto:
       type: object
       properties:

--- a/docs/mobile-api/ALIGNMENT-SPEC.md
+++ b/docs/mobile-api/ALIGNMENT-SPEC.md
@@ -148,8 +148,9 @@ Add to each a short "Backend dependency" line per the cross-reference table, e.g
 | `Dieta.hidratosDeCarbono` | `totalCarbohidratos` |
 | `Ingesta.nombre` | `tipo` |
 | `PlatilloIngesta.name` / `portions` / `energia` | `nombre` / `porciones` / `kcal` |
-| `PlatilloIngesta.hidratosDeCarbono` / `lipidos` | `carbohidratos` / `grasas` |
-| `AlimentoIngesta.*` | same translations as PlatilloIngesta |
+| `PlatilloIngesta.id` | `id` (platilloIngestaId for detail deep links, #354) |
+| `PlatilloIngesta.proteina` / `hidratosDeCarbono` / `lipidos` | `proteina` / `carbohidratos` / `grasas` |
+| `AlimentoIngesta.*` | same translations as PlatilloIngesta (macros optional when null, #354) |
 
 ### F8.2 — Enums (mobile must handle ALL values)
 - `EventStatus`: SCHEDULED / COMPLETED / CANCELLED

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -14,7 +14,7 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`../auth0/PATIENT-POST-LOGIN-GATE.md`](../auth0/PATIENT-POST-LOGIN-GATE.md) | Auth0 Post-Login invitation gate (#140) — Action script + deployment |
 | [`../api/openapi-mobile.yaml`](../api/openapi-mobile.yaml) | OpenAPI 3.1 export (#112, PR #164); regen: `scripts/export-openapi-mobile.sh` |
 
-**Status (2026-06-30):** ~~#349~~ **in-progress** — invitation preview auth routing hints. ~~#132~~–~~#141~~ **done** — Phase 2 invitation onboarding complete ([`INVITATION-SECURITY-AUDIT.md`](INVITATION-SECURITY-AUDIT.md)). ~~#336~~ **done** — `GET /rest/mobile/invitations/by-code/{code}/preview`. ~~#337~~ **done** — public web landing at `GET /links/i/{token}` (not-installed fallback).
+**Status (2026-06-30):** ~~#352~~ **in-progress** — platillo detail endpoint. ~~#354~~ **done** — `DietPlatilloDto` id + macros. ~~#349~~ **done** (PR [#356](https://github.com/diego-torres/nutriconsultas/pull/356)).
 
 ## Related registries (same repo)
 

--- a/src/main/java/com/nutriconsultas/dieta/PlatilloIngestaRepository.java
+++ b/src/main/java/com/nutriconsultas/dieta/PlatilloIngestaRepository.java
@@ -1,5 +1,8 @@
 package com.nutriconsultas.dieta;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -7,6 +10,16 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PlatilloIngestaRepository extends JpaRepository<PlatilloIngesta, Long> {
+
+	@Query("SELECT pi FROM PlatilloIngesta pi JOIN pi.ingesta i JOIN PacienteDieta pd ON pd.dieta = i.dieta "
+			+ "WHERE pi.id = :platilloIngestaId AND pd.id = :assignmentId AND pd.paciente.id = :pacienteId")
+	Optional<PlatilloIngesta> findByIdForPatientAssignment(@Param("platilloIngestaId") Long platilloIngestaId,
+			@Param("assignmentId") Long assignmentId, @Param("pacienteId") Long pacienteId);
+
+	@Query("SELECT pi FROM PlatilloIngesta pi JOIN pi.ingesta i JOIN PacienteDieta pd ON pd.dieta = i.dieta "
+			+ "WHERE pd.id = :assignmentId AND pd.paciente.id = :pacienteId ORDER BY pi.id ASC")
+	List<PlatilloIngesta> findByPatientAssignment(@Param("assignmentId") Long assignmentId,
+			@Param("pacienteId") Long pacienteId);
 
 	@Query("SELECT COUNT(pi) FROM PlatilloIngesta pi WHERE pi.sourcePlatilloId = :platilloId")
 	long countBySourcePlatilloId(@Param("platilloId") Long platilloId);

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanController.java
@@ -16,6 +16,7 @@ import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
 import com.nutriconsultas.mobile.dto.DietPlanPdfResult;
 import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
+import com.nutriconsultas.mobile.dto.DietPlatilloDetailDto;
 import com.nutriconsultas.mobile.dto.PagedResponse;
 import com.nutriconsultas.util.LogRedaction;
 
@@ -75,6 +76,27 @@ public class MobilePatientDietPlanController extends AbstractMobilePatientContro
 		}
 		final DietPlanDetailDto plan = mobilePatientDietPlanService.getDietPlanDetail(pacienteId, assignmentId);
 		return ApiResponse.ok(plan);
+	}
+
+	@GetMapping("/{assignmentId}/platillos/{platilloIngestaId}")
+	@Operation(summary = "Get platillo detail",
+			description = "Returns ingredients, preparation, and nutrition for a platillo in the patient's assignment.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	@MobileOpenApiResponses.NotFoundWhenMissing
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+			description = "Platillo detail with ingredients and nutrition facts")
+	public ApiResponse<DietPlatilloDetailDto> getPlatilloDetail(@AuthenticationPrincipal final Jwt jwt,
+			@Parameter(description = "PacienteDieta assignment identifier") @PathVariable final Long assignmentId,
+			@Parameter(
+					description = "PlatilloIngesta identifier within the assignment") @PathVariable final Long platilloIngestaId) {
+		final Long pacienteId = getAuthenticatedPacienteId(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile get platillo {} assignment {} for patient {}", platilloIngestaId,
+					LogRedaction.redactPacienteDieta(assignmentId), LogRedaction.redactPaciente(pacienteId));
+		}
+		final DietPlatilloDetailDto detail = mobilePatientDietPlanService.getPlatilloDetail(pacienteId, assignmentId,
+				platilloIngestaId);
+		return ApiResponse.ok(detail);
 	}
 
 	@GetMapping(value = "/{assignmentId}/pdf", produces = MediaType.APPLICATION_PDF_VALUE)

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanService.java
@@ -13,9 +13,13 @@ import org.springframework.web.server.ResponseStatusException;
 import com.nutriconsultas.dieta.Dieta;
 import com.nutriconsultas.dieta.DietaPdfService;
 import com.nutriconsultas.dieta.Ingesta;
+import com.nutriconsultas.dieta.IngredientePlatilloIngesta;
+import com.nutriconsultas.dieta.PlatilloIngesta;
+import com.nutriconsultas.dieta.PlatilloIngestaRepository;
 import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
 import com.nutriconsultas.mobile.dto.DietPlanPdfResult;
 import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
+import com.nutriconsultas.mobile.dto.DietPlatilloDetailDto;
 import com.nutriconsultas.mobile.dto.PagedResponse;
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
@@ -32,11 +36,14 @@ public class MobilePatientDietPlanService {
 
 	private final PacienteDietaRepository pacienteDietaRepository;
 
+	private final PlatilloIngestaRepository platilloIngestaRepository;
+
 	private final DietaPdfService dietaPdfService;
 
 	public MobilePatientDietPlanService(final PacienteDietaRepository pacienteDietaRepository,
-			final DietaPdfService dietaPdfService) {
+			final PlatilloIngestaRepository platilloIngestaRepository, final DietaPdfService dietaPdfService) {
 		this.pacienteDietaRepository = pacienteDietaRepository;
+		this.platilloIngestaRepository = platilloIngestaRepository;
 		this.dietaPdfService = dietaPdfService;
 	}
 
@@ -70,6 +77,21 @@ public class MobilePatientDietPlanService {
 	}
 
 	@Transactional(readOnly = true)
+	public DietPlatilloDetailDto getPlatilloDetail(final Long pacienteId, final Long assignmentId,
+			final Long platilloIngestaId) {
+		final PlatilloIngesta platillo = platilloIngestaRepository
+			.findByIdForPatientAssignment(platilloIngestaId, assignmentId, pacienteId)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+		initializePlatilloDetail(platillo);
+		if (log.isDebugEnabled()) {
+			log.debug("Loaded mobile platillo detail platilloIngestaId={} assignmentId={} for patient {}",
+					platilloIngestaId, LogRedaction.redactPacienteDieta(assignmentId),
+					LogRedaction.redactPaciente(pacienteId));
+		}
+		return DietPlatilloDetailDto.fromEntity(platillo);
+	}
+
+	@Transactional(readOnly = true)
 	public DietPlanPdfResult generateDietPlanPdf(final Long pacienteId, final Long assignmentId) {
 		final PacienteDieta assignment = pacienteDietaRepository.findByIdAndPacienteId(assignmentId, pacienteId)
 			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
@@ -81,6 +103,17 @@ public class MobilePatientDietPlanService {
 					LogRedaction.redactPacienteDieta(assignmentId), LogRedaction.redactPaciente(pacienteId));
 		}
 		return new DietPlanPdfResult(pdfBytes, filename);
+	}
+
+	private static void initializePlatilloDetail(final PlatilloIngesta platillo) {
+		if (platillo.getIngredientes() != null) {
+			Hibernate.initialize(platillo.getIngredientes());
+			for (final IngredientePlatilloIngesta ingrediente : platillo.getIngredientes()) {
+				if (ingrediente.getAlimento() != null) {
+					Hibernate.initialize(ingrediente.getAlimento());
+				}
+			}
+		}
 	}
 
 	private static void initializeDietaTree(final Dieta dieta) {

--- a/src/main/java/com/nutriconsultas/mobile/dto/DietAlimentoDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DietAlimentoDto.java
@@ -4,17 +4,18 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.nutriconsultas.dieta.AlimentoIngesta;
 
 /**
- * Patient-facing food item within a meal slot for mobile diet plan detail (#94).
+ * Patient-facing food item within a meal slot for mobile diet plan detail (#94, #354).
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record DietAlimentoDto(String nombre, Integer porciones, Integer kcal, String unidad) {
+public record DietAlimentoDto(String nombre, Integer porciones, Integer kcal, String unidad, Double proteina,
+		Double carbohidratos, Double grasas) {
 
 	public static DietAlimentoDto fromEntity(final AlimentoIngesta alimento) {
 		if (alimento == null) {
 			return null;
 		}
 		return new DietAlimentoDto(alimento.getName(), alimento.getPortions(), alimento.getEnergia(),
-				alimento.getUnidad());
+				alimento.getUnidad(), alimento.getProteina(), alimento.getHidratosDeCarbono(), alimento.getLipidos());
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/mobile/dto/DietPlatilloDetailDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DietPlatilloDetailDto.java
@@ -1,0 +1,32 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.util.Comparator;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.nutriconsultas.dieta.IngredientePlatilloIngesta;
+import com.nutriconsultas.dieta.PlatilloIngesta;
+
+/**
+ * Full platillo detail for mobile diet plan deep links (#352).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DietPlatilloDetailDto(Long id, String nombre, Integer porciones, String imageUrl, String description,
+		String videoUrl, String pdfUrl, List<DietPlatilloIngredientDto> ingredientes,
+		DietPlatilloNutritionFactsDto nutritionFacts) {
+
+	public static DietPlatilloDetailDto fromEntity(final PlatilloIngesta platillo) {
+		if (platillo == null) {
+			return null;
+		}
+		final List<DietPlatilloIngredientDto> ingredientes = platillo.getIngredientes()
+			.stream()
+			.sorted(Comparator.comparingLong(IngredientePlatilloIngesta::getId))
+			.map(DietPlatilloIngredientDto::fromEntity)
+			.toList();
+		return new DietPlatilloDetailDto(platillo.getId(), platillo.getName(), platillo.getPortions(),
+				platillo.getImageUrl(), platillo.getRecommendations(), platillo.getVideoUrl(), platillo.getPdfUrl(),
+				ingredientes, DietPlatilloNutritionFactsDto.fromEntity(platillo));
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/DietPlatilloDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DietPlatilloDto.java
@@ -4,16 +4,18 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.nutriconsultas.dieta.PlatilloIngesta;
 
 /**
- * Patient-facing dish within a meal slot for mobile diet plan detail (#94).
+ * Patient-facing dish within a meal slot for mobile diet plan detail (#94, #354).
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record DietPlatilloDto(String nombre, Integer porciones, Integer kcal, String recommendations, String imageUrl) {
+public record DietPlatilloDto(Long id, String nombre, Integer porciones, Integer kcal, Double proteina,
+		Double carbohidratos, Double grasas, String recommendations, String imageUrl) {
 
 	public static DietPlatilloDto fromEntity(final PlatilloIngesta platillo) {
 		if (platillo == null) {
 			return null;
 		}
-		return new DietPlatilloDto(platillo.getName(), platillo.getPortions(), platillo.getEnergia(),
+		return new DietPlatilloDto(platillo.getId(), platillo.getName(), platillo.getPortions(), platillo.getEnergia(),
+				platillo.getProteina(), platillo.getHidratosDeCarbono(), platillo.getLipidos(),
 				platillo.getRecommendations(), platillo.getImageUrl());
 	}
 

--- a/src/main/java/com/nutriconsultas/mobile/dto/DietPlatilloIngredientDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DietPlatilloIngredientDto.java
@@ -1,0 +1,22 @@
+package com.nutriconsultas.mobile.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.nutriconsultas.dieta.IngredientePlatilloIngesta;
+
+/**
+ * Ingredient row within a patient diet platillo detail (#352).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DietPlatilloIngredientDto(String nombre, String cantidad, String unidad) {
+
+	public static DietPlatilloIngredientDto fromEntity(final IngredientePlatilloIngesta ingrediente) {
+		if (ingrediente == null) {
+			return null;
+		}
+		final String nombre = ingrediente.getAlimento() != null ? ingrediente.getAlimento().getNombreAlimento()
+				: ingrediente.getDescription();
+		return new DietPlatilloIngredientDto(nombre, ingrediente.getDisplayCantSugerida(ingrediente.getUnidad()),
+				ingrediente.getUnidad());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/DietPlatilloNutritionFactsDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DietPlatilloNutritionFactsDto.java
@@ -1,0 +1,21 @@
+package com.nutriconsultas.mobile.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.nutriconsultas.dieta.PlatilloIngesta;
+
+/**
+ * Per-platillo nutrition summary for mobile detail (#352).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DietPlatilloNutritionFactsDto(Integer kcal, Double proteina, Double carbohidratos, Double grasas,
+		Double fibra, Double sodio) {
+
+	public static DietPlatilloNutritionFactsDto fromEntity(final PlatilloIngesta platillo) {
+		if (platillo == null) {
+			return null;
+		}
+		return new DietPlatilloNutritionFactsDto(platillo.getEnergia(), platillo.getProteina(),
+				platillo.getHidratosDeCarbono(), platillo.getLipidos(), platillo.getFibra(), platillo.getSodio());
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanControllerTest.java
@@ -21,6 +21,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import com.nutriconsultas.mobile.dto.ApiResponse;
 import com.nutriconsultas.mobile.dto.DietPlanPdfResult;
 import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
+import com.nutriconsultas.mobile.dto.DietPlatilloDetailDto;
 import com.nutriconsultas.mobile.dto.PagedResponse;
 import com.nutriconsultas.paciente.PacienteDietaStatus;
 import com.nutriconsultas.paciente.projection.PacienteAuthView;
@@ -56,6 +57,23 @@ class MobilePatientDietPlanControllerTest {
 		assertThat(response.data().content().get(0).dietaName()).isEqualTo("Plan A");
 		assertThat(response.timestamp()).isNotNull();
 		verify(mobilePatientDietPlanService).listDietPlans(3L, 0, 20, true);
+	}
+
+	@Test
+	void getPlatilloDetail_returnsApiResponseEnvelope() {
+		final DietPlatilloDetailDto detail = new DietPlatilloDetailDto(30L, "Avena", 2, "/img.jpg", "Prep", null, null,
+				List.of(), null);
+		final Jwt jwt = jwtWithSub(PATIENT_SUB);
+
+		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(authView(3L));
+		when(mobilePatientDietPlanService.getPlatilloDetail(3L, 7L, 30L)).thenReturn(detail);
+
+		final ApiResponse<DietPlatilloDetailDto> response = controller.getPlatilloDetail(jwt, 7L, 30L);
+
+		assertThat(response.data().id()).isEqualTo(30L);
+		assertThat(response.data().nombre()).isEqualTo("Avena");
+		assertThat(response.timestamp()).isNotNull();
+		verify(mobilePatientDietPlanService).getPlatilloDetail(3L, 7L, 30L);
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanIntegrationTest.java
@@ -25,12 +25,16 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.alimentos.AlimentosRepository;
 import com.nutriconsultas.dieta.AlimentoIngesta;
 import com.nutriconsultas.dieta.Dieta;
 import com.nutriconsultas.dieta.DietaPdfService;
 import com.nutriconsultas.dieta.DietaRepository;
 import com.nutriconsultas.dieta.Ingesta;
+import com.nutriconsultas.dieta.IngredientePlatilloIngesta;
 import com.nutriconsultas.dieta.PlatilloIngesta;
+import com.nutriconsultas.dieta.PlatilloIngestaRepository;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
@@ -56,12 +60,20 @@ class MobilePatientDietPlanIntegrationTest {
 	@Autowired
 	private PacienteDietaRepository pacienteDietaRepository;
 
+	@Autowired
+	private AlimentosRepository alimentosRepository;
+
 	@MockBean
 	private DietaPdfService dietaPdfService;
 
 	private Paciente linkedPaciente;
 
 	private PacienteDieta linkedAssignment;
+
+	private Long linkedPlatilloId;
+
+	@Autowired
+	private PlatilloIngestaRepository platilloIngestaRepository;
 
 	@BeforeEach
 	void seedData() {
@@ -70,6 +82,10 @@ class MobilePatientDietPlanIntegrationTest {
 			return pacienteRepository.saveAndFlush(paciente);
 		});
 		linkedAssignment = ensureAssignmentWithMealTree();
+		linkedPlatilloId = platilloIngestaRepository
+			.findByPatientAssignment(linkedAssignment.getId(), linkedPaciente.getId())
+			.get(0)
+			.getId();
 	}
 
 	private PacienteDieta ensureAssignmentWithMealTree() {
@@ -101,8 +117,28 @@ class MobilePatientDietPlanIntegrationTest {
 		platillo.setName("Huevos revueltos");
 		platillo.setPortions(1);
 		platillo.setEnergia(280);
+		platillo.setProteina(18.0);
+		platillo.setHidratosDeCarbono(4.0);
+		platillo.setLipidos(20.0);
 		platillo.setRecommendations("Con verduras");
+		platillo.setVideoUrl("https://video.example/huevos");
+		platillo.setPdfUrl("/uploads/recetas/huevos.pdf");
+		platillo.setPdfUrl("/uploads/recetas/huevos.pdf");
 		platillo.setIngesta(ingesta);
+
+		final Alimento catalogAlimento = new Alimento();
+		catalogAlimento.setNombreAlimento("Huevo");
+		catalogAlimento.setClasificacion("Proteínas");
+		catalogAlimento.setCantSugerida(1.0);
+		catalogAlimento.setUnidad("pieza");
+		final Alimento savedAlimento = alimentosRepository.saveAndFlush(catalogAlimento);
+
+		final IngredientePlatilloIngesta ingrediente = new IngredientePlatilloIngesta();
+		ingrediente.setAlimento(savedAlimento);
+		ingrediente.setCantSugerida(2.0);
+		ingrediente.setUnidad("pieza");
+		ingrediente.setPlatillo(platillo);
+		platillo.setIngredientes(new java.util.ArrayList<>(List.of(ingrediente)));
 
 		final AlimentoIngesta alimento = new AlimentoIngesta();
 		alimento.setName("Pan integral");
@@ -153,10 +189,75 @@ class MobilePatientDietPlanIntegrationTest {
 			.andExpect(jsonPath("$.data.dietaName").value("Dieta integración"))
 			.andExpect(jsonPath("$.data.totalKcal").value(1900))
 			.andExpect(jsonPath("$.data.ingestas[0].tipo").value("Desayuno"))
+			.andExpect(jsonPath("$.data.ingestas[0].platillos[0].id").exists())
 			.andExpect(jsonPath("$.data.ingestas[0].platillos[0].nombre").value("Huevos revueltos"))
 			.andExpect(jsonPath("$.data.ingestas[0].platillos[0].porciones").value(1))
+			.andExpect(jsonPath("$.data.ingestas[0].platillos[0].proteina").value(18.0))
+			.andExpect(jsonPath("$.data.ingestas[0].platillos[0].carbohidratos").value(4.0))
+			.andExpect(jsonPath("$.data.ingestas[0].platillos[0].grasas").value(20.0))
 			.andExpect(jsonPath("$.data.ingestas[0].alimentos[0].nombre").value("Pan integral"))
 			.andExpect(jsonPath("$.timestamp").exists());
+	}
+
+	@Test
+	void getPlatilloDetailWithLinkedJwtReturnsIngredientsAndNutrition() throws Exception {
+		mockMvc
+			.perform(get(
+					"/rest/mobile/patient/diet-plans/" + linkedAssignment.getId() + "/platillos/" + linkedPlatilloId)
+				.with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.id").value(linkedPlatilloId))
+			.andExpect(jsonPath("$.data.nombre").value("Huevos revueltos"))
+			.andExpect(jsonPath("$.data.description").value("Con verduras"))
+			.andExpect(jsonPath("$.data.videoUrl").value("https://video.example/huevos"))
+			.andExpect(jsonPath("$.data.pdfUrl").value("/uploads/recetas/huevos.pdf"))
+			.andExpect(jsonPath("$.data.ingredientes[0].nombre").value("Huevo"))
+			.andExpect(jsonPath("$.data.ingredientes[0].cantidad").value("2"))
+			.andExpect(jsonPath("$.data.ingredientes[0].unidad").value("pieza"))
+			.andExpect(jsonPath("$.data.nutritionFacts.kcal").value(280))
+			.andExpect(jsonPath("$.data.nutritionFacts.proteina").value(18.0))
+			.andExpect(jsonPath("$.timestamp").exists());
+	}
+
+	@Test
+	void getPlatilloDetailForOtherPatientsAssignmentReturnsNotFound() throws Exception {
+		final Paciente otherPatient = pacienteRepository.findByPatientAuthSub("auth0|mobile-diet-plan-other")
+			.orElseGet(() -> {
+				final Paciente paciente = samplePaciente("auth0|mobile-diet-plan-other");
+				return pacienteRepository.saveAndFlush(paciente);
+			});
+		final PacienteDieta otherAssignment = pacienteDietaRepository.findByPacienteId(otherPatient.getId())
+			.stream()
+			.findFirst()
+			.orElseGet(() -> {
+				final Dieta dieta = new Dieta();
+				dieta.setNombre("Dieta ajena");
+				dieta.setUserId("nutritionist-sub");
+				dieta.setEnergia(1500);
+				final Dieta savedDieta = dietaRepository.saveAndFlush(dieta);
+
+				final PacienteDieta assignment = new PacienteDieta();
+				assignment.setPaciente(otherPatient);
+				assignment.setDieta(savedDieta);
+				assignment.setStatus(PacienteDietaStatus.ACTIVE);
+				assignment.setStartDate(
+						Date.from(LocalDate.now().minusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+				return pacienteDietaRepository.saveAndFlush(assignment);
+			});
+
+		mockMvc
+			.perform(
+					get("/rest/mobile/patient/diet-plans/" + otherAssignment.getId() + "/platillos/" + linkedPlatilloId)
+						.with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void getPlatilloDetailForMissingPlatilloReturnsNotFound() throws Exception {
+		mockMvc
+			.perform(get("/rest/mobile/patient/diet-plans/" + linkedAssignment.getId() + "/platillos/999999")
+				.with(mobileJwt(LINKED_SUB)))
+			.andExpect(status().isNotFound());
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanServiceTest.java
@@ -24,8 +24,10 @@ import com.nutriconsultas.dieta.Dieta;
 import com.nutriconsultas.dieta.DietaPdfService;
 import com.nutriconsultas.dieta.Ingesta;
 import com.nutriconsultas.dieta.PlatilloIngesta;
+import com.nutriconsultas.dieta.PlatilloIngestaRepository;
 import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
 import com.nutriconsultas.mobile.dto.DietPlanPdfResult;
+import com.nutriconsultas.mobile.dto.DietPlatilloDetailDto;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
@@ -43,6 +45,34 @@ class MobilePatientDietPlanServiceTest {
 	@Mock
 	private DietaPdfService dietaPdfService;
 
+	@Mock
+	private PlatilloIngestaRepository platilloIngestaRepository;
+
+	@Test
+	void getPlatilloDetail_returnsDetailWhenOwnedByPatient() {
+		final PacienteDieta assignment = sampleAssignment(5L, 1L);
+		final PlatilloIngesta platillo = assignment.getDieta().getIngestas().get(0).getPlatillos().get(0);
+		when(platilloIngestaRepository.findByIdForPatientAssignment(30L, 5L, 1L)).thenReturn(Optional.of(platillo));
+
+		final DietPlatilloDetailDto result = service.getPlatilloDetail(1L, 5L, 30L);
+
+		assertThat(result.id()).isEqualTo(30L);
+		assertThat(result.nombre()).isEqualTo("Avena con fruta");
+		assertThat(result.porciones()).isEqualTo(2);
+		assertThat(result.description()).isEqualTo("Servir tibia");
+		assertThat(result.nutritionFacts().kcal()).isEqualTo(320);
+		assertThat(result.nutritionFacts().proteina()).isEqualTo(12.5);
+	}
+
+	@Test
+	void getPlatilloDetail_throwsNotFoundWhenMissingOrNotOwned() {
+		when(platilloIngestaRepository.findByIdForPatientAssignment(99L, 5L, 1L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.getPlatilloDetail(1L, 5L, 99L)).isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+			.isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
 	@Test
 	void getDietPlanDetail_returnsStructuredMealTreeWhenOwnedByPatient() {
 		final PacienteDieta assignment = sampleAssignment(5L, 1L);
@@ -56,12 +86,17 @@ class MobilePatientDietPlanServiceTest {
 		assertThat(result.ingestas()).hasSize(1);
 		assertThat(result.ingestas().get(0).tipo()).isEqualTo("Desayuno");
 		assertThat(result.ingestas().get(0).platillos()).hasSize(1);
+		assertThat(result.ingestas().get(0).platillos().get(0).id()).isEqualTo(30L);
 		assertThat(result.ingestas().get(0).platillos().get(0).nombre()).isEqualTo("Avena con fruta");
 		assertThat(result.ingestas().get(0).platillos().get(0).porciones()).isEqualTo(2);
 		assertThat(result.ingestas().get(0).platillos().get(0).kcal()).isEqualTo(320);
+		assertThat(result.ingestas().get(0).platillos().get(0).proteina()).isEqualTo(12.5);
+		assertThat(result.ingestas().get(0).platillos().get(0).carbohidratos()).isEqualTo(48.0);
+		assertThat(result.ingestas().get(0).platillos().get(0).grasas()).isEqualTo(8.0);
 		assertThat(result.ingestas().get(0).alimentos()).hasSize(1);
 		assertThat(result.ingestas().get(0).alimentos().get(0).nombre()).isEqualTo("Manzana");
 		assertThat(result.ingestas().get(0).alimentos().get(0).unidad()).isEqualTo("pieza");
+		assertThat(result.ingestas().get(0).alimentos().get(0).proteina()).isEqualTo(0.3);
 	}
 
 	@Test
@@ -122,6 +157,9 @@ class MobilePatientDietPlanServiceTest {
 		platillo.setName("Avena con fruta");
 		platillo.setPortions(2);
 		platillo.setEnergia(320);
+		platillo.setProteina(12.5);
+		platillo.setHidratosDeCarbono(48.0);
+		platillo.setLipidos(8.0);
 		platillo.setRecommendations("Servir tibia");
 		platillo.setIngesta(ingesta);
 
@@ -131,6 +169,9 @@ class MobilePatientDietPlanServiceTest {
 		alimento.setPortions(1);
 		alimento.setEnergia(52);
 		alimento.setUnidad("pieza");
+		alimento.setProteina(0.3);
+		alimento.setHidratosDeCarbono(14.0);
+		alimento.setLipidos(0.2);
 		alimento.setIngesta(ingesta);
 
 		ingesta.setPlatillos(List.of(platillo));

--- a/src/test/java/com/nutriconsultas/mobile/dto/DietPlatilloDetailDtoTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/dto/DietPlatilloDetailDtoTest.java
@@ -1,0 +1,62 @@
+package com.nutriconsultas.mobile.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.dieta.IngredientePlatilloIngesta;
+import com.nutriconsultas.dieta.PlatilloIngesta;
+
+class DietPlatilloDetailDtoTest {
+
+	@Test
+	void fromEntity_mapsIngredientsDescriptionAndNutritionFacts() {
+		final PlatilloIngesta platillo = new PlatilloIngesta();
+		platillo.setId(42L);
+		platillo.setName("Avena con fruta");
+		platillo.setPortions(2);
+		platillo.setRecommendations("Mezclar y servir tibia");
+		platillo.setVideoUrl("https://video.example/avena");
+		platillo.setPdfUrl("/uploads/recetas/avena.pdf");
+		platillo.setEnergia(320);
+		platillo.setProteina(12.5);
+		platillo.setHidratosDeCarbono(48.0);
+		platillo.setLipidos(8.0);
+		platillo.setFibra(6.0);
+		platillo.setSodio(120.0);
+
+		final Alimento alimento = new Alimento();
+		alimento.setNombreAlimento("Avena");
+		final IngredientePlatilloIngesta ingrediente = new IngredientePlatilloIngesta();
+		ingrediente.setId(1L);
+		ingrediente.setAlimento(alimento);
+		ingrediente.setCantSugerida(0.5);
+		ingrediente.setUnidad("taza");
+		ingrediente.setPlatillo(platillo);
+		platillo.setIngredientes(List.of(ingrediente));
+
+		final DietPlatilloDetailDto dto = DietPlatilloDetailDto.fromEntity(platillo);
+
+		assertThat(dto.id()).isEqualTo(42L);
+		assertThat(dto.nombre()).isEqualTo("Avena con fruta");
+		assertThat(dto.porciones()).isEqualTo(2);
+		assertThat(dto.description()).isEqualTo("Mezclar y servir tibia");
+		assertThat(dto.videoUrl()).isEqualTo("https://video.example/avena");
+		assertThat(dto.pdfUrl()).isEqualTo("/uploads/recetas/avena.pdf");
+		assertThat(dto.imageUrl()).isEqualTo("/sbadmin/img/plato-vacio.jpg");
+		assertThat(dto.ingredientes()).hasSize(1);
+		assertThat(dto.ingredientes().get(0).nombre()).isEqualTo("Avena");
+		assertThat(dto.ingredientes().get(0).cantidad()).isEqualTo("1/2");
+		assertThat(dto.ingredientes().get(0).unidad()).isEqualTo("taza");
+		assertThat(dto.nutritionFacts().kcal()).isEqualTo(320);
+		assertThat(dto.nutritionFacts().proteina()).isEqualTo(12.5);
+		assertThat(dto.nutritionFacts().carbohidratos()).isEqualTo(48.0);
+		assertThat(dto.nutritionFacts().grasas()).isEqualTo(8.0);
+		assertThat(dto.nutritionFacts().fibra()).isEqualTo(6.0);
+		assertThat(dto.nutritionFacts().sodio()).isEqualTo(120.0);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/dto/DietPlatilloDtoTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/dto/DietPlatilloDtoTest.java
@@ -1,0 +1,63 @@
+package com.nutriconsultas.mobile.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.dieta.AlimentoIngesta;
+import com.nutriconsultas.dieta.PlatilloIngesta;
+
+class DietPlatilloDtoTest {
+
+	@Test
+	void fromEntity_mapsIdAndMacroFieldsFromPlatilloIngesta() {
+		final PlatilloIngesta platillo = new PlatilloIngesta();
+		platillo.setId(42L);
+		platillo.setName("Avena con fruta");
+		platillo.setPortions(2);
+		platillo.setEnergia(320);
+		platillo.setProteina(12.5);
+		platillo.setHidratosDeCarbono(48.0);
+		platillo.setLipidos(8.0);
+		platillo.setRecommendations("Servir tibia");
+		platillo.setImageUrl("/uploads/platillo.jpg");
+
+		final DietPlatilloDto dto = DietPlatilloDto.fromEntity(platillo);
+
+		assertThat(dto.id()).isEqualTo(42L);
+		assertThat(dto.nombre()).isEqualTo("Avena con fruta");
+		assertThat(dto.porciones()).isEqualTo(2);
+		assertThat(dto.kcal()).isEqualTo(320);
+		assertThat(dto.proteina()).isEqualTo(12.5);
+		assertThat(dto.carbohidratos()).isEqualTo(48.0);
+		assertThat(dto.grasas()).isEqualTo(8.0);
+		assertThat(dto.recommendations()).isEqualTo("Servir tibia");
+		assertThat(dto.imageUrl()).isEqualTo("/uploads/platillo.jpg");
+	}
+
+	@Test
+	void fromEntity_returnsNullForNullPlatillo() {
+		assertThat(DietPlatilloDto.fromEntity(null)).isNull();
+	}
+
+	@Test
+	void fromEntity_alimentoMapsOptionalMacrosWhenPresent() {
+		final AlimentoIngesta alimento = new AlimentoIngesta();
+		alimento.setName("Manzana");
+		alimento.setPortions(1);
+		alimento.setEnergia(52);
+		alimento.setUnidad("pieza");
+		alimento.setProteina(0.3);
+		alimento.setHidratosDeCarbono(14.0);
+		alimento.setLipidos(0.2);
+
+		final DietAlimentoDto dto = DietAlimentoDto.fromEntity(alimento);
+
+		assertThat(dto.nombre()).isEqualTo("Manzana");
+		assertThat(dto.unidad()).isEqualTo("pieza");
+		assertThat(dto.proteina()).isEqualTo(0.3);
+		assertThat(dto.carbohidratos()).isEqualTo(14.0);
+		assertThat(dto.grasas()).isEqualTo(0.2);
+	}
+
+}


### PR DESCRIPTION
## Summary
- Extends `DietPlatilloDto` with `id`, `proteina`, `carbohidratos`, and `grasas`; adds optional macros on `DietAlimentoDto` (#354).
- Adds `GET /rest/mobile/patient/diet-plans/{assignmentId}/platillos/{platilloIngestaId}` returning ingredients, preparation, media URLs, and nutrition facts (#352).
- Patient-scoped ownership guard returns 404 when the platillo is not in the authenticated patient's assignment.

## Test plan
- [x] `./lint.sh` green
- [x] `mvn -B pmd:check -Pci` green
- [x] Unit/controller/integration tests for diet plan list, detail, and platillo detail
- [x] OpenAPI + ALIGNMENT-SPEC updated

Closes #354
Closes #352

Made with [Cursor](https://cursor.com)