### PR TITLE
feat(ai): add get_food_nutrients tool service (Fixes #374)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#374 — Implement Food Nutrient Lookup Tool](https://github.com/diego-torres/nutriconsultas/issues/374) (`NEXT`). ~~#373~~ **done** — `search_food_catalog`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#375 — Implement Dish Catalog Search Tool](https://github.com/diego-torres/nutriconsultas/issues/375) (`NEXT`). ~~#374~~ **done** — `get_food_nutrients`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#374 — Implement Food Nutrient Lookup Tool](https://github.com/diego-torres/nutriconsultas/issues/374) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#373~~ `SearchFoodCatalogToolService`.
+**Current next issue:** [#375 — Implement Dish Catalog Search Tool](https://github.com/diego-torres/nutriconsultas/issues/375) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#374~~ `GetFoodNutrientsToolService`.
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#373~~ food catalog search **done**. **NEXT:** #374.
+**Last updated:** 2026-06-30 — ~~#374~~ food nutrient lookup **done**. **NEXT:** #375.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -103,12 +103,12 @@ Read-only catalog and validation tools for AI orchestration.
 |---|-------|-----|-------|------------|-------|
 | **372** | Epic — Backend Nutrition Tool Services (Phase 3) | https://github.com/diego-torres/nutriconsultas/issues/372 | **open** | **363**, **371** | Milestone 2 — ~~#373~~ |
 | **373** | Implement Food Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/373 | **done** | **372** | `search_food_catalog` |
-| **374** | Implement Food Nutrient Lookup Tool | https://github.com/diego-torres/nutriconsultas/issues/374 | **NEXT** | **372** | `get_food_nutrients` |
-| **375** | Implement Dish Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/375 | **open** | **372** | `search_dish_catalog` |
+| **374** | Implement Food Nutrient Lookup Tool | https://github.com/diego-torres/nutriconsultas/issues/374 | **done** | **372** | `get_food_nutrients` |
+| **375** | Implement Dish Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/375 | **NEXT** | **372** | `search_dish_catalog` |
 | **376** | Implement Recipe Nutrient Calculation Tool | https://github.com/diego-torres/nutriconsultas/issues/376 | **open** | **374** | `calculate_recipe_nutrients` |
 | **377** | Implement Plan Constraint Validation Tool | https://github.com/diego-torres/nutriconsultas/issues/377 | **open** | **376** | `validate_plan_constraints` |
 
-**Suggested order:** ~~#373~~ → #374 + #375 parallel → #376 → #377.
+**Suggested order:** ~~#374~~ → #375 → #376 → #377.
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/FoodNutrientsData.java
+++ b/src/main/java/com/nutriconsultas/ai/FoodNutrientsData.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * {@code data} payload for {@code get_food_nutrients}.
+ */
+public record FoodNutrientsData(long alimentoId, String nombreAlimento, String cantidad, @Nullable Integer pesoNetoG,
+		NutrientSummary nutrientsPerCalculation, NutrientSummary nutrientsTotal) {
+}

--- a/src/main/java/com/nutriconsultas/ai/GetFoodNutrientsToolService.java
+++ b/src/main/java/com/nutriconsultas/ai/GetFoodNutrientsToolService.java
@@ -1,0 +1,17 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+/**
+ * AI tool {@code get_food_nutrients} — nutrient lookup for a catalog food portion.
+ */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
+public interface GetFoodNutrientsToolService {
+
+	String TOOL_NAME = "get_food_nutrients";
+
+	AiToolResult<FoodNutrientsData> getNutrients(@NonNull String nutritionistId, long alimentoId,
+			@NonNull String cantidad, @Nullable Integer pesoNetoG, @Nullable Integer portions, @Nullable String unidad);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/GetFoodNutrientsToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/GetFoodNutrientsToolServiceImpl.java
@@ -1,0 +1,127 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.alimentos.AlimentosRepository;
+import com.nutriconsultas.model.AbstractFraccionable;
+import com.nutriconsultas.platillos.Ingrediente;
+import com.nutriconsultas.util.FractionQuantityParser;
+import com.nutriconsultas.util.IngredienteFromAlimentoCalculator;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class GetFoodNutrientsToolServiceImpl implements GetFoodNutrientsToolService {
+
+	static final int DEFAULT_PORTIONS = 1;
+
+	private final AlimentosRepository alimentosRepository;
+
+	public GetFoodNutrientsToolServiceImpl(final AlimentosRepository alimentosRepository) {
+		this.alimentosRepository = alimentosRepository;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public AiToolResult<FoodNutrientsData> getNutrients(@NonNull final String nutritionistId, final long alimentoId,
+			@NonNull final String cantidad, @Nullable final Integer pesoNetoG, @Nullable final Integer portions,
+			@Nullable final String unidad) {
+		if (!StringUtils.hasText(nutritionistId)) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "Sesión de nutriólogo no válida.");
+		}
+		if (!StringUtils.hasText(cantidad)) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "La cantidad es obligatoria.");
+		}
+		final String trimmedCantidad = cantidad.trim();
+		if (FractionQuantityParser.parseFractionalQuantity(trimmedCantidad) == null) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "La cantidad no es válida.");
+		}
+		if (pesoNetoG != null && pesoNetoG < 1) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El peso neto debe ser al menos 1 g.");
+		}
+		final int effectivePortions = portions == null ? DEFAULT_PORTIONS : portions;
+		if (effectivePortions < 1) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "Las porciones deben ser al menos 1.");
+		}
+
+		final Alimento alimento = alimentosRepository.findById(alimentoId).orElse(null);
+		if (alimento == null) {
+			return AiToolResult.error(AiToolErrorCode.NOT_FOUND, "No se encontró el alimento solicitado.");
+		}
+		if (!isUnitSupported(alimento, unidad)) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"La unidad solicitada no es compatible con el alimento del catálogo.");
+		}
+
+		final Ingrediente calculated = calculateIngredient(alimento, trimmedCantidad, pesoNetoG);
+		if (calculated == null) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "No se pudo calcular el alimento con esos datos.");
+		}
+		final NutrientSummary perCalculation = toNutrientSummary(calculated);
+		final NutrientSummary total = scaleNutrientSummary(perCalculation, effectivePortions);
+		final FoodNutrientsData data = new FoodNutrientsData(alimento.getId(), alimento.getNombreAlimento(),
+				trimmedCantidad, calculated.getPesoNeto(), perCalculation, total);
+		if (log.isInfoEnabled()) {
+			log.info("AI tool get_food_nutrients alimentoId={} portions={}", alimentoId, effectivePortions);
+		}
+		return AiToolResult.success(data);
+	}
+
+	@Nullable
+	private static Ingrediente calculateIngredient(final Alimento alimento, final String trimmedCantidad,
+			@Nullable final Integer pesoNetoG) {
+		final Ingrediente ingrediente = new Ingrediente();
+		try {
+			final Integer effectivePeso = pesoNetoG != null ? pesoNetoG : alimento.getPesoNeto();
+			IngredienteFromAlimentoCalculator.populateCatalogIngredienteFromAlimento(ingrediente, alimento,
+					trimmedCantidad, effectivePeso);
+		}
+		catch (IllegalArgumentException | ArithmeticException ex) {
+			return null;
+		}
+		return ingrediente;
+	}
+
+	private static boolean isUnitSupported(final Alimento alimento, @Nullable final String requestedUnit) {
+		return !StringUtils.hasText(requestedUnit) || (StringUtils.hasText(alimento.getUnidad())
+				&& alimento.getUnidad().trim().equalsIgnoreCase(requestedUnit.trim()));
+	}
+
+	private static NutrientSummary toNutrientSummary(final AbstractFraccionable source) {
+		return new NutrientSummary(source.getEnergia(), source.getProteina(), source.getLipidos(),
+				source.getHidratosDeCarbono(), source.getFibra(), source.getSodio(), source.getPotasio());
+	}
+
+	private static NutrientSummary scaleNutrientSummary(final NutrientSummary summary, final int portions) {
+		if (portions == 1) {
+			return summary;
+		}
+		return new NutrientSummary(scaleInteger(summary.energiaKcal(), portions),
+				scaleDouble(summary.proteinaG(), portions), scaleDouble(summary.lipidosG(), portions),
+				scaleDouble(summary.hidratosDeCarbonoG(), portions), scaleDouble(summary.fibraG(), portions),
+				scaleDouble(summary.sodioMg(), portions), scaleDouble(summary.potasioMg(), portions));
+	}
+
+	@Nullable
+	private static Integer scaleInteger(@Nullable final Integer value, final int portions) {
+		if (value == null) {
+			return null;
+		}
+		return value * portions;
+	}
+
+	@Nullable
+	private static Double scaleDouble(@Nullable final Double value, final int portions) {
+		if (value == null) {
+			return null;
+		}
+		return value * portions;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/NutrientSummary.java
+++ b/src/main/java/com/nutriconsultas/ai/NutrientSummary.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Macros and common micros for AI nutrient tools ({@code docs/ai/TOOL-CONTRACT.md}).
+ */
+public record NutrientSummary(@Nullable Integer energiaKcal, @Nullable Double proteinaG, @Nullable Double lipidosG,
+		@Nullable Double hidratosDeCarbonoG, @Nullable Double fibraG, @Nullable Double sodioMg,
+		@Nullable Double potasioMg) {
+}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressService.java
@@ -145,8 +145,8 @@ public class MobilePatientProgressService {
 			return bodyMetricRecordRepository
 				.findByPacienteIdAndRecordedAtGreaterThanEqualOrderByRecordedAtAscIdAsc(pacienteId, from, pageable);
 		}
-		return bodyMetricRecordRepository.findByPacienteIdAndRecordedAtLessThanEqualOrderByRecordedAtAscIdAsc(pacienteId,
-				to, pageable);
+		return bodyMetricRecordRepository
+			.findByPacienteIdAndRecordedAtLessThanEqualOrderByRecordedAtAscIdAsc(pacienteId, to, pageable);
 	}
 
 	private static int resolveMaxRows(final Integer maxRows) {

--- a/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/metrics/BodyMetricRecordRepository.java
@@ -38,8 +38,8 @@ public interface BodyMetricRecordRepository extends JpaRepository<BodyMetricReco
 	List<BodyMetricRecord> findByPacienteIdAndRecordedAtGreaterThanEqualOrderByRecordedAtAscIdAsc(Long pacienteId,
 			Date from, Pageable pageable);
 
-	List<BodyMetricRecord> findByPacienteIdAndRecordedAtLessThanEqualOrderByRecordedAtAscIdAsc(Long pacienteId,
-			Date to, Pageable pageable);
+	List<BodyMetricRecord> findByPacienteIdAndRecordedAtLessThanEqualOrderByRecordedAtAscIdAsc(Long pacienteId, Date to,
+			Pageable pageable);
 
 	List<BodyMetricRecord> findByPacienteIdAndRecordedAtBetweenOrderByRecordedAtAscIdAsc(Long pacienteId, Date from,
 			Date to, Pageable pageable);

--- a/src/test/java/com/nutriconsultas/ai/GetFoodNutrientsToolServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/GetFoodNutrientsToolServiceTest.java
@@ -1,0 +1,141 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.alimentos.AlimentosRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GetFoodNutrientsToolServiceTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	@InjectMocks
+	private GetFoodNutrientsToolServiceImpl service;
+
+	@Mock
+	private AlimentosRepository alimentosRepository;
+
+	@Test
+	void getNutrientsReturnsCatalogDefaultsForSuggestedQuantity() {
+		final Alimento avena = sampleAlimento(1L, "Avena", "taza", 0.5, 100, 80, 3.0, 2.0, 18.0, 1.5, 5.0, 150.0);
+		when(alimentosRepository.findById(1L)).thenReturn(Optional.of(avena));
+
+		final AiToolResult<FoodNutrientsData> result = service.getNutrients(NUTRITIONIST_ID, 1L, "1/2", null, 1,
+				"taza");
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().alimentoId()).isEqualTo(1L);
+		assertThat(result.data().nombreAlimento()).isEqualTo("Avena");
+		assertThat(result.data().cantidad()).isEqualTo("1/2");
+		assertThat(result.data().nutrientsPerCalculation().energiaKcal()).isEqualTo(100);
+		assertThat(result.data().nutrientsPerCalculation().proteinaG()).isEqualTo(3.0);
+		assertThat(result.data().nutrientsTotal().energiaKcal()).isEqualTo(100);
+	}
+
+	@Test
+	void getNutrientsScalesByCustomQuantity() {
+		final Alimento avena = sampleAlimento(1L, "Avena", "taza", 1.0, 200, 160, 6.0, 4.0, 36.0, 3.0, 10.0, 300.0);
+		when(alimentosRepository.findById(1L)).thenReturn(Optional.of(avena));
+
+		final AiToolResult<FoodNutrientsData> result = service.getNutrients(NUTRITIONIST_ID, 1L, "1/2", null, 1, null);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().nutrientsPerCalculation().energiaKcal()).isEqualTo(100);
+		assertThat(result.data().nutrientsPerCalculation().proteinaG()).isEqualTo(3.0);
+	}
+
+	@Test
+	void getNutrientsScalesByPesoNeto() {
+		final Alimento pollo = sampleAlimento(2L, "Pechuga de pollo", "g", 1.0, 165, 100, 31.0, 3.6, 0.0, 0.0, 74.0,
+				256.0);
+		when(alimentosRepository.findById(2L)).thenReturn(Optional.of(pollo));
+
+		final AiToolResult<FoodNutrientsData> result = service.getNutrients(NUTRITIONIST_ID, 2L, "1", 150, 1, "g");
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().pesoNetoG()).isEqualTo(150);
+		assertThat(result.data().nutrientsPerCalculation().energiaKcal()).isEqualTo(248);
+	}
+
+	@Test
+	void getNutrientsMultipliesTotalsByPortions() {
+		final Alimento avena = sampleAlimento(1L, "Avena", "taza", 0.5, 100, 80, 3.0, 2.0, 18.0, 1.5, 5.0, 150.0);
+		when(alimentosRepository.findById(1L)).thenReturn(Optional.of(avena));
+
+		final AiToolResult<FoodNutrientsData> result = service.getNutrients(NUTRITIONIST_ID, 1L, "1/2", null, 3,
+				"taza");
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().nutrientsPerCalculation().energiaKcal()).isEqualTo(100);
+		assertThat(result.data().nutrientsTotal().energiaKcal()).isEqualTo(300);
+		assertThat(result.data().nutrientsTotal().proteinaG()).isEqualTo(9.0);
+	}
+
+	@Test
+	void getNutrientsReturnsNotFoundForMissingAlimento() {
+		when(alimentosRepository.findById(99L)).thenReturn(Optional.empty());
+
+		final AiToolResult<FoodNutrientsData> result = service.getNutrients(NUTRITIONIST_ID, 99L, "1", null, 1, null);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.NOT_FOUND);
+	}
+
+	@Test
+	void getNutrientsRejectsUnsupportedUnit() {
+		final Alimento avena = sampleAlimento(1L, "Avena", "taza", 0.5, 100, 80, 3.0, 2.0, 18.0, 1.5, 5.0, 150.0);
+		when(alimentosRepository.findById(1L)).thenReturn(Optional.of(avena));
+
+		final AiToolResult<FoodNutrientsData> result = service.getNutrients(NUTRITIONIST_ID, 1L, "1/2", null, 1, "g");
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+	}
+
+	@Test
+	void getNutrientsRejectsInvalidCantidad() {
+		final AiToolResult<FoodNutrientsData> result = service.getNutrients(NUTRITIONIST_ID, 1L, "  ", null, 1, null);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+	}
+
+	@Test
+	void getNutrientsRejectsInvalidPortions() {
+		final AiToolResult<FoodNutrientsData> result = service.getNutrients(NUTRITIONIST_ID, 1L, "1", null, 0, null);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+	}
+
+	private static Alimento sampleAlimento(final long id, final String nombre, final String unidad,
+			final double cantSugerida, final int energia, final int pesoNeto, final double proteina,
+			final double lipidos, final double hidratos, final double fibra, final double sodio, final double potasio) {
+		final Alimento alimento = new Alimento();
+		alimento.setId(id);
+		alimento.setNombreAlimento(nombre);
+		alimento.setClasificacion("Cereales");
+		alimento.setUnidad(unidad);
+		alimento.setCantSugerida(cantSugerida);
+		alimento.setEnergia(energia);
+		alimento.setPesoNeto(pesoNeto);
+		alimento.setProteina(proteina);
+		alimento.setLipidos(lipidos);
+		alimento.setHidratosDeCarbono(hidratos);
+		alimento.setFibra(fibra);
+		alimento.setSodio(sodio);
+		alimento.setPotasio(potasio);
+		return alimento;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `GetFoodNutrientsToolService` implementing `get_food_nutrients` per `TOOL-CONTRACT.md`
- Reuses `IngredienteFromAlimentoCalculator` for quantity/weight scaling from catalog DB values
- Validates unit against catalog, supports optional `pesoNetoG` and `portions` multiplier
- Introduces shared `NutrientSummary` type for Phase 3 nutrient tools

## Test plan
- [x] `mvn test -Dtest=GetFoodNutrientsToolServiceTest`
- [x] `mvn pmd:check -Pci`
- [ ] CI green


Made with [Cursor](https://cursor.com)