### PR TITLE
fix(alimentos): accept fractional cantSugerida and show validation errors

### DIFF
--- a/src/main/java/com/nutriconsultas/alimentos/AlimentosController.java
+++ b/src/main/java/com/nutriconsultas/alimentos/AlimentosController.java
@@ -9,8 +9,10 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.WebDataBinder;
 
 import com.nutriconsultas.controller.AbstractAuthorizedController;
 
@@ -20,6 +22,11 @@ public class AlimentosController extends AbstractAuthorizedController {
 
 	@Autowired
 	private AlimentoService alimentoService;
+
+	@InitBinder("alimento")
+	public void initAlimentoBinder(final WebDataBinder binder) {
+		binder.registerCustomEditor(Double.class, "cantSugerida", new FractionalQuantityPropertyEditor());
+	}
 
 	@GetMapping(path = "/admin/alimentos")
 	public String listado(final Model model) {
@@ -65,6 +72,7 @@ public class AlimentosController extends AbstractAuthorizedController {
 		String resultView;
 		if (result.hasErrors()) {
 			log.warn("Found {} errors on binding result", result.getErrorCount());
+			model.addAttribute("activeMenu", "alimentos");
 			resultView = "sbadmin/alimentos/formulario";
 		}
 		else {

--- a/src/main/java/com/nutriconsultas/alimentos/FractionalQuantityPropertyEditor.java
+++ b/src/main/java/com/nutriconsultas/alimentos/FractionalQuantityPropertyEditor.java
@@ -1,0 +1,40 @@
+package com.nutriconsultas.alimentos;
+
+import java.beans.PropertyEditorSupport;
+
+import com.nutriconsultas.util.FractionQuantityParser;
+
+/**
+ * Binds fractional portion strings (e.g. {@code 1/2}, {@code 1 1/4}) to {@link Double}
+ * for {@link Alimento#cantSugerida}.
+ */
+public final class FractionalQuantityPropertyEditor extends PropertyEditorSupport {
+
+	@Override
+	public void setAsText(final String text) {
+		if (text == null || text.isBlank()) {
+			setValue(null);
+			return;
+		}
+		try {
+			final Double parsed = FractionQuantityParser.parseFractionalQuantity(text);
+			if (parsed == null) {
+				throw new IllegalArgumentException("Cantidad sugerida requerida.");
+			}
+			setValue(parsed);
+		}
+		catch (NumberFormatException ex) {
+			throw new IllegalArgumentException("Use un número o fracción válida (ej. 1/2, 1 1/4, 0.5).", ex);
+		}
+	}
+
+	@Override
+	public String getAsText() {
+		final Object value = getValue();
+		if (value instanceof Double doubleValue) {
+			return doubleValue.toString();
+		}
+		return "";
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/util/FractionQuantityParser.java
+++ b/src/main/java/com/nutriconsultas/util/FractionQuantityParser.java
@@ -18,17 +18,23 @@ public final class FractionQuantityParser {
 			return null;
 		}
 
-		final boolean hasInteger = trimmedGiven.contains(" ") || !trimmedGiven.contains("/");
-		final boolean hasFraction = trimmedGiven.contains("/");
+		if (!trimmedGiven.contains("/")) {
+			return Double.parseDouble(trimmedGiven.replace(',', '.'));
+		}
+
+		final boolean hasInteger = trimmedGiven.contains(" ");
 		final int integerPart = hasInteger ? Integer.parseInt(trimmedGiven.split(" ")[0]) : 0;
-		final int numeratorPart = hasInteger
-				? hasFraction ? Integer.parseInt(trimmedGiven.split(" ")[1].split("/")[0]) : 0
-				: Integer.parseInt(trimmedGiven.split("/")[0]);
-		final int denominatorPart = hasInteger
-				? hasFraction ? Integer.parseInt(trimmedGiven.split(" ")[1].split("/")[1]) : 0
-				: Integer.parseInt(trimmedGiven.split("/")[1]);
-		final double fractionalValue = hasFraction ? (double) numeratorPart / denominatorPart : 0d;
-		return integerPart + fractionalValue;
+		final String fractionPart = hasInteger ? trimmedGiven.split(" ")[1] : trimmedGiven;
+		final String[] fractionTokens = fractionPart.split("/");
+		if (fractionTokens.length != 2) {
+			throw new NumberFormatException("Invalid fraction: " + given);
+		}
+		final int numeratorPart = Integer.parseInt(fractionTokens[0]);
+		final int denominatorPart = Integer.parseInt(fractionTokens[1]);
+		if (denominatorPart == 0) {
+			throw new NumberFormatException("Invalid fraction denominator: " + given);
+		}
+		return integerPart + ((double) numeratorPart / denominatorPart);
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/util/IngredienteFromAlimentoCalculator.java
+++ b/src/main/java/com/nutriconsultas/util/IngredienteFromAlimentoCalculator.java
@@ -6,7 +6,6 @@ import com.nutriconsultas.alimentos.Alimento;
 import com.nutriconsultas.dieta.IngredientePlatilloIngesta;
 import com.nutriconsultas.model.AbstractFraccionable;
 import com.nutriconsultas.platillos.Ingrediente;
-import com.nutriconsultas.util.FractionQuantityParser;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/com/nutriconsultas/util/IngredienteFromAlimentoCalculator.java
+++ b/src/main/java/com/nutriconsultas/util/IngredienteFromAlimentoCalculator.java
@@ -6,6 +6,7 @@ import com.nutriconsultas.alimentos.Alimento;
 import com.nutriconsultas.dieta.IngredientePlatilloIngesta;
 import com.nutriconsultas.model.AbstractFraccionable;
 import com.nutriconsultas.platillos.Ingrediente;
+import com.nutriconsultas.util.FractionQuantityParser;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -81,7 +82,11 @@ public final class IngredienteFromAlimentoCalculator {
 
 	private static void calculateFromCantidadChange(final String given, final AbstractFraccionable ingrediente,
 			final Alimento alimento) {
-		final double parsedQuantity = parseFractionalQuantity(given);
+		final Double parsedQuantityValue = FractionQuantityParser.parseFractionalQuantity(given);
+		if (parsedQuantityValue == null) {
+			throw new IllegalArgumentException("Cantidad inválida: " + given);
+		}
+		final double parsedQuantity = parsedQuantityValue;
 		final double factor = parsedQuantity / alimento.getCantSugerida();
 		applyNutrientFactor(ingrediente, alimento, factor);
 		ingrediente.setCantSugerida(parsedQuantity);
@@ -171,20 +176,6 @@ public final class IngredienteFromAlimentoCalculator {
 		if (alimento.getPesoNeto() != null) {
 			ingrediente.setPesoNeto((int) Math.round(alimento.getPesoNeto() * factor));
 		}
-	}
-
-	private static double parseFractionalQuantity(final String given) {
-		final String trimmedGiven = given.trim();
-		final boolean hasInteger = trimmedGiven.contains(" ") || !trimmedGiven.contains("/");
-		final boolean hasFraction = trimmedGiven.contains("/");
-		final int givenIntPart = hasInteger ? Integer.parseInt(trimmedGiven.split(" ")[0]) : 0;
-		final int givenNumeratorPart = hasInteger
-				? hasFraction ? Integer.parseInt(trimmedGiven.split(" ")[1].split("/")[0]) : 0
-				: Integer.parseInt(trimmedGiven.split("/")[0]);
-		final int givenDenominatorPart = hasInteger
-				? hasFraction ? Integer.parseInt(trimmedGiven.split(" ")[1].split("/")[1]) : 0
-				: Integer.parseInt(trimmedGiven.split("/")[1]);
-		return givenIntPart + (hasFraction ? (givenNumeratorPart / (double) givenDenominatorPart) : 0d);
 	}
 
 }

--- a/src/main/resources/templates/sbadmin/alimentos/formulario.html
+++ b/src/main/resources/templates/sbadmin/alimentos/formulario.html
@@ -55,12 +55,15 @@
                   <div class="info-form p-5">
                     <form th:action="@{/admin/alimentos}" th:object="${alimento}" method="POST">
                       <input type="hidden" th:field="*{id}" />
+                      <div th:if="${#fields.hasAnyErrors()}" class="alert alert-danger" role="alert">
+                        No se pudo guardar el alimento. Revise los campos marcados.
+                      </div>
                       <div class="row">
                         <div class="col-md-6">
                           <div class="form-group">
                             <label>Nombre<span style="color:red;">*</span></label>
                             <input type="text" th:field="*{nombreAlimento}" class="form-control" required>
-                            <span th:if="${fields != null and fields.hasErrors('nombreAlimento')}" th:errors="*{nombreAlimento}"></span>
+                            <span th:if="${#fields.hasErrors('nombreAlimento')}" th:errors="*{nombreAlimento}"></span>
                           </div>
                         </div>
                         <div class="col-md-6">
@@ -94,7 +97,7 @@
                               <option value="PRODUCTOS YAKULT">PRODUCTOS YAKULT</option>
                               <option value="VERDURAS">VERDURAS</option>
                             </select>
-                            <span th:if="${fields != null and fields.hasErrors('clasificacion')}" th:errors="*{clasificacion}"></span>
+                            <span th:if="${#fields.hasErrors('clasificacion')}" th:errors="*{clasificacion}"></span>
                           </div>
                         </div>
                       </div>
@@ -103,14 +106,15 @@
                           <div class="form-group">
                             <label>Cantidad Sugerida</label>
                             <input type="text" class="form-control" th:field="*{cantSugerida}" required>
-                            <span th:if="${fields != null and fields.hasErrors('cantSugerida')}" th:errors="*{cantSugerida}"></span>
+                            <small class="form-text text-muted">Acepta fracciones (1/2, 1 1/4) o decimales (0.5).</small>
+                            <span class="text-danger" th:if="${#fields.hasErrors('cantSugerida')}" th:errors="*{cantSugerida}"></span>
                           </div>
                         </div>
                         <div class="col-md-6">
                           <div class="form-group">
                             <label>Unidad</label>
                             <input type="text" class="form-control" th:field="*{unidad}" required>
-                            <span th:if="${fields != null and fields.hasErrors('unidad')}" th:errors="*{unidad}"></span>
+                            <span th:if="${#fields.hasErrors('unidad')}" th:errors="*{unidad}"></span>
                           </div>
                         </div>
                       </div>
@@ -120,7 +124,7 @@
                             <label>Peso bruto redondeado (g)</label>
                             <input type="number" step="1" class="form-control" th:field="*{pesoBrutoRedondeado}"
                               required min="1" max="300">
-                            <span th:if="${fields != null and fields.hasErrors('pesoBrutoRedondeado')}"
+                            <span th:if="${#fields.hasErrors('pesoBrutoRedondeado')}"
                               th:errors="*{pesoBrutoRedondeado}"></span>
                           </div>
                         </div>
@@ -129,7 +133,7 @@
                             <label>Peso neto (g)</label>
                             <input type="number" step="1" class="form-control" th:field="*{pesoNeto}" required min="1"
                               max="300">
-                            <span th:if="${fields != null and fields.hasErrors('pesoNeto')}" th:errors="*{pesoNeto}"></span>
+                            <span th:if="${#fields.hasErrors('pesoNeto')}" th:errors="*{pesoNeto}"></span>
                           </div>
                         </div>
                         <div class="col-md-4">
@@ -137,7 +141,7 @@
                             <label>Energía (kcal)</label>
                             <input type="number" step="1" class="form-control" th:field="*{energia}" required min="1"
                               max="200">
-                            <span th:if="${fields != null and fields.hasErrors('energia')}" th:errors="*{energia}"></span>
+                            <span th:if="${#fields.hasErrors('energia')}" th:errors="*{energia}"></span>
                           </div>
                         </div>
                       </div>
@@ -146,28 +150,28 @@
                           <div class="form-group">
                             <label>Proteína (g)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{proteina}" max="20">
-                            <span th:if="${fields != null and fields.hasErrors('proteina')}" th:errors="*{proteina}"></span>
+                            <span th:if="${#fields.hasErrors('proteina')}" th:errors="*{proteina}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>Lípidos (g)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{lipidos}" max="10">
-                            <span th:if="${fields != null and fields.hasErrors('lipidos')}" th:errors="*{lipidos}"></span>
+                            <span th:if="${#fields.hasErrors('lipidos')}" th:errors="*{lipidos}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>Hidratos de Carbono (g)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{hidratosDeCarbono}" max="20">
-                            <span th:if="${fields != null and fields.hasErrors('hidratosDeCarbono')}" th:errors="*{hidratosDeCarbono}"></span>
+                            <span th:if="${#fields.hasErrors('hidratosDeCarbono')}" th:errors="*{hidratosDeCarbono}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>Fibra (g)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{fibra}" max="4">
-                            <span th:if="${fields != null and fields.hasErrors('fibra')}" th:errors="*{fibra}"></span>
+                            <span th:if="${#fields.hasErrors('fibra')}" th:errors="*{fibra}"></span>
                           </div>
                         </div>
                       </div>
@@ -176,28 +180,28 @@
                           <div class="form-group">
                             <label>Vitamina A (&micro;g RE)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{vitA}" max="900">
-                            <span th:if="${fields != null and fields.hasErrors('vitA')}" th:errors="*{vitA}"></span>
+                            <span th:if="${#fields.hasErrors('vitA')}" th:errors="*{vitA}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>Acido Ascórbico (mg)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{acidoAscorbico}" max="400">
-                            <span th:if="${fields != null and fields.hasErrors('acidoAscorbico')}" th:errors="*{acidoAscorbico}"></span>
+                            <span th:if="${#fields.hasErrors('acidoAscorbico')}" th:errors="*{acidoAscorbico}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>Acido Fólico (&micro;g)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{acidoFolico}" max="100">
-                            <span th:if="${fields != null and fields.hasErrors('acidoFolico')}" th:errors="*{acidoFolico}"></span>
+                            <span th:if="${#fields.hasErrors('acidoFolico')}" th:errors="*{acidoFolico}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>Hierro NO HEM (mg)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{hierroNoHem}" max="15">
-                            <span th:if="${fields != null and fields.hasErrors('hierroNoHem')}" th:errors="*{hierroNoHem}"></span>
+                            <span th:if="${#fields.hasErrors('hierroNoHem')}" th:errors="*{hierroNoHem}"></span>
                           </div>
                         </div>
                       </div>
@@ -206,28 +210,28 @@
                           <div class="form-group">
                             <label>Potasio (mg)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{potasio}" max="999">
-                            <span th:if="${fields != null and fields.hasErrors('potasio')}" th:errors="*{potasio}"></span>
+                            <span th:if="${#fields.hasErrors('potasio')}" th:errors="*{potasio}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>Índice glicémico</label>
                             <input type="number" step="1" class="form-control" th:field="*{indiceGlicemico}" max="150">
-                            <span th:if="${fields != null and fields.hasErrors('indiceGlicemico')}" th:errors="*{indiceGlicemico}"></span>
+                            <span th:if="${#fields.hasErrors('indiceGlicemico')}" th:errors="*{indiceGlicemico}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>Carga glicémica</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{cargaGlicemica}" max="10">
-                            <span th:if="${fields != null and fields.hasErrors('cargaGlicemica')}" th:errors="*{cargaGlicemica}"></span>
+                            <span th:if="${#fields.hasErrors('cargaGlicemica')}" th:errors="*{cargaGlicemica}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>Calcio (mg)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{calcio}" max="2000">
-                            <span th:if="${fields != null and fields.hasErrors('calcio')}" th:errors="*{calcio}"></span>
+                            <span th:if="${#fields.hasErrors('calcio')}" th:errors="*{calcio}"></span>
                           </div>
                         </div>
                       </div>
@@ -236,28 +240,28 @@
                           <div class="form-group">
                             <label>Hierro (mg)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{hierro}" max="20">
-                            <span th:if="${fields != null and fields.hasErrors('hierro')}" th:errors="*{hierro}"></span>
+                            <span th:if="${#fields.hasErrors('hierro')}" th:errors="*{hierro}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>Sodio (mg)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{sodio}" max="2000">
-                            <span th:if="${fields != null and fields.hasErrors('sodio')}" th:errors="*{sodio}"></span>
+                            <span th:if="${#fields.hasErrors('sodio')}" th:errors="*{sodio}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>Azúcar por equivalente (g)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{azucarPorEquivalente}" max="10">
-                            <span th:if="${fields != null and fields.hasErrors('azucarPorEquivalente')}" th:errors="*{azucarPorEquivalente}"></span>
+                            <span th:if="${#fields.hasErrors('azucarPorEquivalente')}" th:errors="*{azucarPorEquivalente}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>Selenio (&micro;g)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{selenio}" max="10">
-                            <span th:if="${fields != null and fields.hasErrors('selenio')}" th:errors="*{selenio}"></span>
+                            <span th:if="${#fields.hasErrors('selenio')}" th:errors="*{selenio}"></span>
                           </div>
                         </div>
                       </div>
@@ -266,28 +270,28 @@
                           <div class="form-group">
                             <label>Fosforo (g)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{fosforo}" max="200">
-                            <span th:if="${fields != null and fields.hasErrors('fosforo')}" th:errors="*{fosforo}"></span>
+                            <span th:if="${#fields.hasErrors('fosforo')}" th:errors="*{fosforo}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>Colesterol (mg)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{colesterol}" max="200">
-                            <span th:if="${fields != null and fields.hasErrors('colesterol')}" th:errors="*{colesterol}"></span>
+                            <span th:if="${#fields.hasErrors('colesterol')}" th:errors="*{colesterol}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>AG saturados (g)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{agSaturados}" max="10">
-                            <span th:if="${fields != null and fields.hasErrors('agSaturados')}" th:errors="*{agSaturados}"></span>
+                            <span th:if="${#fields.hasErrors('agSaturados')}" th:errors="*{agSaturados}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>AG monoinsaturados (g)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{agMonoinsaturados}" max="10">
-                            <span th:if="${fields != null and fields.hasErrors('agMonoinsaturados')}" th:errors="*{agMonoinsaturados}"></span>
+                            <span th:if="${#fields.hasErrors('agMonoinsaturados')}" th:errors="*{agMonoinsaturados}"></span>
                           </div>
                         </div>
                       </div>
@@ -296,14 +300,14 @@
                           <div class="form-group">
                             <label>AG poliinsaturados (g)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{agPoliinsaturados}" max="10">
-                            <span th:if="${fields != null and fields.hasErrors('agPoliinsaturados')}" th:errors="*{agPoliinsaturados}"></span>
+                            <span th:if="${#fields.hasErrors('agPoliinsaturados')}" th:errors="*{agPoliinsaturados}"></span>
                           </div>
                         </div>
                         <div class="col-md-3">
                           <div class="form-group">
                             <label>Etanol (g)</label>
                             <input type="number" step="0.1" class="form-control" th:field="*{etanol}" max="50">
-                            <span th:if="${fields != null and fields.hasErrors('etanol')}" th:errors="*{etanol}"></span>
+                            <span th:if="${#fields.hasErrors('etanol')}" th:errors="*{etanol}"></span>
                           </div>
                         </div>
                       </div>

--- a/src/test/java/com/nutriconsultas/alimentos/AlimentosControllerTest.java
+++ b/src/test/java/com/nutriconsultas/alimentos/AlimentosControllerTest.java
@@ -1,5 +1,6 @@
 package com.nutriconsultas.alimentos;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -99,7 +100,7 @@ public class AlimentosControllerTest {
 	@Test
 	@WithMockUser(username = "admin", roles = { "ADMIN" })
 	public void testAgregarNuevoAlimento() throws Exception {
-		log.info("Starting testAgregarNuevoAlimento");
+		when(alimentoService.save(any(Alimento.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
 		mockMvc
 			.perform(MockMvcRequestBuilders.post("/admin/alimentos")
@@ -110,7 +111,41 @@ public class AlimentosControllerTest {
 				.with(SecurityMockMvcRequestPostProcessors.csrf()))
 			.andExpect(status().is3xxRedirection())
 			.andExpect(MockMvcResultMatchers.redirectedUrl("/admin/alimentos"));
-		log.info("Finishing testAgregarNuevoAlimento");
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testAgregarNuevoAlimentoWithFractionalCantSugerida() throws Exception {
+		when(alimentoService.save(any(Alimento.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		mockMvc
+			.perform(MockMvcRequestBuilders.post("/admin/alimentos")
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("clasificacion", "LECHE SEMIDESCREMADA")
+				.param("unidad", "pieza")
+				.param("nombreAlimento", "Oikos estilo griego sabor natural")
+				.param("cantSugerida", "1/2")
+				.with(SecurityMockMvcRequestPostProcessors.csrf()))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(MockMvcResultMatchers.redirectedUrl("/admin/alimentos"));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testAgregarNuevoAlimentoShowsValidationErrors() throws Exception {
+		mockMvc
+			.perform(MockMvcRequestBuilders.post("/admin/alimentos")
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("clasificacion", "LECHE SEMIDESCREMADA")
+				.param("unidad", "pieza")
+				.param("nombreAlimento", "")
+				.param("cantSugerida", "1/2")
+				.with(SecurityMockMvcRequestPostProcessors.csrf()))
+			.andExpect(status().isOk())
+			.andExpect(MockMvcResultMatchers.view().name("sbadmin/alimentos/formulario"))
+			.andExpect(MockMvcResultMatchers.model().attribute("activeMenu", "alimentos"))
+			.andExpect(
+					MockMvcResultMatchers.content().string(Matchers.containsString("No se pudo guardar el alimento")));
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/util/FractionQuantityParserTest.java
+++ b/src/test/java/com/nutriconsultas/util/FractionQuantityParserTest.java
@@ -22,6 +22,12 @@ class FractionQuantityParserTest {
 	}
 
 	@Test
+	void parseFractionalQuantity_parsesDecimal() {
+		assertThat(FractionQuantityParser.parseFractionalQuantity("0.5")).isEqualTo(0.5d);
+		assertThat(FractionQuantityParser.parseFractionalQuantity("0,5")).isEqualTo(0.5d);
+	}
+
+	@Test
 	void parseFractionalQuantity_returnsNullForBlankInput() {
 		assertThat(FractionQuantityParser.parseFractionalQuantity("")).isNull();
 		assertThat(FractionQuantityParser.parseFractionalQuantity(null)).isNull();


### PR DESCRIPTION
## Summary
- Parse fractional and decimal values (`1/2`, `1 1/4`, `0.5`) for **Cantidad sugerida** when creating/editing alimentos via `@InitBinder` + `FractionQuantityParser`.
- Fix the alimento form so validation errors actually render (`#fields.hasErrors`) and show a top-of-form alert on failed save.
- Reuse shared fractional parsing in `IngredienteFromAlimentoCalculator`.

Fixes production issue where nutritionists saving new alimentos with `1/2` saw no response (binding failed silently).

## Test plan
- [x] `mvn test -Dtest=FractionQuantityParserTest,AlimentosControllerTest`
- [ ] Manual: `/admin/alimentos/nuevo` → enter name + `1/2` cantidad → **Listo!** → redirects to list
- [ ] Manual: submit with empty name → red alert + field error visible


Made with [Cursor](https://cursor.com)