### PR TITLE
feat(ai): add search_food_catalog tool service (Fixes #373)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#372 — Epic Backend Nutrition Tool Services](https://github.com/diego-torres/nutriconsultas/issues/372) (`NEXT`). ~~#371~~ **done** — `AiDraftLifecycleService`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#374 — Implement Food Nutrient Lookup Tool](https://github.com/diego-torres/nutriconsultas/issues/374) (`NEXT`). ~~#373~~ **done** — `search_food_catalog`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#372 — Epic Backend Nutrition Tool Services](https://github.com/diego-torres/nutriconsultas/issues/372) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#371~~ lifecycle: `AiDraftLifecycleService`.
+**Current next issue:** [#374 — Implement Food Nutrient Lookup Tool](https://github.com/diego-torres/nutriconsultas/issues/374) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#373~~ `SearchFoodCatalogToolService`.
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#371~~ draft lifecycle **done**. **NEXT:** #372.
+**Last updated:** 2026-06-30 — ~~#373~~ food catalog search **done**. **NEXT:** #374.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -101,14 +101,14 @@ Read-only catalog and validation tools for AI orchestration.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **372** | Epic — Backend Nutrition Tool Services (Phase 3) | https://github.com/diego-torres/nutriconsultas/issues/372 | **NEXT** | **363**, **371** | Milestone 2 |
-| **373** | Implement Food Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/373 | **open** | **372** | `search_food_catalog` |
-| **374** | Implement Food Nutrient Lookup Tool | https://github.com/diego-torres/nutriconsultas/issues/374 | **open** | **372** | `get_food_nutrients` |
+| **372** | Epic — Backend Nutrition Tool Services (Phase 3) | https://github.com/diego-torres/nutriconsultas/issues/372 | **open** | **363**, **371** | Milestone 2 — ~~#373~~ |
+| **373** | Implement Food Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/373 | **done** | **372** | `search_food_catalog` |
+| **374** | Implement Food Nutrient Lookup Tool | https://github.com/diego-torres/nutriconsultas/issues/374 | **NEXT** | **372** | `get_food_nutrients` |
 | **375** | Implement Dish Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/375 | **open** | **372** | `search_dish_catalog` |
 | **376** | Implement Recipe Nutrient Calculation Tool | https://github.com/diego-torres/nutriconsultas/issues/376 | **open** | **374** | `calculate_recipe_nutrients` |
 | **377** | Implement Plan Constraint Validation Tool | https://github.com/diego-torres/nutriconsultas/issues/377 | **open** | **376** | `validate_plan_constraints` |
 
-**Suggested order:** #373 + #374 + #375 parallel → #376 → #377.
+**Suggested order:** ~~#373~~ → #374 + #375 parallel → #376 → #377.
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/AiToolErrorCode.java
+++ b/src/main/java/com/nutriconsultas/ai/AiToolErrorCode.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Error codes for AI tool responses ({@code docs/ai/TOOL-CONTRACT.md}).
+ */
+public enum AiToolErrorCode {
+
+	NOT_FOUND, FORBIDDEN, VALIDATION, RATE_LIMIT, INTERNAL
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiToolResult.java
+++ b/src/main/java/com/nutriconsultas/ai/AiToolResult.java
@@ -1,0 +1,19 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Common success/error envelope for AI tool handlers.
+ */
+public record AiToolResult<T>(boolean success, @Nullable T data, @Nullable AiToolErrorCode errorCode,
+		@Nullable String message) {
+
+	public static <T> AiToolResult<T> success(final T data) {
+		return new AiToolResult<>(true, data, null, null);
+	}
+
+	public static <T> AiToolResult<T> error(final AiToolErrorCode errorCode, final String message) {
+		return new AiToolResult<>(false, null, errorCode, message);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/FoodCatalogSearchData.java
+++ b/src/main/java/com/nutriconsultas/ai/FoodCatalogSearchData.java
@@ -1,0 +1,9 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+/**
+ * {@code data} payload for {@code search_food_catalog}.
+ */
+public record FoodCatalogSearchData(List<FoodCatalogSearchItem> items, int totalReturned, boolean truncated) {
+}

--- a/src/main/java/com/nutriconsultas/ai/FoodCatalogSearchItem.java
+++ b/src/main/java/com/nutriconsultas/ai/FoodCatalogSearchItem.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Single row returned by {@code search_food_catalog}.
+ */
+public record FoodCatalogSearchItem(long alimentoId, String nombreAlimento, @Nullable String clasificacion,
+		@Nullable String unidad, @Nullable Double cantSugerida, @Nullable Integer energiaKcalPorPorcion) {
+}

--- a/src/main/java/com/nutriconsultas/ai/SearchFoodCatalogToolService.java
+++ b/src/main/java/com/nutriconsultas/ai/SearchFoodCatalogToolService.java
@@ -1,0 +1,17 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+/**
+ * AI tool {@code search_food_catalog} — read-only global food catalog search.
+ */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
+public interface SearchFoodCatalogToolService {
+
+	String TOOL_NAME = "search_food_catalog";
+
+	AiToolResult<FoodCatalogSearchData> search(@NonNull String nutritionistId, @NonNull String query,
+			@Nullable String clasificacion, @Nullable Integer limit);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/SearchFoodCatalogToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/SearchFoodCatalogToolServiceImpl.java
@@ -1,0 +1,97 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.alimentos.AlimentosRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class SearchFoodCatalogToolServiceImpl implements SearchFoodCatalogToolService {
+
+	static final int DEFAULT_LIMIT = 10;
+
+	static final int MAX_LIMIT = 25;
+
+	static final int MIN_QUERY_LENGTH = 2;
+
+	static final int MAX_QUERY_LENGTH = 120;
+
+	static final int MAX_CLASIFICACION_LENGTH = 80;
+
+	private final AlimentosRepository alimentosRepository;
+
+	public SearchFoodCatalogToolServiceImpl(final AlimentosRepository alimentosRepository) {
+		this.alimentosRepository = alimentosRepository;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public AiToolResult<FoodCatalogSearchData> search(@NonNull final String nutritionistId, @NonNull final String query,
+			@Nullable final String clasificacion, @Nullable final Integer limit) {
+		if (!StringUtils.hasText(nutritionistId)) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "Sesión de nutriólogo no válida.");
+		}
+		final String trimmedQuery = query.trim();
+		if (trimmedQuery.length() < MIN_QUERY_LENGTH) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"La búsqueda debe tener al menos " + MIN_QUERY_LENGTH + " caracteres.");
+		}
+		if (trimmedQuery.length() > MAX_QUERY_LENGTH) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"La búsqueda no puede superar " + MAX_QUERY_LENGTH + " caracteres.");
+		}
+		if (clasificacion != null && clasificacion.length() > MAX_CLASIFICACION_LENGTH) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"La clasificación no puede superar " + MAX_CLASIFICACION_LENGTH + " caracteres.");
+		}
+		final int effectiveLimit = resolveLimit(limit);
+		if (effectiveLimit < 1 || effectiveLimit > MAX_LIMIT) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El límite debe estar entre 1 y " + MAX_LIMIT + ".");
+		}
+
+		final String searchPattern = "%" + trimmedQuery + "%";
+		final String clasificacionFilter = buildClasificacionFilter(clasificacion);
+		final long totalMatches = alimentosRepository.countForCatalogSearch(searchPattern, clasificacionFilter);
+		final List<Alimento> alimentos = alimentosRepository
+			.findForCatalogSearch(searchPattern, clasificacionFilter, PageRequest.of(0, effectiveLimit))
+			.getContent();
+		final List<FoodCatalogSearchItem> items = alimentos.stream().map(this::toItem).toList();
+		final boolean truncated = totalMatches > items.size();
+		final FoodCatalogSearchData data = new FoodCatalogSearchData(items, items.size(), truncated);
+		if (log.isInfoEnabled()) {
+			log.info("AI tool search_food_catalog resultCount={} truncated={}", data.totalReturned(), truncated);
+		}
+		return AiToolResult.success(data);
+	}
+
+	private static int resolveLimit(@Nullable final Integer limit) {
+		if (limit == null) {
+			return DEFAULT_LIMIT;
+		}
+		return limit;
+	}
+
+	@Nullable
+	private static String buildClasificacionFilter(@Nullable final String clasificacion) {
+		if (!StringUtils.hasText(clasificacion)) {
+			return null;
+		}
+		return "%" + clasificacion.trim() + "%";
+	}
+
+	private FoodCatalogSearchItem toItem(final Alimento alimento) {
+		return new FoodCatalogSearchItem(alimento.getId(), alimento.getNombreAlimento(), alimento.getClasificacion(),
+				alimento.getUnidad(), alimento.getCantSugerida(), alimento.getEnergia());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/alimentos/AlimentosRepository.java
+++ b/src/main/java/com/nutriconsultas/alimentos/AlimentosRepository.java
@@ -25,4 +25,16 @@ public interface AlimentosRepository extends JpaRepository<Alimento, Long> {
 			+ "(LOWER(a.nombreAlimento) LIKE LOWER(:searchTerm) OR LOWER(a.clasificacion) LIKE LOWER(:searchTerm))")
 	long countBySearchTerm(@Param("searchTerm") String searchTerm);
 
+	@Query("SELECT a FROM Alimento a WHERE "
+			+ "(LOWER(a.nombreAlimento) LIKE LOWER(:searchTerm) OR LOWER(a.clasificacion) LIKE LOWER(:searchTerm)) "
+			+ "AND (:clasificacionFilter IS NULL OR LOWER(a.clasificacion) LIKE LOWER(:clasificacionFilter))")
+	Page<Alimento> findForCatalogSearch(@Param("searchTerm") String searchTerm,
+			@Param("clasificacionFilter") String clasificacionFilter, Pageable pageable);
+
+	@Query("SELECT COUNT(a) FROM Alimento a WHERE "
+			+ "(LOWER(a.nombreAlimento) LIKE LOWER(:searchTerm) OR LOWER(a.clasificacion) LIKE LOWER(:searchTerm)) "
+			+ "AND (:clasificacionFilter IS NULL OR LOWER(a.clasificacion) LIKE LOWER(:clasificacionFilter))")
+	long countForCatalogSearch(@Param("searchTerm") String searchTerm,
+			@Param("clasificacionFilter") String clasificacionFilter);
+
 }

