### PR TITLE
feat(ai): add draft lifecycle service (Fixes #371)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#371 — Implement AI Draft Lifecycle](https://github.com/diego-torres/nutriconsultas/issues/371) (`NEXT`). ~~#369~~/#370 **done** — `ai_chat_*` schema + repos. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#372 — Epic Backend Nutrition Tool Services](https://github.com/diego-torres/nutriconsultas/issues/372) (`NEXT`). ~~#371~~ **done** — `AiDraftLifecycleService`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#371 — Implement AI Draft Lifecycle](https://github.com/diego-torres/nutriconsultas/issues/371) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#369~~ schema + entities on `main` path.
+**Current next issue:** [#372 — Epic Backend Nutrition Tool Services](https://github.com/diego-torres/nutriconsultas/issues/372) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#371~~ lifecycle: `AiDraftLifecycleService`.
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#369~~ AI chat schema **done**. **NEXT:** #371.
+**Last updated:** 2026-06-30 — ~~#371~~ draft lifecycle **done**. **NEXT:** #372.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -86,12 +86,12 @@ Store chat threads, messages, and generated drafts.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **368** | Epic — AI Chat Persistence and Draft Storage (Phase 2) | https://github.com/diego-torres/nutriconsultas/issues/368 | **open** | **364** | Milestone 1 — ~~#369–#370~~ |
+| **368** | Epic — AI Chat Persistence and Draft Storage (Phase 2) | https://github.com/diego-torres/nutriconsultas/issues/368 | **done** | **364** | Milestone 1 — ~~#369–#371~~ |
 | **369** | Add Liquibase Schema for AI Chat Tables | https://github.com/diego-torres/nutriconsultas/issues/369 | **done** | **368**, #46 | `024-ai-chat-schema.yaml` |
 | **370** | Implement AI Chat Domain Entities and Repositories | https://github.com/diego-torres/nutriconsultas/issues/370 | **done** | **369** | `com.nutriconsultas.ai` entities/repos |
-| **371** | Implement AI Draft Lifecycle | https://github.com/diego-torres/nutriconsultas/issues/371 | **NEXT** | **370** | DRAFT / ACCEPTED / DISCARDED |
+| **371** | Implement AI Draft Lifecycle | https://github.com/diego-torres/nutriconsultas/issues/371 | **done** | **370** | `AiDraftLifecycleService` |
 
-**Suggested order:** ~~#369~~ → ~~#370~~ → #371.
+**Suggested order:** ~~#371~~.
 
 ---
 
@@ -101,7 +101,7 @@ Read-only catalog and validation tools for AI orchestration.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **372** | Epic — Backend Nutrition Tool Services (Phase 3) | https://github.com/diego-torres/nutriconsultas/issues/372 | **open** | **363**, **371** | Milestone 2 |
+| **372** | Epic — Backend Nutrition Tool Services (Phase 3) | https://github.com/diego-torres/nutriconsultas/issues/372 | **NEXT** | **363**, **371** | Milestone 2 |
 | **373** | Implement Food Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/373 | **open** | **372** | `search_food_catalog` |
 | **374** | Implement Food Nutrient Lookup Tool | https://github.com/diego-torres/nutriconsultas/issues/374 | **open** | **372** | `get_food_nutrients` |
 | **375** | Implement Dish Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/375 | **open** | **372** | `search_dish_catalog` |

--- a/src/main/java/com/nutriconsultas/ai/AiDraftLifecycleException.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftLifecycleException.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Draft lifecycle errors for nutritionist-scoped AI drafts (#371).
+ */
+public class AiDraftLifecycleException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public AiDraftLifecycleException(final String message) {
+		super(message);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftLifecycleService.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftLifecycleService.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Nutritionist-scoped lifecycle for AI-generated drafts (#371).
+ */
+public interface AiDraftLifecycleService {
+
+	AiGeneratedDraft createDraft(Long threadId, String nutritionistId, AiDraftType draftType, String jsonPayload);
+
+	AiGeneratedDraft acceptDraft(Long draftId, String nutritionistId);
+
+	AiGeneratedDraft discardDraft(Long draftId, String nutritionistId);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftLifecycleServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftLifecycleServiceImpl.java
@@ -1,0 +1,85 @@
+package com.nutriconsultas.ai;
+
+import java.time.Instant;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class AiDraftLifecycleServiceImpl implements AiDraftLifecycleService {
+
+	private final AiChatThreadRepository threadRepository;
+
+	private final AiGeneratedDraftRepository draftRepository;
+
+	public AiDraftLifecycleServiceImpl(final AiChatThreadRepository threadRepository,
+			final AiGeneratedDraftRepository draftRepository) {
+		this.threadRepository = threadRepository;
+		this.draftRepository = draftRepository;
+	}
+
+	@Override
+	@Transactional
+	public AiGeneratedDraft createDraft(@NonNull final Long threadId, @NonNull final String nutritionistId,
+			@NonNull final AiDraftType draftType, @NonNull final String jsonPayload) {
+		final AiChatThread thread = loadOwnedThread(threadId, nutritionistId);
+		if (!StringUtils.hasText(jsonPayload)) {
+			throw new AiDraftLifecycleException("El borrador no tiene contenido.");
+		}
+		final AiGeneratedDraft draft = new AiGeneratedDraft();
+		draft.setThread(thread);
+		draft.setDraftType(draftType);
+		draft.setJsonPayload(jsonPayload.trim());
+		draft.setStatus(AiDraftStatus.DRAFT);
+		final AiGeneratedDraft saved = draftRepository.save(draft);
+		if (log.isInfoEnabled()) {
+			log.info("AI draft created id={} threadId={} type={}", saved.getId(), threadId, draftType);
+		}
+		return saved;
+	}
+
+	@Override
+	@Transactional
+	public AiGeneratedDraft acceptDraft(@NonNull final Long draftId, @NonNull final String nutritionistId) {
+		final AiGeneratedDraft draft = loadMutableDraft(draftId, nutritionistId);
+		draft.setStatus(AiDraftStatus.ACCEPTED);
+		draft.setAcceptedAt(Instant.now());
+		final AiGeneratedDraft saved = draftRepository.save(draft);
+		if (log.isInfoEnabled()) {
+			log.info("AI draft accepted id={} threadId={}", saved.getId(), saved.getThread().getId());
+		}
+		return saved;
+	}
+
+	@Override
+	@Transactional
+	public AiGeneratedDraft discardDraft(@NonNull final Long draftId, @NonNull final String nutritionistId) {
+		final AiGeneratedDraft draft = loadMutableDraft(draftId, nutritionistId);
+		draft.setStatus(AiDraftStatus.DISCARDED);
+		final AiGeneratedDraft saved = draftRepository.save(draft);
+		if (log.isInfoEnabled()) {
+			log.info("AI draft discarded id={} threadId={}", saved.getId(), saved.getThread().getId());
+		}
+		return saved;
+	}
+
+	private AiChatThread loadOwnedThread(final Long threadId, final String nutritionistId) {
+		return threadRepository.findByIdAndNutritionistId(threadId, nutritionistId)
+			.orElseThrow(() -> new AiDraftLifecycleException("Conversación no encontrada."));
+	}
+
+	private AiGeneratedDraft loadMutableDraft(final Long draftId, final String nutritionistId) {
+		final AiGeneratedDraft draft = draftRepository.findByIdAndThreadNutritionistId(draftId, nutritionistId)
+			.orElseThrow(() -> new AiDraftLifecycleException("Borrador no encontrado."));
+		if (draft.getStatus() != AiDraftStatus.DRAFT) {
+			throw new AiDraftLifecycleException("El borrador ya no se puede modificar.");
+		}
+		return draft;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiDraftLifecycleServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftLifecycleServiceTest.java
@@ -1,0 +1,153 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AiDraftLifecycleServiceTest {
+
+	private static final String NUTRITIONIST_A = "auth0|nutritionist-a";
+
+	private static final String NUTRITIONIST_B = "auth0|nutritionist-b";
+
+	@InjectMocks
+	private AiDraftLifecycleServiceImpl service;
+
+	@Mock
+	private AiChatThreadRepository threadRepository;
+
+	@Mock
+	private AiGeneratedDraftRepository draftRepository;
+
+	private AiChatThread thread;
+
+	@BeforeEach
+	void setUp() {
+		thread = new AiChatThread();
+		thread.setId(10L);
+		thread.setNutritionistId(NUTRITIONIST_A);
+		thread.setTitle("Menú");
+	}
+
+	@Test
+	void createDraftPersistsDraftStatus() {
+		when(threadRepository.findByIdAndNutritionistId(10L, NUTRITIONIST_A)).thenReturn(Optional.of(thread));
+		when(draftRepository.save(any(AiGeneratedDraft.class))).thenAnswer(invocation -> {
+			final AiGeneratedDraft draft = invocation.getArgument(0);
+			draft.setId(99L);
+			return draft;
+		});
+
+		final AiGeneratedDraft created = service.createDraft(10L, NUTRITIONIST_A, AiDraftType.MENU,
+				"{\"title\":\"Menú lunes\"}");
+
+		assertThat(created.getId()).isEqualTo(99L);
+		assertThat(created.getStatus()).isEqualTo(AiDraftStatus.DRAFT);
+		assertThat(created.getDraftType()).isEqualTo(AiDraftType.MENU);
+		assertThat(created.getAcceptedAt()).isNull();
+	}
+
+	@Test
+	void createDraftRejectsUnknownThread() {
+		when(threadRepository.findByIdAndNutritionistId(10L, NUTRITIONIST_B)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.createDraft(10L, NUTRITIONIST_B, AiDraftType.DISH, "{}"))
+			.isInstanceOf(AiDraftLifecycleException.class)
+			.hasMessageContaining("Conversación no encontrada");
+
+		verify(draftRepository, never()).save(any());
+	}
+
+	@Test
+	void acceptDraftSetsAcceptedTimestamp() {
+		final AiGeneratedDraft draft = sampleDraft(AiDraftStatus.DRAFT);
+		when(draftRepository.findByIdAndThreadNutritionistId(99L, NUTRITIONIST_A)).thenReturn(Optional.of(draft));
+		when(draftRepository.save(draft)).thenReturn(draft);
+
+		final AiGeneratedDraft accepted = service.acceptDraft(99L, NUTRITIONIST_A);
+
+		assertThat(accepted.getStatus()).isEqualTo(AiDraftStatus.ACCEPTED);
+		assertThat(accepted.getAcceptedAt()).isNotNull();
+	}
+
+	@Test
+	void discardDraftSetsDiscardedStatus() {
+		final AiGeneratedDraft draft = sampleDraft(AiDraftStatus.DRAFT);
+		when(draftRepository.findByIdAndThreadNutritionistId(99L, NUTRITIONIST_A)).thenReturn(Optional.of(draft));
+		when(draftRepository.save(draft)).thenReturn(draft);
+
+		final AiGeneratedDraft discarded = service.discardDraft(99L, NUTRITIONIST_A);
+
+		assertThat(discarded.getStatus()).isEqualTo(AiDraftStatus.DISCARDED);
+		assertThat(discarded.getAcceptedAt()).isNull();
+	}
+
+	@Test
+	void acceptDraftBlocksCrossTenantAccess() {
+		when(draftRepository.findByIdAndThreadNutritionistId(99L, NUTRITIONIST_B)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.acceptDraft(99L, NUTRITIONIST_B)).isInstanceOf(AiDraftLifecycleException.class)
+			.hasMessageContaining("Borrador no encontrado");
+
+		verify(draftRepository, never()).save(any());
+	}
+
+	@Test
+	void acceptDraftRejectsAlreadyAcceptedDraft() {
+		final AiGeneratedDraft draft = sampleDraft(AiDraftStatus.ACCEPTED);
+		when(draftRepository.findByIdAndThreadNutritionistId(99L, NUTRITIONIST_A)).thenReturn(Optional.of(draft));
+
+		assertThatThrownBy(() -> service.acceptDraft(99L, NUTRITIONIST_A)).isInstanceOf(AiDraftLifecycleException.class)
+			.hasMessageContaining("ya no se puede modificar");
+
+		verify(draftRepository, never()).save(any());
+	}
+
+	@Test
+	void discardDraftRejectsDiscardedDraft() {
+		final AiGeneratedDraft draft = sampleDraft(AiDraftStatus.DISCARDED);
+		when(draftRepository.findByIdAndThreadNutritionistId(99L, NUTRITIONIST_A)).thenReturn(Optional.of(draft));
+
+		assertThatThrownBy(() -> service.discardDraft(99L, NUTRITIONIST_A))
+			.isInstanceOf(AiDraftLifecycleException.class);
+
+		verify(draftRepository, never()).save(any());
+	}
+
+	@Test
+	void createDraftTrimsJsonPayload() {
+		when(threadRepository.findByIdAndNutritionistId(10L, NUTRITIONIST_A)).thenReturn(Optional.of(thread));
+		when(draftRepository.save(any(AiGeneratedDraft.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		service.createDraft(10L, NUTRITIONIST_A, AiDraftType.DISH, "  {\"name\":\"Tacos\"}  ");
+
+		final ArgumentCaptor<AiGeneratedDraft> captor = ArgumentCaptor.forClass(AiGeneratedDraft.class);
+		verify(draftRepository).save(captor.capture());
+		assertThat(captor.getValue().getJsonPayload()).isEqualTo("{\"name\":\"Tacos\"}");
+	}
+
+	private AiGeneratedDraft sampleDraft(final AiDraftStatus status) {
+		final AiGeneratedDraft draft = new AiGeneratedDraft();
+		draft.setId(99L);
+		draft.setThread(thread);
+		draft.setDraftType(AiDraftType.MENU);
+		draft.setJsonPayload("{\"title\":\"Menú\"}");
+		draft.setStatus(status);
+		return draft;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `AiDraftLifecycleService` with create, accept, and discard operations for `ai_generated_draft` rows
- Enforce nutritionist scoping via thread ownership; only `DRAFT` status is mutable; accepted drafts are immutable
- Unit tests cover happy paths, cross-tenant denial, and immutability after accept/discard
- Completes Phase 2 epic #368; registry updated — **NEXT: #372**

## Test plan
- [x] `mvn test -Dtest=AiDraftLifecycleServiceTest`
- [x] `mvn pmd:check -Pci`
- [ ] CI green


Made with [Cursor](https://cursor.com)