### PR TITLE
docs(ai): define AI data access rules (Fixes #362)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#362 — Define AI Data Access Rules](https://github.com/diego-torres/nutriconsultas/issues/362) (`NEXT`). ~~#361~~ **done** — [`docs/ai/FUNCTIONAL-SCOPE.md`](docs/ai/FUNCTIONAL-SCOPE.md). See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#363 — Design AI Tool Contract](https://github.com/diego-torres/nutriconsultas/issues/363) (`NEXT`). ~~#362~~ **done** — [`docs/ai/DATA-ACCESS-RULES.md`](docs/ai/DATA-ACCESS-RULES.md). See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#362 — Define AI Data Access Rules](https://github.com/diego-torres/nutriconsultas/issues/362) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). Issue #361 functional scope: [`docs/ai/FUNCTIONAL-SCOPE.md`](docs/ai/FUNCTIONAL-SCOPE.md).
+**Current next issue:** [#363 — Design AI Tool Contract](https://github.com/diego-torres/nutriconsultas/issues/363) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#362~~ data access: [`docs/ai/DATA-ACCESS-RULES.md`](docs/ai/DATA-ACCESS-RULES.md).
 
 ---
 
@@ -26,7 +26,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | **Feature flag** | `AI_ENABLED=false` by default until release checklist (#408) passes. |
 | **Drafts only** | AI creates `DRAFT` records; nutritionist must accept before real platillo/dieta/patient assignment. |
 | **Multi-tenant** | All catalog and patient-context tools scoped to authenticated nutritionist / clinic — same rules as [`Paciente.userId`](src/main/java/com/nutriconsultas/paciente/Paciente.java). |
-| **Privacy** | Minimum patient data to OpenAI; no names/emails/phones in prompts or unstructured logs; use `LogRedaction`. |
+| **Privacy** | Minimum patient data to OpenAI; no names/emails/phones in prompts or unstructured logs; see [`DATA-ACCESS-RULES.md`](docs/ai/DATA-ACCESS-RULES.md) (#362). |
 | **Schema gate** | #46 Liquibase baseline on `main`. All `ai_chat_*` tables → incremental changesets ([`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md)). |
 | **Medical safety** | Assistant is a **drafting tool** — include assumptions, warnings, clarifying questions; never auto-assign diets. |
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#361~~ functional scope **done**. **NEXT:** #362.
+**Last updated:** 2026-06-30 — ~~#362~~ data access rules **done**. **NEXT:** #363.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -58,8 +58,8 @@ Document architecture, security model, data flow, and first implementation scope
 |---|-------|-----|-------|------------|-------|
 | **360** | Epic — Discovery and Architecture (Phase 0) | https://github.com/diego-torres/nutriconsultas/issues/360 | **open** | — | Milestone 1 |
 | **361** | Define AI Assistant Functional Scope | https://github.com/diego-torres/nutriconsultas/issues/361 | **done** | **360** | [`docs/ai/FUNCTIONAL-SCOPE.md`](docs/ai/FUNCTIONAL-SCOPE.md) |
-| **362** | Define AI Data Access Rules | https://github.com/diego-torres/nutriconsultas/issues/362 | **NEXT** | **360** | PHI redaction, scoping |
-| **363** | Design AI Tool Contract | https://github.com/diego-torres/nutriconsultas/issues/363 | **open** | **360**, **362** | Tool schemas; read vs draft |
+| **362** | Define AI Data Access Rules | https://github.com/diego-torres/nutriconsultas/issues/362 | **done** | **360** | [`docs/ai/DATA-ACCESS-RULES.md`](docs/ai/DATA-ACCESS-RULES.md) |
+| **363** | Design AI Tool Contract | https://github.com/diego-torres/nutriconsultas/issues/363 | **NEXT** | **360**, **362** | Tool schemas; read vs draft |
 
 **Suggested order:** #361 + #362 parallel → #363.
 

--- a/docs/ai/AI-ASSISTANT-PLAN.md
+++ b/docs/ai/AI-ASSISTANT-PLAN.md
@@ -94,7 +94,7 @@ The backend owns all sensitive logic. The frontend is only a chat interface and 
 
 ## Privacy
 
-- Send **minimum** patient data to OpenAI.
+- Send **minimum** patient data to OpenAI — see [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md) (#362).
 - Avoid names, emails, phone numbers, free-text notes unless strictly required.
 - Prefer internal IDs and structured clinical/nutrition constraints.
 - Store chat history and drafts in PostgreSQL with retention rules.

--- a/docs/ai/DATA-ACCESS-RULES.md
+++ b/docs/ai/DATA-ACCESS-RULES.md
@@ -1,0 +1,262 @@
+# AI Nutrition Assistant — Data Access Rules (v1)
+
+**Issue:** [#362](https://github.com/diego-torres/nutriconsultas/issues/362) · Epic [#360](https://github.com/diego-torres/nutriconsultas/issues/360)  
+**Related:** [`FUNCTIONAL-SCOPE.md`](FUNCTIONAL-SCOPE.md) (#361) · [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md)
+
+Rules for what the AI assistant may read, send to OpenAI, persist, and log. Implementation follows in orchestration (#385), tools (#372–#378), and audit (#397).
+
+---
+
+## Principles
+
+| Rule | Detail |
+|------|--------|
+| **Backend gatekeeper** | Only Spring services build outbound OpenAI payloads; browser never sees API keys or raw patient rows. |
+| **Minimum necessary** | Send the smallest structured subset needed for drafting; prefer IDs + numeric constraints over free text. |
+| **Tenant isolation** | Same boundaries as nutritionist web: `Paciente.userId`, catalog ownership, plan tier (#409). |
+| **No silent writes** | Tools may create **drafts** only; no final patient assignment or catalog mutation without nutritionist accept (#382). |
+| **Spanish comms** | User-facing assistant text is es-MX; internal JSON field names may stay English. |
+
+---
+
+## Authentication and plan gating
+
+| Check | When | Failure |
+|-------|------|---------|
+| OAuth2 session (nutritionist) | Every `/nutritionist/ai/**` and MCP call | 401 / redirect to login |
+| `AI_ENABLED=true` | Feature flag | 503 friendly Spanish message |
+| `Entitlement.AI_ASSISTANT` (#409) | Plus + Consultorio only | 403 upgrade message (Spanish) |
+| Rate limit (#386) | Per nutritionist / window | 429 friendly message |
+
+OpenAI credentials (`OPENAI_API_KEY`, legacy `OPEN_API_KEY`) exist **only** in server env / `app.env` — never in Thymeleaf, JavaScript, REST JSON, Git, or application logs.
+
+---
+
+## Nutritionist and clinic scoping
+
+### v1 — owning nutritionist (default)
+
+All AI data access uses the authenticated nutritionist’s OAuth **`sub`** as `userId`.
+
+| Resource | Access rule | Repository / pattern |
+|----------|-------------|----------------------|
+| **Patient** | `paciente.userId == principal.sub` | `findByIdAndUserId(id, userId)` + `verifyPatientOwnership()` |
+| **AI chat thread** | `thread.nutritionistId == principal.sub` | Scoped repository lookup |
+| **Platillo catalog** | System rows + rows where `platillo.userId == userId` (or platform admin) | `PlatilloAuthorization` |
+| **Dieta catalog** | System templates + owned + patient copies for owned patients | `DietaAuthorization`, `pacienteId` check |
+| **Alimento catalog** | Global reference catalog (read); tenant does not split alimentos by user in v1 | Existing `AlimentosRepository` |
+| **Drafts** | `draft.thread.nutritionistId == userId` | Join through `ai_chat_thread` |
+
+**Cross-tenant access is forbidden.** Another nutritionist’s patients, threads, drafts, or owned platillos must return **404** (prefer over 403 for IDOR on patient/thread IDs).
+
+### Clinic / director (v1)
+
+**Out of scope for v1.** A `director-consultorio` does **not** automatically receive another member’s patients in AI chat. Directors use existing clinic admin flows; AI threads are always owned by the **nutritionist who created them**.
+
+Future issue may allow director read-only oversight with explicit audit — not in v1.
+
+### Platform admin
+
+Platform admins (`PlatformAdminService`) are not AI super-users in v1. AI assistant remains a **nutritionist workflow** tool.
+
+---
+
+## Patient-context access rules
+
+Patient context is **optional**. It is loaded only when:
+
+1. The nutritionist starts or continues a thread with `patient_id` set, **and**
+2. `findByIdAndUserId(patientId, userId)` succeeds.
+
+If the patient is not owned by the user, **do not** attach context and return 404 on thread access.
+
+### Caloric target resolution
+
+Reuse existing diet-assignment logic, extended for stress:
+
+| Field | Include in OpenAI context | Notes |
+|-------|---------------------------|-------|
+| `requerimientoKcal` | yes | `totalAdjustedKcal` if set, else `getKcal` — same as [`resolveRequerimientoKcal`](../../src/main/java/com/nutriconsultas/paciente/PacienteController.java) |
+| `finalTotalKcal` | yes, when `physiologicalStressActive == true` | Preferred planning target under stress |
+| `bmr`, `getKcal`, `tefKcal`, `stressKcal` | optional breakdown | Helps assistant explain assumptions |
+| `peso`, `estatura`, `imc`, `nivelPeso` | yes | Numeric / enum only |
+| `gender` | yes | `M` / `F` — needed for some calculations |
+| `pregnancy` | yes | Boolean |
+
+Do **not** send `dob` or age derived to OpenAI in v1 unless a later issue requires it; nutritionist can state age band in chat if needed.
+
+### Pathology and restrictions
+
+| Field | OpenAI v1 | Notes |
+|-------|-----------|-------|
+| Pathology booleans (`diabetes`, `hipertension`, …) | **Allow** | From `PacienteMedicalHistory` |
+| `alergias` | **Allow** (truncated) | Max **500 characters**; strip control chars; required for exclusion lists |
+| `historialAlimenticio` | **Deny** default | High PHI density; nutritionist can paraphrase in chat |
+| `antecedentesPatologicosPersonales` / `Familiares` | **Deny** | Use booleans + chat instead |
+| `complicaciones`, `desarrolloPsicomotor`, prenatal/natal text | **Deny** | |
+| `tipoSanguineo` | **Deny** | Not needed for menu drafting in v1 |
+| `responsibleName`, `parentesco` | **Deny** | Contact PHI |
+
+### Energy preferences
+
+| Field | OpenAI v1 |
+|-------|-----------|
+| `physicalActivityLevel`, `activityFactor` | Allow |
+| `physiologicalStressActive`, `physiologicalStressType` | Allow (enum names) |
+| `tefMethod`, `tefFixedPercent`, macro TEF percents | Allow |
+| `stressValidFrom` / `stressValidUntil` | Deny (dates) |
+
+### Identifiers in OpenAI payload
+
+| Field | OpenAI v1 |
+|-------|-----------|
+| `patientId` (internal Long) | **Allow** — opaque ID, not PHI by itself |
+| `assignedId` | **Deny** — often human-readable clinical code |
+| `name`, `displayName` | **Deny** |
+| `email`, `emailHint`, `phone` | **Deny** |
+| `patientAuthSub` | **Deny** |
+| `userId` (nutritionist) | **Deny** in patient DTO — already implied by session |
+
+### Proposed DTO shape (implementation #385)
+
+Server builds `AiPatientContext` (name illustrative):
+
+```json
+{
+  "patientId": 42,
+  "gender": "F",
+  "pregnancy": false,
+  "requerimientoKcal": 2457.0,
+  "finalTotalKcal": 2600.0,
+  "physiologicalStressActive": true,
+  "imc": 23.7,
+  "nivelPeso": "NORMAL",
+  "pathologyFlags": {
+    "diabetes": false,
+    "hipertension": true,
+    "obesidad": false
+  },
+  "alergias": "Mariscos, nueces",
+  "activityLevel": "MODERATE"
+}
+```
+
+Never serialize the full `Paciente` entity to OpenAI.
+
+---
+
+## Catalog and tool data boundaries
+
+| Tool class | Data returned to model | Scoping |
+|------------|------------------------|---------|
+| Read-only catalog | Food/dish IDs, names, nutrients, units | Authorized rows only; cap result count (e.g. 10–25) |
+| Nutrient calculation | Computed numbers from DB | Input food IDs validated against catalog |
+| Draft creation | Draft JSON stored in PostgreSQL | `nutritionistId` from session |
+| Patient clinical timeline | **Not exposed** | No `CalendarEvent`, `ClinicalExam`, `AnthropometricMeasurement` series, `PatientMessage` tools in v1 |
+| Mobile / `patientAuthSub` | **Not exposed** | |
+
+System catalog platillos/dietas are readable like today’s web app; mutating system rows remains platform-admin only (unchanged).
+
+---
+
+## OpenAI payload hygiene
+
+### Always exclude from outbound requests
+
+- API keys, webhook secrets, Auth0 secrets
+- Patient name, email, phone, DOB, responsible contact
+- Free-text antecedents and clinical notes
+- Full chat history from **other** nutritionists or patients
+- Other tenants’ catalog rows
+- Raw SQL, stack traces, or internal stack metadata
+
+### Conversation history sent to OpenAI
+
+- Messages from **current thread** only, owned by caller
+- System prompt (#367) includes safety + Spanish + tool-use rules
+- Optional: truncate older turns beyond token budget (implementation #385); persist full history locally regardless
+
+### `OPENAI_STORE`
+
+Default **`false`** (`nutriconsultas.ai.openai.store=${OPENAI_STORE:false}`). Do not enable provider-side conversation retention for PHI-bearing threads without legal review.
+
+---
+
+## Logging and audit (#397)
+
+Align with [`PHI-LOGGING-AUDIT.md`](../mobile-api/PHI-LOGGING-AUDIT.md) and [`LogRedaction`](../../src/main/java/com/nutriconsultas/util/LogRedaction.java).
+
+### May log (INFO)
+
+| Event | Example |
+|-------|---------|
+| Thread created | `AI thread id=123 nutritionist=[redacted-user]` |
+| Message sent | `AI message threadId=123 role=user` (not full body at INFO) |
+| Tool invoked | `AI tool search_food_catalog threadId=123 resultCount=8` |
+| Draft created | `AI draft id=456 type=DIET_PLAN threadId=123` |
+| Draft accept/discard | `AI draft id=456 status=ACCEPTED` |
+| OpenAI error class | `AI openai_error type=rate_limit threadId=123` |
+| Plan denied | `AI access_denied reason=missing_entitlement` |
+
+### Must not log (any level unless DEBUG with redaction policy)
+
+- OpenAI API key or request `Authorization` header
+- Full user/assistant message bodies containing `alergias` or patient context at INFO
+- Patient `name`, `email`, `phone`, `dob`
+- Entire `Paciente` or `PacienteMedicalHistory` objects
+- Raw OpenAI request/response JSON at INFO
+
+### DEBUG
+
+- If DEBUG logging of prompts is needed in development, gate behind profile `dev` + explicit property `nutriconsultas.ai.debug-log-prompts=false` default **false** in all deployed environments.
+
+### Audit trail (database)
+
+Persist in `ai_chat_message` / `ai_generated_draft` (#369). Retention: follow general application backup policy; document in #405/#406.
+
+---
+
+## API key handling (confirmation)
+
+| Location | Allowed |
+|----------|---------|
+| EC2 `/opt/nutriconsultas/app.env`, local `.env` (gitignored) | yes |
+| Spring `Environment` / `@Value` in server beans | yes |
+| Thymeleaf model attributes | **no** |
+| Browser JS, HTML comments, REST responses | **no** |
+| INFO/WARN/ERROR logs | **no** |
+| Git, CI logs, error trackers | **no** |
+| OpenAI request from browser | **no** — all calls server-side |
+
+Rotate keys if exposed. Use separate test keys locally; never commit `.env`.
+
+---
+
+## Security test expectations (#395, #403)
+
+- User A cannot read user B’s thread, drafts, or patient-linked context (404)
+- Profesional/Básico user receives 403 on AI endpoints when #409 enforced
+- Patient context omitted when `patient_id` null
+- Outbound OpenAI payload snapshot tests assert deny-list fields absent
+- Logs under test do not contain sample patient name/email from fixtures
+
+---
+
+## Related documents
+
+| Doc | Issue |
+|-----|-------|
+| [`FUNCTIONAL-SCOPE.md`](FUNCTIONAL-SCOPE.md) | Workflows and patient-linked UX |
+| Tool JSON schemas | #363 |
+| Audit logging implementation | #397 |
+| Production setup | #406 |
+
+---
+
+## Acceptance checklist (#362)
+
+- [x] Nutritionist/clinic scoping rules defined
+- [x] Patient-context access rules defined
+- [x] Safe vs excluded OpenAI fields defined
+- [x] Logging and audit requirements defined
+- [x] API keys backend-only confirmed

--- a/docs/ai/FUNCTIONAL-SCOPE.md
+++ b/docs/ai/FUNCTIONAL-SCOPE.md
@@ -261,23 +261,22 @@ Used when:
 - **Patient diet editor** — [`DietaController`](../../src/main/java/com/nutriconsultas/dieta/DietaController.java) when `Dieta.pacienteId` is set
 - **Diet picker REST** — `GET /rest/dietas/picker?requerimientoKcal=…` via [`DietasRestController`](../../src/main/java/com/nutriconsultas/dieta/DietasRestController.java)
 
-**Note:** `resolveRequerimientoKcal` uses **GET+TEF** (`totalAdjustedKcal`), not `finalTotalKcal` (which adds stress). Profile and antropométricos UI show both; AI context should expose **`finalTotalKcal` when stress is active**, or document which target the nutritionist expects (#362).
+**Note:** `resolveRequerimientoKcal` uses **GET+TEF** (`totalAdjustedKcal`), not `finalTotalKcal` (which adds stress). When stress is active, AI context should prefer `finalTotalKcal` — see [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md).
 
 ### Suggested AI patient context (for prompt / tools)
 
-When `patient_id` is set on the thread, backend builds a **structured, redacted** object (no name/email/phone in the OpenAI prompt — see #362):
+When `patient_id` is set on the thread, backend builds **`AiPatientContext`** per [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md) (#362) — not the full `Paciente` entity.
 
 | Include | Source | Example use |
 |---------|--------|-------------|
 | `requerimientoKcal` | Same as `resolveRequerimientoKcal` | Default calorie target for menus/plans |
 | `finalTotalKcal` | `Paciente.finalTotalKcal` | When `physiologicalStressActive` |
 | Pathology booleans | `PacienteMedicalHistory` | Constraint validation, stress awareness |
-| `alergias` | text | Excluded foods — **minimum necessary text** |
-| `pregnancy`, `nivelPeso`, `imc` | demographics / snapshot | Clarifying questions |
-| `historialAlimenticio` | text | Optional summary only if short — redact in #362 |
+| `alergias` | text (max 500 chars) | Excluded foods |
+| `pregnancy`, `nivelPeso`, `imc`, `gender` | demographics / snapshot | Clarifying questions |
 | Activity / stress enums | `PacienteEnergyPreferences` | Explain GET calculation assumptions |
 
-**Do not** send full `antecedentesPatologicosPersonales` free text to OpenAI by default; prefer booleans + `alergias` + nutritionist-stated constraints in chat.
+**Exclude** name, email, phone, DOB, `assignedId`, `patientAuthSub`, and free-text antecedents — see deny list in DATA-ACCESS-RULES.
 
 ### Entry points (v1 UI)
 
@@ -300,7 +299,7 @@ Orchestration (#385) merges this context into the system prompt (#367) so the as
 | Image generation for platillos | Future issue |
 | Import from photo or PDF | Future issue |
 | Multi-language assistant | Future — v1 es-MX only |
-| Clinic director acting on behalf of member | Define in #362 if needed |
+| Clinic director AI on member patients | Future — v1 owner nutritionist only ([#362](DATA-ACCESS-RULES.md)) |
 
 ---
 
@@ -309,7 +308,7 @@ Orchestration (#385) merges this context into the system prompt (#367) so the as
 | Doc | Issue |
 |-----|-------|
 | [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) | Architecture |
-| Data access rules (planned) | #362 |
+| [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md) | PHI, scoping, logging (#362) |
 | Tool JSON schemas (planned) | #363 |
 | System prompt requirements | #367 |
 | Plan gating | #409 |

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -4,6 +4,7 @@ Documentation for the **AI Nutrition Assistant** track.
 
 | Doc | Purpose |
 |-----|---------|
+| [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md) | PHI, scoping, OpenAI allow/deny lists, logging (#362) |
 | [`FUNCTIONAL-SCOPE.md`](FUNCTIONAL-SCOPE.md) | Supported workflows, prompts, confirmation rules (#361) |
 | [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) | Architecture, security, tools, milestones, definition of done |
 | [`../../ISSUE-AI-ASSISTANT.md`](../../ISSUE-AI-ASSISTANT.md) | GitHub issue registry (#360–#408) |


### PR DESCRIPTION
## Summary
- Adds [`docs/ai/DATA-ACCESS-RULES.md`](docs/ai/DATA-ACCESS-RULES.md) covering nutritionist tenant scoping, patient-context allow/deny lists for OpenAI, proposed `AiPatientContext` shape, logging/audit rules, and backend-only API key handling.
- Updates registry (`ISSUE-AI-ASSISTANT.md`), workflow pointers, and cross-links from `FUNCTIONAL-SCOPE.md` and `AI-ASSISTANT-PLAN.md`.
- Marks #362 done; **NEXT** is #363 (Design AI Tool Contract).

## Test plan
- [x] Acceptance criteria in #362 reflected in doc checklist
- [x] Cross-links resolve to new doc
- [x] No code changes; docs-only PR

Fixes #362

Made with [Cursor](https://cursor.com)