### PR TITLE
docs(ai): register AI Nutrition Assistant track (#360–#409)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,8 @@ JDBC_DATABASE_PASSWORD=nutriconsultas
 # STRIPE_WEBHOOK_SECRET=whsec_...
 # STRIPE_SUCCESS_URL=http://localhost:3000/admin
 # STRIPE_CANCEL_URL=http://localhost:3000/admin
+
+# OpenAI — optional; set AI_ENABLED=false to disable AI features locally
+# OPEN_API_KEY=sk-proj-your_openai_api_key_here
+# OPENAI_MODEL=gpt-5.5
+# AI_ENABLED=true

--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -39,6 +39,14 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) | `[Public Booking]` epic #245–#248 |
 | [`docs/public-booking/AVAILABILITY.md`](docs/public-booking/AVAILABILITY.md) | Working hours model, timezone, REST (#246) |
 
+**Parallel track (AI assistant — do not mix into mobile/subscription PRs unless coupled):**
+
+| File | Purpose |
+|------|---------|
+| [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md) | `[AI Assistant]` issues (#360–#409), epics, milestones |
+| [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md) | Agent workflow for AI nutrition assistant |
+| [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md) | Architecture, security, tools, definition of done |
+
 **Current next issue (public booking):** None — epic ~~#245~~ **done**; ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~, ~~#300~~, ~~#302~~ done. Deferred follow-ups need new issues. See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
 **Current next issue (mobile):** [#353 — Grocery list for patient diet plan](https://github.com/diego-torres/nutriconsultas/issues/353) (`in-progress`). ~~#354~~ ~~#352~~ **done** (PR [#357](https://github.com/diego-torres/nutriconsultas/pull/357)).
@@ -46,6 +54,8 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 **Current next issue (subscription):** Registered track **complete** (~~#244~~ ✓ on `subscription/244-contact-form-prefill`). Triage open `[Subscription]` GitHub issues. See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
+
+**Current next issue (AI assistant):** [#361 — Define AI Assistant Functional Scope](https://github.com/diego-torres/nutriconsultas/issues/361) (`NEXT`). Track registered 2026-06-30 (#360–#409). See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -606,6 +606,12 @@ Issue registry: [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md). Plan: 
 
 **Epic ~~#341~~** (2026-06-26): nutritionist web mobile app invitation — ~~#341~~ **done** (branch `issue-341-web-mobile-invitation`, 38f358e): session REST `/rest/pacientes/{id}/mobile-invitation`, patient grid **App móvil** column, Afiliación send/resend/revoke. Post-login linkage: `POST /rest/mobile/invitations/reconcile` (branch `feat/invitation-redeem-by-human-code`). See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
+## AI Nutrition Assistant (tracking)
+
+Issue registry: [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md). Plan: [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md). Workflow: [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md).
+
+**Epics #360–#409** (2026-06-30): OpenAI-backed chat for nutritionists to draft recipes, menus, and diet plans via backend catalog tools — **registered**, not started. **NEXT:** [#361](https://github.com/diego-torres/nutriconsultas/issues/361) functional scope (Phase 0). Plan gating: [#409](https://github.com/diego-torres/nutriconsultas/issues/409) (Plus + Consultorio). **All user-facing AI communications in Spanish (es-MX).** Milestones: M1 foundation (#360–#371) → M2 nutrition tools (#372–#382) → M3 chat UX (#383–#390) → M4 MCP (#391–#395) → M5 safety & release (#396–#408).
+
 ## Public booking (tracking)
 
 Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic ~~**#245**~~ **done** (v1 shipped, 2026-06-19): shareable `/consultas/{id}/agendar-cita` link. ~~#246~~ **done**; ~~#247~~ **done** (PR [#295](https://github.com/diego-torres/nutriconsultas/pull/295)); ~~#248~~ **done** (PR [#298](https://github.com/diego-torres/nutriconsultas/pull/298)); ~~#297~~ **done** (PR [#299](https://github.com/diego-torres/nutriconsultas/pull/299)); ~~#300~~ **done** (PR [#301](https://github.com/diego-torres/nutriconsultas/pull/301)); ~~#302~~ **done** (PR [#303](https://github.com/diego-torres/nutriconsultas/pull/303)). Track complete; deferred follow-ups (verification, SMTP) need new issues.

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -1,0 +1,161 @@
+# AI Nutrition Assistant — Agent Workflow
+
+How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torres/nutriconsultas`**. Separate from mobile API, subscription, and public booking — do not mix OpenAI orchestration into unrelated PRs.
+
+**Registries**
+
+| File | Purpose |
+|------|---------|
+| [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md) | `[AI Assistant]` issues #360–#409, states, dependencies |
+| [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md) | Architecture, security, tools, milestones |
+| [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
+| [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
+
+**Current next issue:** [#361 — Define AI Assistant Functional Scope](https://github.com/diego-torres/nutriconsultas/issues/361) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)).
+
+---
+
+## Product context (read before every session)
+
+| Topic | Guidance |
+|-------|----------|
+| **Language** | **Spanish (es-MX) only** for all AI assistant user-facing text — model output, UI, errors, drafts (#367, #399, #401). See track principles in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md). |
+| **Audience** | **Licensed nutritionists** on `/admin/**` — not patients, not mobile API consumers in v1. |
+| **API key** | `OPENAI_API_KEY` server-only (`OPEN_API_KEY` legacy alias may exist in `.env`). Never in browser, logs, or Git. |
+| **Plan gating** | **Plus + Consultorio only** (#409) — new `AI_ASSISTANT` entitlement; `AI_ENABLED` does not bypass plan check |
+| **Feature flag** | `AI_ENABLED=false` by default until release checklist (#408) passes. |
+| **Drafts only** | AI creates `DRAFT` records; nutritionist must accept before real platillo/dieta/patient assignment. |
+| **Multi-tenant** | All catalog and patient-context tools scoped to authenticated nutritionist / clinic — same rules as [`Paciente.userId`](src/main/java/com/nutriconsultas/paciente/Paciente.java). |
+| **Privacy** | Minimum patient data to OpenAI; no names/emails/phones in prompts or unstructured logs; use `LogRedaction`. |
+| **Schema gate** | #46 Liquibase baseline on `main`. All `ai_chat_*` tables → incremental changesets ([`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md)). |
+| **Medical safety** | Assistant is a **drafting tool** — include assumptions, warnings, clarifying questions; never auto-assign diets. |
+
+---
+
+## Overview
+
+```mermaid
+flowchart LR
+  A[1. Triage registry] --> B[2. Branch & plan]
+  B --> C[3. Implement]
+  C --> D[4. Review]
+  D --> E[5. Tests]
+  E --> F[6. CI validation]
+  F --> G[7. Summaries]
+  G --> H[8. PR & registry]
+```
+
+Phases mirror [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md).
+
+---
+
+## Phase 1 — Triage & registry sync
+
+1. Pull latest on `main`.
+2. Open [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md) — find `NEXT`; confirm dependencies `done`.
+3. Sync GitHub:
+   ```bash
+   gh issue view 361
+   gh issue list --search "[AI Assistant] in:title" --state open
+   ```
+4. Read [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md) for security and tool contracts before coding.
+
+---
+
+## Phase 2 — Branch & plan
+
+- Branch: `issue-361-ai-functional-scope` (replace number/topic).
+- One issue per PR when possible; epics are tracking-only.
+- Phase 0 (#361–#363) is **docs-only** — output lands in `docs/ai/`.
+- Phase 1+ requires tests per project rules.
+
+---
+
+## Phase 3 — Implement
+
+### Package layout (suggested)
+
+```text
+com.nutriconsultas.ai/
+  config/          — OpenAI properties, feature flag
+  client/          — OpenAiClientService
+  orchestration/   — chat + tool loop
+  tools/           — catalog, nutrient, draft tools
+  persistence/     — entities, repos, draft lifecycle
+  web/             — AiChatController
+  mcp/             — Phase 7 MCP dispatch
+```
+
+### Security checklist (every PR)
+
+- [ ] User-facing AI copy is **Spanish (es-MX)** — assistant messages, UI, errors, draft labels
+- [ ] No API key in frontend, templates, or responses
+- [ ] Endpoints under authenticated nutritionist paths
+- [ ] Tool handlers verify tenant ownership
+- [ ] No direct patient diet assignment from AI tools
+- [ ] Logs redact PHI and secrets
+
+---
+
+## Phase 4 — Review
+
+- Confirm issue acceptance criteria in PR description.
+- Link `Fixes #NNN` or `Refs #NNN` for doc-only work.
+- Security-sensitive: MCP (#391–#395), orchestration (#385), data access doc (#362).
+
+---
+
+## Phase 5 — Tests
+
+| Layer | Requirement |
+|-------|-------------|
+| Service | Mockito unit tests for tools, orchestration, draft lifecycle |
+| Controller | `@SpringBootTest` + `@AutoConfigureMockMvc` for `/nutritionist/ai/**` |
+| Liquibase | Migration test for `ai_chat_*` changesets |
+| Templates | Update validators for chat UI (#388–#390) |
+| Security | Cross-tenant access denied tests (#403, #395) |
+
+Mock OpenAI in tests — never call live API in CI.
+
+---
+
+## Phase 6 — CI validation
+
+```bash
+mvn spring-javaformat:apply
+./lint.sh
+mvn test
+```
+
+---
+
+## Phase 7 — PR & registry
+
+1. Update [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md): `in-progress` → `done` when merged.
+2. Update epic row if all children complete.
+3. For config/docs issues: update `.env.example` and `docs/ai/` in same PR.
+
+---
+
+## Milestone gates
+
+| Gate | Required before |
+|------|-----------------|
+| M1 complete | Any live OpenAI call in staging |
+| M2 complete | Orchestration tool loop (#385) |
+| M3 complete | Nutritionist beta (`AI_ENABLED=true` staging) |
+| M4 complete | External MCP clients |
+| M5 + #408 | Production `AI_ENABLED=true` |
+
+---
+
+## Local & production config
+
+| Variable | Purpose |
+|----------|---------|
+| `AI_ENABLED` | Feature flag |
+| `OPENAI_API_KEY` / `OPEN_API_KEY` | Server secret |
+| `OPENAI_MODEL` | e.g. `gpt-5.5` |
+| `AI_MAX_TOOL_CALLS` | Orchestration limit (default 8) |
+
+EC2: `/opt/nutriconsultas/app.env` — update via SSM (see #406).

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -1,0 +1,256 @@
+# Issue Registry — `[AI Assistant]` track
+
+Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-backed chat for nutritionists to draft recipes, menus, and diet plans using application catalog tools. Update when status changes (commit on the PR that closes work).
+
+**Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
+**Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
+**Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
+**Last updated:** 2026-06-30 — track registered (#360–#409). **NEXT:** #361.
+
+> **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
+
+---
+
+## Track principles
+
+| Principle | Rule |
+|-----------|------|
+| **Language** | All AI assistant **user-facing** text is **Spanish (es-MX)** — assistant replies, clarifying questions, assumptions, warnings, draft labels, errors, empty states, and upgrade/plan-denial copy. System prompts instruct the model to respond in Spanish. Structured JSON field names may stay English; human-readable strings inside drafts must be Spanish. |
+| **Drafts only** | Generated content is a draft until the nutritionist accepts — never auto-assign to patients. |
+| **Backend-only secrets** | OpenAI API key never in browser, templates, logs, or Git. |
+| **Plan gating** | Plus + Consultorio only (#409) — separate from `REPORTS_ADVANCED`. |
+
+Applies to every issue in this track unless explicitly noted otherwise.
+
+---
+
+## Legend
+
+| State | Meaning |
+|-------|---------|
+| `NEXT` | Active — pick this up now (if unblocked) |
+| `open` | Not started |
+| `in-progress` | Branch / PR open |
+| `done` | Merged to `main` |
+| `deferred` | Paused |
+
+---
+
+## Milestone map
+
+| Milestone | Epics | Issue range | Outcome |
+|-----------|-------|-------------|---------|
+| **1 — AI Foundation** | Phase 0–2 | #360–#371 | Design + OpenAI backend + DB persistence |
+| **2 — Nutrition Tools** | Phase 3–4 | #372–#382 | Catalog tools + draft creation |
+| **3 — Chat UX** | Phase 5–6 | #383–#390 | REST API + Thymeleaf chat UI |
+| **4 — MCP** | Phase 7 | #391–#395 | MCP tool server |
+| **5 — Safety & Release** | Phase 8–10 | #396–#408 | Audit, evaluation, docs, rollout |
+
+**Suggested order:** Milestone 1 → 2 → 3 → 4 (optional parallel after M2) → 5.
+
+---
+
+## Epic — Discovery and Architecture (Phase 0)
+
+Document architecture, security model, data flow, and first implementation scope.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|------------|-------|
+| **360** | Epic — Discovery and Architecture (Phase 0) | https://github.com/diego-torres/nutriconsultas/issues/360 | **open** | — | Milestone 1 |
+| **361** | Define AI Assistant Functional Scope | https://github.com/diego-torres/nutriconsultas/issues/361 | **NEXT** | **360** | Supported/unsupported prompts; **Spanish-only** comms |
+| **362** | Define AI Data Access Rules | https://github.com/diego-torres/nutriconsultas/issues/362 | **open** | **360** | PHI redaction, scoping |
+| **363** | Design AI Tool Contract | https://github.com/diego-torres/nutriconsultas/issues/363 | **open** | **360**, **362** | Tool schemas; read vs draft |
+
+**Suggested order:** #361 + #362 parallel → #363.
+
+---
+
+## Epic — Backend OpenAI Integration (Phase 1)
+
+Backend-only OpenAI configuration and client service.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|------------|-------|
+| **364** | Epic — Backend OpenAI Integration (Phase 1) | https://github.com/diego-torres/nutriconsultas/issues/364 | **open** | **363** | Milestone 1 |
+| **365** | Add OpenAI Configuration Properties | https://github.com/diego-torres/nutriconsultas/issues/365 | **open** | **364**, **363** | `AI_ENABLED`, `OPENAI_*` |
+| **366** | Add OpenAI Java Client or HTTP Client Integration | https://github.com/diego-torres/nutriconsultas/issues/366 | **open** | **365** | `OpenAiClientService` |
+| **367** | Create AI System Prompt Template | https://github.com/diego-torres/nutriconsultas/issues/367 | **open** | **364**, **361** | Server-side safety prompt; **respond in Spanish** |
+
+**Suggested order:** #365 → #366; #367 after #361.
+
+---
+
+## Epic — AI Chat Persistence and Draft Storage (Phase 2)
+
+Store chat threads, messages, and generated drafts.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|------------|-------|
+| **368** | Epic — AI Chat Persistence and Draft Storage (Phase 2) | https://github.com/diego-torres/nutriconsultas/issues/368 | **open** | **364** | Milestone 1 |
+| **369** | Add Liquibase Schema for AI Chat Tables | https://github.com/diego-torres/nutriconsultas/issues/369 | **open** | **368**, #46 | `ai_chat_*` tables |
+| **370** | Implement AI Chat Domain Entities and Repositories | https://github.com/diego-torres/nutriconsultas/issues/370 | **open** | **369** | JPA + scoped repos |
+| **371** | Implement AI Draft Lifecycle | https://github.com/diego-torres/nutriconsultas/issues/371 | **open** | **370** | DRAFT / ACCEPTED / DISCARDED |
+
+**Suggested order:** #369 → #370 → #371.
+
+---
+
+## Epic — Backend Nutrition Tool Services (Phase 3)
+
+Read-only catalog and validation tools for AI orchestration.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|------------|-------|
+| **372** | Epic — Backend Nutrition Tool Services (Phase 3) | https://github.com/diego-torres/nutriconsultas/issues/372 | **open** | **363**, **371** | Milestone 2 |
+| **373** | Implement Food Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/373 | **open** | **372** | `search_food_catalog` |
+| **374** | Implement Food Nutrient Lookup Tool | https://github.com/diego-torres/nutriconsultas/issues/374 | **open** | **372** | `get_food_nutrients` |
+| **375** | Implement Dish Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/375 | **open** | **372** | `search_dish_catalog` |
+| **376** | Implement Recipe Nutrient Calculation Tool | https://github.com/diego-torres/nutriconsultas/issues/376 | **open** | **374** | `calculate_recipe_nutrients` |
+| **377** | Implement Plan Constraint Validation Tool | https://github.com/diego-torres/nutriconsultas/issues/377 | **open** | **376** | `validate_plan_constraints` |
+
+**Suggested order:** #373 + #374 + #375 parallel → #376 → #377.
+
+---
+
+## Epic — AI Draft Creation Tools (Phase 4)
+
+Draft-creation tools and acceptance flow (no direct patient assignment).
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|------------|-------|
+| **378** | Epic — AI Draft Creation Tools (Phase 4) | https://github.com/diego-torres/nutriconsultas/issues/378 | **open** | **372** | Milestone 2 |
+| **379** | Implement Dish Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/379 | **open** | **378**, **371** | `create_dish_draft` |
+| **380** | Implement Menu Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/380 | **open** | **378**, **371** | `create_menu_draft` |
+| **381** | Implement Diet Plan Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/381 | **open** | **378**, **371** | `create_diet_plan_draft` |
+| **382** | Implement Draft Acceptance Flow | https://github.com/diego-torres/nutriconsultas/issues/382 | **open** | **379**, **380**, **381** | Convert draft → real record |
+
+**Suggested order:** #379 + #380 + #381 parallel → #382.
+
+---
+
+## Epic — AI Chat REST API (Phase 5)
+
+Authenticated endpoints for chat and draft management.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|------------|-------|
+| **383** | Epic — AI Chat REST API (Phase 5) | https://github.com/diego-torres/nutriconsultas/issues/383 | **open** | **366**, **382** | Milestone 3 |
+| **384** | Create AI Chat Controller | https://github.com/diego-torres/nutriconsultas/issues/384 | **open** | **383**, **385** | `/nutritionist/ai/**` |
+| **385** | Implement AI Orchestration Service | https://github.com/diego-torres/nutriconsultas/issues/385 | **open** | **366**, **372**, **378** | OpenAI + tools |
+| **386** | Add Rate Limiting for AI Chat | https://github.com/diego-torres/nutriconsultas/issues/386 | **open** | **385** | Resilience4j |
+
+**Suggested order:** #385 → #384 + #386.
+
+---
+
+## Epic — Nutritionist AI Chat UI (Phase 6)
+
+Thymeleaf chat window and draft preview.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|------------|-------|
+| **387** | Epic — Nutritionist AI Chat UI (Phase 6) | https://github.com/diego-torres/nutriconsultas/issues/387 | **open** | **384** | Milestone 3 |
+| **388** | Add AI Chat Entry Point to Nutritionist UI | https://github.com/diego-torres/nutriconsultas/issues/388 | **open** | **387**, **365** | Gated by `AI_ENABLED` |
+| **389** | Build AI Chat Window | https://github.com/diego-torres/nutriconsultas/issues/389 | **open** | **388**, **384** | Chat UI + loading/errors |
+| **390** | Build Draft Preview UI | https://github.com/diego-torres/nutriconsultas/issues/390 | **open** | **389**, **382** | Accept/discard + SweetAlert |
+
+**Suggested order:** #388 → #389 → #390.
+
+---
+
+## Epic — MCP Tool Server (Phase 7)
+
+MCP-compatible exposure of nutrition tools.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|------------|-------|
+| **391** | Epic — MCP Tool Server for Nutriconsultas (Phase 7) | https://github.com/diego-torres/nutriconsultas/issues/391 | **open** | **372**, **378** | Milestone 4 |
+| **392** | Design MCP Server Endpoint | https://github.com/diego-torres/nutriconsultas/issues/392 | **open** | **391**, **363** | `POST /mcp/nutriconsultas` |
+| **393** | Implement MCP Tool Descriptors | https://github.com/diego-torres/nutriconsultas/issues/393 | **open** | **392** | Stable tool names |
+| **394** | Implement MCP Tool Dispatch | https://github.com/diego-torres/nutriconsultas/issues/394 | **open** | **393**, **372** | Map to Spring services |
+| **395** | Add MCP Security Review | https://github.com/diego-torres/nutriconsultas/issues/395 | **open** | **394** | Auth + scoping tests |
+
+**Suggested order:** #392 → #393 → #394 → #395.
+
+---
+
+## Epic — AI Safety and Observability (Phase 8)
+
+Audit logging, metrics, and error UX.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|------------|-------|
+| **396** | Epic — AI Safety and Observability (Phase 8) | https://github.com/diego-torres/nutriconsultas/issues/396 | **open** | **385** | Milestone 5 |
+| **397** | Add AI Audit Logging | https://github.com/diego-torres/nutriconsultas/issues/397 | **open** | **396** | Redacted logs |
+| **398** | Add AI Usage Metrics | https://github.com/diego-torres/nutriconsultas/issues/398 | **open** | **396** | No PHI in metrics |
+| **399** | Add AI Error Handling UX | https://github.com/diego-torres/nutriconsultas/issues/399 | **open** | **389**, **385** | Friendly errors |
+
+**Suggested order:** #397 + #398 parallel with #399 after #389.
+
+---
+
+## Epic — AI Nutrition Evaluation Suite (Phase 9)
+
+Golden prompts, schema validation, E2E tests.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|------------|-------|
+| **400** | Epic — AI Nutrition Evaluation Suite (Phase 9) | https://github.com/diego-torres/nutriconsultas/issues/400 | **open** | **382**, **385** | Milestone 5 |
+| **401** | Add Golden Prompt Test Cases | https://github.com/diego-torres/nutriconsultas/issues/401 | **open** | **400**, **361** | Documented scenarios |
+| **402** | Add Structured Output Validation | https://github.com/diego-torres/nutriconsultas/issues/402 | **open** | **379**, **380**, **381** | JSON schemas |
+| **403** | Add End-to-End AI Draft Flow Test | https://github.com/diego-torres/nutriconsultas/issues/403 | **open** | **384**, **390** | Mock OpenAI + IDOR |
+
+**Suggested order:** #402 after draft tools; #403 after UI; #401 anytime in M5.
+
+---
+
+## Epic — Documentation and Release (Phase 10)
+
+Setup docs, nutritionist guidance, release checklist.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|------------|-------|
+| **404** | Epic — AI Assistant Documentation and Release (Phase 10) | https://github.com/diego-torres/nutriconsultas/issues/404 | **open** | **396**, **403** | Milestone 5 |
+| **405** | Document Local AI Setup | https://github.com/diego-torres/nutriconsultas/issues/405 | **open** | **365** | `.env` / `dev-start.sh` |
+| **406** | Document Production AI Setup | https://github.com/diego-torres/nutriconsultas/issues/406 | **open** | **365** | EC2 `app.env`, SSM |
+| **407** | Add Nutritionist User Guidance | https://github.com/diego-torres/nutriconsultas/issues/407 | **open** | **390** | In-app or docs |
+| **408** | Create AI Assistant Release Checklist | https://github.com/diego-torres/nutriconsultas/issues/408 | **open** | **404** | Rollout gate |
+
+**Suggested order:** #405 + #406 early; #407 + #408 before production enable.
+
+---
+
+## Subscription gating — Plus and Consultorio only
+
+AI assistant is a **new entitlement** — do **not** replace `REPORTS_ADVANCED` (reportes avanzados). That flag is implemented (#187 ✓) for Profesional+ and must stay.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|------------|-------|
+| **409** | Gate AI assistant by plan — Plus and Consultorio only | https://github.com/diego-torres/nutriconsultas/issues/409 | **open** | #181, **384**, **388** | New `Entitlement.AI_ASSISTANT`; pricing row on `eterna/index.html` |
+
+**Suggested order:** Implement #409 before or with #384/#388; required before production `AI_ENABLED=true`.
+
+---
+
+## Cross-track links
+
+| Track | Interaction |
+|-------|-------------|
+| #46 Liquibase | All `ai_chat_*` schema via incremental changesets |
+| [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Draft acceptance may create platillos/dietas via existing flows |
+| [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) | **#409** — new `AI_ASSISTANT` entitlement (Plus + Consultorio); do not reuse `REPORTS_ADVANCED` |
+| [`ISSUE.md`](ISSUE.md) | Mobile API orthogonal — no patient AI chat in v1 |
+| Multi-tenant | Reuse `Paciente.userId` / clinic scoping patterns |
+| `LogRedaction` | AI audit logs must not leak PHI |
+
+---
+
+## Definition of done (project)
+
+See [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md#definition-of-done-whole-project).
+
+---
+
+**How to update this file**
+
+Same convention as [`ISSUE.md`](ISSUE.md): mark `in-progress` when PR opens, `done` when merged. Reference from [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md) and [`AGENTS.md`](AGENTS.md).

--- a/docs/ai/AI-ASSISTANT-PLAN.md
+++ b/docs/ai/AI-ASSISTANT-PLAN.md
@@ -1,0 +1,203 @@
+# AI Nutrition Assistant — Plan
+
+Canonical design for the **AI-powered chat assistant** for licensed nutritionists on the Minutriporcion / Nutriconsultas web app.
+
+**Issue registry:** [`ISSUE-AI-ASSISTANT.md`](../../ISSUE-AI-ASSISTANT.md)  
+**Agent workflow:** [`AI-ASSISTANT-WORKFLOW.md`](../../AI-ASSISTANT-WORKFLOW.md)  
+**Epic range:** GitHub #360–#409
+
+---
+
+## Language (track-wide)
+
+All AI assistant communications are **in Spanish (es-MX)**:
+
+- Model replies, follow-up questions, assumptions, and warnings
+- Draft preview copy (“borrador IA — revisión requerida”, nutrient labels shown to nutritionists)
+- Chat UI strings, loading/error/empty states, SweetAlert confirmations
+- Plan-gating and rate-limit messages (#409, #386, #399)
+- Golden prompt evaluation cases may use Spanish prompts (#401)
+
+Implementation: system prompt (#367) must require Spanish output; UI follows existing admin `messages_es_MX.properties` patterns. Tests should assert Spanish for representative flows (#401, #403).
+
+---
+
+Add an AI chat feature so nutritionists can draft:
+
+- Dish recipes
+- Daily menus
+- Weekly menus
+- Dietary plan drafts
+
+The assistant uses existing **food, dish, recipe, nutrient, diet, and patient-context** data through controlled backend tools. It must **not** directly save or assign final diets to patients without explicit nutritionist review and approval.
+
+---
+
+## Core product behavior
+
+Example prompts:
+
+- “Create a 7-day 1800 kcal plan for a patient who wants weight loss.”
+- “Generate a high-protein breakfast using foods from my catalog.”
+- “Create a low-sodium menu with 3 meals and 2 snacks.”
+- “Build a recipe using chicken, rice, vegetables, and calculate nutrients.”
+
+The assistant must:
+
+1. Ask follow-up questions when data is missing.
+2. Search application catalogs instead of inventing nutrient values.
+3. Calculate nutrients using application data.
+4. Return structured drafts.
+5. Show assumptions and warnings.
+6. Let the nutritionist edit, approve, discard, or save the draft.
+7. Never expose the OpenAI API key to the browser.
+8. Never directly assign a diet/menu to a patient without nutritionist confirmation.
+
+---
+
+## Architecture
+
+```text
+Nutritionist browser chat UI
+        ↓
+Spring Boot AI chat controller
+        ↓
+AI orchestration service
+        ↓
+OpenAI Responses API
+        ↓
+Application tool handlers / MCP tools
+        ↓
+Nutriconsultas PostgreSQL catalogs and patient context
+        ↓
+Structured draft returned to nutritionist
+```
+
+The backend owns all sensitive logic. The frontend is only a chat interface and draft viewer.
+
+---
+
+## Security
+
+| Rule | Detail |
+|------|--------|
+| API key | `OPENAI_API_KEY` (or legacy `OPEN_API_KEY`) **server-only** — never in JS, Thymeleaf, REST responses, logs, or Git |
+| Auth | All AI endpoints require authenticated nutritionist access |
+| Scoping | Catalog and patient lookups scoped to authenticated nutritionist / clinic |
+| Isolation | No cross-tenant patient, recipe, menu, or catalog exposure |
+
+---
+
+## Privacy
+
+- Send **minimum** patient data to OpenAI.
+- Avoid names, emails, phone numbers, free-text notes unless strictly required.
+- Prefer internal IDs and structured clinical/nutrition constraints.
+- Store chat history and drafts in PostgreSQL with retention rules.
+- Mark all generated plans **“AI draft — nutritionist review required.”**
+
+---
+
+## Medical / nutrition safety
+
+- Drafting tool only — not an autonomous clinical decision-maker.
+- Nutritionist approval required before save or patient assignment.
+- Warnings when constraints are missing, contradictory, or outside catalog data.
+- Clarifying questions for allergies, calorie target, meal count, restrictions, disease constraints, portions.
+
+---
+
+## Configuration
+
+```properties
+nutriconsultas.ai.enabled=${AI_ENABLED:false}
+nutriconsultas.ai.openai.api-key=${OPENAI_API_KEY:}
+nutriconsultas.ai.openai.model=${OPENAI_MODEL:}
+nutriconsultas.ai.openai.store=${OPENAI_STORE:false}
+nutriconsultas.ai.max-tool-calls=${AI_MAX_TOOL_CALLS:8}
+```
+
+Local `.env` / EC2 `app.env`: see issues #365 and #405.
+
+---
+
+## Subscription gating (Plus+)
+
+Issue **#409**: dedicated `Entitlement.AI_ASSISTANT` for **Plus and Consultorio** only.
+
+**Do not replace `REPORTS_ADVANCED`.** Reportes avanzados is already implemented (`assertCanAccessAdvancedReports`, #187) and included on **Profesional, Plus, and Consultorio**. AI assistant is a separate Plus+ differentiator — add a new pricing-table row on `eterna/index.html`, not a swap.
+
+---
+
+## Tool layer (initial)
+
+| Tool | Type | Purpose |
+|------|------|---------|
+| `search_food_catalog` | read | Search authorized foods |
+| `get_food_nutrients` | read | Nutrients for food + quantity + unit |
+| `search_dish_catalog` | read | Search authorized dishes |
+| `get_dish_recipe` | read | Dish recipe detail |
+| `calculate_recipe_nutrients` | read | Total / per-serving nutrients |
+| `get_diet_templates` | read | Template diets |
+| `validate_plan_constraints` | read | Calorie/macro/allergy validation |
+| `create_dish_draft` | draft | Store recipe draft |
+| `create_menu_draft` | draft | Store daily/weekly menu draft |
+| `create_diet_plan_draft` | draft | Store diet plan draft |
+
+**No tool** may assign a final plan to a patient.
+
+MCP names (Phase 7): `catalog.search_foods`, `catalog.get_food_nutrients`, `catalog.search_dishes`, `nutrition.calculate_recipe`, `nutrition.validate_menu`, `draft.create_dish`, `draft.create_menu`, `draft.create_diet_plan`.
+
+---
+
+## Data model (draft persistence)
+
+```text
+ai_chat_thread       — nutritionist_id, clinic_id, patient_id?, title, timestamps
+ai_chat_message      — thread_id, role, content, tool_name?, created_at
+ai_generated_draft   — thread_id, draft_type, status (DRAFT|ACCEPTED|DISCARDED), json_payload, timestamps
+```
+
+Liquibase incremental changesets only — see [`docs/db/LIQUIBASE.md`](../db/LIQUIBASE.md).
+
+---
+
+## REST API (proposed)
+
+```http
+POST /nutritionist/ai/chat/start
+POST /nutritionist/ai/chat/message
+GET  /nutritionist/ai/chat/{threadId}
+GET  /nutritionist/ai/chat/{threadId}/drafts
+POST /nutritionist/ai/drafts/{draftId}/accept
+POST /nutritionist/ai/drafts/{draftId}/discard
+```
+
+MCP (Phase 7): `POST /mcp/nutriconsultas`
+
+---
+
+## Milestones
+
+| Milestone | Phases | Outcome |
+|-----------|--------|---------|
+| **1 — AI Foundation** | 0, 1, 2 (#360–#371) | Secure OpenAI backend + chat/draft persistence |
+| **2 — Nutrition Tools** | 3, 4 (#372–#382) | Catalog search, nutrient calc, draft creation |
+| **3 — Chat UX** | 5, 6 (#383–#390) | Nutritionist chat window + draft review |
+| **4 — MCP** | 7 (#391–#395) | MCP-compatible tool server |
+| **5 — Safety & Release** | 8, 9, 10 (#396–#408) | Audit, evaluation, docs, rollout |
+
+---
+
+## Definition of done (whole project)
+
+- [ ] Nutritionists can open AI chat and request dish/menu/diet drafts
+- [ ] AI uses application tools for catalogs and nutrients
+- [ ] Clarifying questions when required
+- [ ] Drafts stored; accept/discard by owner nutritionist
+- [ ] No patient assignment without explicit approval
+- [ ] API key server-side only; endpoints authenticated and scoped
+- [ ] Liquibase migrations tested
+- [ ] Unit, integration, template, and security tests pass
+- [ ] Local, production, and nutritionist documentation complete
+- [ ] Feature disable via `AI_ENABLED=false`

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -1,0 +1,9 @@
+# AI Assistant docs
+
+Documentation for the **AI Nutrition Assistant** track.
+
+| Doc | Purpose |
+|-----|---------|
+| [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) | Architecture, security, tools, milestones, definition of done |
+| [`../../ISSUE-AI-ASSISTANT.md`](../../ISSUE-AI-ASSISTANT.md) | GitHub issue registry (#360–#408) |
+| [`../../AI-ASSISTANT-WORKFLOW.md`](../../AI-ASSISTANT-WORKFLOW.md) | Agent implementation workflow |

--- a/scripts/create-ai-assistant-issues.sh
+++ b/scripts/create-ai-assistant-issues.sh
@@ -1,0 +1,832 @@
+#!/usr/bin/env bash
+# One-time bootstrap: created GitHub issues #360–#408 on 2026-06-30.
+# Do not re-run unless extending the track with new issues.
+set -euo pipefail
+
+REPO="diego-torres/nutriconsultas"
+OUT="/tmp/ai-assistant-issues.json"
+echo "[]" > "$OUT"
+
+append_issue() {
+  local num="$1"
+  local title="$2"
+  local epic="$3"
+  local phase="$4"
+  jq --arg n "$num" --arg t "$title" --arg e "$epic" --arg p "$phase" \
+    '. += [{number: ($n|tonumber), title: $t, epic: ($e|tonumber), phase: $p}]' "$OUT" > "${OUT}.tmp" && mv "${OUT}.tmp" "$OUT"
+}
+
+create_epic() {
+  local phase="$1"
+  local title="$2"
+  local body="$3"
+  local labels="$4"
+  local url num
+  url="$(gh issue create --repo "$REPO" \
+    --title "[AI Assistant] Epic — $title" \
+    --label "$labels" \
+    --body "$body")"
+  num="${url##*/}"
+  append_issue "$num" "[AI Assistant] Epic — $title" "$num" "$phase"
+  echo "$num"
+}
+
+create_child() {
+  local epic="$1"
+  local phase="$2"
+  local title="$3"
+  local body="$4"
+  local labels="$5"
+  local url num
+  url="$(gh issue create --repo "$REPO" \
+    --title "[AI Assistant] $title" \
+    --label "$labels" \
+    --body "$body")"
+  num="${url##*/}"
+  append_issue "$num" "[AI Assistant] $title" "$epic" "$phase"
+  echo "$num"
+}
+
+EPIC0="$(create_epic "0" "Discovery and Architecture (Phase 0)" "$(cat <<'EOF'
+## Goal
+
+Document the architecture, security model, data flow, and first implementation scope for the AI nutrition assistant.
+
+## Milestone
+
+**Milestone 1 — AI Foundation** (with Phase 1 and Phase 2).
+
+## Child issues
+
+Created as part of this epic; see [`ISSUE-AI-ASSISTANT.md`](https://github.com/diego-torres/nutriconsultas/blob/main/ISSUE-AI-ASSISTANT.md).
+
+## Plan
+
+[`docs/ai/AI-ASSISTANT-PLAN.md`](https://github.com/diego-torres/nutriconsultas/blob/main/docs/ai/AI-ASSISTANT-PLAN.md)
+EOF
+)" "ai,documentation")"
+
+create_child "$EPIC0" "0" "Define AI Assistant Functional Scope" "$(cat <<EOF
+Part of epic #$EPIC0.
+
+## Description
+
+Define the first supported AI assistant workflows:
+
+- Create dish recipe draft
+- Create daily menu draft
+- Create weekly menu draft
+- Create dietary plan draft
+- Calculate nutrient totals
+- Validate plan constraints
+
+## Acceptance criteria
+
+- [ ] Document supported user prompts
+- [ ] Document unsupported prompts
+- [ ] Define what the assistant may do automatically
+- [ ] Define what requires nutritionist confirmation
+- [ ] Include examples for dish, menu, and diet-plan generation
+EOF
+)" "ai,documentation,nutrition"
+
+create_child "$EPIC0" "0" "Define AI Data Access Rules" "$(cat <<EOF
+Part of epic #$EPIC0.
+
+## Description
+
+Document what data the AI assistant may access and under which conditions.
+
+## Acceptance criteria
+
+- [ ] Define nutritionist/clinic scoping rules
+- [ ] Define patient-context access rules
+- [ ] Define which fields are safe to send to OpenAI
+- [ ] Define which fields must be excluded or redacted
+- [ ] Define logging and audit requirements
+- [ ] Confirm API keys are backend-only
+EOF
+)" "ai,documentation,security"
+
+create_child "$EPIC0" "0" "Design AI Tool Contract" "$(cat <<EOF
+Part of epic #$EPIC0.
+
+## Description
+
+Design backend tools that allow the AI assistant to interact with application data safely.
+
+## Initial tool list
+
+\`\`\`text
+search_food_catalog
+get_food_nutrients
+search_dish_catalog
+get_dish_recipe
+calculate_recipe_nutrients
+get_diet_templates
+validate_plan_constraints
+create_dish_draft
+create_menu_draft
+create_diet_plan_draft
+\`\`\`
+
+## Acceptance criteria
+
+- [ ] Each tool has a name, description, input schema, and output schema
+- [ ] Read-only tools are separated from draft-creation tools
+- [ ] No tool directly assigns final plans to patients
+- [ ] All tools include auth and clinic/nutritionist scoping requirements
+EOF
+)" "ai,documentation,mcp,backend"
+
+EPIC1="$(create_epic "1" "Backend OpenAI Integration (Phase 1)" "$(cat <<'EOF'
+## Goal
+
+Add backend-only OpenAI configuration and a service capable of sending chat requests and receiving structured responses.
+
+## Milestone
+
+**Milestone 1 — AI Foundation** (with Phase 0 and Phase 2).
+
+## Security
+
+- `OPENAI_API_KEY` / `OPEN_API_KEY` stored only in server environment variables
+- Never expose API key to browser, logs, or Git
+EOF
+)" "ai,backend,security")"
+
+create_child "$EPIC1" "1" "Add OpenAI Configuration Properties" "$(cat <<EOF
+Part of epic #$EPIC1.
+
+## Description
+
+Add backend configuration for OpenAI.
+
+## Required properties
+
+\`\`\`properties
+nutriconsultas.ai.enabled=\${AI_ENABLED:false}
+nutriconsultas.ai.openai.api-key=\${OPENAI_API_KEY:}
+nutriconsultas.ai.openai.model=\${OPENAI_MODEL:}
+nutriconsultas.ai.openai.store=\${OPENAI_STORE:false}
+nutriconsultas.ai.max-tool-calls=\${AI_MAX_TOOL_CALLS:8}
+\`\`\`
+
+## Acceptance criteria
+
+- [ ] Properties added to \`application.properties\`
+- [ ] \`.env.example\` documents the new variables
+- [ ] App fails safely when AI is enabled but API key is missing
+- [ ] API key is never logged
+- [ ] Unit test covers missing/disabled config behavior
+EOF
+)" "ai,backend,tests"
+
+create_child "$EPIC1" "1" "Add OpenAI Java Client or HTTP Client Integration" "$(cat <<EOF
+Part of epic #$EPIC1.
+
+## Description
+
+Add the backend integration used to call OpenAI from Spring Boot.
+
+## Acceptance criteria
+
+- [ ] Add required Maven dependency or implement Spring HTTP client
+- [ ] Create \`AiClient\` or \`OpenAiClientService\`
+- [ ] Support sending user messages and system instructions
+- [ ] Support structured output or tool/function calls
+- [ ] Add timeout handling
+- [ ] Add error handling for rate limits, auth failures, and unavailable model
+- [ ] Add unit tests with mocked responses
+EOF
+)" "ai,backend,integration,tests"
+
+create_child "$EPIC1" "1" "Create AI System Prompt Template" "$(cat <<EOF
+Part of epic #$EPIC1.
+
+## Description
+
+Create a server-side prompt template for nutrition drafting.
+
+## Prompt requirements
+
+The assistant should:
+
+- Help licensed nutrition professionals
+- Prefer application catalog tools over memory
+- Ask clarifying questions when needed
+- Return structured recipe/menu/diet drafts
+- Include assumptions and warnings
+- Never claim medical appropriateness without nutritionist review
+- Never directly assign a diet to a patient
+
+## Acceptance criteria
+
+- [ ] Prompt template stored server-side
+- [ ] Prompt supports locale, nutritionist context, and optional patient constraints
+- [ ] Unit tests verify key safety instructions are included
+EOF
+)" "ai,backend,nutrition,tests"
+
+EPIC2="$(create_epic "2" "AI Chat Persistence and Draft Storage (Phase 2)" "$(cat <<'EOF'
+## Goal
+
+Store AI chat threads, messages, and generated drafts in the database.
+
+## Milestone
+
+**Milestone 1 — AI Foundation** (with Phase 0 and Phase 1).
+EOF
+)" "ai,backend,liquibase,db")"
+
+create_child "$EPIC2" "2" "Add Liquibase Schema for AI Chat Tables" "$(cat <<EOF
+Part of epic #$EPIC2.
+
+## Description
+
+Create incremental Liquibase changesets for AI chat persistence.
+
+## Proposed tables
+
+\`\`\`text
+ai_chat_thread — id, nutritionist_id, clinic_id, patient_id (nullable), title, created_at, updated_at
+ai_chat_message — id, thread_id, role, content, tool_name (nullable), created_at
+ai_generated_draft — id, thread_id, draft_type, status, json_payload, created_at, accepted_at (nullable)
+\`\`\`
+
+## Acceptance criteria
+
+- [ ] New Liquibase changeset under \`db/changelog/changes/\`
+- [ ] Master changelog includes the new changeset
+- [ ] PostgreSQL migration works
+- [ ] H2/test migration works or is covered by integration test
+- [ ] No existing baseline changesets edited
+- [ ] Entity mappings and repositories added
+- [ ] Migration test added
+EOF
+)" "ai,liquibase,db,tests"
+
+create_child "$EPIC2" "2" "Implement AI Chat Domain Entities and Repositories" "$(cat <<EOF
+Part of epic #$EPIC2.
+
+Depends on Liquibase schema issue in this epic.
+
+## Acceptance criteria
+
+- [ ] Entities for chat thread, message, and generated draft
+- [ ] Repositories with scoped lookup methods
+- [ ] Created/updated timestamps
+- [ ] Draft status enum (\`DRAFT\`, \`ACCEPTED\`, \`DISCARDED\`)
+- [ ] Draft type enum
+- [ ] Unit tests cover persistence behavior
+EOF
+)" "ai,backend,db,tests"
+
+create_child "$EPIC2" "2" "Implement AI Draft Lifecycle" "$(cat <<EOF
+Part of epic #$EPIC2.
+
+## Acceptance criteria
+
+- [ ] Drafts created as \`DRAFT\`
+- [ ] Drafts can be accepted by owning nutritionist
+- [ ] Drafts can be discarded by owning nutritionist
+- [ ] Drafts cannot be accepted by another nutritionist
+- [ ] Accepted draft records are immutable or audit-safe
+- [ ] Service tests added
+EOF
+)" "ai,backend,tests"
+
+EPIC3="$(create_epic "3" "Backend Nutrition Tool Services (Phase 3)" "$(cat <<'EOF'
+## Goal
+
+Create safe backend services that the AI can call to search catalogs, calculate nutrients, and validate constraints.
+
+## Milestone
+
+**Milestone 2 — Nutrition Tools** (with Phase 4).
+EOF
+)" "ai,backend,nutrition,mcp")"
+
+create_child "$EPIC3" "3" "Implement Food Catalog Search Tool (search_food_catalog)" "$(cat <<EOF
+Part of epic #$EPIC3.
+
+## Tool name
+
+\`search_food_catalog\`
+
+## Acceptance criteria
+
+- [ ] Searches foods available to authenticated nutritionist
+- [ ] Supports query text and optional filters
+- [ ] Limits result count
+- [ ] Returns food ID, name, category, default unit, summary nutrients
+- [ ] Does not expose unauthorized catalog rows
+- [ ] Service tests included
+EOF
+)" "ai,backend,nutrition,tests"
+
+create_child "$EPIC3" "3" "Implement Food Nutrient Lookup Tool (get_food_nutrients)" "$(cat <<EOF
+Part of epic #$EPIC3.
+
+## Tool name
+
+\`get_food_nutrients\`
+
+## Acceptance criteria
+
+- [ ] Accepts food ID, quantity, and unit
+- [ ] Converts or validates units where supported
+- [ ] Returns calories, macros, and available micronutrients
+- [ ] Returns validation error when unit unsupported
+- [ ] Uses application database values, not model guesses
+- [ ] Unit tests included
+EOF
+)" "ai,backend,nutrition,tests"
+
+create_child "$EPIC3" "3" "Implement Dish Catalog Search Tool (search_dish_catalog)" "$(cat <<EOF
+Part of epic #$EPIC3.
+
+## Tool name
+
+\`search_dish_catalog\`
+
+## Acceptance criteria
+
+- [ ] Searches only authorized dishes
+- [ ] Returns dish ID, name, tags/category, serving info, nutrient summary
+- [ ] Supports max result limit
+- [ ] Tests for scoping included
+EOF
+)" "ai,backend,nutrition,tests"
+
+create_child "$EPIC3" "3" "Implement Recipe Nutrient Calculation Tool (calculate_recipe_nutrients)" "$(cat <<EOF
+Part of epic #$EPIC3.
+
+## Tool name
+
+\`calculate_recipe_nutrients\`
+
+## Acceptance criteria
+
+- [ ] Accepts ingredient list with food IDs, quantities, and units
+- [ ] Calculates total nutrients
+- [ ] Calculates per-serving nutrients
+- [ ] Returns warnings for missing nutrient values
+- [ ] Rejects unknown food IDs or unsupported units
+- [ ] Deterministic tests included
+EOF
+)" "ai,backend,nutrition,tests"
+
+create_child "$EPIC3" "3" "Implement Plan Constraint Validation Tool (validate_plan_constraints)" "$(cat <<EOF
+Part of epic #$EPIC3.
+
+## Tool name
+
+\`validate_plan_constraints\`
+
+## Acceptance criteria
+
+- [ ] Accepts structured draft and constraint object
+- [ ] Returns pass/warn/fail status
+- [ ] Returns specific warnings
+- [ ] Does not make clinical claims
+- [ ] Tests for common constraints included
+EOF
+)" "ai,backend,nutrition,tests"
+
+EPIC4="$(create_epic "4" "AI Draft Creation Tools (Phase 4)" "$(cat <<'EOF'
+## Goal
+
+Allow AI to create application draft records that nutritionists can review before saving final records.
+
+## Milestone
+
+**Milestone 2 — Nutrition Tools** (with Phase 3).
+
+## Rule
+
+No tool directly assigns final plans to patients.
+EOF
+)" "ai,backend,nutrition")"
+
+create_child "$EPIC4" "4" "Implement Dish Draft Creation Tool (create_dish_draft)" "$(cat <<EOF
+Part of epic #$EPIC4.
+
+## Acceptance criteria
+
+- [ ] Accepts structured recipe JSON
+- [ ] Stores draft as \`DRAFT\`
+- [ ] Includes ingredients, instructions, servings, nutrients, assumptions, warnings
+- [ ] Does not create final dish record
+- [ ] Requires authenticated nutritionist
+- [ ] Tests included
+EOF
+)" "ai,backend,nutrition,tests"
+
+create_child "$EPIC4" "4" "Implement Menu Draft Creation Tool (create_menu_draft)" "$(cat <<EOF
+Part of epic #$EPIC4.
+
+## Acceptance criteria
+
+- [ ] Accepts structured menu JSON
+- [ ] Supports daily and weekly menus
+- [ ] Includes meals, snacks, dishes, portions, nutrients, assumptions, warnings
+- [ ] Stores draft as \`DRAFT\`
+- [ ] Does not assign menu to patient
+- [ ] Tests included
+EOF
+)" "ai,backend,nutrition,tests"
+
+create_child "$EPIC4" "4" "Implement Diet Plan Draft Creation Tool (create_diet_plan_draft)" "$(cat <<EOF
+Part of epic #$EPIC4.
+
+## Acceptance criteria
+
+- [ ] Accepts structured diet-plan JSON
+- [ ] Supports patient-context constraints when authorized
+- [ ] Includes meals, portions, nutrients, assumptions, warnings
+- [ ] Stores draft as \`DRAFT\`
+- [ ] Does not assign plan to patient
+- [ ] Tests included
+EOF
+)" "ai,backend,nutrition,tests"
+
+create_child "$EPIC4" "4" "Implement Draft Acceptance Flow" "$(cat <<EOF
+Part of epic #$EPIC4.
+
+## Acceptance criteria
+
+- [ ] Nutritionist can accept own draft
+- [ ] Nutritionist can edit before saving where supported by existing UI patterns
+- [ ] Accepted dish draft creates real dish/recipe record
+- [ ] Accepted menu/diet draft creates appropriate application record
+- [ ] Draft status changes to \`ACCEPTED\`
+- [ ] Operation is audited
+- [ ] Controller and service tests included
+EOF
+)" "ai,backend,nutrition,tests,ux"
+
+EPIC5="$(create_epic "5" "AI Chat REST API (Phase 5)" "$(cat <<'EOF'
+## Goal
+
+Expose authenticated backend endpoints for the frontend chat window.
+
+## Milestone
+
+**Milestone 3 — Chat UX** (with Phase 6).
+EOF
+)" "ai,backend,security")"
+
+create_child "$EPIC5" "5" "Create AI Chat Controller" "$(cat <<EOF
+Part of epic #$EPIC5.
+
+## Proposed endpoints
+
+\`\`\`http
+POST /nutritionist/ai/chat/start
+POST /nutritionist/ai/chat/message
+GET /nutritionist/ai/chat/{threadId}
+GET /nutritionist/ai/chat/{threadId}/drafts
+POST /nutritionist/ai/drafts/{draftId}/accept
+POST /nutritionist/ai/drafts/{draftId}/discard
+\`\`\`
+
+## Acceptance criteria
+
+- [ ] All endpoints require authenticated nutritionist access
+- [ ] Thread access scoped to owner/clinic
+- [ ] Message endpoint calls AI orchestration service
+- [ ] Draft accept/discard endpoints validate ownership
+- [ ] Controller integration tests added
+EOF
+)" "ai,backend,security,tests"
+
+create_child "$EPIC5" "5" "Implement AI Orchestration Service" "$(cat <<EOF
+Part of epic #$EPIC5.
+
+## Acceptance criteria
+
+- [ ] Saves user message
+- [ ] Calls OpenAI with system prompt and conversation context
+- [ ] Executes allowed tools
+- [ ] Enforces max tool-call limit
+- [ ] Saves assistant response
+- [ ] Saves tool call summaries where useful
+- [ ] Handles OpenAI errors gracefully
+- [ ] Unit tests with mocked AI client and tools
+EOF
+)" "ai,backend,integration,tests"
+
+create_child "$EPIC5" "5" "Add Rate Limiting for AI Chat" "$(cat <<EOF
+Part of epic #$EPIC5.
+
+## Acceptance criteria
+
+- [ ] Resilience4j rate limiter for AI chat
+- [ ] Limit configurable through application properties
+- [ ] Friendly error when limit exceeded
+- [ ] Tests for rate-limited behavior
+EOF
+)" "ai,backend,security,tests"
+
+EPIC6="$(create_epic "6" "Nutritionist AI Chat UI (Phase 6)" "$(cat <<'EOF'
+## Goal
+
+Add a chat window in the nutritionist web interface.
+
+## Milestone
+
+**Milestone 3 — Chat UX** (with Phase 5).
+EOF
+)" "ai,frontend,ux")"
+
+create_child "$EPIC6" "6" "Add AI Chat Entry Point to Nutritionist UI" "$(cat <<EOF
+Part of epic #$EPIC6.
+
+## Acceptance criteria
+
+- [ ] Navigation/button/link added where appropriate
+- [ ] Only visible when \`AI_ENABLED=true\`
+- [ ] Hidden or disabled when AI is off
+- [ ] Does not expose API keys or backend configuration
+- [ ] Template validation updated
+EOF
+)" "ai,frontend,ux,tests"
+
+create_child "$EPIC6" "6" "Build AI Chat Window" "$(cat <<EOF
+Part of epic #$EPIC6.
+
+## Acceptance criteria
+
+- [ ] Displays conversation messages
+- [ ] Sends user messages to backend endpoint
+- [ ] Shows assistant responses
+- [ ] Shows loading state and errors
+- [ ] Supports starting new thread
+- [ ] Supports selecting existing thread if implemented
+- [ ] Accessible labels and keyboard-friendly behavior
+EOF
+)" "ai,frontend,ux,tests"
+
+create_child "$EPIC6" "6" "Build Draft Preview UI" "$(cat <<EOF
+Part of epic #$EPIC6.
+
+## Acceptance criteria
+
+- [ ] Shows draft type
+- [ ] Shows ingredients, meals, portions, nutrients, assumptions, warnings
+- [ ] Accept and Discard actions with explicit confirmation
+- [ ] Displays "AI draft, nutritionist review required"
+- [ ] Template validator updated
+- [ ] Controller tests added
+EOF
+)" "ai,frontend,ux,tests"
+
+EPIC7="$(create_epic "7" "MCP Tool Server for Nutriconsultas (Phase 7)" "$(cat <<'EOF'
+## Goal
+
+Expose selected nutrition tools through an MCP-compatible server endpoint so the same backend tool layer can be reused by AI agents.
+
+## Milestone
+
+**Milestone 4 — MCP and Agent Readiness**.
+EOF
+)" "ai,mcp,backend,security")"
+
+create_child "$EPIC7" "7" "Design MCP Server Endpoint" "$(cat <<EOF
+Part of epic #$EPIC7.
+
+## Proposed endpoint
+
+\`POST /mcp/nutriconsultas\`
+
+## Acceptance criteria
+
+- [ ] Document transport choice
+- [ ] Document authentication approach
+- [ ] Document available tools
+- [ ] Document read-only vs approval-required tools
+- [ ] Document input/output schemas
+- [ ] Do not expose patient data without authorization
+EOF
+)" "ai,mcp,documentation,security"
+
+create_child "$EPIC7" "7" "Implement MCP Tool Descriptors" "$(cat <<EOF
+Part of epic #$EPIC7.
+
+## Initial tools
+
+\`\`\`text
+catalog.search_foods
+catalog.get_food_nutrients
+catalog.search_dishes
+nutrition.calculate_recipe
+nutrition.validate_menu
+draft.create_dish
+draft.create_menu
+draft.create_diet_plan
+\`\`\`
+
+## Acceptance criteria
+
+- [ ] Each descriptor has name, title, description, input schema
+- [ ] Read-only tools marked read-only
+- [ ] Draft-creation tools require app-side confirmation before final save
+- [ ] Tool names stable and versionable
+- [ ] Tests verify descriptor output
+EOF
+)" "ai,mcp,backend,tests"
+
+create_child "$EPIC7" "7" "Implement MCP Tool Dispatch" "$(cat <<EOF
+Part of epic #$EPIC7.
+
+## Acceptance criteria
+
+- [ ] Dispatch maps MCP tool names to Spring services
+- [ ] Input validation enforced
+- [ ] Auth context required
+- [ ] Structured error responses
+- [ ] Tool calls logged with redaction
+- [ ] Tests cover success and failure
+EOF
+)" "ai,mcp,backend,security,tests"
+
+create_child "$EPIC7" "7" "Add MCP Security Review" "$(cat <<EOF
+Part of epic #$EPIC7.
+
+## Acceptance criteria
+
+- [ ] MCP endpoint requires authentication
+- [ ] Tool calls scoped to authenticated nutritionist/clinic
+- [ ] No global catalog or patient data leaks
+- [ ] No destructive write actions exposed
+- [ ] Draft creation allowed only as draft, not final save
+- [ ] Security tests added
+EOF
+)" "ai,mcp,security,tests"
+
+EPIC8="$(create_epic "8" "AI Safety and Observability (Phase 8)" "$(cat <<'EOF'
+## Goal
+
+Make AI usage safe, observable, auditable, and debuggable.
+
+## Milestone
+
+**Milestone 5 — Safety and Release** (with Phase 9 and Phase 10).
+EOF
+)" "ai,security,backend")"
+
+create_child "$EPIC8" "8" "Add AI Audit Logging" "$(cat <<EOF
+Part of epic #$EPIC8.
+
+## Acceptance criteria
+
+- [ ] Log chat request metadata
+- [ ] Log tool names called
+- [ ] Log draft creation and accept/discard events
+- [ ] Redact API keys and sensitive content
+- [ ] Tests for redaction behavior
+EOF
+)" "ai,security,backend,tests"
+
+create_child "$EPIC8" "8" "Add AI Usage Metrics" "$(cat <<EOF
+Part of epic #$EPIC8.
+
+## Acceptance criteria
+
+- [ ] Track chat messages, generated drafts, accepted drafts
+- [ ] Track OpenAI errors and rate-limited requests
+- [ ] Metrics do not include PHI
+EOF
+)" "ai,backend,tests"
+
+create_child "$EPIC8" "8" "Add AI Error Handling UX" "$(cat <<EOF
+Part of epic #$EPIC8.
+
+## Acceptance criteria
+
+- [ ] Handle missing API key, disabled AI, OpenAI timeout, rate limit
+- [ ] Handle malformed tool response and unavailable catalog data
+- [ ] UI displays helpful error without stack trace
+EOF
+)" "ai,frontend,ux,tests"
+
+EPIC9="$(create_epic "9" "AI Nutrition Evaluation Suite (Phase 9)" "$(cat <<'EOF'
+## Goal
+
+Create repeatable tests and sample prompts to evaluate quality and safety.
+
+## Milestone
+
+**Milestone 5 — Safety and Release** (with Phase 8 and Phase 10).
+EOF
+)" "ai,tests,nutrition")"
+
+create_child "$EPIC9" "9" "Add Golden Prompt Test Cases" "$(cat <<EOF
+Part of epic #$EPIC9.
+
+## Suggested cases
+
+High-protein breakfast; low-sodium day menu; 7-day weight-loss menu; egg allergy; diabetic-friendly menu; vegetarian weekly plan; unsupported ingredient; menu missing calorie target.
+
+## Acceptance criteria
+
+- [ ] Test cases documented
+- [ ] Expected tool usage documented
+- [ ] Expected warnings documented
+- [ ] Cases runnable manually or via automated tests
+EOF
+)" "ai,tests,nutrition,documentation"
+
+create_child "$EPIC9" "9" "Add Structured Output Validation" "$(cat <<EOF
+Part of epic #$EPIC9.
+
+## Acceptance criteria
+
+- [ ] Dish, menu, and diet-plan draft JSON schemas exist
+- [ ] Invalid JSON rejected
+- [ ] Missing required fields rejected
+- [ ] Validation errors shown to nutritionist or handled gracefully
+EOF
+)" "ai,backend,tests,nutrition"
+
+create_child "$EPIC9" "9" "Add End-to-End AI Draft Flow Test" "$(cat <<EOF
+Part of epic #$EPIC9.
+
+## Acceptance criteria
+
+- [ ] Mock OpenAI response
+- [ ] Mock tool calls or use test catalog data
+- [ ] Send chat message; verify assistant response stored
+- [ ] Verify generated draft stored
+- [ ] Verify draft accept/discard
+- [ ] Verify unauthorized nutritionist cannot access
+EOF
+)" "ai,tests,backend,security"
+
+EPIC10="$(create_epic "10" "AI Assistant Documentation and Release (Phase 10)" "$(cat <<'EOF'
+## Goal
+
+Document setup, configuration, behavior, and rollout steps.
+
+## Milestone
+
+**Milestone 5 — Safety and Release** (with Phase 8 and Phase 9).
+EOF
+)" "ai,documentation,infrastructure")"
+
+create_child "$EPIC10" "10" "Document Local AI Setup" "$(cat <<EOF
+Part of epic #$EPIC10.
+
+## Acceptance criteria
+
+- [ ] Document \`OPENAI_API_KEY\`, \`OPENAI_MODEL\`, \`AI_ENABLED\`
+- [ ] Document how to disable AI locally
+- [ ] Warn not to commit keys
+- [ ] Troubleshooting steps included
+EOF
+)" "ai,documentation"
+
+create_child "$EPIC10" "10" "Document Production AI Setup" "$(cat <<EOF
+Part of epic #$EPIC10.
+
+## Acceptance criteria
+
+- [ ] Where production key is stored (EC2 \`app.env\`, SSM scripts)
+- [ ] Backend-only usage explained
+- [ ] Rate limits and spend controls documented
+- [ ] Rollback/disable strategy documented
+EOF
+)" "ai,documentation,infrastructure,security"
+
+create_child "$EPIC10" "10" "Add Nutritionist User Guidance" "$(cat <<EOF
+Part of epic #$EPIC10.
+
+## Acceptance criteria
+
+- [ ] AI outputs are drafts; nutritionist review required
+- [ ] Examples of good prompts
+- [ ] Limitations explained
+- [ ] How to accept/discard drafts
+EOF
+)" "ai,documentation,ux,nutrition"
+
+create_child "$EPIC10" "10" "Create AI Assistant Release Checklist" "$(cat <<EOF
+Part of epic #$EPIC10.
+
+## Checklist must include
+
+- [ ] AI disabled by default
+- [ ] API key in staging/production secret store
+- [ ] Rate limiting enabled
+- [ ] Audit logging enabled
+- [ ] Draft approval flow tested
+- [ ] Security tests passing
+- [ ] Liquibase migration tested
+- [ ] Rollback plan documented
+- [ ] Nutritionist guidance published
+EOF
+)" "ai,documentation,infrastructure,security"
+
+echo "Created issues. Output: $OUT"
+cat "$OUT"


### PR DESCRIPTION
## Summary
- Adds the `[AI Assistant]` issue registry (`ISSUE-AI-ASSISTANT.md`), plan (`docs/ai/AI-ASSISTANT-PLAN.md`), and agent workflow for GitHub issues #360–#409.
- Documents track principles: Spanish-only user-facing comms, Plus+ plan gating (#409), draft-only workflow, and backend-only OpenAI secrets.
- Links the new track from `AGENTS.md` and `AGENT-WORKFLOW.md`; adds placeholder OpenAI vars to `.env.example` (no real keys).
- Includes one-time bootstrap script `scripts/create-ai-assistant-issues.sh` (issues already created on GitHub).

## Test plan
- [x] Confirm `.env` is gitignored and not in the commit
- [x] Review registry links to GitHub issues #360–#409
- [ ] Merge docs-only PR; no runtime changes to validate


Made with [Cursor](https://cursor.com)