### PR TITLE
feat(ai): add validate_plan_constraints tool (Fixes #377)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#377 — Implement Plan Constraint Validation Tool](https://github.com/diego-torres/nutriconsultas/issues/377) (`NEXT`). ~~#376~~ **done** — `calculate_recipe_nutrients`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#378 — Epic AI Draft Creation Tools](https://github.com/diego-torres/nutriconsultas/issues/378) (`NEXT`). ~~#377~~ **done** — Phase 3 complete. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#377 — Implement Plan Constraint Validation Tool](https://github.com/diego-torres/nutriconsultas/issues/377) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#376~~ `CalculateRecipeNutrientsToolService`.
+**Current next issue:** [#378 — Epic AI Draft Creation Tools](https://github.com/diego-torres/nutriconsultas/issues/378) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#377~~ `ValidatePlanConstraintsToolService`; Phase 3 **complete**.
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#376~~ recipe nutrient calc **done**. **NEXT:** #377.
+**Last updated:** 2026-06-30 — ~~#377~~ plan constraint validation **done**. **NEXT:** #378.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -101,14 +101,14 @@ Read-only catalog and validation tools for AI orchestration.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **372** | Epic — Backend Nutrition Tool Services (Phase 3) | https://github.com/diego-torres/nutriconsultas/issues/372 | **open** | **363**, **371** | Milestone 2 — ~~#373~~ |
+| **372** | Epic — Backend Nutrition Tool Services (Phase 3) | https://github.com/diego-torres/nutriconsultas/issues/372 | **done** | **363**, **371** | Milestone 2 — ~~#373–#377~~ |
 | **373** | Implement Food Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/373 | **done** | **372** | `search_food_catalog` |
 | **374** | Implement Food Nutrient Lookup Tool | https://github.com/diego-torres/nutriconsultas/issues/374 | **done** | **372** | `get_food_nutrients` |
 | **375** | Implement Dish Catalog Search Tool | https://github.com/diego-torres/nutriconsultas/issues/375 | **done** | **372** | `search_dish_catalog` |
 | **376** | Implement Recipe Nutrient Calculation Tool | https://github.com/diego-torres/nutriconsultas/issues/376 | **done** | **374** | `calculate_recipe_nutrients` |
-| **377** | Implement Plan Constraint Validation Tool | https://github.com/diego-torres/nutriconsultas/issues/377 | **NEXT** | **376** | `validate_plan_constraints` |
+| **377** | Implement Plan Constraint Validation Tool | https://github.com/diego-torres/nutriconsultas/issues/377 | **done** | **376** | `validate_plan_constraints` |
 
-**Suggested order:** ~~#376~~ → #377.
+**Suggested order:** ~~#377~~.
 
 ---
 
@@ -118,7 +118,7 @@ Draft-creation tools and acceptance flow (no direct patient assignment).
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **378** | Epic — AI Draft Creation Tools (Phase 4) | https://github.com/diego-torres/nutriconsultas/issues/378 | **open** | **372** | Milestone 2 |
+| **378** | Epic — AI Draft Creation Tools (Phase 4) | https://github.com/diego-torres/nutriconsultas/issues/378 | **NEXT** | **372** | Milestone 2 |
 | **379** | Implement Dish Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/379 | **open** | **378**, **371** | `create_dish_draft` |
 | **380** | Implement Menu Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/380 | **open** | **378**, **371** | `create_menu_draft` |
 | **381** | Implement Diet Plan Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/381 | **open** | **378**, **371** | `create_diet_plan_draft` |

--- a/src/main/java/com/nutriconsultas/ai/AiIngestaNutrientCalculator.java
+++ b/src/main/java/com/nutriconsultas/ai/AiIngestaNutrientCalculator.java
@@ -1,0 +1,205 @@
+package com.nutriconsultas.ai;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.alimentos.AlimentosRepository;
+import com.nutriconsultas.platillos.Platillo;
+import com.nutriconsultas.platillos.PlatilloCatalogConstants;
+import com.nutriconsultas.platillos.PlatilloRepository;
+
+/**
+ * Computes nutrient totals from AI plan draft structures.
+ */
+@Component
+public class AiIngestaNutrientCalculator {
+
+	private final AlimentosRepository alimentosRepository;
+
+	private final PlatilloRepository platilloRepository;
+
+	private final CalculateRecipeNutrientsToolService recipeNutrientsToolService;
+
+	public AiIngestaNutrientCalculator(final AlimentosRepository alimentosRepository,
+			final PlatilloRepository platilloRepository,
+			final CalculateRecipeNutrientsToolService recipeNutrientsToolService) {
+		this.alimentosRepository = alimentosRepository;
+		this.platilloRepository = platilloRepository;
+		this.recipeNutrientsToolService = recipeNutrientsToolService;
+	}
+
+	public AiToolResult<IngestaNutrientComputation> computeDish(@NonNull final String nutritionistId,
+			@NonNull final DishPlanInput dish) {
+		if (dish.ingredients() == null || dish.ingredients().isEmpty()) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El platillo debe incluir ingredientes.");
+		}
+		final AiToolResult<RecipeNutrientsData> recipeResult = recipeNutrientsToolService.calculate(nutritionistId,
+				dish.ingredients(), dish.portions(), null);
+		if (!recipeResult.success()) {
+			return AiToolResult.error(Objects.requireNonNull(recipeResult.errorCode()),
+					Objects.requireNonNull(recipeResult.message()));
+		}
+		final RecipeNutrientsData recipeData = Objects.requireNonNull(recipeResult.data());
+		final List<PlanConstraintWarning> warnings = new ArrayList<>();
+		for (final RecipeIngredientNutrientResult ingredientResult : recipeData.ingredientResults()) {
+			for (final String warning : ingredientResult.warnings()) {
+				warnings.add(new PlanConstraintWarning(PlanConstraintWarningCode.MISSING_NUTRIENT_DATA, warning,
+						PlanConstraintWarningSeverity.WARNING));
+			}
+		}
+		final Set<Long> alimentoIds = new HashSet<>();
+		dish.ingredients().forEach(ingredient -> alimentoIds.add(ingredient.alimentoId()));
+		return AiToolResult
+			.success(new IngestaNutrientComputation(recipeData.nutrientsPerPortion(), warnings, alimentoIds));
+	}
+
+	public AiToolResult<IngestaNutrientComputation> computeIngestas(@NonNull final String nutritionistId,
+			@Nullable final List<IngestaSlotInput> ingestas) {
+		if (ingestas == null || ingestas.isEmpty()) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El plan debe incluir al menos una ingesta.");
+		}
+		NutrientSummary totals = AiNutrientToolSupport.emptyNutrientSummary();
+		final List<PlanConstraintWarning> warnings = new ArrayList<>();
+		final Set<Long> alimentoIds = new HashSet<>();
+		for (final IngestaSlotInput ingesta : ingestas) {
+			if (ingesta.items() == null) {
+				continue;
+			}
+			for (final IngestaSlotItemInput item : ingesta.items()) {
+				final AiToolResult<ItemNutrientContribution> itemResult = computeItem(nutritionistId, item);
+				if (!itemResult.success()) {
+					return AiToolResult.error(Objects.requireNonNull(itemResult.errorCode()),
+							Objects.requireNonNull(itemResult.message()));
+				}
+				final ItemNutrientContribution contribution = Objects.requireNonNull(itemResult.data());
+				totals = AiNutrientToolSupport.addNutrientSummaries(totals, contribution.nutrients());
+				warnings.addAll(contribution.warnings());
+				alimentoIds.addAll(contribution.alimentoIds());
+			}
+		}
+		return AiToolResult.success(new IngestaNutrientComputation(totals, warnings, alimentoIds));
+	}
+
+	private AiToolResult<ItemNutrientContribution> computeItem(final String nutritionistId,
+			final IngestaSlotItemInput item) {
+		final String type = item.type() != null ? item.type().trim().toUpperCase(Locale.ROOT) : "";
+		return switch (type) {
+			case "PLATILLO" -> computePlatilloItem(nutritionistId, item);
+			case "ALIMENTO" -> computeAlimentoItem(item);
+			case "RECIPE" -> computeRecipeItem(nutritionistId, item);
+			default -> AiToolResult.error(AiToolErrorCode.VALIDATION, "Tipo de ítem de ingesta no válido.");
+		};
+	}
+
+	private AiToolResult<ItemNutrientContribution> computePlatilloItem(final String nutritionistId,
+			final IngestaSlotItemInput item) {
+		if (item.platilloId() == null || item.platilloId() <= 0) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El platillo no es válido.");
+		}
+		final Platillo platillo = platilloRepository.findById(item.platilloId()).orElse(null);
+		if (platillo == null || !isAuthorizedPlatillo(platillo, nutritionistId)) {
+			return AiToolResult.error(AiToolErrorCode.NOT_FOUND, "No se encontró el platillo solicitado.");
+		}
+		final int portions = resolvePortions(item.portions());
+		final NutrientSummary nutrients = AiNutrientToolSupport.platilloNutrients(platillo, portions);
+		final Set<Long> alimentoIds = new HashSet<>();
+		if (platillo.getIngredientes() != null) {
+			platillo.getIngredientes()
+				.stream()
+				.filter(ingrediente -> ingrediente.getAlimento() != null)
+				.forEach(ingrediente -> alimentoIds.add(ingrediente.getAlimento().getId()));
+		}
+		return AiToolResult.success(new ItemNutrientContribution(nutrients, List.of(), alimentoIds));
+	}
+
+	private AiToolResult<ItemNutrientContribution> computeAlimentoItem(final IngestaSlotItemInput item) {
+		if (item.alimentoId() == null || item.alimentoId() <= 0) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El alimento no es válido.");
+		}
+		final Alimento alimento = alimentosRepository.findById(item.alimentoId()).orElse(null);
+		if (alimento == null) {
+			return AiToolResult.error(AiToolErrorCode.NOT_FOUND, "No se encontró el alimento solicitado.");
+		}
+		final int portions = resolvePortions(item.portions());
+		final String cantidad = alimento.getFractionalCantSugerida();
+		if (!StringUtils.hasText(cantidad)) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"El alimento " + alimento.getId() + " no tiene cantidad sugerida en el catálogo.");
+		}
+		final com.nutriconsultas.platillos.Ingrediente calculated = AiNutrientToolSupport.calculateIngredient(alimento,
+				cantidad, alimento.getPesoNeto());
+		if (calculated == null) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"No se pudo calcular el alimento con id " + alimento.getId() + ".");
+		}
+		final NutrientSummary nutrients = AiNutrientToolSupport
+			.scaleNutrientSummary(AiNutrientToolSupport.toNutrientSummary(calculated), portions);
+		final List<PlanConstraintWarning> warnings = buildMissingDataWarnings(alimento);
+		return AiToolResult.success(new ItemNutrientContribution(nutrients, warnings, Set.of(alimento.getId())));
+	}
+
+	private AiToolResult<ItemNutrientContribution> computeRecipeItem(final String nutritionistId,
+			final IngestaSlotItemInput item) {
+		if (item.ingredients() == null || item.ingredients().isEmpty()) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "La receta inline debe incluir ingredientes.");
+		}
+		final AiToolResult<RecipeNutrientsData> recipeResult = recipeNutrientsToolService.calculate(nutritionistId,
+				item.ingredients(), item.portions(), null);
+		if (!recipeResult.success()) {
+			return AiToolResult.error(Objects.requireNonNull(recipeResult.errorCode()),
+					Objects.requireNonNull(recipeResult.message()));
+		}
+		final RecipeNutrientsData recipeData = Objects.requireNonNull(recipeResult.data());
+		final List<PlanConstraintWarning> warnings = new ArrayList<>();
+		final Set<Long> alimentoIds = new HashSet<>();
+		for (final RecipeIngredientNutrientResult ingredientResult : recipeData.ingredientResults()) {
+			alimentoIds.add(ingredientResult.alimentoId());
+			for (final String warning : ingredientResult.warnings()) {
+				warnings.add(new PlanConstraintWarning(PlanConstraintWarningCode.MISSING_NUTRIENT_DATA, warning,
+						PlanConstraintWarningSeverity.WARNING));
+			}
+		}
+		return AiToolResult.success(new ItemNutrientContribution(recipeData.nutrientsTotal(), warnings, alimentoIds));
+	}
+
+	private static List<PlanConstraintWarning> buildMissingDataWarnings(final Alimento alimento) {
+		final List<PlanConstraintWarning> warnings = new ArrayList<>();
+		if (alimento.getEnergia() == null || alimento.getEnergia() == 0) {
+			warnings.add(new PlanConstraintWarning(PlanConstraintWarningCode.MISSING_NUTRIENT_DATA,
+					"El alimento " + alimento.getId() + " no tiene energía registrada en el catálogo.",
+					PlanConstraintWarningSeverity.WARNING));
+		}
+		return warnings;
+	}
+
+	private static boolean isAuthorizedPlatillo(final Platillo platillo, final String nutritionistId) {
+		return PlatilloCatalogConstants.isSystemCatalog(platillo)
+				|| Objects.equals(nutritionistId, platillo.getUserId());
+	}
+
+	private static int resolvePortions(@Nullable final Integer portions) {
+		if (portions == null || portions < 1) {
+			return 1;
+		}
+		return portions;
+	}
+
+	record IngestaNutrientComputation(NutrientSummary nutrients, List<PlanConstraintWarning> warnings,
+			Set<Long> alimentoIds) {
+	}
+
+	private record ItemNutrientContribution(NutrientSummary nutrients, List<PlanConstraintWarning> warnings,
+			Set<Long> alimentoIds) {
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiNutrientToolSupport.java
+++ b/src/main/java/com/nutriconsultas/ai/AiNutrientToolSupport.java
@@ -61,6 +61,26 @@ public final class AiNutrientToolSupport {
 				divideDouble(summary.sodioMg(), portions), divideDouble(summary.potasioMg(), portions));
 	}
 
