### PR TITLE
feat(ai): add AI chat schema and persistence (Fixes #369)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#368 — Epic AI Chat Persistence](https://github.com/diego-torres/nutriconsultas/issues/368) (`NEXT`). ~~#367~~ **done** — `AiSystemPromptService`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#371 — Implement AI Draft Lifecycle](https://github.com/diego-torres/nutriconsultas/issues/371) (`NEXT`). ~~#369~~/#370 **done** — `ai_chat_*` schema + repos. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#368 — Epic AI Chat Persistence](https://github.com/diego-torres/nutriconsultas/issues/368) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#367~~ prompt: `AiSystemPromptService`.
+**Current next issue:** [#371 — Implement AI Draft Lifecycle](https://github.com/diego-torres/nutriconsultas/issues/371) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#369~~ schema + entities on `main` path.
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#367~~ system prompt **done**. **NEXT:** #368.
+**Last updated:** 2026-06-30 — ~~#369~~ AI chat schema **done**. **NEXT:** #371.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -86,12 +86,12 @@ Store chat threads, messages, and generated drafts.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **368** | Epic — AI Chat Persistence and Draft Storage (Phase 2) | https://github.com/diego-torres/nutriconsultas/issues/368 | **NEXT** | **364** | Milestone 1 |
-| **369** | Add Liquibase Schema for AI Chat Tables | https://github.com/diego-torres/nutriconsultas/issues/369 | **open** | **368**, #46 | `ai_chat_*` tables |
-| **370** | Implement AI Chat Domain Entities and Repositories | https://github.com/diego-torres/nutriconsultas/issues/370 | **open** | **369** | JPA + scoped repos |
-| **371** | Implement AI Draft Lifecycle | https://github.com/diego-torres/nutriconsultas/issues/371 | **open** | **370** | DRAFT / ACCEPTED / DISCARDED |
+| **368** | Epic — AI Chat Persistence and Draft Storage (Phase 2) | https://github.com/diego-torres/nutriconsultas/issues/368 | **open** | **364** | Milestone 1 — ~~#369–#370~~ |
+| **369** | Add Liquibase Schema for AI Chat Tables | https://github.com/diego-torres/nutriconsultas/issues/369 | **done** | **368**, #46 | `024-ai-chat-schema.yaml` |
+| **370** | Implement AI Chat Domain Entities and Repositories | https://github.com/diego-torres/nutriconsultas/issues/370 | **done** | **369** | `com.nutriconsultas.ai` entities/repos |
+| **371** | Implement AI Draft Lifecycle | https://github.com/diego-torres/nutriconsultas/issues/371 | **NEXT** | **370** | DRAFT / ACCEPTED / DISCARDED |
 
-**Suggested order:** #369 → #370 → #371.
+**Suggested order:** ~~#369~~ → ~~#370~~ → #371.
 
 ---
 

--- a/docs/db/LIQUIBASE.md
+++ b/docs/db/LIQUIBASE.md
@@ -15,6 +15,7 @@ Nutriconsultas uses [Liquibase](https://www.liquibase.org/) for schema and catal
 | `changes/006-subscription-notification-log.yaml` | Lifecycle notification log (#185, PR #215) |
 | `changes/007-patient-invitation-onboarding.yaml` | `PacienteStatus` columns + `patient_invitation` table (#132, PR #214) |
 | `changes/023-patient-invitation-human-code.yaml` | `human_code` on `patient_invitation` (#336) |
+| `changes/024-ai-chat-schema.yaml` | AI chat thread, message, and draft tables (#369) |
 | `changes/008-platillo-ingesta-source-platillo-id.yaml` | `source_platillo_id` on `platillo_ingesta` + catalog backfill (#250) |
 | `data/alimentos-seed.sql` | SMAE alimentos catalog (from `alimentos.sql`) |
 | `data/platillos-seed.sql` | Catalog `platillo` + `ingrediente` rows |

--- a/src/main/java/com/nutriconsultas/ai/AiChatMessage.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatMessage.java
@@ -1,0 +1,65 @@
+package com.nutriconsultas.ai;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "ai_chat_message")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(exclude = "thread")
+@ToString(exclude = "thread")
+public class AiChatMessage {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
+	@JoinColumn(name = "thread_id", nullable = false)
+	@JsonBackReference
+	private AiChatThread thread;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private AiChatMessageRole role;
+
+	@Lob
+	@Column(nullable = false)
+	private String content;
+
+	@Column(name = "tool_name", length = 120)
+	private String toolName;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private Instant createdAt;
+
+	@PrePersist
+	void onCreate() {
+		if (createdAt == null) {
+			createdAt = Instant.now();
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiChatMessageRepository.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatMessageRepository.java
@@ -1,0 +1,18 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AiChatMessageRepository extends JpaRepository<AiChatMessage, Long> {
+
+	List<AiChatMessage> findByThreadIdOrderByCreatedAtAscIdAsc(Long threadId);
+
+	@Query("SELECT m FROM AiChatMessage m JOIN m.thread t WHERE m.id = :messageId AND t.nutritionistId = :nutritionistId")
+	Optional<AiChatMessage> findByIdAndThreadNutritionistId(@Param("messageId") Long messageId,
+			@Param("nutritionistId") String nutritionistId);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiChatMessageRole.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatMessageRole.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.ai;
+
+public enum AiChatMessageRole {
+
+	SYSTEM, USER, ASSISTANT, TOOL
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiChatThread.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatThread.java
@@ -1,0 +1,84 @@
+package com.nutriconsultas.ai;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.nutriconsultas.paciente.Paciente;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "ai_chat_thread")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(exclude = { "messages", "drafts" })
+@ToString(exclude = { "messages", "drafts" })
+public class AiChatThread {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "nutritionist_id", nullable = false, length = 255)
+	private String nutritionistId;
+
+	@Column(name = "clinic_id")
+	private Long clinicId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "patient_id")
+	private Paciente patient;
+
+	@Column(nullable = false, length = 200)
+	private String title;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private Instant createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private Instant updatedAt;
+
+	@OneToMany(mappedBy = "thread", fetch = FetchType.LAZY)
+	@JsonManagedReference
+	private List<AiChatMessage> messages = new ArrayList<>();
+
+	@OneToMany(mappedBy = "thread", fetch = FetchType.LAZY)
+	@JsonManagedReference
+	private List<AiGeneratedDraft> drafts = new ArrayList<>();
+
+	@PrePersist
+	void onCreate() {
+		final Instant now = Instant.now();
+		if (createdAt == null) {
+			createdAt = now;
+		}
+		if (updatedAt == null) {
+			updatedAt = now;
+		}
+	}
+
+	@PreUpdate
+	void onUpdate() {
+		updatedAt = Instant.now();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiChatThreadRepository.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatThreadRepository.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AiChatThreadRepository extends JpaRepository<AiChatThread, Long> {
+
+	Optional<AiChatThread> findByIdAndNutritionistId(Long id, String nutritionistId);
+
+	List<AiChatThread> findByNutritionistIdOrderByUpdatedAtDesc(String nutritionistId);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftStatus.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftStatus.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.ai;
+
+public enum AiDraftStatus {
+
+	DRAFT, ACCEPTED, DISCARDED
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftType.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftType.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.ai;
+
+public enum AiDraftType {
+
+	DISH, MENU, DIET_PLAN
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiGeneratedDraft.java
+++ b/src/main/java/com/nutriconsultas/ai/AiGeneratedDraft.java
@@ -1,0 +1,72 @@
+package com.nutriconsultas.ai;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "ai_generated_draft")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(exclude = "thread")
+@ToString(exclude = "thread")
+public class AiGeneratedDraft {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
+	@JoinColumn(name = "thread_id", nullable = false)
+	@JsonBackReference
+	private AiChatThread thread;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "draft_type", nullable = false, length = 20)
+	private AiDraftType draftType;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private AiDraftStatus status = AiDraftStatus.DRAFT;
+
+	@Lob
+	@Column(name = "json_payload", nullable = false)
+	private String jsonPayload;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private Instant createdAt;
+
+	@Column(name = "accepted_at")
+	private Instant acceptedAt;
+
+	@PrePersist
+	void onCreate() {
+		if (createdAt == null) {
+			createdAt = Instant.now();
+		}
+		if (status == null) {
+			status = AiDraftStatus.DRAFT;
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiGeneratedDraftRepository.java
+++ b/src/main/java/com/nutriconsultas/ai/AiGeneratedDraftRepository.java
@@ -1,0 +1,20 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AiGeneratedDraftRepository extends JpaRepository<AiGeneratedDraft, Long> {
+
+	List<AiGeneratedDraft> findByThreadIdOrderByCreatedAtDescIdDesc(Long threadId);
+
+	@Query("SELECT d FROM AiGeneratedDraft d JOIN d.thread t WHERE d.id = :draftId AND t.nutritionistId = :nutritionistId")
+	Optional<AiGeneratedDraft> findByIdAndThreadNutritionistId(@Param("draftId") Long draftId,
+			@Param("nutritionistId") String nutritionistId);
+
+	List<AiGeneratedDraft> findByThreadIdAndStatusOrderByCreatedAtDescIdDesc(Long threadId, AiDraftStatus status);
+
+}

--- a/src/main/resources/db/changelog/changes/024-ai-chat-schema.yaml
+++ b/src/main/resources/db/changelog/changes/024-ai-chat-schema.yaml
@@ -1,0 +1,188 @@
+databaseChangeLog:
+  - changeSet:
+      id: 024-ai-chat-thread-table
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            tableExists:
+              tableName: ai_chat_thread
+      changes:
+        - createTable:
+            tableName: ai_chat_thread
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: nutritionist_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: clinic_id
+                  type: BIGINT
+                  constraints:
+                    nullable: true
+              - column:
+                  name: patient_id
+                  type: BIGINT
+                  constraints:
+                    nullable: true
+              - column:
+                  name: title
+                  type: VARCHAR(200)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: ai_chat_thread
+            baseColumnNames: patient_id
+            referencedTableName: paciente
+            referencedColumnNames: id
+            constraintName: fk_ai_chat_thread_paciente
+            onDelete: SET NULL
+        - createIndex:
+            indexName: idx_ai_chat_thread_nutritionist_id
+            tableName: ai_chat_thread
+            columns:
+              - column:
+                  name: nutritionist_id
+        - createIndex:
+            indexName: idx_ai_chat_thread_patient_id
+            tableName: ai_chat_thread
+            columns:
+              - column:
+                  name: patient_id
+  - changeSet:
+      id: 024-ai-chat-message-table
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            tableExists:
+              tableName: ai_chat_message
+      changes:
+        - createTable:
+            tableName: ai_chat_message
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: thread_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: role
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: content
+                  type: CLOB
+                  constraints:
+                    nullable: false
+              - column:
+                  name: tool_name
+                  type: VARCHAR(120)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: ai_chat_message
+            baseColumnNames: thread_id
+            referencedTableName: ai_chat_thread
+            referencedColumnNames: id
+            constraintName: fk_ai_chat_message_thread
+            onDelete: CASCADE
+        - createIndex:
+            indexName: idx_ai_chat_message_thread_id
+            tableName: ai_chat_message
+            columns:
+              - column:
+                  name: thread_id
+  - changeSet:
+      id: 024-ai-generated-draft-table
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            tableExists:
+              tableName: ai_generated_draft
+      changes:
+        - createTable:
+            tableName: ai_generated_draft
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: thread_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: draft_type
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: json_payload
+                  type: CLOB
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: accepted_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: true
+        - addForeignKeyConstraint:
+            baseTableName: ai_generated_draft
+            baseColumnNames: thread_id
+            referencedTableName: ai_chat_thread
+            referencedColumnNames: id
+            constraintName: fk_ai_generated_draft_thread
+            onDelete: CASCADE
+        - createIndex:
+            indexName: idx_ai_generated_draft_thread_id
+            tableName: ai_generated_draft
+            columns:
+              - column:
+                  name: thread_id

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -68,3 +68,6 @@ databaseChangeLog:
   - include:
       file: changes/023-patient-invitation-human-code.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/024-ai-chat-schema.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -59,3 +59,6 @@ databaseChangeLog:
   - include:
       file: changes/023-patient-invitation-human-code.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/024-ai-chat-schema.yaml
+      relativeToChangelogFile: true

--- a/src/test/java/com/nutriconsultas/ai/AiChatPersistenceRepositoryTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatPersistenceRepositoryTest.java
@@ -1,0 +1,133 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class AiChatPersistenceRepositoryTest {
+
+	private static final String NUTRITIONIST_A = "auth0|nutritionist-ai-a";
+
+	private static final String NUTRITIONIST_B = "auth0|nutritionist-ai-b";
+
+	@Autowired
+	private AiChatThreadRepository threadRepository;
+
+	@Autowired
+	private AiChatMessageRepository messageRepository;
+
+	@Autowired
+	private AiGeneratedDraftRepository draftRepository;
+
+	@Autowired
+	private com.nutriconsultas.paciente.PacienteRepository pacienteRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	void threadMessageAndDraftRoundTrip() {
+		final AiChatThread thread = threadRepository.saveAndFlush(sampleThread(NUTRITIONIST_A, "Menú semanal"));
+		final AiChatMessage message = new AiChatMessage();
+		message.setThread(thread);
+		message.setRole(AiChatMessageRole.USER);
+		message.setContent("Genera un menú de 1800 kcal");
+		messageRepository.saveAndFlush(message);
+
+		final AiGeneratedDraft draft = new AiGeneratedDraft();
+		draft.setThread(thread);
+		draft.setDraftType(AiDraftType.MENU);
+		draft.setJsonPayload("{\"title\":\"Menú lunes\"}");
+		draftRepository.saveAndFlush(draft);
+
+		entityManager.clear();
+
+		final AiChatThread loaded = threadRepository.findByIdAndNutritionistId(thread.getId(), NUTRITIONIST_A)
+			.orElseThrow();
+		assertThat(loaded.getTitle()).isEqualTo("Menú semanal");
+		assertThat(loaded.getCreatedAt()).isNotNull();
+		assertThat(loaded.getUpdatedAt()).isNotNull();
+		assertThat(messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(thread.getId())).hasSize(1);
+		assertThat(
+				draftRepository.findByThreadIdAndStatusOrderByCreatedAtDescIdDesc(thread.getId(), AiDraftStatus.DRAFT))
+			.hasSize(1);
+	}
+
+	@Test
+	void findByIdAndNutritionistId_blocksCrossTenantAccess() {
+		final AiChatThread thread = threadRepository.saveAndFlush(sampleThread(NUTRITIONIST_A, "Borrador platillo"));
+
+		assertThat(threadRepository.findByIdAndNutritionistId(thread.getId(), NUTRITIONIST_A)).isPresent();
+		assertThat(threadRepository.findByIdAndNutritionistId(thread.getId(), NUTRITIONIST_B)).isEmpty();
+	}
+
+	@Test
+	void draftScopedLookupUsesThreadNutritionistId() {
+		final AiChatThread thread = threadRepository.saveAndFlush(sampleThread(NUTRITIONIST_A, "Plan 7 días"));
+		final AiGeneratedDraft draft = new AiGeneratedDraft();
+		draft.setThread(thread);
+		draft.setDraftType(AiDraftType.DIET_PLAN);
+		draft.setJsonPayload("{\"dayCount\":7}");
+		draftRepository.saveAndFlush(draft);
+
+		assertThat(draftRepository.findByIdAndThreadNutritionistId(draft.getId(), NUTRITIONIST_A)).isPresent();
+		assertThat(draftRepository.findByIdAndThreadNutritionistId(draft.getId(), NUTRITIONIST_B)).isEmpty();
+	}
+
+	@Test
+	void threadCanLinkOptionalPatient() {
+		final com.nutriconsultas.paciente.Paciente paciente = pacienteRepository.saveAndFlush(samplePaciente());
+		final AiChatThread thread = sampleThread(NUTRITIONIST_A, "Paciente vinculado");
+		thread.setPatient(paciente);
+		threadRepository.saveAndFlush(thread);
+
+		entityManager.clear();
+
+		final AiChatThread loaded = threadRepository.findById(thread.getId()).orElseThrow();
+		assertThat(loaded.getPatient().getId()).isEqualTo(paciente.getId());
+	}
+
+	@Test
+	void listThreadsByNutritionistOrdersByUpdatedAtDesc() {
+		final AiChatThread older = sampleThread(NUTRITIONIST_A, "Antiguo");
+		threadRepository.saveAndFlush(older);
+		final AiChatThread newer = sampleThread(NUTRITIONIST_A, "Reciente");
+		threadRepository.saveAndFlush(newer);
+
+		final List<AiChatThread> threads = threadRepository.findByNutritionistIdOrderByUpdatedAtDesc(NUTRITIONIST_A);
+
+		assertThat(threads).hasSizeGreaterThanOrEqualTo(2);
+		assertThat(threads.getFirst().getTitle()).isEqualTo("Reciente");
+	}
+
+	private static AiChatThread sampleThread(final String nutritionistId, final String title) {
+		final AiChatThread thread = new AiChatThread();
+		thread.setNutritionistId(nutritionistId);
+		thread.setTitle(title);
+		return thread;
+	}
+
+	private static com.nutriconsultas.paciente.Paciente samplePaciente() {
+		final com.nutriconsultas.paciente.Paciente paciente = new com.nutriconsultas.paciente.Paciente();
+		paciente.setName("AI Test Patient");
+		paciente.setUserId(NUTRITIONIST_A);
+		paciente.setStatus(com.nutriconsultas.paciente.PacienteStatus.ACTIVE);
+		final LocalDate dob = LocalDate.now().minusYears(28);
+		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		paciente.setGender("F");
+		return paciente;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/db/LiquibaseMigrationTest.java
+++ b/src/test/java/com/nutriconsultas/db/LiquibaseMigrationTest.java
@@ -102,4 +102,11 @@ public class LiquibaseMigrationTest {
 			.isEqualTo(97L);
 	}
 
+	@Test
+	public void testAiChatSchemaTablesExist() {
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM ai_chat_thread", Long.class)).isEqualTo(0L);
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM ai_chat_message", Long.class)).isEqualTo(0L);
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM ai_generated_draft", Long.class)).isEqualTo(0L);
+	}
+
 }


### PR DESCRIPTION
## Summary
- Add Liquibase changeset `024-ai-chat-schema.yaml` for `ai_chat_thread`, `ai_chat_message`, and `ai_generated_draft` tables.
- Implement JPA entities, enums, and tenant-scoped repositories in `com.nutriconsultas.ai` (fulfills #370).
- Add repository integration tests and Liquibase migration assertion for the new tables.

## Test plan
- [x] `mvn test -Dtest=AiChatPersistenceRepositoryTest,LiquibaseMigrationTest#testAiChatSchemaTablesExist`
- [x] `mvn pmd:check -Pci`
- [x] `mvn checkstyle:check`
- [ ] CI green

Fixes #369

Made with [Cursor](https://cursor.com)