### PR TITLE
feat(ai): add calculate_recipe_nutrients tool (Fixes #376)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#376 — Implement Recipe Nutrient Calculation Tool](https://github.com/diego-torres/nutriconsultas/issues/376) (`NEXT`). ~~#375~~ **done** — `search_dish_catalog`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#377 — Implement Plan Constraint Validation Tool](https://github.com/diego-torres/nutriconsultas/issues/377) (`NEXT`). ~~#376~~ **done** — `calculate_recipe_nutrients`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#376 — Implement Recipe Nutrient Calculation Tool](https://github.com/diego-torres/nutriconsultas/issues/376) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#375~~ `SearchDishCatalogToolService`.
+**Current next issue:** [#377 — Implement Plan Constraint Validation Tool](https://github.com/diego-torres/nutriconsultas/issues/377) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#376~~ `CalculateRecipeNutrientsToolService`.
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#375~~ dish catalog search **done**. **NEXT:** #376.
+**Last updated:** 2026-06-30 — ~~#376~~ recipe nutrient calc **done**. **NEXT:** #377.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -105,10 +105,10 @@ Read-only catalog and validation tools for AI orchestration.
 | **373** | Implement Food Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/373 | **done** | **372** | `search_food_catalog` |
 | **374** | Implement Food Nutrient Lookup Tool | https://github.com/diego-torres/nutriconsultas/issues/374 | **done** | **372** | `get_food_nutrients` |
 | **375** | Implement Dish Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/375 | **done** | **372** | `search_dish_catalog` |
-| **376** | Implement Recipe Nutrient Calculation Tool | https://github.com/diego-torres/nutriconsultas/issues/376 | **NEXT** | **374** | `calculate_recipe_nutrients` |
-| **377** | Implement Plan Constraint Validation Tool | https://github.com/diego-torres/nutriconsultas/issues/377 | **open** | **376** | `validate_plan_constraints` |
+| **376** | Implement Recipe Nutrient Calculation Tool | https://github.com/diego-torres/nutriconsultas/issues/376 | **done** | **374** | `calculate_recipe_nutrients` |
+| **377** | Implement Plan Constraint Validation Tool | https://github.com/diego-torres/nutriconsultas/issues/377 | **NEXT** | **376** | `validate_plan_constraints` |
 
-**Suggested order:** ~~#375~~ → #376 → #377.
+**Suggested order:** ~~#376~~ → #377.
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/AiNutrientToolSupport.java
+++ b/src/main/java/com/nutriconsultas/ai/AiNutrientToolSupport.java
@@ -1,0 +1,96 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.model.AbstractFraccionable;
+import com.nutriconsultas.platillos.Ingrediente;
+import com.nutriconsultas.util.IngredienteFromAlimentoCalculator;
+
+/**
+ * Shared nutrient calculation helpers for AI catalog tools.
+ */
+public final class AiNutrientToolSupport {
+
+	private AiNutrientToolSupport() {
+	}
+
+	@Nullable
+	public static Ingrediente calculateIngredient(final Alimento alimento, final String trimmedCantidad,
+			@Nullable final Integer pesoNetoG) {
+		final Ingrediente ingrediente = new Ingrediente();
+		try {
+			final Integer effectivePeso = pesoNetoG != null ? pesoNetoG : alimento.getPesoNeto();
+			IngredienteFromAlimentoCalculator.populateCatalogIngredienteFromAlimento(ingrediente, alimento,
+					trimmedCantidad, effectivePeso);
+		}
+		catch (IllegalArgumentException | ArithmeticException ex) {
+			return null;
+		}
+		return ingrediente;
+	}
+
+	public static boolean isUnitSupported(final Alimento alimento, @Nullable final String requestedUnit) {
+		return !StringUtils.hasText(requestedUnit) || (StringUtils.hasText(alimento.getUnidad())
+				&& alimento.getUnidad().trim().equalsIgnoreCase(requestedUnit.trim()));
+	}
+
+	public static NutrientSummary toNutrientSummary(final AbstractFraccionable source) {
+		return new NutrientSummary(source.getEnergia(), source.getProteina(), source.getLipidos(),
+				source.getHidratosDeCarbono(), source.getFibra(), source.getSodio(), source.getPotasio());
+	}
+
+	public static NutrientSummary scaleNutrientSummary(final NutrientSummary summary, final int portions) {
+		if (portions == 1) {
+			return summary;
+		}
+		return new NutrientSummary(scaleInteger(summary.energiaKcal(), portions),
+				scaleDouble(summary.proteinaG(), portions), scaleDouble(summary.lipidosG(), portions),
+				scaleDouble(summary.hidratosDeCarbonoG(), portions), scaleDouble(summary.fibraG(), portions),
+				scaleDouble(summary.sodioMg(), portions), scaleDouble(summary.potasioMg(), portions));
+	}
+
+	public static NutrientSummary divideNutrientSummary(final NutrientSummary summary, final int portions) {
+		if (portions == 1) {
+			return summary;
+		}
+		return new NutrientSummary(divideInteger(summary.energiaKcal(), portions),
+				divideDouble(summary.proteinaG(), portions), divideDouble(summary.lipidosG(), portions),
+				divideDouble(summary.hidratosDeCarbonoG(), portions), divideDouble(summary.fibraG(), portions),
+				divideDouble(summary.sodioMg(), portions), divideDouble(summary.potasioMg(), portions));
+	}
+
+	@Nullable
+	private static Integer scaleInteger(@Nullable final Integer value, final int portions) {
+		if (value == null) {
+			return null;
+		}
+		return value * portions;
+	}
+
+	@Nullable
+	private static Double scaleDouble(@Nullable final Double value, final int portions) {
+		if (value == null) {
+			return null;
+		}
+		return value * portions;
+	}
+
+	@Nullable
+	private static Integer divideInteger(@Nullable final Integer value, final int portions) {
+		if (value == null) {
+			return null;
+		}
+		return (int) Math.round((double) value / portions);
+	}
+
+	@Nullable
+	private static Double divideDouble(@Nullable final Double value, final int portions) {
+		if (value == null) {
+			return null;
+		}
+		return value / portions;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/CalculateRecipeNutrientsToolService.java
+++ b/src/main/java/com/nutriconsultas/ai/CalculateRecipeNutrientsToolService.java
@@ -1,0 +1,20 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+/**
+ * AI tool {@code calculate_recipe_nutrients} — aggregate nutrients for a recipe
+ * ingredient list.
+ */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
+public interface CalculateRecipeNutrientsToolService {
+
+	String TOOL_NAME = "calculate_recipe_nutrients";
+
+	AiToolResult<RecipeNutrientsData> calculate(@NonNull String nutritionistId,
+			@NonNull List<RecipeIngredientInput> ingredients, @Nullable Integer portions, @Nullable String label);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/CalculateRecipeNutrientsToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/CalculateRecipeNutrientsToolServiceImpl.java
@@ -1,0 +1,154 @@
+package com.nutriconsultas.ai;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.alimentos.AlimentosRepository;
+import com.nutriconsultas.platillos.Ingrediente;
+import com.nutriconsultas.util.FractionQuantityParser;
+import com.nutriconsultas.util.NutrientSummarizer;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class CalculateRecipeNutrientsToolServiceImpl implements CalculateRecipeNutrientsToolService {
+
+	static final int DEFAULT_PORTIONS = 1;
+
+	static final int MIN_INGREDIENTS = 1;
+
+	static final int MAX_INGREDIENTS = 40;
+
+	static final int MAX_LABEL_LENGTH = 120;
+
+	private final AlimentosRepository alimentosRepository;
+
+	public CalculateRecipeNutrientsToolServiceImpl(final AlimentosRepository alimentosRepository) {
+		this.alimentosRepository = alimentosRepository;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public AiToolResult<RecipeNutrientsData> calculate(@NonNull final String nutritionistId,
+			@NonNull final List<RecipeIngredientInput> ingredients, @Nullable final Integer portions,
+			@Nullable final String label) {
+		if (!StringUtils.hasText(nutritionistId)) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "Sesión de nutriólogo no válida.");
+		}
+		if (ingredients.isEmpty() || ingredients.size() > MAX_INGREDIENTS) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"La receta debe tener entre " + MIN_INGREDIENTS + " y " + MAX_INGREDIENTS + " ingredientes.");
+		}
+		if (label != null && label.length() > MAX_LABEL_LENGTH) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"La etiqueta no puede superar " + MAX_LABEL_LENGTH + " caracteres.");
+		}
+		final int effectivePortions = portions == null ? DEFAULT_PORTIONS : portions;
+		if (effectivePortions < 1) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "Las porciones deben ser al menos 1.");
+		}
+
+		final AiToolResult<Void> ingredientValidation = validateIngredients(ingredients);
+		if (!ingredientValidation.success()) {
+			return AiToolResult.error(Objects.requireNonNull(ingredientValidation.errorCode()),
+					Objects.requireNonNull(ingredientValidation.message()));
+		}
+
+		final Map<Long, Alimento> alimentosById = loadAlimentos(ingredients);
+		for (final RecipeIngredientInput ingredient : ingredients) {
+			if (!alimentosById.containsKey(ingredient.alimentoId())) {
+				return AiToolResult.error(AiToolErrorCode.NOT_FOUND, "No se encontró el alimento solicitado.");
+			}
+		}
+
+		final Ingrediente recipeTotals = new Ingrediente();
+		NutrientSummarizer.resetNutrients(recipeTotals);
+		final List<RecipeIngredientNutrientResult> ingredientResults = new ArrayList<>();
+		for (final RecipeIngredientInput ingredient : ingredients) {
+			final Alimento alimento = alimentosById.get(ingredient.alimentoId());
+			if (!AiNutrientToolSupport.isUnitSupported(alimento, ingredient.unidad())) {
+				return AiToolResult.error(AiToolErrorCode.VALIDATION,
+						"La unidad solicitada no es compatible con el alimento del catálogo.");
+			}
+			final Ingrediente calculated = AiNutrientToolSupport.calculateIngredient(alimento,
+					ingredient.cantidad().trim(), ingredient.pesoNetoG());
+			if (calculated == null) {
+				return AiToolResult.error(AiToolErrorCode.VALIDATION,
+						"No se pudo calcular el alimento con id " + ingredient.alimentoId() + ".");
+			}
+			NutrientSummarizer.addNutrients(recipeTotals, calculated);
+			final List<String> warnings = buildMissingNutrientWarnings(alimento);
+			ingredientResults.add(new RecipeIngredientNutrientResult(ingredient.alimentoId(),
+					AiNutrientToolSupport.toNutrientSummary(calculated), warnings));
+		}
+
+		final NutrientSummary nutrientsTotal = AiNutrientToolSupport.toNutrientSummary(recipeTotals);
+		final NutrientSummary nutrientsPerPortion = AiNutrientToolSupport.divideNutrientSummary(nutrientsTotal,
+				effectivePortions);
+		final RecipeNutrientsData data = new RecipeNutrientsData(effectivePortions, ingredientResults,
+				nutrientsPerPortion, nutrientsTotal);
+		if (log.isInfoEnabled()) {
+			log.info("AI tool calculate_recipe_nutrients ingredientCount={} portions={}", ingredients.size(),
+					effectivePortions);
+		}
+		return AiToolResult.success(data);
+	}
+
+	private Map<Long, Alimento> loadAlimentos(final List<RecipeIngredientInput> ingredients) {
+		final List<Long> ids = ingredients.stream().map(RecipeIngredientInput::alimentoId).distinct().toList();
+		final Map<Long, Alimento> alimentosById = new HashMap<>();
+		alimentosRepository.findAllById(ids).forEach(alimento -> alimentosById.put(alimento.getId(), alimento));
+		return alimentosById;
+	}
+
+	private static AiToolResult<Void> validateIngredients(final List<RecipeIngredientInput> ingredients) {
+		for (final RecipeIngredientInput ingredient : ingredients) {
+			if (ingredient.alimentoId() <= 0) {
+				return AiToolResult.error(AiToolErrorCode.VALIDATION, "El identificador de alimento no es válido.");
+			}
+			if (!StringUtils.hasText(ingredient.cantidad())) {
+				return AiToolResult.error(AiToolErrorCode.VALIDATION,
+						"La cantidad es obligatoria para cada ingrediente.");
+			}
+			if (FractionQuantityParser.parseFractionalQuantity(ingredient.cantidad().trim()) == null) {
+				return AiToolResult.error(AiToolErrorCode.VALIDATION, "La cantidad no es válida.");
+			}
+			if (ingredient.pesoNetoG() != null && ingredient.pesoNetoG() < 1) {
+				return AiToolResult.error(AiToolErrorCode.VALIDATION, "El peso neto debe ser al menos 1 g.");
+			}
+		}
+		return AiToolResult.success(null);
+	}
+
+	private static List<String> buildMissingNutrientWarnings(final Alimento alimento) {
+		final List<String> warnings = new ArrayList<>();
+		if (alimento.getCantSugerida() == null) {
+			warnings.add("El alimento " + alimento.getId() + " no tiene cantidad sugerida en el catálogo.");
+		}
+		if (alimento.getEnergia() == null || alimento.getEnergia() == 0) {
+			warnings.add("El alimento " + alimento.getId() + " no tiene energía registrada en el catálogo.");
+		}
+		if (alimento.getProteina() == null || alimento.getProteina() == 0.0) {
+			warnings.add("El alimento " + alimento.getId() + " no tiene proteína registrada en el catálogo.");
+		}
+		if (alimento.getFibra() == null || alimento.getFibra() == 0.0) {
+			warnings.add("El alimento " + alimento.getId() + " no tiene fibra registrada en el catálogo.");
+		}
+		if (alimento.getSodio() == null || alimento.getSodio() == 0.0) {
+			warnings.add("El alimento " + alimento.getId() + " no tiene sodio registrado en el catálogo.");
+		}
+		return warnings;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/GetFoodNutrientsToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/GetFoodNutrientsToolServiceImpl.java
@@ -8,10 +8,8 @@ import org.springframework.util.StringUtils;
 
 import com.nutriconsultas.alimentos.Alimento;
 import com.nutriconsultas.alimentos.AlimentosRepository;
-import com.nutriconsultas.model.AbstractFraccionable;
 import com.nutriconsultas.platillos.Ingrediente;
 import com.nutriconsultas.util.FractionQuantityParser;
-import com.nutriconsultas.util.IngredienteFromAlimentoCalculator;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -54,74 +52,23 @@ public class GetFoodNutrientsToolServiceImpl implements GetFoodNutrientsToolServ
 		if (alimento == null) {
 			return AiToolResult.error(AiToolErrorCode.NOT_FOUND, "No se encontró el alimento solicitado.");
 		}
-		if (!isUnitSupported(alimento, unidad)) {
+		if (!AiNutrientToolSupport.isUnitSupported(alimento, unidad)) {
 			return AiToolResult.error(AiToolErrorCode.VALIDATION,
 					"La unidad solicitada no es compatible con el alimento del catálogo.");
 		}
 
-		final Ingrediente calculated = calculateIngredient(alimento, trimmedCantidad, pesoNetoG);
+		final Ingrediente calculated = AiNutrientToolSupport.calculateIngredient(alimento, trimmedCantidad, pesoNetoG);
 		if (calculated == null) {
 			return AiToolResult.error(AiToolErrorCode.VALIDATION, "No se pudo calcular el alimento con esos datos.");
 		}
-		final NutrientSummary perCalculation = toNutrientSummary(calculated);
-		final NutrientSummary total = scaleNutrientSummary(perCalculation, effectivePortions);
+		final NutrientSummary perCalculation = AiNutrientToolSupport.toNutrientSummary(calculated);
+		final NutrientSummary total = AiNutrientToolSupport.scaleNutrientSummary(perCalculation, effectivePortions);
 		final FoodNutrientsData data = new FoodNutrientsData(alimento.getId(), alimento.getNombreAlimento(),
 				trimmedCantidad, calculated.getPesoNeto(), perCalculation, total);
 		if (log.isInfoEnabled()) {
 			log.info("AI tool get_food_nutrients alimentoId={} portions={}", alimentoId, effectivePortions);
 		}
 		return AiToolResult.success(data);
-	}
-
-	@Nullable
-	private static Ingrediente calculateIngredient(final Alimento alimento, final String trimmedCantidad,
-			@Nullable final Integer pesoNetoG) {
-		final Ingrediente ingrediente = new Ingrediente();
-		try {
-			final Integer effectivePeso = pesoNetoG != null ? pesoNetoG : alimento.getPesoNeto();
-			IngredienteFromAlimentoCalculator.populateCatalogIngredienteFromAlimento(ingrediente, alimento,
-					trimmedCantidad, effectivePeso);
-		}
-		catch (IllegalArgumentException | ArithmeticException ex) {
-			return null;
-		}
-		return ingrediente;
-	}
-
-	private static boolean isUnitSupported(final Alimento alimento, @Nullable final String requestedUnit) {
-		return !StringUtils.hasText(requestedUnit) || (StringUtils.hasText(alimento.getUnidad())
-				&& alimento.getUnidad().trim().equalsIgnoreCase(requestedUnit.trim()));
-	}
-
-	private static NutrientSummary toNutrientSummary(final AbstractFraccionable source) {
-		return new NutrientSummary(source.getEnergia(), source.getProteina(), source.getLipidos(),
-				source.getHidratosDeCarbono(), source.getFibra(), source.getSodio(), source.getPotasio());
-	}
-
-	private static NutrientSummary scaleNutrientSummary(final NutrientSummary summary, final int portions) {
-		if (portions == 1) {
-			return summary;
-		}
-		return new NutrientSummary(scaleInteger(summary.energiaKcal(), portions),
-				scaleDouble(summary.proteinaG(), portions), scaleDouble(summary.lipidosG(), portions),
-				scaleDouble(summary.hidratosDeCarbonoG(), portions), scaleDouble(summary.fibraG(), portions),
-				scaleDouble(summary.sodioMg(), portions), scaleDouble(summary.potasioMg(), portions));
-	}
-
-	@Nullable
-	private static Integer scaleInteger(@Nullable final Integer value, final int portions) {
-		if (value == null) {
-			return null;
-		}
-		return value * portions;
-	}
-
-	@Nullable
-	private static Double scaleDouble(@Nullable final Double value, final int portions) {
-		if (value == null) {
-			return null;
-		}
-		return value * portions;
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/ai/RecipeIngredientInput.java
+++ b/src/main/java/com/nutriconsultas/ai/RecipeIngredientInput.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Ingredient line for {@code calculate_recipe_nutrients}.
+ */
+public record RecipeIngredientInput(long alimentoId, String cantidad, @Nullable Integer pesoNetoG,
+		@Nullable String unidad) {
+}

--- a/src/main/java/com/nutriconsultas/ai/RecipeIngredientNutrientResult.java
+++ b/src/main/java/com/nutriconsultas/ai/RecipeIngredientNutrientResult.java
@@ -1,0 +1,9 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+/**
+ * Per-ingredient nutrient result for {@code calculate_recipe_nutrients}.
+ */
+public record RecipeIngredientNutrientResult(long alimentoId, NutrientSummary nutrients, List<String> warnings) {
+}

--- a/src/main/java/com/nutriconsultas/ai/RecipeNutrientsData.java
+++ b/src/main/java/com/nutriconsultas/ai/RecipeNutrientsData.java
@@ -1,0 +1,12 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * {@code data} payload for {@code calculate_recipe_nutrients}.
+ */
+public record RecipeNutrientsData(int portions, @Nullable List<RecipeIngredientNutrientResult> ingredientResults,
+		NutrientSummary nutrientsPerPortion, NutrientSummary nutrientsTotal) {
+}

--- a/src/test/java/com/nutriconsultas/ai/CalculateRecipeNutrientsToolServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/CalculateRecipeNutrientsToolServiceTest.java
@@ -1,0 +1,133 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.alimentos.AlimentosRepository;
+
+@ExtendWith(MockitoExtension.class)
+class CalculateRecipeNutrientsToolServiceTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	@InjectMocks
+	private CalculateRecipeNutrientsToolServiceImpl service;
+
+	@Mock
+	private AlimentosRepository alimentosRepository;
+
+	@Test
+	void calculateSumsIngredientsAndDividesPerPortion() {
+		final Alimento avena = sampleAlimento(1L, "Avena", "taza", 1.0, 200, 160, 6.0, 4.0, 36.0, 3.0, 10.0, 300.0);
+		final Alimento leche = sampleAlimento(2L, "Leche", "taza", 1.0, 120, 240, 8.0, 4.5, 12.0, 0.0, 105.0, 380.0);
+		when(alimentosRepository.findAllById(any())).thenReturn(List.of(avena, leche));
+
+		final AiToolResult<RecipeNutrientsData> result = service.calculate(NUTRITIONIST_ID, List
+			.of(new RecipeIngredientInput(1L, "1/2", null, "taza"), new RecipeIngredientInput(2L, "1/2", null, "taza")),
+				2, "Avena con leche");
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().portions()).isEqualTo(2);
+		assertThat(result.data().ingredientResults()).hasSize(2);
+		assertThat(result.data().nutrientsTotal().energiaKcal()).isEqualTo(160);
+		assertThat(result.data().nutrientsPerPortion().energiaKcal()).isEqualTo(80);
+		assertThat(result.data().nutrientsTotal().proteinaG()).isEqualTo(7.0);
+	}
+
+	@Test
+	void calculateReturnsNotFoundForUnknownAlimento() {
+		when(alimentosRepository.findAllById(any())).thenReturn(List.of());
+
+		final AiToolResult<RecipeNutrientsData> result = service.calculate(NUTRITIONIST_ID,
+				List.of(new RecipeIngredientInput(99L, "1", null, null)), 1, null);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.NOT_FOUND);
+	}
+
+	@Test
+	void calculateRejectsUnsupportedUnit() {
+		final Alimento avena = sampleAlimento(1L, "Avena", "taza", 1.0, 200, 160, 6.0, 4.0, 36.0, 3.0, 10.0, 300.0);
+		when(alimentosRepository.findAllById(any())).thenReturn(List.of(avena));
+
+		final AiToolResult<RecipeNutrientsData> result = service.calculate(NUTRITIONIST_ID,
+				List.of(new RecipeIngredientInput(1L, "1", null, "g")), 1, null);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+	}
+
+	@Test
+	void calculateIncludesMissingNutrientWarnings() {
+		final Alimento incomplete = sampleAlimento(3L, "Agua", "taza", 1.0, 0, 240, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+		when(alimentosRepository.findAllById(any())).thenReturn(List.of(incomplete));
+
+		final AiToolResult<RecipeNutrientsData> result = service.calculate(NUTRITIONIST_ID,
+				List.of(new RecipeIngredientInput(3L, "1", null, null)), 1, null);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().ingredientResults().get(0).warnings()).isNotEmpty();
+	}
+
+	@Test
+	void calculateRejectsEmptyIngredientList() {
+		final AiToolResult<RecipeNutrientsData> result = service.calculate(NUTRITIONIST_ID, List.of(), 1, null);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+	}
+
+	@Test
+	void calculateRejectsInvalidCantidad() {
+		final AiToolResult<RecipeNutrientsData> result = service.calculate(NUTRITIONIST_ID,
+				List.of(new RecipeIngredientInput(1L, "  ", null, null)), 1, null);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+	}
+
+	@Test
+	void calculateScalesByPesoNeto() {
+		final Alimento pollo = sampleAlimento(4L, "Pechuga de pollo", "g", 1.0, 165, 100, 31.0, 3.6, 0.0, 0.0, 74.0,
+				256.0);
+		when(alimentosRepository.findAllById(any())).thenReturn(List.of(pollo));
+
+		final AiToolResult<RecipeNutrientsData> result = service.calculate(NUTRITIONIST_ID,
+				List.of(new RecipeIngredientInput(4L, "1", 200, "g")), 1, null);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().nutrientsTotal().energiaKcal()).isEqualTo(330);
+		assertThat(result.data().nutrientsTotal().proteinaG()).isEqualTo(62.0);
+	}
+
+	private static Alimento sampleAlimento(final long id, final String nombre, final String unidad,
+			final double cantSugerida, final int energia, final int pesoNeto, final double proteina,
+			final double lipidos, final double hidratos, final double fibra, final double sodio, final double potasio) {
+		final Alimento alimento = new Alimento();
+		alimento.setId(id);
+		alimento.setNombreAlimento(nombre);
+		alimento.setClasificacion("Cereales");
+		alimento.setUnidad(unidad);
+		alimento.setCantSugerida(cantSugerida);
+		alimento.setEnergia(energia);
+		alimento.setPesoNeto(pesoNeto);
+		alimento.setProteina(proteina);
+		alimento.setLipidos(lipidos);
+		alimento.setHidratosDeCarbono(hidratos);
+		alimento.setFibra(fibra);
+		alimento.setSodio(sodio);
+		alimento.setPotasio(potasio);
+		return alimento;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `CalculateRecipeNutrientsToolService` implementing `calculate_recipe_nutrients` per `TOOL-CONTRACT.md`
- Sums ingredient nutrients via `IngredienteFromAlimentoCalculator` + `NutrientSummarizer`; divides totals by portions
- Per-ingredient warnings for missing catalog nutrient data; rejects unknown IDs and unsupported units
- Extract `AiNutrientToolSupport` shared with `GetFoodNutrientsToolService`

## Test plan
- [x] `mvn test -Dtest=CalculateRecipeNutrientsToolServiceTest,GetFoodNutrientsToolServiceTest`
- [x] `mvn pmd:check -Pci`
- [ ] CI green


Made with [Cursor](https://cursor.com)