### PR TITLE
Implement create_diet_plan_draft AI tool (#381)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#381 — Implement Diet Plan Draft Creation Tool](https://github.com/diego-torres/nutriconsultas/issues/381) (`NEXT`). ~~#380~~ **done** — `create_menu_draft`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#382 — Implement Draft Acceptance Flow](https://github.com/diego-torres/nutriconsultas/issues/382) (`NEXT`). ~~#381~~ **done** — `create_diet_plan_draft`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#381 — Implement Diet Plan Draft Creation Tool](https://github.com/diego-torres/nutriconsultas/issues/381) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#380~~ `CreateMenuDraftToolService`.
+**Current next issue:** [#382 — Implement Draft Acceptance Flow](https://github.com/diego-torres/nutriconsultas/issues/382) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#381~~ `CreateDietPlanDraftToolService`.
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#380~~ menu draft creation **done**. **NEXT:** #381.
+**Last updated:** 2026-06-30 — ~~#381~~ diet plan draft creation **done**. **NEXT:** #382.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -118,13 +118,13 @@ Draft-creation tools and acceptance flow (no direct patient assignment).
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **378** | Epic — AI Draft Creation Tools (Phase 4) | https://github.com/diego-torres/nutriconsultas/issues/378 | **open** | **372** | Milestone 2 — ~~#379~~ ~~#380~~ |
+| **378** | Epic — AI Draft Creation Tools (Phase 4) | https://github.com/diego-torres/nutriconsultas/issues/378 | **open** | **372** | Milestone 2 — ~~#379–#381~~ |
 | **379** | Implement Dish Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/379 | **done** | **378**, **371** | `create_dish_draft` |
 | **380** | Implement Menu Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/380 | **done** | **378**, **371** | `create_menu_draft` |
-| **381** | Implement Diet Plan Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/381 | **NEXT** | **378**, **371** | `create_diet_plan_draft` |
-| **382** | Implement Draft Acceptance Flow | https://github.com/diego-torres/nutriconsultas/issues/382 | **open** | **379**, **380**, **381** | Convert draft → real record |
+| **381** | Implement Diet Plan Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/381 | **done** | **378**, **371** | `create_diet_plan_draft` |
+| **382** | Implement Draft Acceptance Flow | https://github.com/diego-torres/nutriconsultas/issues/382 | **NEXT** | **379**, **380**, **381** | Convert draft → real record |
 
-**Suggested order:** ~~#379~~ ~~#380~~ → #381 → #382.
+**Suggested order:** ~~#379–#381~~ → #382 (closes epic #378).
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/CreateDietPlanDraftToolService.java
+++ b/src/main/java/com/nutriconsultas/ai/CreateDietPlanDraftToolService.java
@@ -1,0 +1,17 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.NonNull;
+
+/**
+ * AI tool {@code create_diet_plan_draft} — persist a multi-day diet plan draft for
+ * nutritionist review.
+ */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
+public interface CreateDietPlanDraftToolService {
+
+	String TOOL_NAME = "create_diet_plan_draft";
+
+	AiToolResult<AiDraftCreationData> createDraft(@NonNull String nutritionistId, long threadId,
+			@NonNull DietPlanDraftInput input);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/CreateDietPlanDraftToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/CreateDietPlanDraftToolServiceImpl.java
@@ -1,0 +1,241 @@
+package com.nutriconsultas.ai;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class CreateDietPlanDraftToolServiceImpl implements CreateDietPlanDraftToolService {
+
+	static final String DRAFT_LABEL = "Borrador IA — revisión del nutriólogo requerida";
+
+	static final String DEFAULT_PLAN_TITLE = "Plan alimenticio";
+
+	static final int MAX_TITLE_LENGTH = 120;
+
+	static final int MIN_DAYS = 1;
+
+	static final int MAX_DAYS = 14;
+
+	static final int MAX_DAY_LABEL_LENGTH = 80;
+
+	static final int MIN_INGESTAS = 1;
+
+	static final int MAX_INGESTAS = 12;
+
+	static final int MAX_INGESTA_NAME_LENGTH = 80;
+
+	static final int MAX_VALIDATION_SUMMARY_LENGTH = 2000;
+
+	static final int MAX_NOTE_LENGTH = 300;
+
+	private final AiDraftLifecycleService draftLifecycleService;
+
+	private final AiIngestaNutrientCalculator ingestaNutrientCalculator;
+
+	public CreateDietPlanDraftToolServiceImpl(final AiDraftLifecycleService draftLifecycleService,
+			final AiIngestaNutrientCalculator ingestaNutrientCalculator) {
+		this.draftLifecycleService = draftLifecycleService;
+		this.ingestaNutrientCalculator = ingestaNutrientCalculator;
+	}
+
+	@Override
+	@Transactional
+	public AiToolResult<AiDraftCreationData> createDraft(@NonNull final String nutritionistId, final long threadId,
+			@NonNull final DietPlanDraftInput input) {
+		if (!StringUtils.hasText(nutritionistId)) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "Sesión de nutriólogo no válida.");
+		}
+		if (threadId <= 0) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "La conversación no es válida.");
+		}
+		final AiToolResult<Void> validation = validateInput(input);
+		if (!validation.success()) {
+			return AiToolResult.error(Objects.requireNonNull(validation.errorCode()),
+					Objects.requireNonNull(validation.message()));
+		}
+
+		final AiToolResult<PlanNutrientComputation> nutrientsResult = computePlanNutrients(nutritionistId,
+				input.days());
+		if (!nutrientsResult.success()) {
+			return AiToolResult.error(Objects.requireNonNull(nutrientsResult.errorCode()),
+					Objects.requireNonNull(nutrientsResult.message()));
+		}
+		final PlanNutrientComputation computation = Objects.requireNonNull(nutrientsResult.data());
+		final String displayTitle = resolveDisplayTitle(input);
+		final DietPlanDraftPayload payload = new DietPlanDraftPayload(trimToNull(input.title()), input.days().size(),
+				input.targetKcalPerDay(), computation.dayPayloads(), computation.weeklyAverageNutrients(),
+				trimToNull(input.validationSummary()), input.assumptions(), input.warnings(), DRAFT_LABEL);
+		try {
+			final String jsonPayload = AiDraftPayloadSerializer.toJson(payload);
+			final AiGeneratedDraft draft = draftLifecycleService.createDraft(threadId, nutritionistId,
+					AiDraftType.DIET_PLAN, jsonPayload);
+			final String summary = DRAFT_LABEL + ": " + displayTitle;
+			final AiDraftCreationData data = new AiDraftCreationData(draft.getId(), AiDraftType.DIET_PLAN,
+					draft.getStatus(), summary);
+			if (log.isInfoEnabled()) {
+				log.info("AI tool create_diet_plan_draft draftId={} threadId={} dayCount={}", draft.getId(), threadId,
+						input.days().size());
+			}
+			return AiToolResult.success(data);
+		}
+		catch (AiDraftLifecycleException ex) {
+			return mapLifecycleException(ex);
+		}
+	}
+
+	private AiToolResult<PlanNutrientComputation> computePlanNutrients(final String nutritionistId,
+			final List<DietPlanDayInput> days) {
+		final List<DietPlanDayPayload> dayPayloads = new ArrayList<>();
+		NutrientSummary weeklySum = AiNutrientToolSupport.emptyNutrientSummary();
+		for (final DietPlanDayInput day : days) {
+			final AiToolResult<AiIngestaNutrientCalculator.IngestaNutrientComputation> dayResult = ingestaNutrientCalculator
+				.computeIngestas(nutritionistId, day.ingestas());
+			if (!dayResult.success()) {
+				return AiToolResult.error(Objects.requireNonNull(dayResult.errorCode()),
+						Objects.requireNonNull(dayResult.message()));
+			}
+			final NutrientSummary dayNutrients = Objects.requireNonNull(dayResult.data()).nutrients();
+			dayPayloads
+				.add(new DietPlanDayPayload(day.dayIndex(), trimToNull(day.label()), day.ingestas(), dayNutrients));
+			weeklySum = AiNutrientToolSupport.addNutrientSummaries(weeklySum, dayNutrients);
+		}
+		final NutrientSummary weeklyAverage = AiNutrientToolSupport.divideNutrientSummary(weeklySum, days.size());
+		return AiToolResult.success(new PlanNutrientComputation(dayPayloads, weeklyAverage));
+	}
+
+	private static AiToolResult<Void> validateInput(final DietPlanDraftInput input) {
+		if (input.title() != null && input.title().length() > MAX_TITLE_LENGTH) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"El título del plan no puede superar " + MAX_TITLE_LENGTH + " caracteres.");
+		}
+		if (input.targetKcalPerDay() != null && input.targetKcalPerDay() < 0) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El objetivo calórico diario no puede ser negativo.");
+		}
+		if (input.days() == null || input.days().size() < MIN_DAYS || input.days().size() > MAX_DAYS) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"El plan debe tener entre " + MIN_DAYS + " y " + MAX_DAYS + " días.");
+		}
+		if (input.dayCount() != null && (input.dayCount() < MIN_DAYS || input.dayCount() > MAX_DAYS
+				|| input.dayCount() != input.days().size())) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"El número de días no coincide con los días del plan.");
+		}
+		final Set<Integer> dayIndexes = new HashSet<>();
+		for (final DietPlanDayInput day : input.days()) {
+			final AiToolResult<Void> dayValidation = validateDay(day, dayIndexes);
+			if (!dayValidation.success()) {
+				return dayValidation;
+			}
+		}
+		if (input.validationSummary() != null && input.validationSummary().length() > MAX_VALIDATION_SUMMARY_LENGTH) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"El resumen de validación no puede superar " + MAX_VALIDATION_SUMMARY_LENGTH + " caracteres.");
+		}
+		final AiToolResult<Void> assumptionsValidation = validateStringList(input.assumptions(), Integer.MAX_VALUE,
+				MAX_NOTE_LENGTH, "supuesto");
+		if (!assumptionsValidation.success()) {
+			return assumptionsValidation;
+		}
+		final AiToolResult<Void> warningsValidation = validateStringList(input.warnings(), Integer.MAX_VALUE,
+				MAX_NOTE_LENGTH, "advertencia");
+		if (!warningsValidation.success()) {
+			return warningsValidation;
+		}
+		return AiToolResult.success(null);
+	}
+
+	private static AiToolResult<Void> validateDay(final DietPlanDayInput day, final Set<Integer> dayIndexes) {
+		if (day.dayIndex() < 1) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El índice del día debe ser al menos 1.");
+		}
+		if (!dayIndexes.add(day.dayIndex())) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El plan no puede repetir el mismo día.");
+		}
+		if (day.label() != null && day.label().length() > MAX_DAY_LABEL_LENGTH) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"La etiqueta del día no puede superar " + MAX_DAY_LABEL_LENGTH + " caracteres.");
+		}
+		if (day.ingestas() == null || day.ingestas().size() < MIN_INGESTAS || day.ingestas().size() > MAX_INGESTAS) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"Cada día debe tener entre " + MIN_INGESTAS + " y " + MAX_INGESTAS + " ingestas.");
+		}
+		for (final IngestaSlotInput ingesta : day.ingestas()) {
+			final AiToolResult<Void> ingestaValidation = validateIngesta(ingesta);
+			if (!ingestaValidation.success()) {
+				return ingestaValidation;
+			}
+		}
+		return AiToolResult.success(null);
+	}
+
+	private static AiToolResult<Void> validateIngesta(final IngestaSlotInput ingesta) {
+		if (ingesta.nombre() != null && ingesta.nombre().length() > MAX_INGESTA_NAME_LENGTH) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"El nombre de la ingesta no puede superar " + MAX_INGESTA_NAME_LENGTH + " caracteres.");
+		}
+		if (ingesta.items() == null || ingesta.items().isEmpty()) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "Cada ingesta debe incluir al menos un ítem.");
+		}
+		for (final IngestaSlotItemInput item : ingesta.items()) {
+			if (item.portions() != null && item.portions() < 1) {
+				return AiToolResult.error(AiToolErrorCode.VALIDATION, "Las porciones deben ser al menos 1.");
+			}
+		}
+		return AiToolResult.success(null);
+	}
+
+	private static AiToolResult<Void> validateStringList(final List<String> values, final int maxItems,
+			final int maxLength, final String label) {
+		if (values == null) {
+			return AiToolResult.success(null);
+		}
+		if (values.size() > maxItems) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"El plan no puede tener más de " + maxItems + " " + label + "s.");
+		}
+		for (final String value : values) {
+			if (value != null && value.length() > maxLength) {
+				return AiToolResult.error(AiToolErrorCode.VALIDATION,
+						"Cada " + label + " no puede superar " + maxLength + " caracteres.");
+			}
+		}
+		return AiToolResult.success(null);
+	}
+
+	private static String resolveDisplayTitle(final DietPlanDraftInput input) {
+		if (StringUtils.hasText(input.title())) {
+			return input.title().trim();
+		}
+		return DEFAULT_PLAN_TITLE;
+	}
+
+	private static AiToolResult<AiDraftCreationData> mapLifecycleException(final AiDraftLifecycleException ex) {
+		if (ex.getMessage() != null && ex.getMessage().contains("Conversación no encontrada")) {
+			return AiToolResult.error(AiToolErrorCode.NOT_FOUND, ex.getMessage());
+		}
+		return AiToolResult.error(AiToolErrorCode.VALIDATION, ex.getMessage());
+	}
+
+	private static String trimToNull(final String value) {
+		if (!StringUtils.hasText(value)) {
+			return null;
+		}
+		return value.trim();
+	}
+
+	private record PlanNutrientComputation(List<DietPlanDayPayload> dayPayloads,
+			NutrientSummary weeklyAverageNutrients) {
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/DietPlanDayPayload.java
+++ b/src/main/java/com/nutriconsultas/ai/DietPlanDayPayload.java
@@ -1,0 +1,12 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Single day inside a persisted diet plan draft payload.
+ */
+public record DietPlanDayPayload(int dayIndex, @Nullable String label, List<IngestaSlotInput> ingestas,
+		NutrientSummary nutrientsTotal) {
+}

--- a/src/main/java/com/nutriconsultas/ai/DietPlanDraftInput.java
+++ b/src/main/java/com/nutriconsultas/ai/DietPlanDraftInput.java
@@ -1,0 +1,13 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Input for {@code create_diet_plan_draft}.
+ */
+public record DietPlanDraftInput(@Nullable String title, @Nullable Integer dayCount, @Nullable Double targetKcalPerDay,
+		List<DietPlanDayInput> days, @Nullable String validationSummary, @Nullable List<String> assumptions,
+		@Nullable List<String> warnings) {
+}

--- a/src/main/java/com/nutriconsultas/ai/DietPlanDraftPayload.java
+++ b/src/main/java/com/nutriconsultas/ai/DietPlanDraftPayload.java
@@ -1,0 +1,13 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * JSON payload persisted for a diet plan draft ({@code create_diet_plan_draft}).
+ */
+public record DietPlanDraftPayload(@Nullable String title, int dayCount, @Nullable Double targetKcalPerDay,
+		List<DietPlanDayPayload> days, NutrientSummary weeklyAverageNutrients, @Nullable String validationSummary,
+		@Nullable List<String> assumptions, @Nullable List<String> warnings, String label) {
+}

--- a/src/test/java/com/nutriconsultas/ai/CreateDietPlanDraftToolServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/CreateDietPlanDraftToolServiceTest.java
@@ -1,0 +1,122 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CreateDietPlanDraftToolServiceTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	private static final long THREAD_ID = 42L;
+
+	@InjectMocks
+	private CreateDietPlanDraftToolServiceImpl service;
+
+	@Mock
+	private AiDraftLifecycleService draftLifecycleService;
+
+	@Mock
+	private AiIngestaNutrientCalculator ingestaNutrientCalculator;
+
+	@Test
+	void createDraftPersistsDietPlanDraftWithComputedNutrients() {
+		final NutrientSummary dayNutrients = new NutrientSummary(1800, 90.0, 60.0, 200.0, 25.0, 2000.0, 3500.0);
+		when(ingestaNutrientCalculator.computeIngestas(eq(NUTRITIONIST_ID), any())).thenReturn(AiToolResult
+			.success(new AiIngestaNutrientCalculator.IngestaNutrientComputation(dayNutrients, List.of(), Set.of(1L))));
+		final AiGeneratedDraft saved = new AiGeneratedDraft();
+		saved.setId(77L);
+		saved.setStatus(AiDraftStatus.DRAFT);
+		when(draftLifecycleService.createDraft(eq(THREAD_ID), eq(NUTRITIONIST_ID), eq(AiDraftType.DIET_PLAN), any()))
+			.thenReturn(saved);
+
+		final DietPlanDraftInput input = new DietPlanDraftInput("Plan semanal", 2, 1800.0,
+				List.of(day(1, "Lunes"), day(2, "Martes")), "Cumple objetivos", List.of("Sin restricciones"),
+				List.of("Revisar fibra"));
+		final AiToolResult<AiDraftCreationData> result = service.createDraft(NUTRITIONIST_ID, THREAD_ID, input);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().draftId()).isEqualTo(77L);
+		assertThat(result.data().draftType()).isEqualTo(AiDraftType.DIET_PLAN);
+		assertThat(result.data().status()).isEqualTo(AiDraftStatus.DRAFT);
+		assertThat(result.data().summary()).contains("Plan semanal");
+		verify(draftLifecycleService).createDraft(eq(THREAD_ID), eq(NUTRITIONIST_ID), eq(AiDraftType.DIET_PLAN), any());
+		verify(ingestaNutrientCalculator, times(2)).computeIngestas(eq(NUTRITIONIST_ID), any());
+	}
+
+	@Test
+	void createDraftRejectsEmptyDays() {
+		final DietPlanDraftInput input = new DietPlanDraftInput(null, null, null, List.of(), null, null, null);
+
+		final AiToolResult<AiDraftCreationData> result = service.createDraft(NUTRITIONIST_ID, THREAD_ID, input);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+		verify(ingestaNutrientCalculator, never()).computeIngestas(any(), any());
+		verify(draftLifecycleService, never()).createDraft(any(), any(), any(), any());
+	}
+
+	@Test
+	void createDraftRejectsMismatchedDayCount() {
+		final DietPlanDraftInput input = new DietPlanDraftInput(null, 3, null, List.of(day(1, null)), null, null, null);
+
+		final AiToolResult<AiDraftCreationData> result = service.createDraft(NUTRITIONIST_ID, THREAD_ID, input);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.VALIDATION);
+		verify(ingestaNutrientCalculator, never()).computeIngestas(any(), any());
+	}
+
+	@Test
+	void createDraftPropagatesNutrientComputationErrors() {
+		when(ingestaNutrientCalculator.computeIngestas(eq(NUTRITIONIST_ID), any()))
+			.thenReturn(AiToolResult.error(AiToolErrorCode.NOT_FOUND, "No se encontró el platillo solicitado."));
+
+		final DietPlanDraftInput input = new DietPlanDraftInput(null, null, null,
+				List.of(new DietPlanDayInput(1, null,
+						List.of(new IngestaSlotInput("Comida", 1,
+								List.of(new IngestaSlotItemInput("PLATILLO", 99L, null, 1, null)))))),
+				null, null, null);
+		final AiToolResult<AiDraftCreationData> result = service.createDraft(NUTRITIONIST_ID, THREAD_ID, input);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.NOT_FOUND);
+		verify(draftLifecycleService, never()).createDraft(any(), any(), any(), any());
+	}
+
+	@Test
+	void createDraftMapsUnknownThreadToNotFound() {
+		when(ingestaNutrientCalculator.computeIngestas(eq(NUTRITIONIST_ID), any()))
+			.thenReturn(AiToolResult.success(new AiIngestaNutrientCalculator.IngestaNutrientComputation(
+					new NutrientSummary(500, 20.0, 10.0, 60.0, 5.0, 400.0, 800.0), List.of(), Set.of(1L))));
+		when(draftLifecycleService.createDraft(eq(THREAD_ID), eq(NUTRITIONIST_ID), eq(AiDraftType.DIET_PLAN), any()))
+			.thenThrow(new AiDraftLifecycleException("Conversación no encontrada."));
+
+		final DietPlanDraftInput input = new DietPlanDraftInput(null, null, null, List.of(day(1, null)), null, null,
+				null);
+		final AiToolResult<AiDraftCreationData> result = service.createDraft(NUTRITIONIST_ID, THREAD_ID, input);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.NOT_FOUND);
+	}
+
+	private static DietPlanDayInput day(final int dayIndex, final String label) {
+		return new DietPlanDayInput(dayIndex, label, List
+			.of(new IngestaSlotInput("Desayuno", 1, List.of(new IngestaSlotItemInput("ALIMENTO", null, 1L, 1, null)))));
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds `CreateDietPlanDraftToolService` (`create_diet_plan_draft`) to validate multi-day plan input (1–14 days), compute per-day `nutrientsTotal` and `weeklyAverageNutrients` server-side via `AiIngestaNutrientCalculator`, and persist a `DIET_PLAN` draft through `AiDraftLifecycleService` (no patient assignment).
- Introduces `DietPlanDraftInput`, `DietPlanDayPayload`, and `DietPlanDraftPayload` per `docs/ai/TOOL-CONTRACT.md`.
- Unit tests cover happy path, empty days, dayCount mismatch, auth/nutrient errors, and unknown thread (`NOT_FOUND`).

Fixes #381

## Test plan
- [x] `mvn test -Dtest=CreateDietPlanDraftToolServiceTest`
- [x] `mvn pmd:check -Pci`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)