### PR TITLE
feat(ai): add search_dish_catalog tool service (Fixes #375)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#375 — Implement Dish Catalog Search Tool](https://github.com/diego-torres/nutriconsultas/issues/375) (`NEXT`). ~~#374~~ **done** — `get_food_nutrients`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#376 — Implement Recipe Nutrient Calculation Tool](https://github.com/diego-torres/nutriconsultas/issues/376) (`NEXT`). ~~#375~~ **done** — `search_dish_catalog`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#375 — Implement Dish Catalog Search Tool](https://github.com/diego-torres/nutriconsultas/issues/375) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#374~~ `GetFoodNutrientsToolService`.
+**Current next issue:** [#376 — Implement Recipe Nutrient Calculation Tool](https://github.com/diego-torres/nutriconsultas/issues/376) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#375~~ `SearchDishCatalogToolService`.
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#374~~ food nutrient lookup **done**. **NEXT:** #375.
+**Last updated:** 2026-06-30 — ~~#375~~ dish catalog search **done**. **NEXT:** #376.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -104,11 +104,11 @@ Read-only catalog and validation tools for AI orchestration.
 | **372** | Epic — Backend Nutrition Tool Services (Phase 3) | https://github.com/diego-torres/nutriconsultas/issues/372 | **open** | **363**, **371** | Milestone 2 — ~~#373~~ |
 | **373** | Implement Food Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/373 | **done** | **372** | `search_food_catalog` |
 | **374** | Implement Food Nutrient Lookup Tool | https://github.com/diego-torres/nutriconsultas/issues/374 | **done** | **372** | `get_food_nutrients` |
-| **375** | Implement Dish Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/375 | **NEXT** | **372** | `search_dish_catalog` |
-| **376** | Implement Recipe Nutrient Calculation Tool | https://github.com/diego-torres/nutriconsultas/issues/376 | **open** | **374** | `calculate_recipe_nutrients` |
+| **375** | Implement Dish Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/375 | **done** | **372** | `search_dish_catalog` |
+| **376** | Implement Recipe Nutrient Calculation Tool | https://github.com/diego-torres/nutriconsultas/issues/376 | **NEXT** | **374** | `calculate_recipe_nutrients` |
 | **377** | Implement Plan Constraint Validation Tool | https://github.com/diego-torres/nutriconsultas/issues/377 | **open** | **376** | `validate_plan_constraints` |
 
-**Suggested order:** ~~#374~~ → #375 → #376 → #377.
+**Suggested order:** ~~#375~~ → #376 → #377.
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/DishCatalogSearchData.java
+++ b/src/main/java/com/nutriconsultas/ai/DishCatalogSearchData.java
@@ -1,0 +1,9 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+/**
+ * {@code data} payload for {@code search_dish_catalog}.
+ */
+public record DishCatalogSearchData(List<DishCatalogSearchItem> items, int totalReturned) {
+}

--- a/src/main/java/com/nutriconsultas/ai/DishCatalogSearchItem.java
+++ b/src/main/java/com/nutriconsultas/ai/DishCatalogSearchItem.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Single row returned by {@code search_dish_catalog}.
+ */
+public record DishCatalogSearchItem(long platilloId, String name, @Nullable String ingestasSugeridas,
+		@Nullable Integer energiaKcal, @Nullable Double proteinaG, boolean ownedByNutritionist, boolean systemCatalog) {
+}

--- a/src/main/java/com/nutriconsultas/ai/SearchDishCatalogToolService.java
+++ b/src/main/java/com/nutriconsultas/ai/SearchDishCatalogToolService.java
@@ -1,0 +1,17 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+/**
+ * AI tool {@code search_dish_catalog} — authorized platillo catalog search.
+ */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
+public interface SearchDishCatalogToolService {
+
+	String TOOL_NAME = "search_dish_catalog";
+
+	AiToolResult<DishCatalogSearchData> search(@NonNull String nutritionistId, @NonNull String query,
+			@Nullable String ingestasSugeridas, @Nullable Integer limit);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/SearchDishCatalogToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/SearchDishCatalogToolServiceImpl.java
@@ -1,0 +1,104 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.platillos.Platillo;
+import com.nutriconsultas.platillos.PlatilloCatalogConstants;
+import com.nutriconsultas.platillos.PlatilloRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class SearchDishCatalogToolServiceImpl implements SearchDishCatalogToolService {
+
+	static final int DEFAULT_LIMIT = 10;
+
+	static final int MAX_LIMIT = 25;
+
+	static final int MIN_QUERY_LENGTH = 2;
+
+	static final int MAX_QUERY_LENGTH = 120;
+
+	static final int MAX_INGESTAS_LENGTH = 80;
+
+	private final PlatilloRepository platilloRepository;
+
+	public SearchDishCatalogToolServiceImpl(final PlatilloRepository platilloRepository) {
+		this.platilloRepository = platilloRepository;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public AiToolResult<DishCatalogSearchData> search(@NonNull final String nutritionistId, @NonNull final String query,
+			@Nullable final String ingestasSugeridas, @Nullable final Integer limit) {
+		if (!StringUtils.hasText(nutritionistId)) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "Sesión de nutriólogo no válida.");
+		}
+		final String trimmedQuery = query.trim();
+		if (trimmedQuery.length() < MIN_QUERY_LENGTH) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"La búsqueda debe tener al menos " + MIN_QUERY_LENGTH + " caracteres.");
+		}
+		if (trimmedQuery.length() > MAX_QUERY_LENGTH) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"La búsqueda no puede superar " + MAX_QUERY_LENGTH + " caracteres.");
+		}
+		if (ingestasSugeridas != null && ingestasSugeridas.length() > MAX_INGESTAS_LENGTH) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"El filtro de ingesta no puede superar " + MAX_INGESTAS_LENGTH + " caracteres.");
+		}
+		final int effectiveLimit = resolveLimit(limit);
+		if (effectiveLimit < 1 || effectiveLimit > MAX_LIMIT) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El límite debe estar entre 1 y " + MAX_LIMIT + ".");
+		}
+
+		final List<String> authorizedUserIds = List.of(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID,
+				nutritionistId.trim());
+		final String searchPattern = "%" + trimmedQuery + "%";
+		final String ingestasFilter = buildIngestasFilter(ingestasSugeridas);
+		final List<Platillo> platillos = platilloRepository
+			.findForAuthorizedCatalogSearch(authorizedUserIds, searchPattern, ingestasFilter,
+					PageRequest.of(0, effectiveLimit))
+			.getContent();
+		final List<DishCatalogSearchItem> items = platillos.stream()
+			.map(platillo -> toItem(platillo, nutritionistId.trim()))
+			.toList();
+		final DishCatalogSearchData data = new DishCatalogSearchData(items, items.size());
+		if (log.isInfoEnabled()) {
+			log.info("AI tool search_dish_catalog resultCount={}", data.totalReturned());
+		}
+		return AiToolResult.success(data);
+	}
+
+	private static int resolveLimit(@Nullable final Integer limit) {
+		if (limit == null) {
+			return DEFAULT_LIMIT;
+		}
+		return limit;
+	}
+
+	@Nullable
+	private static String buildIngestasFilter(@Nullable final String ingestasSugeridas) {
+		if (!StringUtils.hasText(ingestasSugeridas)) {
+			return null;
+		}
+		return "%" + ingestasSugeridas.trim() + "%";
+	}
+
+	private static DishCatalogSearchItem toItem(final Platillo platillo, final String nutritionistId) {
+		final boolean systemCatalog = PlatilloCatalogConstants.isSystemCatalog(platillo);
+		return new DishCatalogSearchItem(platillo.getId(), platillo.getName(), platillo.getIngestasSugeridas(),
+				platillo.getEnergia(), platillo.getProteina(), Objects.equals(nutritionistId, platillo.getUserId()),
+				systemCatalog);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloRepository.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloRepository.java
@@ -40,4 +40,11 @@ public interface PlatilloRepository extends JpaRepository<Platillo, Long> {
 			+ "(p.ingestasSugeridas IS NOT NULL AND LOWER(p.ingestasSugeridas) LIKE LOWER(:searchTerm)))")
 	long countBySearchTerm(@Param("searchTerm") String searchTerm);
 
+	@Query("SELECT p FROM Platillo p WHERE p.userId IN :userIds AND " + "(LOWER(p.name) LIKE LOWER(:searchTerm) OR "
+			+ "(p.ingestasSugeridas IS NOT NULL AND LOWER(p.ingestasSugeridas) LIKE LOWER(:searchTerm))) "
+			+ "AND (:ingestasFilter IS NULL OR (p.ingestasSugeridas IS NOT NULL "
+			+ "AND LOWER(p.ingestasSugeridas) LIKE LOWER(:ingestasFilter)))")
+	Page<Platillo> findForAuthorizedCatalogSearch(@Param("userIds") Collection<String> userIds,
+			@Param("searchTerm") String searchTerm, @Param("ingestasFilter") String ingestasFilter, Pageable pageable);
+
 }