--- a/src/test/java/com/nutriconsultas/ai/SearchFoodCatalogToolServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/SearchFoodCatalogToolServiceTest.java
@@ -1,0 +1,146 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.alimentos.AlimentosRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SearchFoodCatalogToolServiceTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	@InjectMocks
+	private SearchFoodCatalogToolServiceImpl service;
+
+	@Mock
+	private AlimentosRepository alimentosRepository;
+
+	@Test
+	void searchReturnsMappedItemsWithDefaultLimit() {
+		final Alimento avena = sampleAlimento(1L, "Avena", "Cereales", "taza", 0.5, 150);
+		when(alimentosRepository.countForCatalogSearch("%avena%", null)).thenReturn(1L);
+		when(alimentosRepository.findForCatalogSearch(eq("%avena%"), eq(null), any(Pageable.class)))
+			.thenReturn(new PageImpl<>(List.of(avena)));
+
+		final AiToolResult<FoodCatalogSearchData> result = service.search(NUTRITIONIST_ID, "avena", null, null);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().items()).hasSize(1);
+		assertThat(result.data().items().get(0).alimentoId()).isEqualTo(1L);
+		assertThat(result.data().items().get(0).nombreAlimento()).isEqualTo("Avena");
+		assertThat(result.data().items().get(0).clasificacion()).isEqualTo("Cereales");
+		assertThat(result.data().items().get(0).unidad()).isEqualTo("taza");
+		assertThat(result.data().items().get(0).cantSugerida()).isEqualTo(0.5);
+		assertThat(result.data().items().get(0).energiaKcalPorPorcion()).isEqualTo(150);
+		assertThat(result.data().totalReturned()).isEqualTo(1);
+		assertThat(result.data().truncated()).isFalse();
+
+		final ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+		verify(alimentosRepository).findForCatalogSearch(eq("%avena%"), eq(null), pageableCaptor.capture());
+		assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(SearchFoodCatalogToolServiceImpl.DEFAULT_LIMIT);
+	}
+
+	@Test
+	void searchAppliesClasificacionFilterAndCustomLimit() {
+		when(alimentosRepository.countForCatalogSearch("%leche%", "%lácteos%")).thenReturn(1L);
+		when(alimentosRepository.findForCatalogSearch(eq("%leche%"), eq("%lácteos%"), any(Pageable.class)))
+			.thenReturn(new PageImpl<>(List.of(sampleAlimento(2L, "Leche", "Lácteos", "taza", 1.0, 120))));
+
+		final AiToolResult<FoodCatalogSearchData> result = service.search(NUTRITIONIST_ID, "leche", "lácteos", 5);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().truncated()).isFalse();
+		verify(alimentosRepository).findForCatalogSearch(eq("%leche%"), eq("%lácteos%"), any(Pageable.class));
+	}
+
+	@Test
+	void searchMarksTruncatedWhenMoreMatchesExist() {
+		when(alimentosRepository.countForCatalogSearch("%arroz%", null)).thenReturn(40L);
+		when(alimentosRepository.findForCatalogSearch(eq("%arroz%"), eq(null), any(Pageable.class)))
+			.thenReturn(new PageImpl<>(List.of(sampleAlimento(3L, "Arroz", "Cereales", "taza", 1.0, 200))));
+
+		final AiToolResult<FoodCatalogSearchData> result = service.search(NUTRITIONIST_ID, "arroz", null, 10);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().totalReturned()).isEqualTo(1);
+		assertThat(result.data().truncated()).isTrue();
+	}
+
+	@Test
+	void searchRejectsShortQuery() {
+		final AiToolResult<FoodCatalogSearchData> result = service.search(NUTRITIONIST_ID, "a", null, null);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+	}
+
+	@Test
+	void searchRejectsOversizedQuery() {
+		final String longQuery = "x".repeat(SearchFoodCatalogToolServiceImpl.MAX_QUERY_LENGTH + 1);
+
+		final AiToolResult<FoodCatalogSearchData> result = service.search(NUTRITIONIST_ID, longQuery, null, null);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+	}
+
+	@Test
+	void searchRejectsLimitAboveMaximum() {
+		final AiToolResult<FoodCatalogSearchData> result = service.search(NUTRITIONIST_ID, "avena", null, 30);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+	}
+
+	@Test
+	void searchRejectsBlankNutritionistId() {
+		final AiToolResult<FoodCatalogSearchData> result = service.search("  ", "avena", null, null);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+	}
+
+	@Test
+	void searchReturnsEmptyListWhenNoMatches() {
+		when(alimentosRepository.countForCatalogSearch("%xyzq%", null)).thenReturn(0L);
+		when(alimentosRepository.findForCatalogSearch(eq("%xyzq%"), eq(null), any(Pageable.class)))
+			.thenReturn(Page.empty());
+
+		final AiToolResult<FoodCatalogSearchData> result = service.search(NUTRITIONIST_ID, "xyzq", null, null);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().items()).isEmpty();
+		assertThat(result.data().totalReturned()).isZero();
+		assertThat(result.data().truncated()).isFalse();
+	}
+
+	private static Alimento sampleAlimento(final long id, final String nombre, final String clasificacion,
+			final String unidad, final double cantSugerida, final int energia) {
+		final Alimento alimento = new Alimento();
+		alimento.setId(id);
+		alimento.setNombreAlimento(nombre);
+		alimento.setClasificacion(clasificacion);
+		alimento.setUnidad(unidad);
+		alimento.setCantSugerida(cantSugerida);
+		alimento.setEnergia(energia);
+		return alimento;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `SearchFoodCatalogToolService` implementing the `search_food_catalog` read-only tool per `TOOL-CONTRACT.md`
- Supports query text, optional `clasificacion` filter, and limit (1–25, default 10); returns food ID, name, category, unit, suggested quantity, and kcal per portion
- Introduces shared `AiToolResult` / `AiToolErrorCode` envelope for Phase 3 tools
- Extends `AlimentosRepository` with catalog search queries

## Test plan
- [x] `mvn test -Dtest=SearchFoodCatalogToolServiceTest`
- [x] `mvn pmd:check -Pci`
- [ ] CI green


Made with [Cursor](https://cursor.com)