### PR TITLE
Implement create_dish_draft AI tool (#379)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#378 — Epic AI Draft Creation Tools](https://github.com/diego-torres/nutriconsultas/issues/378) (`NEXT`). ~~#377~~ **done** — Phase 3 complete. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#380 — Implement Menu Draft Creation Tool](https://github.com/diego-torres/nutriconsultas/issues/380) (`NEXT`). ~~#379~~ **done** — `create_dish_draft`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#378 — Epic AI Draft Creation Tools](https://github.com/diego-torres/nutriconsultas/issues/378) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#377~~ `ValidatePlanConstraintsToolService`; Phase 3 **complete**.
+**Current next issue:** [#380 — Implement Menu Draft Creation Tool](https://github.com/diego-torres/nutriconsultas/issues/380) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#379~~ `CreateDishDraftToolService`.
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#377~~ plan constraint validation **done**. **NEXT:** #378.
+**Last updated:** 2026-06-30 — ~~#379~~ dish draft creation **done**. **NEXT:** #380.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -118,13 +118,13 @@ Draft-creation tools and acceptance flow (no direct patient assignment).
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **378** | Epic — AI Draft Creation Tools (Phase 4) | https://github.com/diego-torres/nutriconsultas/issues/378 | **NEXT** | **372** | Milestone 2 |
-| **379** | Implement Dish Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/379 | **open** | **378**, **371** | `create_dish_draft` |
-| **380** | Implement Menu Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/380 | **open** | **378**, **371** | `create_menu_draft` |
+| **378** | Epic — AI Draft Creation Tools (Phase 4) | https://github.com/diego-torres/nutriconsultas/issues/378 | **open** | **372** | Milestone 2 — ~~#379~~ |
+| **379** | Implement Dish Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/379 | **done** | **378**, **371** | `create_dish_draft` |
+| **380** | Implement Menu Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/380 | **NEXT** | **378**, **371** | `create_menu_draft` |
 | **381** | Implement Diet Plan Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/381 | **open** | **378**, **371** | `create_diet_plan_draft` |
 | **382** | Implement Draft Acceptance Flow | https://github.com/diego-torres/nutriconsultas/issues/382 | **open** | **379**, **380**, **381** | Convert draft → real record |
 
-**Suggested order:** #379 + #380 + #381 parallel → #382.
+**Suggested order:** ~~#379~~ → #380 + #381 parallel → #382.
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/AiDraftCreationData.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftCreationData.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Common success payload for draft-creation tools.
+ */
+public record AiDraftCreationData(long draftId, AiDraftType draftType, AiDraftStatus status, String summary) {
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftLifecycleException.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftLifecycleException.java
@@ -11,4 +11,8 @@ public class AiDraftLifecycleException extends RuntimeException {
 		super(message);
 	}
 
+	public AiDraftLifecycleException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
 }

--- a/src/main/java/com/nutriconsultas/ai/AiDraftPayloadSerializer.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftPayloadSerializer.java
@@ -1,0 +1,25 @@
+package com.nutriconsultas.ai;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Serializes AI draft payloads to JSON for persistence.
+ */
+public final class AiDraftPayloadSerializer {
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	private AiDraftPayloadSerializer() {
+	}
+
+	public static String toJson(final Object payload) {
+		try {
+			return OBJECT_MAPPER.writeValueAsString(payload);
+		}
+		catch (JsonProcessingException ex) {
+			throw new AiDraftLifecycleException("No se pudo serializar el borrador.", ex);
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/CreateDishDraftToolService.java
+++ b/src/main/java/com/nutriconsultas/ai/CreateDishDraftToolService.java
@@ -1,0 +1,17 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.NonNull;
+
+/**
+ * AI tool {@code create_dish_draft} — persist a dish/recipe draft for nutritionist
+ * review.
+ */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
+public interface CreateDishDraftToolService {
+
+	String TOOL_NAME = "create_dish_draft";
+
+	AiToolResult<AiDraftCreationData> createDraft(@NonNull String nutritionistId, long threadId,
+			@NonNull DishDraftInput input);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/CreateDishDraftToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/CreateDishDraftToolServiceImpl.java
@@ -1,0 +1,166 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class CreateDishDraftToolServiceImpl implements CreateDishDraftToolService {
+
+	static final String DRAFT_LABEL = "Borrador IA — revisión del nutriólogo requerida";
+
+	static final int MIN_NAME_LENGTH = 2;
+
+	static final int MAX_NAME_LENGTH = 120;
+
+	static final int MAX_DESCRIPTION_LENGTH = 2000;
+
+	static final int MAX_INGESTAS_LENGTH = 80;
+
+	static final int MAX_PREPARATION_STEPS = 30;
+
+	static final int MAX_STEP_LENGTH = 500;
+
+	static final int MAX_NOTE_LENGTH = 300;
+
+	static final int MIN_INGREDIENTS = 1;
+
+	static final int MAX_INGREDIENTS = 40;
+
+	private final AiDraftLifecycleService draftLifecycleService;
+
+	private final CalculateRecipeNutrientsToolService recipeNutrientsToolService;
+
+	public CreateDishDraftToolServiceImpl(final AiDraftLifecycleService draftLifecycleService,
+			final CalculateRecipeNutrientsToolService recipeNutrientsToolService) {
+		this.draftLifecycleService = draftLifecycleService;
+		this.recipeNutrientsToolService = recipeNutrientsToolService;
+	}
+
+	@Override
+	@Transactional
+	public AiToolResult<AiDraftCreationData> createDraft(@NonNull final String nutritionistId, final long threadId,
+			@NonNull final DishDraftInput input) {
+		if (!StringUtils.hasText(nutritionistId)) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "Sesión de nutriólogo no válida.");
+		}
+		if (threadId <= 0) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "La conversación no es válida.");
+		}
+		final AiToolResult<Void> validation = validateInput(input);
+		if (!validation.success()) {
+			return AiToolResult.error(Objects.requireNonNull(validation.errorCode()),
+					Objects.requireNonNull(validation.message()));
+		}
+
+		final int portions = input.portions() == null ? 1 : input.portions();
+		final AiToolResult<RecipeNutrientsData> nutrientsResult = recipeNutrientsToolService.calculate(nutritionistId,
+				input.ingredients(), portions, null);
+		if (!nutrientsResult.success()) {
+			return AiToolResult.error(Objects.requireNonNull(nutrientsResult.errorCode()),
+					Objects.requireNonNull(nutrientsResult.message()));
+		}
+		final RecipeNutrientsData nutrientsData = Objects.requireNonNull(nutrientsResult.data());
+		final DishDraftPayload payload = new DishDraftPayload(input.name().trim(), trimToNull(input.description()),
+				input.preparationSteps(), trimToNull(input.ingestasSugeridas()), input.ingredients(), portions,
+				nutrientsData.nutrientsPerPortion(), input.assumptions(), input.warnings(), DRAFT_LABEL);
+		try {
+			final String jsonPayload = AiDraftPayloadSerializer.toJson(payload);
+			final AiGeneratedDraft draft = draftLifecycleService.createDraft(threadId, nutritionistId, AiDraftType.DISH,
+					jsonPayload);
+			final String summary = DRAFT_LABEL + ": " + input.name().trim();
+			final AiDraftCreationData data = new AiDraftCreationData(draft.getId(), AiDraftType.DISH, draft.getStatus(),
+					summary);
+			if (log.isInfoEnabled()) {
+				log.info("AI tool create_dish_draft draftId={} threadId={}", draft.getId(), threadId);
+			}
+			return AiToolResult.success(data);
+		}
+		catch (AiDraftLifecycleException ex) {
+			return mapLifecycleException(ex);
+		}
+	}
+
+	private static AiToolResult<Void> validateInput(final DishDraftInput input) {
+		if (!StringUtils.hasText(input.name()) || input.name().trim().length() < MIN_NAME_LENGTH) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"El nombre del platillo debe tener al menos " + MIN_NAME_LENGTH + " caracteres.");
+		}
+		if (input.name().trim().length() > MAX_NAME_LENGTH) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"El nombre del platillo no puede superar " + MAX_NAME_LENGTH + " caracteres.");
+		}
+		if (input.description() != null && input.description().length() > MAX_DESCRIPTION_LENGTH) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"La descripción no puede superar " + MAX_DESCRIPTION_LENGTH + " caracteres.");
+		}
+		if (input.ingestasSugeridas() != null && input.ingestasSugeridas().length() > MAX_INGESTAS_LENGTH) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"Las ingestas sugeridas no pueden superar " + MAX_INGESTAS_LENGTH + " caracteres.");
+		}
+		if (input.ingredients() == null || input.ingredients().size() < MIN_INGREDIENTS
+				|| input.ingredients().size() > MAX_INGREDIENTS) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"El platillo debe tener entre " + MIN_INGREDIENTS + " y " + MAX_INGREDIENTS + " ingredientes.");
+		}
+		if (input.portions() != null && input.portions() < 1) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "Las porciones deben ser al menos 1.");
+		}
+		final AiToolResult<Void> stepsValidation = validateStringList(input.preparationSteps(), MAX_PREPARATION_STEPS,
+				MAX_STEP_LENGTH, "paso de preparación");
+		if (!stepsValidation.success()) {
+			return stepsValidation;
+		}
+		final AiToolResult<Void> assumptionsValidation = validateStringList(input.assumptions(), Integer.MAX_VALUE,
+				MAX_NOTE_LENGTH, "supuesto");
+		if (!assumptionsValidation.success()) {
+			return assumptionsValidation;
+		}
+		final AiToolResult<Void> warningsValidation = validateStringList(input.warnings(), Integer.MAX_VALUE,
+				MAX_NOTE_LENGTH, "advertencia");
+		if (!warningsValidation.success()) {
+			return warningsValidation;
+		}
+		return AiToolResult.success(null);
+	}
+
+	private static AiToolResult<Void> validateStringList(final List<String> values, final int maxItems,
+			final int maxLength, final String label) {
+		if (values == null) {
+			return AiToolResult.success(null);
+		}
+		if (values.size() > maxItems) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"El platillo no puede tener más de " + maxItems + " " + label + "s.");
+		}
+		for (final String value : values) {
+			if (value != null && value.length() > maxLength) {
+				return AiToolResult.error(AiToolErrorCode.VALIDATION,
+						"Cada " + label + " no puede superar " + maxLength + " caracteres.");
+			}
+		}
+		return AiToolResult.success(null);
+	}
+
+	private static AiToolResult<AiDraftCreationData> mapLifecycleException(final AiDraftLifecycleException ex) {
+		if (ex.getMessage() != null && ex.getMessage().contains("Conversación no encontrada")) {
+			return AiToolResult.error(AiToolErrorCode.NOT_FOUND, ex.getMessage());
+		}
+		return AiToolResult.error(AiToolErrorCode.VALIDATION, ex.getMessage());
+	}
+
+	private static String trimToNull(final String value) {
+		if (!StringUtils.hasText(value)) {
+			return null;
+		}
+		return value.trim();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/DishDraftInput.java
+++ b/src/main/java/com/nutriconsultas/ai/DishDraftInput.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Input for {@code create_dish_draft}.
+ */
+public record DishDraftInput(String name, @Nullable String description, @Nullable List<String> preparationSteps,
+		@Nullable String ingestasSugeridas, List<RecipeIngredientInput> ingredients, @Nullable Integer portions,
+		@Nullable NutrientSummary nutrientsPerPortion, @Nullable List<String> assumptions,
+		@Nullable List<String> warnings) {
+}

--- a/src/main/java/com/nutriconsultas/ai/DishDraftPayload.java
+++ b/src/main/java/com/nutriconsultas/ai/DishDraftPayload.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * JSON payload persisted for a dish draft ({@code create_dish_draft}).
+ */
+public record DishDraftPayload(String name, @Nullable String description, @Nullable List<String> preparationSteps,
+		@Nullable String ingestasSugeridas, List<RecipeIngredientInput> ingredients, int portions,
+		NutrientSummary nutrientsPerPortion, @Nullable List<String> assumptions, @Nullable List<String> warnings,
+		String label) {
+}

--- a/src/test/java/com/nutriconsultas/ai/CreateDishDraftToolServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/CreateDishDraftToolServiceTest.java
@@ -1,0 +1,102 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CreateDishDraftToolServiceTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	private static final long THREAD_ID = 42L;
+
+	@InjectMocks
+	private CreateDishDraftToolServiceImpl service;
+
+	@Mock
+	private AiDraftLifecycleService draftLifecycleService;
+
+	@Mock
+	private CalculateRecipeNutrientsToolService recipeNutrientsToolService;
+
+	@Test
+	void createDraftPersistsDishDraftWithComputedNutrients() {
+		final RecipeNutrientsData nutrients = new RecipeNutrientsData(1, List.of(),
+				new NutrientSummary(250, 20.0, 8.0, 30.0, 4.0, 300.0, 500.0),
+				new NutrientSummary(250, 20.0, 8.0, 30.0, 4.0, 300.0, 500.0));
+		when(recipeNutrientsToolService.calculate(eq(NUTRITIONIST_ID), any(), eq(2), eq(null)))
+			.thenReturn(AiToolResult.success(nutrients));
+		final AiGeneratedDraft saved = new AiGeneratedDraft();
+		saved.setId(99L);
+		saved.setStatus(AiDraftStatus.DRAFT);
+		when(draftLifecycleService.createDraft(eq(THREAD_ID), eq(NUTRITIONIST_ID), eq(AiDraftType.DISH), any()))
+			.thenReturn(saved);
+
+		final DishDraftInput input = new DishDraftInput("Tacos de pollo", "Receta ligera", List.of("Cocinar el pollo"),
+				"Comida", List.of(new RecipeIngredientInput(1L, "1", null, null)), 2, null, List.of("Porción estándar"),
+				List.of("Revisar sodio"));
+		final AiToolResult<AiDraftCreationData> result = service.createDraft(NUTRITIONIST_ID, THREAD_ID, input);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().draftId()).isEqualTo(99L);
+		assertThat(result.data().draftType()).isEqualTo(AiDraftType.DISH);
+		assertThat(result.data().status()).isEqualTo(AiDraftStatus.DRAFT);
+		assertThat(result.data().summary()).contains("Tacos de pollo");
+		verify(draftLifecycleService).createDraft(eq(THREAD_ID), eq(NUTRITIONIST_ID), eq(AiDraftType.DISH), any());
+	}
+
+	@Test
+	void createDraftRejectsInvalidName() {
+		final DishDraftInput input = new DishDraftInput("a", null, null, null,
+				List.of(new RecipeIngredientInput(1L, "1", null, null)), 1, null, null, null);
+
+		final AiToolResult<AiDraftCreationData> result = service.createDraft(NUTRITIONIST_ID, THREAD_ID, input);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+		verify(draftLifecycleService, never()).createDraft(any(), any(), any(), any());
+	}
+
+	@Test
+	void createDraftPropagatesNutrientCalculationErrors() {
+		when(recipeNutrientsToolService.calculate(eq(NUTRITIONIST_ID), any(), any(), any()))
+			.thenReturn(AiToolResult.error(AiToolErrorCode.NOT_FOUND, "No se encontró el alimento solicitado."));
+
+		final DishDraftInput input = new DishDraftInput("Ensalada", null, null, null,
+				List.of(new RecipeIngredientInput(99L, "1", null, null)), 1, null, null, null);
+		final AiToolResult<AiDraftCreationData> result = service.createDraft(NUTRITIONIST_ID, THREAD_ID, input);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.NOT_FOUND);
+		verify(draftLifecycleService, never()).createDraft(any(), any(), any(), any());
+	}
+
+	@Test
+	void createDraftMapsUnknownThreadToNotFound() {
+		when(recipeNutrientsToolService.calculate(eq(NUTRITIONIST_ID), any(), any(), any())).thenReturn(AiToolResult
+			.success(new RecipeNutrientsData(1, List.of(), new NutrientSummary(100, 10.0, 5.0, 12.0, 2.0, 100.0, 200.0),
+					new NutrientSummary(100, 10.0, 5.0, 12.0, 2.0, 100.0, 200.0))));
+		when(draftLifecycleService.createDraft(eq(THREAD_ID), eq(NUTRITIONIST_ID), eq(AiDraftType.DISH), any()))
+			.thenThrow(new AiDraftLifecycleException("Conversación no encontrada."));
+
+		final DishDraftInput input = new DishDraftInput("Sopa", null, null, null,
+				List.of(new RecipeIngredientInput(1L, "1", null, null)), 1, null, null, null);
+		final AiToolResult<AiDraftCreationData> result = service.createDraft(NUTRITIONIST_ID, THREAD_ID, input);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.NOT_FOUND);
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds `CreateDishDraftToolService` (`create_dish_draft`) to validate dish/recipe input, compute nutrients server-side via `CalculateRecipeNutrientsToolService`, and persist a `DISH` draft through `AiDraftLifecycleService` (no final `Platillo` rows).
- Introduces shared `AiDraftCreationData`, `AiDraftPayloadSerializer`, and dish draft input/payload records per `docs/ai/TOOL-CONTRACT.md`.
- Unit tests cover happy path, validation errors, nutrient calculation failures, and unknown thread (`NOT_FOUND`).

Fixes #379

## Test plan
- [x] `mvn test -Dtest=CreateDishDraftToolServiceTest`
- [x] `mvn pmd:check -Pci`
- [x] `mvn checkstyle:check`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)