### PR TITLE
feat(ai): add AI system prompt template (Fixes #367)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#367 — Create AI System Prompt Template](https://github.com/diego-torres/nutriconsultas/issues/367) (`NEXT`). ~~#366~~ **done** — `OpenAiClientService`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#368 — Epic AI Chat Persistence](https://github.com/diego-torres/nutriconsultas/issues/368) (`NEXT`). ~~#367~~ **done** — `AiSystemPromptService`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#367 — Create AI System Prompt Template](https://github.com/diego-torres/nutriconsultas/issues/367) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#366~~ client: `OpenAiClientService`.
+**Current next issue:** [#368 — Epic AI Chat Persistence](https://github.com/diego-torres/nutriconsultas/issues/368) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#367~~ prompt: `AiSystemPromptService`.
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#366~~ OpenAI client **done**. **NEXT:** #367.
+**Last updated:** 2026-06-30 — ~~#367~~ system prompt **done**. **NEXT:** #368.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -71,12 +71,12 @@ Backend-only OpenAI configuration and client service.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **364** | Epic — Backend OpenAI Integration (Phase 1) | https://github.com/diego-torres/nutriconsultas/issues/364 | **open** | **363** | Milestone 1 |
+| **364** | Epic — Backend OpenAI Integration (Phase 1) | https://github.com/diego-torres/nutriconsultas/issues/364 | **done** | **363** | Milestone 1 — ~~#365–#367~~ |
 | **365** | Add OpenAI Configuration Properties | https://github.com/diego-torres/nutriconsultas/issues/365 | **done** | **364**, **363** | `AiProperties`, `application.properties` |
 | **366** | Add OpenAI Java Client or HTTP Client Integration | https://github.com/diego-torres/nutriconsultas/issues/366 | **done** | **365** | `OpenAiClientService` |
-| **367** | Create AI System Prompt Template | https://github.com/diego-torres/nutriconsultas/issues/367 | **NEXT** | **364**, **361** | Server-side safety prompt; **respond in Spanish** |
+| **367** | Create AI System Prompt Template | https://github.com/diego-torres/nutriconsultas/issues/367 | **done** | **364**, **361** | `AiSystemPromptService`, `ai/system-prompt-base.txt` |
 
-**Suggested order:** ~~#366~~ → #367.
+**Suggested order:** ~~#367~~.
 
 ---
 
@@ -86,7 +86,7 @@ Store chat threads, messages, and generated drafts.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **368** | Epic — AI Chat Persistence and Draft Storage (Phase 2) | https://github.com/diego-torres/nutriconsultas/issues/368 | **open** | **364** | Milestone 1 |
+| **368** | Epic — AI Chat Persistence and Draft Storage (Phase 2) | https://github.com/diego-torres/nutriconsultas/issues/368 | **NEXT** | **364** | Milestone 1 |
 | **369** | Add Liquibase Schema for AI Chat Tables | https://github.com/diego-torres/nutriconsultas/issues/369 | **open** | **368**, #46 | `ai_chat_*` tables |
 | **370** | Implement AI Chat Domain Entities and Repositories | https://github.com/diego-torres/nutriconsultas/issues/370 | **open** | **369** | JPA + scoped repos |
 | **371** | Implement AI Draft Lifecycle | https://github.com/diego-torres/nutriconsultas/issues/371 | **open** | **370** | DRAFT / ACCEPTED / DISCARDED |

--- a/docs/ai/DATA-ACCESS-RULES.md
+++ b/docs/ai/DATA-ACCESS-RULES.md
@@ -247,7 +247,7 @@ Rotate keys if exposed. Use separate test keys locally; never commit `.env`.
 | Doc | Issue |
 |-----|-------|
 | [`FUNCTIONAL-SCOPE.md`](FUNCTIONAL-SCOPE.md) | Workflows and patient-linked UX |
-| [`TOOL-CONTRACT.md`](TOOL-CONTRACT.md) | Tool JSON schemas (#363) |
+| System prompt (#367) | `AiSystemPromptService`, `ai/system-prompt-base.txt` |
 | Audit logging implementation | #397 |
 | Production setup | #406 |
 

--- a/docs/ai/FUNCTIONAL-SCOPE.md
+++ b/docs/ai/FUNCTIONAL-SCOPE.md
@@ -310,7 +310,7 @@ Orchestration (#385) merges this context into the system prompt (#367) so the as
 | [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) | Architecture |
 | [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md) | PHI, scoping, logging (#362) |
 | [`TOOL-CONTRACT.md`](TOOL-CONTRACT.md) | Tool JSON schemas (#363) |
-| System prompt requirements | #367 |
+| System prompt | #367 — `AiSystemPromptService`, `ai/system-prompt-base.txt` |
 | Plan gating | #409 |
 
 ---

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -7,6 +7,7 @@ Documentation for the **AI Nutrition Assistant** track.
 | [`TOOL-CONTRACT.md`](TOOL-CONTRACT.md) | Tool names, JSON schemas, read vs draft (#363) |
 | [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md) | PHI, scoping, OpenAI allow/deny lists, logging (#362) |
 | [`FUNCTIONAL-SCOPE.md`](FUNCTIONAL-SCOPE.md) | Supported workflows, prompts, confirmation rules (#361) |
+| `ai/system-prompt-base.txt` + `AiSystemPromptService` | Server system prompt (#367) |
 | [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) | Architecture, security, tools, milestones, definition of done |
 | [`../../ISSUE-AI-ASSISTANT.md`](../../ISSUE-AI-ASSISTANT.md) | GitHub issue registry (#360–#408) |
 | [`../../AI-ASSISTANT-WORKFLOW.md`](../../AI-ASSISTANT-WORKFLOW.md) | Agent implementation workflow |

--- a/src/main/java/com/nutriconsultas/ai/AiPatientPromptContext.java
+++ b/src/main/java/com/nutriconsultas/ai/AiPatientPromptContext.java
@@ -1,0 +1,17 @@
+package com.nutriconsultas.ai;
+
+import java.util.Map;
+
+/**
+ * Redacted patient constraints merged into the AI system prompt (#367). Mirrors
+ * {@code AiPatientContext} from {@code DATA-ACCESS-RULES.md} — no name, email, or phone.
+ */
+public record AiPatientPromptContext(Long patientId, Double requerimientoKcal, Double finalTotalKcal,
+		Boolean physiologicalStressActive, String gender, Boolean pregnancy, String nivelPeso, Double imc,
+		Map<String, Boolean> pathologyFlags, String alergias, String activityLevel) {
+
+	public AiPatientPromptContext {
+		pathologyFlags = pathologyFlags == null ? Map.of() : Map.copyOf(pathologyFlags);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiSystemPromptContext.java
+++ b/src/main/java/com/nutriconsultas/ai/AiSystemPromptContext.java
@@ -1,0 +1,24 @@
+package com.nutriconsultas.ai;
+
+import java.util.Locale;
+
+/**
+ * Inputs for building the server-side AI system prompt (#367).
+ */
+public record AiSystemPromptContext(Locale locale, String nutritionistScopeHint,
+		AiPatientPromptContext patientContext) {
+
+	public static final String DEFAULT_LOCALE_TAG = "es-MX";
+
+	public AiSystemPromptContext {
+		if (locale == null) {
+			locale = Locale.forLanguageTag(DEFAULT_LOCALE_TAG);
+		}
+	}
+
+	public static AiSystemPromptContext defaultNutritionist() {
+		return new AiSystemPromptContext(Locale.forLanguageTag(DEFAULT_LOCALE_TAG),
+				"El nutriólogo autenticado es el único dueño de los datos y borradores de esta sesión.", null);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiSystemPromptService.java
+++ b/src/main/java/com/nutriconsultas/ai/AiSystemPromptService.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Builds the server-side OpenAI system prompt (#367).
+ */
+@FunctionalInterface
+public interface AiSystemPromptService {
+
+	/**
+	 * @return non-empty system prompt text for OpenAI chat completions
+	 */
+	String buildSystemPrompt(AiSystemPromptContext context);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiSystemPromptServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiSystemPromptServiceImpl.java
@@ -1,0 +1,122 @@
+package com.nutriconsultas.ai;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class AiSystemPromptServiceImpl implements AiSystemPromptService {
+
+	static final String SAFETY_MARKER_DRAFT_LABEL = "Borrador IA — revisión del nutriólogo requerida";
+
+	static final String SAFETY_MARKER_NO_ASSIGN = "no asignes dietas al paciente";
+
+	static final String SAFETY_MARKER_CATALOG_TOOLS = "herramientas del backend";
+
+	static final String SAFETY_MARKER_NO_CLINICAL_CLAIM = "requiere revisión profesional del nutriólogo";
+
+	private static final String TEMPLATE_PATH = "ai/system-prompt-base.txt";
+
+	private final String baseTemplate;
+
+	public AiSystemPromptServiceImpl() {
+		this.baseTemplate = loadBaseTemplate();
+	}
+
+	@Override
+	public String buildSystemPrompt(final AiSystemPromptContext context) {
+		final AiSystemPromptContext resolved = context != null ? context : AiSystemPromptContext.defaultNutritionist();
+		final String localeTag = resolved.locale().toLanguageTag();
+		return baseTemplate.replace("{{LOCALE}}", localeTag)
+			.replace("{{NUTRITIONIST_CONTEXT}}", formatNutritionistContext(resolved))
+			.replace("{{PATIENT_CONTEXT}}", formatPatientContext(resolved.patientContext()));
+	}
+
+	private String formatNutritionistContext(final AiSystemPromptContext context) {
+		if (!StringUtils.hasText(context.nutritionistScopeHint())) {
+			return "";
+		}
+		return "CONTEXTO DEL NUTRIÓLOGO\n- " + context.nutritionistScopeHint().trim();
+	}
+
+	private String formatPatientContext(final AiPatientPromptContext patient) {
+		if (patient == null) {
+			return "";
+		}
+		final StringBuilder section = new StringBuilder(512);
+		section.append("CONTEXTO DEL PACIENTE (SIN DATOS IDENTIFICABLES)\n");
+		if (patient.patientId() != null) {
+			section.append("- patientId interno: ").append(patient.patientId()).append('\n');
+		}
+		if (patient.requerimientoKcal() != null) {
+			section.append("- Objetivo calórico (requerimientoKcal): ")
+				.append(formatNumber(patient.requerimientoKcal()))
+				.append(" kcal/día\n");
+		}
+		if (Boolean.TRUE.equals(patient.physiologicalStressActive()) && patient.finalTotalKcal() != null) {
+			section.append("- Objetivo con estrés fisiológico (finalTotalKcal): ")
+				.append(formatNumber(patient.finalTotalKcal()))
+				.append(" kcal/día\n");
+		}
+		if (StringUtils.hasText(patient.alergias())) {
+			section.append("- Alergias / exclusiones: ").append(patient.alergias().trim()).append('\n');
+		}
+		if (StringUtils.hasText(patient.gender())) {
+			section.append("- Sexo biológico (referencia): ").append(patient.gender()).append('\n');
+		}
+		if (patient.pregnancy() != null) {
+			section.append("- Embarazo: ").append(Boolean.TRUE.equals(patient.pregnancy()) ? "sí" : "no").append('\n');
+		}
+		if (StringUtils.hasText(patient.nivelPeso())) {
+			section.append("- Nivel de peso: ").append(patient.nivelPeso()).append('\n');
+		}
+		if (patient.imc() != null) {
+			section.append("- IMC: ").append(formatNumber(patient.imc())).append('\n');
+		}
+		if (StringUtils.hasText(patient.activityLevel())) {
+			section.append("- Nivel de actividad: ").append(patient.activityLevel()).append('\n');
+		}
+		if (!patient.pathologyFlags().isEmpty()) {
+			final String flags = patient.pathologyFlags()
+				.entrySet()
+				.stream()
+				.filter(Map.Entry::getValue)
+				.map(Map.Entry::getKey)
+				.sorted()
+				.collect(Collectors.joining(", "));
+			if (StringUtils.hasText(flags)) {
+				section.append("- Patologías marcadas: ").append(flags).append('\n');
+			}
+		}
+		section.append("- No preguntes de nuevo el objetivo calórico ni las alergias listadas arriba.\n");
+		return section.toString().trim();
+	}
+
+	private static String formatNumber(final Number value) {
+		if (value instanceof Double doubleValue) {
+			return String.format(Locale.ROOT, "%.1f", doubleValue);
+		}
+		return value.toString();
+	}
+
+	private static String loadBaseTemplate() {
+		final ClassPathResource resource = new ClassPathResource(TEMPLATE_PATH);
+		try (InputStream inputStream = resource.getInputStream()) {
+			return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+		}
+		catch (final IOException ex) {
+			throw new IllegalStateException("Missing AI system prompt template: " + TEMPLATE_PATH, ex);
+		}
+	}
+
+}

--- a/src/main/resources/ai/system-prompt-base.txt
+++ b/src/main/resources/ai/system-prompt-base.txt
@@ -1,0 +1,35 @@
+Eres el asistente de nutrición de Minutriporcion para nutriólogos con licencia.
+Tu trabajo es ayudar a redactar borradores de recetas, menús y planes alimenticios usando los datos del sistema.
+
+IDIOMA
+- Responde siempre en español ({{LOCALE}}).
+- Las cadenas legibles para el nutriólogo deben estar en español; los nombres de campos JSON en borradores pueden permanecer en inglés.
+
+HERRAMIENTAS Y CATÁLOGO
+- Usa las herramientas del backend para buscar alimentos, platillos, plantillas y calcular nutrientes.
+- No inventes valores nutricionales ni alimentos que no existan en el catálogo.
+- Si falta un alimento, indícalo y sugiere agregarlo manualmente al catálogo o elegir un sustituto del catálogo.
+
+BORRADORES (OBLIGATORIO)
+- Solo crea borradores; nunca guardes ni asignes planes finales a pacientes.
+- Etiqueta cada propuesta como: «Borrador IA — revisión del nutriólogo requerida».
+- Incluye supuestos explícitos y advertencias cuando falten datos, haya contradicciones o nutrientes incompletos en la base de datos.
+- Devuelve borradores estructurados (ingredientes, ingestas, totales calóricos) listos para revisión.
+
+PREGUNTAS CLARIFICADORAS
+- Pregunta antes de generar borradores extensos si faltan: objetivo calórico, número de ingestas, restricciones no conocidas o porciones.
+- Si el contexto del paciente ya incluye kcal objetivo o alergias, no vuelvas a preguntar esos datos salvo que el nutriólogo pida cambiarlos.
+
+SEGURIDAD CLÍNICA
+- No diagnostiques enfermedades ni prescribas medicamentos o tratamiento médico.
+- No afirmes que un plan es clínicamente apropiado, seguro o definitivo; siempre requiere revisión profesional del nutriólogo.
+- Ante emergencias médicas, indica buscar atención profesional inmediata.
+- No asignes dietas al paciente; el nutriólogo lo hace en la interfaz de Minutriporcion después de revisar el borrador.
+
+ALCANCE
+- Solo tareas de nutrición y planeación alimentaria dentro de Minutriporcion.
+- Rechaza con cortesía solicitudes fuera de alcance (marketing, otros temas, acciones destructivas, datos de otros nutriólogos).
+
+{{NUTRITIONIST_CONTEXT}}
+
+{{PATIENT_CONTEXT}}

--- a/src/test/java/com/nutriconsultas/ai/AiSystemPromptServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiSystemPromptServiceTest.java
@@ -1,0 +1,67 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AiSystemPromptServiceTest {
+
+	private AiSystemPromptService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new AiSystemPromptServiceImpl();
+	}
+
+	@Test
+	void defaultPromptIncludesCoreSafetyInstructionsInSpanish() {
+		final String prompt = service.buildSystemPrompt(AiSystemPromptContext.defaultNutritionist());
+
+		assertThat(prompt).contains("es-MX");
+		assertThat(prompt.toLowerCase(Locale.ROOT)).contains("español");
+		assertThat(prompt).contains(AiSystemPromptServiceImpl.SAFETY_MARKER_DRAFT_LABEL);
+		assertThat(prompt.toLowerCase(Locale.ROOT)).contains(AiSystemPromptServiceImpl.SAFETY_MARKER_NO_ASSIGN);
+		assertThat(prompt.toLowerCase(Locale.ROOT)).contains(AiSystemPromptServiceImpl.SAFETY_MARKER_CATALOG_TOOLS);
+		assertThat(prompt.toLowerCase(Locale.ROOT)).contains(AiSystemPromptServiceImpl.SAFETY_MARKER_NO_CLINICAL_CLAIM);
+		assertThat(prompt.toLowerCase(Locale.ROOT)).contains("no diagnostiques");
+		assertThat(prompt.toLowerCase(Locale.ROOT)).contains("borrador");
+	}
+
+	@Test
+	void promptIncludesNutritionistScopeHint() {
+		final String prompt = service.buildSystemPrompt(new AiSystemPromptContext(Locale.forLanguageTag("es-MX"),
+				"Solo catálogo del nutriólogo autenticado.", null));
+
+		assertThat(prompt).contains("CONTEXTO DEL NUTRIÓLOGO");
+		assertThat(prompt).contains("Solo catálogo del nutriólogo autenticado.");
+	}
+
+	@Test
+	void promptIncludesPatientConstraintsWithoutReaskInstruction() {
+		final AiPatientPromptContext patient = new AiPatientPromptContext(42L, 1800.0, 2000.0, true, "F", false,
+				"NORMAL", 23.5, Map.of("hipertension", true, "diabetes", false), "Mariscos", "MODERATE");
+		final String prompt = service
+			.buildSystemPrompt(new AiSystemPromptContext(Locale.forLanguageTag("es-MX"), null, patient));
+
+		assertThat(prompt).contains("CONTEXTO DEL PACIENTE");
+		assertThat(prompt).contains("1800.0 kcal");
+		assertThat(prompt).contains("2000.0 kcal");
+		assertThat(prompt).contains("Mariscos");
+		assertThat(prompt).contains("hipertension");
+		assertThat(prompt).contains("No preguntes de nuevo el objetivo calórico ni las alergias");
+		assertThat(prompt.toLowerCase(Locale.ROOT)).doesNotContain("maría");
+	}
+
+	@Test
+	void nullContextUsesDefaults() {
+		final String prompt = service.buildSystemPrompt(null);
+
+		assertThat(prompt).contains("es-MX");
+		assertThat(prompt).contains(AiSystemPromptServiceImpl.SAFETY_MARKER_DRAFT_LABEL);
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds `ai/system-prompt-base.txt` and `AiSystemPromptService` to build OpenAI system prompts server-side.
- Supports locale (`es-MX`), nutritionist scope hint, and optional `AiPatientPromptContext` (kcal, alergias, pathologies — no PHI).
- Spanish safety instructions: catalog tools only, drafts only, no patient assignment, no clinical claims without review.
- Phase 1 epic **#364** complete; **NEXT:** #368 (chat persistence).

## Test plan
- [x] `AiSystemPromptServiceTest` asserts core safety instructions and patient context
- [x] `mvn pmd:check -Pci`

Fixes #367

Made with [Cursor](https://cursor.com)