+	public static NutrientSummary addNutrientSummaries(final NutrientSummary left, final NutrientSummary right) {
+		return new NutrientSummary(addInteger(left.energiaKcal(), right.energiaKcal()),
+				addDouble(left.proteinaG(), right.proteinaG()), addDouble(left.lipidosG(), right.lipidosG()),
+				addDouble(left.hidratosDeCarbonoG(), right.hidratosDeCarbonoG()),
+				addDouble(left.fibraG(), right.fibraG()), addDouble(left.sodioMg(), right.sodioMg()),
+				addDouble(left.potasioMg(), right.potasioMg()));
+	}
+
+	public static NutrientSummary emptyNutrientSummary() {
+		return new NutrientSummary(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+	}
+
+	public static NutrientSummary platilloNutrients(final com.nutriconsultas.platillos.Platillo platillo,
+			final int portions) {
+		final NutrientSummary perPortion = new NutrientSummary(platillo.getEnergia(), platillo.getProteina(),
+				platillo.getLipidos(), platillo.getHidratosDeCarbono(), platillo.getFibra(), platillo.getSodio(),
+				platillo.getPotasio());
+		return scaleNutrientSummary(perPortion, portions);
+	}
+
 	@Nullable
 	private static Integer scaleInteger(@Nullable final Integer value, final int portions) {
 		if (value == null) {
@@ -91,6 +111,23 @@ public final class AiNutrientToolSupport {
 			return null;
 		}
 		return value / portions;
+	}
+
+	@Nullable
+	private static Integer addInteger(@Nullable final Integer left, @Nullable final Integer right) {
+		return safeInt(left) + safeInt(right);
+	}
+
+	private static double addDouble(@Nullable final Double left, @Nullable final Double right) {
+		return safeDouble(left) + safeDouble(right);
+	}
+
+	private static int safeInt(@Nullable final Integer value) {
+		return value != null ? value : 0;
+	}
+
+	private static double safeDouble(@Nullable final Double value) {
+		return value != null ? value : 0.0;
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/ai/AiPlanConstraintEvaluator.java
+++ b/src/main/java/com/nutriconsultas/ai/AiPlanConstraintEvaluator.java
@@ -1,0 +1,189 @@
+package com.nutriconsultas.ai;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.alimentos.AlimentosRepository;
+
+/**
+ * Evaluates computed nutrients against plan constraints and patient context.
+ */
+public final class AiPlanConstraintEvaluator {
+
+	private static final double DEFAULT_TOLERANCE_KCAL = 50.0;
+
+	private AiPlanConstraintEvaluator() {
+	}
+
+	public static List<PlanConstraintWarning> evaluate(final NutrientSummary computed,
+			final ValidatePlanConstraintsRequest request, @Nullable final AiPatientPromptContext patientContext,
+			final Set<Long> alimentoIds, final AlimentosRepository alimentosRepository) {
+		final List<PlanConstraintWarning> warnings = new ArrayList<>();
+		final Double targetKcal = resolveTargetKcal(request, patientContext);
+		final double tolerance = request.toleranceKcal() != null ? request.toleranceKcal() : DEFAULT_TOLERANCE_KCAL;
+		evaluateKcal(computed, targetKcal, tolerance, warnings);
+		evaluateProtein(computed, request.targetProteinaG(), warnings);
+		evaluateSodium(computed, request.maxSodioMg(), warnings);
+		evaluateExclusions(alimentoIds, request.excludedAlimentoIds(), alimentosRepository, warnings);
+		evaluateAllergies(alimentoIds, patientContext, alimentosRepository, warnings);
+		evaluatePathologyNotes(patientContext, warnings);
+		return warnings;
+	}
+
+	public static boolean isValid(final List<PlanConstraintWarning> warnings) {
+		return warnings.stream().noneMatch(warning -> warning.severity() == PlanConstraintWarningSeverity.ERROR);
+	}
+
+	public static boolean patientContextApplied(@Nullable final AiPatientPromptContext patientContext,
+			final ValidatePlanConstraintsRequest request, final List<PlanConstraintWarning> warnings) {
+		if (patientContext == null) {
+			return false;
+		}
+		final boolean targetFromPatient = request.targetKcal() == null
+				&& resolveTargetKcal(request, patientContext) != null;
+		final boolean allergyWarning = warnings.stream()
+			.anyMatch(warning -> warning.code() == PlanConstraintWarningCode.ALLERGY_RISK);
+		final boolean pathologyNote = warnings.stream()
+			.anyMatch(warning -> warning.code() == PlanConstraintWarningCode.PATHOLOGY_NOTE);
+		return targetFromPatient || StringUtils.hasText(patientContext.alergias()) || allergyWarning || pathologyNote
+				|| hasActivePathology(patientContext);
+	}
+
+	@Nullable
+	private static Double resolveTargetKcal(final ValidatePlanConstraintsRequest request,
+			@Nullable final AiPatientPromptContext patientContext) {
+		if (request.targetKcal() != null) {
+			return request.targetKcal();
+		}
+		if (patientContext == null) {
+			return null;
+		}
+		if (Boolean.TRUE.equals(patientContext.physiologicalStressActive())
+				&& patientContext.finalTotalKcal() != null) {
+			return patientContext.finalTotalKcal();
+		}
+		return patientContext.requerimientoKcal();
+	}
+
+	private static void evaluateKcal(final NutrientSummary computed, @Nullable final Double targetKcal,
+			final double tolerance, final List<PlanConstraintWarning> warnings) {
+		if (targetKcal == null || computed.energiaKcal() == null) {
+			return;
+		}
+		final double delta = Math.abs(computed.energiaKcal() - targetKcal);
+		if (delta <= tolerance) {
+			return;
+		}
+		final PlanConstraintWarningSeverity severity = delta > tolerance * 2 ? PlanConstraintWarningSeverity.ERROR
+				: PlanConstraintWarningSeverity.WARNING;
+		warnings.add(new PlanConstraintWarning(
+				PlanConstraintWarningCode.KCAL_OUT_OF_RANGE, "Las kcal calculadas (" + computed.energiaKcal()
+						+ ") están fuera del objetivo (" + targetKcal.intValue() + " ± " + (int) tolerance + ").",
+				severity));
+	}
+
+	private static void evaluateProtein(final NutrientSummary computed, @Nullable final Double targetProteinaG,
+			final List<PlanConstraintWarning> warnings) {
+		if (targetProteinaG == null || computed.proteinaG() == null) {
+			return;
+		}
+		if (computed.proteinaG() + 0.001 < targetProteinaG) {
+			warnings.add(new PlanConstraintWarning(PlanConstraintWarningCode.PROTEIN_LOW,
+					"La proteína calculada (" + formatDouble(computed.proteinaG())
+							+ " g) está por debajo del objetivo (" + formatDouble(targetProteinaG) + " g).",
+					PlanConstraintWarningSeverity.WARNING));
+		}
+	}
+
+	private static void evaluateSodium(final NutrientSummary computed, @Nullable final Double maxSodioMg,
+			final List<PlanConstraintWarning> warnings) {
+		if (maxSodioMg == null || computed.sodioMg() == null) {
+			return;
+		}
+		if (computed.sodioMg() > maxSodioMg) {
+			warnings.add(new PlanConstraintWarning(
+					PlanConstraintWarningCode.SODIUM_HIGH, "El sodio calculado (" + formatDouble(computed.sodioMg())
+							+ " mg) supera el máximo permitido (" + formatDouble(maxSodioMg) + " mg).",
+					PlanConstraintWarningSeverity.WARNING));
+		}
+	}
+
+	private static void evaluateExclusions(final Set<Long> alimentoIds, @Nullable final List<Long> excludedAlimentoIds,
+			final AlimentosRepository alimentosRepository, final List<PlanConstraintWarning> warnings) {
+		if (excludedAlimentoIds == null || excludedAlimentoIds.isEmpty()) {
+			return;
+		}
+		for (final Long excludedId : excludedAlimentoIds) {
+			if (alimentoIds.contains(excludedId)) {
+				final String name = alimentosRepository.findById(excludedId)
+					.map(Alimento::getNombreAlimento)
+					.orElse("ID " + excludedId);
+				warnings.add(new PlanConstraintWarning(PlanConstraintWarningCode.ALLERGY_RISK,
+						"El plan incluye un alimento excluido: " + name + ".", PlanConstraintWarningSeverity.ERROR));
+			}
+		}
+	}
+
+	private static void evaluateAllergies(final Set<Long> alimentoIds,
+			@Nullable final AiPatientPromptContext patientContext, final AlimentosRepository alimentosRepository,
+			final List<PlanConstraintWarning> warnings) {
+		if (patientContext == null || !StringUtils.hasText(patientContext.alergias())) {
+			return;
+		}
+		for (final Long alimentoId : alimentoIds) {
+			alimentosRepository.findById(alimentoId).ifPresent(alimento -> {
+				if (matchesAllergy(alimento.getNombreAlimento(), patientContext.alergias())) {
+					warnings.add(new PlanConstraintWarning(PlanConstraintWarningCode.ALLERGY_RISK,
+							"Posible alérgeno en el plan: " + alimento.getNombreAlimento() + ".",
+							PlanConstraintWarningSeverity.ERROR));
+				}
+			});
+		}
+	}
+
+	private static void evaluatePathologyNotes(@Nullable final AiPatientPromptContext patientContext,
+			final List<PlanConstraintWarning> warnings) {
+		if (!hasActivePathology(patientContext)) {
+			return;
+		}
+		warnings.add(new PlanConstraintWarning(PlanConstraintWarningCode.PATHOLOGY_NOTE,
+				"Revise el plan considerando las patologías registradas del paciente; esta validación no sustituye criterio clínico.",
+				PlanConstraintWarningSeverity.INFO));
+	}
+
+	private static boolean hasActivePathology(@Nullable final AiPatientPromptContext patientContext) {
+		if (patientContext == null || patientContext.pathologyFlags() == null) {
+			return false;
+		}
+		return patientContext.pathologyFlags().entrySet().stream().anyMatch(Map.Entry::getValue);
+	}
+
+	private static boolean matchesAllergy(final String foodName, final String alergias) {
+		if (!StringUtils.hasText(foodName) || !StringUtils.hasText(alergias)) {
+			return false;
+		}
+		final String lowerName = foodName.toLowerCase(Locale.ROOT);
+		for (final String term : alergias.split(",")) {
+			final String trimmed = term.trim();
+			if (StringUtils.hasText(trimmed) && lowerName.contains(trimmed.toLowerCase(Locale.ROOT))) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static String formatDouble(final double value) {
+		if (Math.rint(value) == value) {
+			return String.valueOf((long) value);
+		}
+		return String.format(Locale.ROOT, "%.1f", value);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiPlanType.java
+++ b/src/main/java/com/nutriconsultas/ai/AiPlanType.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Plan types supported by {@code validate_plan_constraints}.
+ */
+public enum AiPlanType {
+
+	MENU, DIET_PLAN, DISH
+
+}

--- a/src/main/java/com/nutriconsultas/ai/DietPlanDayInput.java
+++ b/src/main/java/com/nutriconsultas/ai/DietPlanDayInput.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Single day inside a multi-day diet plan draft.
+ */
+public record DietPlanDayInput(int dayIndex, @Nullable String label, List<IngestaSlotInput> ingestas) {
+}

--- a/src/main/java/com/nutriconsultas/ai/DietPlanInput.java
+++ b/src/main/java/com/nutriconsultas/ai/DietPlanInput.java
@@ -1,0 +1,9 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+/**
+ * Multi-day diet plan payload for plan validation.
+ */
+public record DietPlanInput(List<DietPlanDayInput> days) {
+}

--- a/src/main/java/com/nutriconsultas/ai/DishPlanInput.java
+++ b/src/main/java/com/nutriconsultas/ai/DishPlanInput.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Dish/recipe payload for plan validation.
+ */
+public record DishPlanInput(List<RecipeIngredientInput> ingredients, @Nullable Integer portions) {
+}

--- a/src/main/java/com/nutriconsultas/ai/IngestaSlotInput.java
+++ b/src/main/java/com/nutriconsultas/ai/IngestaSlotInput.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Meal slot in a menu or diet plan draft.
+ */
+public record IngestaSlotInput(@Nullable String nombre, @Nullable Integer orden, List<IngestaSlotItemInput> items) {
+}

--- a/src/main/java/com/nutriconsultas/ai/IngestaSlotItemInput.java
+++ b/src/main/java/com/nutriconsultas/ai/IngestaSlotItemInput.java
@@ -1,0 +1,12 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Item inside an {@link IngestaSlotInput} for plan validation.
+ */
+public record IngestaSlotItemInput(String type, @Nullable Long platilloId, @Nullable Long alimentoId,
+		@Nullable Integer portions, @Nullable List<RecipeIngredientInput> ingredients) {
+}

--- a/src/main/java/com/nutriconsultas/ai/MenuPlanInput.java
+++ b/src/main/java/com/nutriconsultas/ai/MenuPlanInput.java
@@ -1,0 +1,9 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+/**
+ * One-day menu payload for plan validation.
+ */
+public record MenuPlanInput(List<IngestaSlotInput> ingestas) {
+}

--- a/src/main/java/com/nutriconsultas/ai/PlanConstraintValidationData.java
+++ b/src/main/java/com/nutriconsultas/ai/PlanConstraintValidationData.java
@@ -1,0 +1,12 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * {@code data} payload for {@code validate_plan_constraints}.
+ */
+public record PlanConstraintValidationData(boolean valid, @Nullable NutrientSummary computedNutrients,
+		List<PlanConstraintWarning> warnings, boolean patientContextApplied) {
+}

--- a/src/main/java/com/nutriconsultas/ai/PlanConstraintWarning.java
+++ b/src/main/java/com/nutriconsultas/ai/PlanConstraintWarning.java
@@ -1,0 +1,8 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Structured warning from {@code validate_plan_constraints}.
+ */
+public record PlanConstraintWarning(PlanConstraintWarningCode code, String message,
+		PlanConstraintWarningSeverity severity) {
+}

--- a/src/main/java/com/nutriconsultas/ai/PlanConstraintWarningCode.java
+++ b/src/main/java/com/nutriconsultas/ai/PlanConstraintWarningCode.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Warning codes for {@code validate_plan_constraints}.
+ */
+public enum PlanConstraintWarningCode {
+
+	KCAL_OUT_OF_RANGE, PROTEIN_LOW, SODIUM_HIGH, ALLERGY_RISK, MISSING_NUTRIENT_DATA, PATHOLOGY_NOTE
+
+}

--- a/src/main/java/com/nutriconsultas/ai/PlanConstraintWarningSeverity.java
+++ b/src/main/java/com/nutriconsultas/ai/PlanConstraintWarningSeverity.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Severity levels for plan constraint warnings.
+ */
+public enum PlanConstraintWarningSeverity {
+
+	INFO, WARNING, ERROR
+
+}

--- a/src/main/java/com/nutriconsultas/ai/ValidatePlanConstraintsRequest.java
+++ b/src/main/java/com/nutriconsultas/ai/ValidatePlanConstraintsRequest.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Input for {@code validate_plan_constraints}.
+ */
+public record ValidatePlanConstraintsRequest(AiPlanType planType, @Nullable MenuPlanInput menu,
+		@Nullable DietPlanInput dietPlan, @Nullable DishPlanInput dish, @Nullable Double targetKcal,
+		@Nullable Double targetProteinaG, @Nullable Double targetLipidosG, @Nullable Double targetHidratosG,
+		@Nullable Double maxSodioMg, @Nullable List<Long> excludedAlimentoIds, @Nullable Double toleranceKcal) {
+}

--- a/src/main/java/com/nutriconsultas/ai/ValidatePlanConstraintsToolService.java
+++ b/src/main/java/com/nutriconsultas/ai/ValidatePlanConstraintsToolService.java
@@ -1,0 +1,17 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+/**
+ * AI tool {@code validate_plan_constraints} — read-only draft constraint validation.
+ */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
+public interface ValidatePlanConstraintsToolService {
+
+	String TOOL_NAME = "validate_plan_constraints";
+
+	AiToolResult<PlanConstraintValidationData> validate(@NonNull String nutritionistId,
+			@NonNull ValidatePlanConstraintsRequest request, @Nullable AiPatientPromptContext patientContext);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/ValidatePlanConstraintsToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/ValidatePlanConstraintsToolServiceImpl.java
@@ -1,0 +1,163 @@
+package com.nutriconsultas.ai;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.alimentos.AlimentosRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class ValidatePlanConstraintsToolServiceImpl implements ValidatePlanConstraintsToolService {
+
+	static final int MAX_DIET_DAYS = 14;
+
+	static final double MIN_TARGET_KCAL = 500.0;
+
+	static final double MAX_TARGET_KCAL = 10_000.0;
+
+	private final AiIngestaNutrientCalculator ingestaNutrientCalculator;
+
+	private final AlimentosRepository alimentosRepository;
+
+	public ValidatePlanConstraintsToolServiceImpl(final AiIngestaNutrientCalculator ingestaNutrientCalculator,
+			final AlimentosRepository alimentosRepository) {
+		this.ingestaNutrientCalculator = ingestaNutrientCalculator;
+		this.alimentosRepository = alimentosRepository;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public AiToolResult<PlanConstraintValidationData> validate(@NonNull final String nutritionistId,
+			@NonNull final ValidatePlanConstraintsRequest request,
+			@Nullable final AiPatientPromptContext patientContext) {
+		if (!StringUtils.hasText(nutritionistId)) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "Sesión de nutriólogo no válida.");
+		}
+		if (request.planType() == null) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El tipo de plan es obligatorio.");
+		}
+		final AiToolResult<Void> requestValidation = validateRequestBounds(request);
+		if (!requestValidation.success()) {
+			return AiToolResult.error(Objects.requireNonNull(requestValidation.errorCode()),
+					Objects.requireNonNull(requestValidation.message()));
+		}
+
+		final AiToolResult<ComputationBundle> computation = computePlanNutrients(nutritionistId, request);
+		if (!computation.success()) {
+			return AiToolResult.error(Objects.requireNonNull(computation.errorCode()),
+					Objects.requireNonNull(computation.message()));
+		}
+		final ComputationBundle bundle = Objects.requireNonNull(computation.data());
+		final List<PlanConstraintWarning> warnings = new ArrayList<>(bundle.computationWarnings());
+		warnings.addAll(AiPlanConstraintEvaluator.evaluate(bundle.nutrients(), request, patientContext,
+				bundle.alimentoIds(), alimentosRepository));
+		final boolean valid = AiPlanConstraintEvaluator.isValid(warnings);
+		final boolean patientContextApplied = AiPlanConstraintEvaluator.patientContextApplied(patientContext, request,
+				warnings);
+		final PlanConstraintValidationData data = new PlanConstraintValidationData(valid, bundle.nutrients(), warnings,
+				patientContextApplied);
+		if (log.isInfoEnabled()) {
+			log.info("AI tool validate_plan_constraints valid={} warningCount={}", valid, warnings.size());
+		}
+		return AiToolResult.success(data);
+	}
+
+	private AiToolResult<ComputationBundle> computePlanNutrients(final String nutritionistId,
+			final ValidatePlanConstraintsRequest request) {
+		return switch (request.planType()) {
+			case DISH -> computeDishPlan(nutritionistId, request.dish());
+			case MENU -> computeMenuPlan(nutritionistId, request.menu());
+			case DIET_PLAN -> computeDietPlan(nutritionistId, request.dietPlan());
+		};
+	}
+
+	private AiToolResult<ComputationBundle> computeDishPlan(final String nutritionistId,
+			@Nullable final DishPlanInput dish) {
+		if (dish == null) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El platillo es obligatorio para este tipo de plan.");
+		}
+		final AiToolResult<AiIngestaNutrientCalculator.IngestaNutrientComputation> result = ingestaNutrientCalculator
+			.computeDish(nutritionistId, dish);
+		return mapComputation(result);
+	}
+
+	private AiToolResult<ComputationBundle> computeMenuPlan(final String nutritionistId,
+			@Nullable final MenuPlanInput menu) {
+		if (menu == null) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El menú es obligatorio para este tipo de plan.");
+		}
+		final AiToolResult<AiIngestaNutrientCalculator.IngestaNutrientComputation> result = ingestaNutrientCalculator
+			.computeIngestas(nutritionistId, menu.ingestas());
+		return mapComputation(result);
+	}
+
+	private AiToolResult<ComputationBundle> computeDietPlan(final String nutritionistId,
+			@Nullable final DietPlanInput dietPlan) {
+		if (dietPlan == null || dietPlan.days() == null || dietPlan.days().isEmpty()) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El plan debe incluir al menos un día.");
+		}
+		if (dietPlan.days().size() > MAX_DIET_DAYS) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"El plan no puede superar " + MAX_DIET_DAYS + " días.");
+		}
+		NutrientSummary averageDaily = AiNutrientToolSupport.emptyNutrientSummary();
+		final List<PlanConstraintWarning> warnings = new ArrayList<>();
+		final Set<Long> alimentoIds = new HashSet<>();
+		for (final DietPlanDayInput day : dietPlan.days()) {
+			final AiToolResult<AiIngestaNutrientCalculator.IngestaNutrientComputation> dayResult = ingestaNutrientCalculator
+				.computeIngestas(nutritionistId, day.ingestas());
+			if (!dayResult.success()) {
+				return AiToolResult.error(Objects.requireNonNull(dayResult.errorCode()),
+						Objects.requireNonNull(dayResult.message()));
+			}
+			final AiIngestaNutrientCalculator.IngestaNutrientComputation dayComputation = Objects
+				.requireNonNull(dayResult.data());
+			averageDaily = AiNutrientToolSupport.addNutrientSummaries(averageDaily, dayComputation.nutrients());
+			warnings.addAll(dayComputation.warnings());
+			alimentoIds.addAll(dayComputation.alimentoIds());
+		}
+		final NutrientSummary dailyAverage = AiNutrientToolSupport.divideNutrientSummary(averageDaily,
+				dietPlan.days().size());
+		return AiToolResult.success(new ComputationBundle(dailyAverage, warnings, alimentoIds));
+	}
+
+	private static AiToolResult<ComputationBundle> mapComputation(
+			final AiToolResult<AiIngestaNutrientCalculator.IngestaNutrientComputation> result) {
+		if (!result.success()) {
+			return AiToolResult.error(Objects.requireNonNull(result.errorCode()),
+					Objects.requireNonNull(result.message()));
+		}
+		final AiIngestaNutrientCalculator.IngestaNutrientComputation computation = Objects
+			.requireNonNull(result.data());
+		return AiToolResult
+			.success(new ComputationBundle(computation.nutrients(), computation.warnings(), computation.alimentoIds()));
+	}
+
+	private static AiToolResult<Void> validateRequestBounds(final ValidatePlanConstraintsRequest request) {
+		if (request.targetKcal() != null
+				&& (request.targetKcal() < MIN_TARGET_KCAL || request.targetKcal() > MAX_TARGET_KCAL)) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El objetivo calórico debe estar entre "
+					+ (int) MIN_TARGET_KCAL + " y " + (int) MAX_TARGET_KCAL + ".");
+		}
+		if (request.toleranceKcal() != null && request.toleranceKcal() < 0) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "La tolerancia calórica no puede ser negativa.");
+		}
+		return AiToolResult.success(null);
+	}
+
+	private record ComputationBundle(NutrientSummary nutrients, List<PlanConstraintWarning> computationWarnings,
+			Set<Long> alimentoIds) {
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiIngestaNutrientCalculatorTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiIngestaNutrientCalculatorTest.java
@@ -1,0 +1,122 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.alimentos.AlimentosRepository;
+import com.nutriconsultas.platillos.Platillo;
+import com.nutriconsultas.platillos.PlatilloCatalogConstants;
+import com.nutriconsultas.platillos.PlatilloRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AiIngestaNutrientCalculatorTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	@InjectMocks
+	private AiIngestaNutrientCalculator calculator;
+
+	@Mock
+	private AlimentosRepository alimentosRepository;
+
+	@Mock
+	private PlatilloRepository platilloRepository;
+
+	@Mock
+	private CalculateRecipeNutrientsToolService recipeNutrientsToolService;
+
+	@Test
+	void computeIngestasSumsAlimentoItems() {
+		final Alimento avena = sampleAlimento(1L, "Avena", "taza", 1.0, 200, 160, 6.0, 4.0, 36.0);
+		when(alimentosRepository.findById(1L)).thenReturn(Optional.of(avena));
+
+		final AiToolResult<AiIngestaNutrientCalculator.IngestaNutrientComputation> result = calculator
+			.computeIngestas(NUTRITIONIST_ID, List.of(new IngestaSlotInput("Desayuno", 1,
+					List.of(new IngestaSlotItemInput("ALIMENTO", null, 1L, 2, null)))));
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().nutrients().energiaKcal()).isEqualTo(400);
+		assertThat(result.data().alimentoIds()).contains(1L);
+	}
+
+	@Test
+	void computeIngestasUsesAuthorizedPlatillo() {
+		final Platillo platillo = new Platillo();
+		platillo.setId(10L);
+		platillo.setName("Ensalada");
+		platillo.setUserId(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID);
+		platillo.setEnergia(150);
+		platillo.setProteina(5.0);
+		platillo.setLipidos(8.0);
+		platillo.setHidratosDeCarbono(12.0);
+		when(platilloRepository.findById(10L)).thenReturn(Optional.of(platillo));
+
+		final AiToolResult<AiIngestaNutrientCalculator.IngestaNutrientComputation> result = calculator
+			.computeIngestas(NUTRITIONIST_ID, List.of(new IngestaSlotInput("Comida", 1,
+					List.of(new IngestaSlotItemInput("PLATILLO", 10L, null, 2, null)))));
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().nutrients().energiaKcal()).isEqualTo(300);
+	}
+
+	@Test
+	void computeIngestasRejectsUnauthorizedPlatillo() {
+		final Platillo platillo = new Platillo();
+		platillo.setId(11L);
+		platillo.setUserId("auth0|other");
+		when(platilloRepository.findById(11L)).thenReturn(Optional.of(platillo));
+
+		final AiToolResult<AiIngestaNutrientCalculator.IngestaNutrientComputation> result = calculator
+			.computeIngestas(NUTRITIONIST_ID, List.of(new IngestaSlotInput("Comida", 1,
+					List.of(new IngestaSlotItemInput("PLATILLO", 11L, null, 1, null)))));
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.NOT_FOUND);
+	}
+
+	@Test
+	void computeDishDelegatesToRecipeService() {
+		final RecipeNutrientsData recipeData = new RecipeNutrientsData(1,
+				List.of(new RecipeIngredientNutrientResult(1L,
+						new NutrientSummary(300, 20.0, 10.0, 30.0, 4.0, 200.0, 400.0), List.of())),
+				new NutrientSummary(300, 20.0, 10.0, 30.0, 4.0, 200.0, 400.0),
+				new NutrientSummary(300, 20.0, 10.0, 30.0, 4.0, 200.0, 400.0));
+		when(recipeNutrientsToolService.calculate(any(), any(), any(), any()))
+			.thenReturn(AiToolResult.success(recipeData));
+
+		final AiToolResult<AiIngestaNutrientCalculator.IngestaNutrientComputation> result = calculator.computeDish(
+				NUTRITIONIST_ID, new DishPlanInput(List.of(new RecipeIngredientInput(1L, "1", null, null)), 1));
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().nutrients().energiaKcal()).isEqualTo(300);
+	}
+
+	private static Alimento sampleAlimento(final long id, final String nombre, final String unidad,
+			final double cantSugerida, final int energia, final int pesoNeto, final double proteina,
+			final double lipidos, final double hidratos) {
+		final Alimento alimento = new Alimento();
+		alimento.setId(id);
+		alimento.setNombreAlimento(nombre);
+		alimento.setClasificacion("Cereales");
+		alimento.setUnidad(unidad);
+		alimento.setCantSugerida(cantSugerida);
+		alimento.setEnergia(energia);
+		alimento.setPesoNeto(pesoNeto);
+		alimento.setProteina(proteina);
+		alimento.setLipidos(lipidos);
+		alimento.setHidratosDeCarbono(hidratos);
+		return alimento;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiPlanConstraintEvaluatorTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiPlanConstraintEvaluatorTest.java
@@ -1,0 +1,107 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.alimentos.AlimentosRepository;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AiPlanConstraintEvaluatorTest {
+
+	@Test
+	void evaluateFlagsKcalOutOfRange() {
+		final NutrientSummary computed = new NutrientSummary(2200, 120.0, 70.0, 200.0, 25.0, 1800.0, 3000.0);
+		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.MENU, null, null,
+				null, 2000.0, null, null, null, null, null, 50.0);
+
+		final List<PlanConstraintWarning> warnings = AiPlanConstraintEvaluator.evaluate(computed, request, null,
+				Set.of(), mock(AlimentosRepository.class));
+
+		assertThat(warnings).anyMatch(warning -> warning.code() == PlanConstraintWarningCode.KCAL_OUT_OF_RANGE);
+	}
+
+	@Test
+	void evaluateFlagsProteinLow() {
+		final NutrientSummary computed = new NutrientSummary(1800, 90.0, 60.0, 180.0, 20.0, 1500.0, 2800.0);
+		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.MENU, null, null,
+				null, null, 120.0, null, null, null, null, null);
+
+		final List<PlanConstraintWarning> warnings = AiPlanConstraintEvaluator.evaluate(computed, request, null,
+				Set.of(), mock(AlimentosRepository.class));
+
+		assertThat(warnings).anyMatch(warning -> warning.code() == PlanConstraintWarningCode.PROTEIN_LOW);
+	}
+
+	@Test
+	void evaluateFlagsSodiumHigh() {
+		final NutrientSummary computed = new NutrientSummary(1800, 120.0, 60.0, 180.0, 20.0, 2500.0, 2800.0);
+		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.MENU, null, null,
+				null, null, null, null, null, 2000.0, null, null);
+
+		final List<PlanConstraintWarning> warnings = AiPlanConstraintEvaluator.evaluate(computed, request, null,
+				Set.of(), mock(AlimentosRepository.class));
+
+		assertThat(warnings).anyMatch(warning -> warning.code() == PlanConstraintWarningCode.SODIUM_HIGH);
+	}
+
+	@Test
+	void evaluateUsesPatientKcalTargetWhenStressActive() {
+		final NutrientSummary computed = new NutrientSummary(2300, 120.0, 60.0, 180.0, 20.0, 1500.0, 2800.0);
+		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.MENU, null, null,
+				null, null, null, null, null, null, null, 50.0);
+		final AiPatientPromptContext patientContext = new AiPatientPromptContext(1L, 2000.0, 2200.0, true, "F", false,
+				null, null, Map.of(), null, null);
+
+		final List<PlanConstraintWarning> warnings = AiPlanConstraintEvaluator.evaluate(computed, request,
+				patientContext, Set.of(), mock(AlimentosRepository.class));
+
+		assertThat(warnings).anyMatch(warning -> warning.code() == PlanConstraintWarningCode.KCAL_OUT_OF_RANGE);
+		assertThat(AiPlanConstraintEvaluator.patientContextApplied(patientContext, request, warnings)).isTrue();
+	}
+
+	@Test
+	void evaluateFlagsAllergyRiskFromPatientContext() {
+		final AlimentosRepository repository = mock(AlimentosRepository.class);
+		final Alimento mani = new Alimento();
+		mani.setId(5L);
+		mani.setNombreAlimento("Crema de cacahuate");
+		mani.setClasificacion("Grasas");
+		when(repository.findById(5L)).thenReturn(java.util.Optional.of(mani));
+
+		final AiPatientPromptContext patientContext = new AiPatientPromptContext(1L, 2000.0, null, false, "F", false,
+				null, null, Map.of(), "cacahuate, mariscos", null);
+		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.DISH, null, null,
+				null, null, null, null, null, null, null, null);
+
+		final List<PlanConstraintWarning> warnings = AiPlanConstraintEvaluator.evaluate(
+				new NutrientSummary(500, 20.0, 30.0, 10.0, 5.0, 200.0, 300.0), request, patientContext, Set.of(5L),
+				repository);
+
+		assertThat(warnings).anyMatch(warning -> warning.code() == PlanConstraintWarningCode.ALLERGY_RISK
+				&& warning.severity() == PlanConstraintWarningSeverity.ERROR);
+	}
+
+	@Test
+	void evaluateAddsPathologyInfoNote() {
+		final AiPatientPromptContext patientContext = new AiPatientPromptContext(1L, 2000.0, null, false, "F", false,
+				null, null, Map.of("diabetes", true), null, null);
+		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.MENU, null, null,
+				null, null, null, null, null, null, null, null);
+
+		final List<PlanConstraintWarning> warnings = AiPlanConstraintEvaluator.evaluate(
+				new NutrientSummary(1800, 100.0, 50.0, 150.0, 20.0, 1200.0, 2500.0), request, patientContext, Set.of(),
+				mock(AlimentosRepository.class));
+
+		assertThat(warnings).anyMatch(warning -> warning.code() == PlanConstraintWarningCode.PATHOLOGY_NOTE
+				&& warning.severity() == PlanConstraintWarningSeverity.INFO);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/ValidatePlanConstraintsToolServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/ValidatePlanConstraintsToolServiceTest.java
@@ -1,0 +1,95 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.alimentos.AlimentosRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ValidatePlanConstraintsToolServiceTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	@InjectMocks
+	private ValidatePlanConstraintsToolServiceImpl service;
+
+	@Mock
+	private AiIngestaNutrientCalculator ingestaNutrientCalculator;
+
+	@Mock
+	private AlimentosRepository alimentosRepository;
+
+	@Test
+	void validateReturnsValidWhenConstraintsMet() {
+		final NutrientSummary nutrients = new NutrientSummary(2000, 130.0, 70.0, 200.0, 25.0, 1500.0, 3000.0);
+		when(ingestaNutrientCalculator.computeIngestas(eq(NUTRITIONIST_ID), any())).thenReturn(AiToolResult
+			.success(new AiIngestaNutrientCalculator.IngestaNutrientComputation(nutrients, List.of(), Set.of(1L))));
+
+		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.MENU,
+				new MenuPlanInput(List.of(new IngestaSlotInput("Desayuno", 1,
+						List.of(new IngestaSlotItemInput("ALIMENTO", null, 1L, 1, null))))),
+				null, null, 2000.0, 120.0, null, null, 2000.0, null, 50.0);
+
+		final AiToolResult<PlanConstraintValidationData> result = service.validate(NUTRITIONIST_ID, request, null);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().valid()).isTrue();
+		assertThat(result.data().computedNutrients().energiaKcal()).isEqualTo(2000);
+	}
+
+	@Test
+	void validateReturnsInvalidWhenKcalFarFromTarget() {
+		final NutrientSummary nutrients = new NutrientSummary(2600, 130.0, 70.0, 200.0, 25.0, 1500.0, 3000.0);
+		when(ingestaNutrientCalculator.computeIngestas(eq(NUTRITIONIST_ID), any())).thenReturn(AiToolResult
+			.success(new AiIngestaNutrientCalculator.IngestaNutrientComputation(nutrients, List.of(), Set.of())));
+
+		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.MENU,
+				new MenuPlanInput(List.of(new IngestaSlotInput("Comida", 1, List.of()))), null, null, 2000.0, null,
+				null, null, null, null, 50.0);
+
+		final AiToolResult<PlanConstraintValidationData> result = service.validate(NUTRITIONIST_ID, request, null);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().valid()).isFalse();
+		assertThat(result.data().warnings()).anyMatch(w -> w.code() == PlanConstraintWarningCode.KCAL_OUT_OF_RANGE);
+	}
+
+	@Test
+	void validateRejectsMissingMenuForMenuPlanType() {
+		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.MENU, null, null,
+				null, null, null, null, null, null, null, null);
+
+		final AiToolResult<PlanConstraintValidationData> result = service.validate(NUTRITIONIST_ID, request, null);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+	}
+
+	@Test
+	void validateDelegatesDishComputation() {
+		final NutrientSummary nutrients = new NutrientSummary(400, 30.0, 10.0, 40.0, 5.0, 300.0, 500.0);
+		when(ingestaNutrientCalculator.computeDish(eq(NUTRITIONIST_ID), any())).thenReturn(AiToolResult
+			.success(new AiIngestaNutrientCalculator.IngestaNutrientComputation(nutrients, List.of(), Set.of(2L))));
+
+		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.DISH, null, null,
+				new DishPlanInput(List.of(new RecipeIngredientInput(2L, "1", null, null)), 1), null, null, null, null,
+				null, null, null);
+
+		final AiToolResult<PlanConstraintValidationData> result = service.validate(NUTRITIONIST_ID, request, null);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().computedNutrients().energiaKcal()).isEqualTo(400);
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `ValidatePlanConstraintsToolService` implementing `validate_plan_constraints` per `TOOL-CONTRACT.md`
- `AiIngestaNutrientCalculator` aggregates nutrients from platillo, alimento, and inline recipe items
- `AiPlanConstraintEvaluator` checks kcal tolerance, protein, sodium, exclusions, patient allergies, and pathology notes
- Completes Phase 3 epic **#372** — **NEXT: #378**

## Test plan
- [x] `mvn test -Dtest=AiPlanConstraintEvaluatorTest,ValidatePlanConstraintsToolServiceTest,AiIngestaNutrientCalculatorTest`
- [x] `mvn pmd:check -Pci`
- [ ] CI green


Made with [Cursor](https://cursor.com)