--- a/src/test/java/com/nutriconsultas/ai/SearchDishCatalogToolServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/SearchDishCatalogToolServiceTest.java
@@ -1,0 +1,153 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.nutriconsultas.platillos.Platillo;
+import com.nutriconsultas.platillos.PlatilloCatalogConstants;
+import com.nutriconsultas.platillos.PlatilloRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SearchDishCatalogToolServiceTest {
+
+	private static final String NUTRITIONIST_A = "auth0|nutritionist-a";
+
+	private static final String NUTRITIONIST_B = "auth0|nutritionist-b";
+
+	@InjectMocks
+	private SearchDishCatalogToolServiceImpl service;
+
+	@Mock
+	private PlatilloRepository platilloRepository;
+
+	@Test
+	void searchReturnsMappedItemsWithDefaultLimit() {
+		final Platillo systemDish = samplePlatillo(1L, "Ensalada verde",
+				PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID, "Comida", 120, 4.0);
+		when(platilloRepository.findForAuthorizedCatalogSearch(any(), eq("%ensalada%"), eq(null), any(Pageable.class)))
+			.thenReturn(new PageImpl<>(List.of(systemDish)));
+
+		final AiToolResult<DishCatalogSearchData> result = service.search(NUTRITIONIST_A, "ensalada", null, null);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().items()).hasSize(1);
+		assertThat(result.data().items().get(0).platilloId()).isEqualTo(1L);
+		assertThat(result.data().items().get(0).name()).isEqualTo("Ensalada verde");
+		assertThat(result.data().items().get(0).ingestasSugeridas()).isEqualTo("Comida");
+		assertThat(result.data().items().get(0).energiaKcal()).isEqualTo(120);
+		assertThat(result.data().items().get(0).proteinaG()).isEqualTo(4.0);
+		assertThat(result.data().items().get(0).systemCatalog()).isTrue();
+		assertThat(result.data().items().get(0).ownedByNutritionist()).isFalse();
+		assertThat(result.data().totalReturned()).isEqualTo(1);
+
+		final ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+		verify(platilloRepository).findForAuthorizedCatalogSearch(any(), eq("%ensalada%"), eq(null),
+				pageableCaptor.capture());
+		assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(SearchDishCatalogToolServiceImpl.DEFAULT_LIMIT);
+	}
+
+	@Test
+	void searchScopesToSystemCatalogAndAuthenticatedNutritionist() {
+		when(platilloRepository.findForAuthorizedCatalogSearch(any(), any(), any(), any(Pageable.class)))
+			.thenReturn(new PageImpl<>(List.of()));
+
+		service.search(NUTRITIONIST_A, "tacos", null, 5);
+
+		@SuppressWarnings("unchecked")
+		final ArgumentCaptor<List<String>> userIdsCaptor = ArgumentCaptor.forClass(List.class);
+		verify(platilloRepository).findForAuthorizedCatalogSearch(userIdsCaptor.capture(), eq("%tacos%"), eq(null),
+				any(Pageable.class));
+		assertThat(userIdsCaptor.getValue()).containsExactly(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID,
+				NUTRITIONIST_A);
+		assertThat(userIdsCaptor.getValue()).doesNotContain(NUTRITIONIST_B);
+	}
+
+	@Test
+	void searchMarksOwnedNutritionistPlatillos() {
+		final Platillo ownedDish = samplePlatillo(2L, "Tacos de pollo", NUTRITIONIST_A, "Cena", 300, 18.0);
+		when(platilloRepository.findForAuthorizedCatalogSearch(any(), eq("%tacos%"), eq(null), any(Pageable.class)))
+			.thenReturn(new PageImpl<>(List.of(ownedDish)));
+
+		final AiToolResult<DishCatalogSearchData> result = service.search(NUTRITIONIST_A, "tacos", null, null);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().items().get(0).ownedByNutritionist()).isTrue();
+		assertThat(result.data().items().get(0).systemCatalog()).isFalse();
+	}
+
+	@Test
+	void searchAppliesIngestasFilter() {
+		when(platilloRepository.findForAuthorizedCatalogSearch(any(), eq("%avena%"), eq("%desayuno%"),
+				any(Pageable.class)))
+			.thenReturn(new PageImpl<>(List.of()));
+
+		final AiToolResult<DishCatalogSearchData> result = service.search(NUTRITIONIST_A, "avena", "desayuno", 10);
+
+		assertThat(result.success()).isTrue();
+		verify(platilloRepository).findForAuthorizedCatalogSearch(any(), eq("%avena%"), eq("%desayuno%"),
+				any(Pageable.class));
+	}
+
+	@Test
+	void searchRejectsShortQuery() {
+		final AiToolResult<DishCatalogSearchData> result = service.search(NUTRITIONIST_A, "a", null, null);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+	}
+
+	@Test
+	void searchRejectsLimitAboveMaximum() {
+		final AiToolResult<DishCatalogSearchData> result = service.search(NUTRITIONIST_A, "tacos", null, 30);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+	}
+
+	@Test
+	void searchRejectsBlankNutritionistId() {
+		final AiToolResult<DishCatalogSearchData> result = service.search("  ", "tacos", null, null);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+	}
+
+	@Test
+	void searchReturnsEmptyListWhenNoMatches() {
+		when(platilloRepository.findForAuthorizedCatalogSearch(any(), eq("%xyzq%"), eq(null), any(Pageable.class)))
+			.thenReturn(new PageImpl<>(List.of()));
+
+		final AiToolResult<DishCatalogSearchData> result = service.search(NUTRITIONIST_A, "xyzq", null, null);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().items()).isEmpty();
+		assertThat(result.data().totalReturned()).isZero();
+	}
+
+	private static Platillo samplePlatillo(final long id, final String name, final String userId,
+			final String ingestasSugeridas, final int energia, final double proteina) {
+		final Platillo platillo = new Platillo();
+		platillo.setId(id);
+		platillo.setName(name);
+		platillo.setUserId(userId);
+		platillo.setIngestasSugeridas(ingestasSugeridas);
+		platillo.setEnergia(energia);
+		platillo.setProteina(proteina);
+		return platillo;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `SearchDishCatalogToolService` implementing `search_dish_catalog` per `TOOL-CONTRACT.md`
- Scopes results to system catalog + authenticated nutritionist (`PlatilloCatalogConstants` + `userId`)
- Returns dish ID, name, suggested meal slot, kcal, protein, and ownership flags
- Extends `PlatilloRepository` with authorized catalog search query

## Test plan
- [x] `mvn test -Dtest=SearchDishCatalogToolServiceTest`
- [x] `mvn pmd:check -Pci`
- [x] CI green


Made with [Cursor](https://cursor.com)