### PR TITLE
Implement AI draft acceptance flow (#382)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#382 — Implement Draft Acceptance Flow](https://github.com/diego-torres/nutriconsultas/issues/382) (`NEXT`). ~~#381~~ **done** — `create_diet_plan_draft`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#383 — Epic AI Chat REST API](https://github.com/diego-torres/nutriconsultas/issues/383) (`NEXT`). ~~#382~~ **done** — draft acceptance flow; Phase 4 **complete**. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#382 — Implement Draft Acceptance Flow](https://github.com/diego-torres/nutriconsultas/issues/382) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#381~~ `CreateDietPlanDraftToolService`.
+**Current next issue:** [#383 — Epic AI Chat REST API](https://github.com/diego-torres/nutriconsultas/issues/383) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#382~~ `AiDraftAcceptanceService` + REST accept/discard.
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#381~~ diet plan draft creation **done**. **NEXT:** #382.
+**Last updated:** 2026-06-30 — ~~#382~~ draft acceptance flow **done**. **NEXT:** #383.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -118,13 +118,13 @@ Draft-creation tools and acceptance flow (no direct patient assignment).
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **378** | Epic — AI Draft Creation Tools (Phase 4) | https://github.com/diego-torres/nutriconsultas/issues/378 | **open** | **372** | Milestone 2 — ~~#379–#381~~ |
+| **378** | Epic — AI Draft Creation Tools (Phase 4) | https://github.com/diego-torres/nutriconsultas/issues/378 | **done** | **372** | ~~#379–#382~~ |
 | **379** | Implement Dish Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/379 | **done** | **378**, **371** | `create_dish_draft` |
 | **380** | Implement Menu Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/380 | **done** | **378**, **371** | `create_menu_draft` |
 | **381** | Implement Diet Plan Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/381 | **done** | **378**, **371** | `create_diet_plan_draft` |
-| **382** | Implement Draft Acceptance Flow | https://github.com/diego-torres/nutriconsultas/issues/382 | **NEXT** | **379**, **380**, **381** | Convert draft → real record |
+| **382** | Implement Draft Acceptance Flow | https://github.com/diego-torres/nutriconsultas/issues/382 | **done** | **379**, **380**, **381** | Convert draft → real record |
 
-**Suggested order:** ~~#379–#381~~ → #382 (closes epic #378).
+**Phase 4 complete.** **NEXT:** #383 (AI Chat REST API epic).
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/AiDraftAcceptanceResult.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftAcceptanceResult.java
@@ -1,0 +1,8 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Result of accepting an AI draft and materializing it into catalog data.
+ */
+public record AiDraftAcceptanceResult(long draftId, AiDraftType draftType, AiDraftStatus status,
+		AiDraftCreatedEntityType createdEntityType, long createdEntityId, String summary) {
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftAcceptanceService.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftAcceptanceService.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.NonNull;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+/**
+ * Accepts AI drafts and materializes them into catalog records (#382).
+ */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
+public interface AiDraftAcceptanceService {
+
+	AiDraftAcceptanceResult accept(@NonNull Long draftId, @NonNull String nutritionistId, @NonNull OidcUser principal);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftAcceptanceServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftAcceptanceServiceImpl.java
@@ -1,0 +1,101 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.NonNull;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.platillos.Platillo;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class AiDraftAcceptanceServiceImpl implements AiDraftAcceptanceService {
+
+	private final AiGeneratedDraftRepository draftRepository;
+
+	private final AiDraftMaterializationService materializationService;
+
+	private final AiDraftLifecycleService draftLifecycleService;
+
+	public AiDraftAcceptanceServiceImpl(final AiGeneratedDraftRepository draftRepository,
+			final AiDraftMaterializationService materializationService,
+			final AiDraftLifecycleService draftLifecycleService) {
+		this.draftRepository = draftRepository;
+		this.materializationService = materializationService;
+		this.draftLifecycleService = draftLifecycleService;
+	}
+
+	@Override
+	@Transactional
+	public AiDraftAcceptanceResult accept(@NonNull final Long draftId, @NonNull final String nutritionistId,
+			@NonNull final OidcUser principal) {
+		if (!StringUtils.hasText(nutritionistId)) {
+			throw new AiDraftLifecycleException("Sesión de nutriólogo no válida.");
+		}
+		final AiGeneratedDraft draft = loadMutableDraft(draftId, nutritionistId);
+		final MaterializedEntity entity = materialize(draft, nutritionistId, principal);
+		final AiGeneratedDraft accepted = draftLifecycleService.acceptDraft(draftId, nutritionistId);
+		final String summary = buildSummary(draft.getDraftType(), entity);
+		if (log.isInfoEnabled()) {
+			log.info("AI draft accepted id={} status={} createdEntityType={} createdEntityId={}", accepted.getId(),
+					accepted.getStatus(), entity.entityType(), entity.entityId());
+		}
+		return new AiDraftAcceptanceResult(accepted.getId(), accepted.getDraftType(), accepted.getStatus(),
+				entity.entityType(), entity.entityId(), summary);
+	}
+
+	private AiGeneratedDraft loadMutableDraft(final Long draftId, final String nutritionistId) {
+		final AiGeneratedDraft draft = draftRepository.findByIdAndThreadNutritionistId(draftId, nutritionistId)
+			.orElseThrow(() -> new AiDraftLifecycleException("Borrador no encontrado."));
+		if (draft.getStatus() != AiDraftStatus.DRAFT) {
+			throw new AiDraftLifecycleException("El borrador ya no se puede modificar.");
+		}
+		return draft;
+	}
+
+	private MaterializedEntity materialize(final AiGeneratedDraft draft, final String nutritionistId,
+			final OidcUser principal) {
+		return switch (draft.getDraftType()) {
+			case DISH -> materializeDish(draft, nutritionistId, principal);
+			case MENU -> materializeMenu(draft, nutritionistId, principal);
+			case DIET_PLAN -> materializeDietPlan(draft, nutritionistId, principal);
+		};
+	}
+
+	private MaterializedEntity materializeDish(final AiGeneratedDraft draft, final String nutritionistId,
+			final OidcUser principal) {
+		final DishDraftPayload payload = AiDraftPayloadDeserializer.dish(draft.getJsonPayload());
+		final Platillo platillo = materializationService.materializeDish(payload, nutritionistId, principal);
+		return new MaterializedEntity(AiDraftCreatedEntityType.PLATILLO, platillo.getId());
+	}
+
+	private MaterializedEntity materializeMenu(final AiGeneratedDraft draft, final String nutritionistId,
+			final OidcUser principal) {
+		final MenuDraftPayload payload = AiDraftPayloadDeserializer.menu(draft.getJsonPayload());
+		final Dieta dieta = materializationService.materializeMenu(payload, nutritionistId, principal);
+		return new MaterializedEntity(AiDraftCreatedEntityType.DIETA, dieta.getId());
+	}
+
+	private MaterializedEntity materializeDietPlan(final AiGeneratedDraft draft, final String nutritionistId,
+			final OidcUser principal) {
+		final DietPlanDraftPayload payload = AiDraftPayloadDeserializer.dietPlan(draft.getJsonPayload());
+		final Dieta dieta = materializationService.materializeDietPlan(payload, nutritionistId, principal);
+		return new MaterializedEntity(AiDraftCreatedEntityType.DIETA, dieta.getId());
+	}
+
+	private static String buildSummary(final AiDraftType draftType, final MaterializedEntity entity) {
+		return switch (draftType) {
+			case DISH -> "Platillo creado en catálogo (id=" + entity.entityId() + ").";
+			case MENU -> "Menú guardado como dieta en catálogo (id=" + entity.entityId() + ").";
+			case DIET_PLAN -> "Plan alimenticio guardado en catálogo (id=" + entity.entityId() + ").";
+		};
+	}
+
+	private record MaterializedEntity(AiDraftCreatedEntityType entityType, long entityId) {
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftCreatedEntityType.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftCreatedEntityType.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.ai;
+
+public enum AiDraftCreatedEntityType {
+
+	PLATILLO, DIETA
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftIngestaMaterializer.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftIngestaMaterializer.java
@@ -1,0 +1,193 @@
+package com.nutriconsultas.ai;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.alimentos.AlimentosRepository;
+import com.nutriconsultas.dieta.AlimentoIngesta;
+import com.nutriconsultas.dieta.DietaService;
+import com.nutriconsultas.dieta.IngredientePlatilloIngesta;
+import com.nutriconsultas.dieta.Ingesta;
+import com.nutriconsultas.dieta.PlatilloIngesta;
+import com.nutriconsultas.dieta.PlatilloIngestaMapping;
+import com.nutriconsultas.platillos.Ingrediente;
+import com.nutriconsultas.platillos.Platillo;
+import com.nutriconsultas.platillos.PlatilloCatalogConstants;
+import com.nutriconsultas.platillos.PlatilloRepository;
+
+/**
+ * Maps AI draft ingesta slot items into persisted dieta structures.
+ */
+@Component
+public class AiDraftIngestaMaterializer {
+
+	private final AlimentosRepository alimentosRepository;
+
+	private final PlatilloRepository platilloRepository;
+
+	private final DietaService dietaService;
+
+	public AiDraftIngestaMaterializer(final AlimentosRepository alimentosRepository,
+			final PlatilloRepository platilloRepository, final DietaService dietaService) {
+		this.alimentosRepository = alimentosRepository;
+		this.platilloRepository = platilloRepository;
+		this.dietaService = dietaService;
+	}
+
+	public void addItemsToIngesta(@NonNull final Ingesta ingesta, @NonNull final List<IngestaSlotItemInput> items,
+			@NonNull final String nutritionistId) {
+		for (final IngestaSlotItemInput item : items) {
+			final String type = item.type() != null ? item.type().trim().toUpperCase(Locale.ROOT) : "";
+			switch (type) {
+				case "PLATILLO" -> addPlatilloItem(ingesta, item, nutritionistId);
+				case "ALIMENTO" -> addAlimentoItem(ingesta, item);
+				case "RECIPE" -> addRecipeItem(ingesta, item);
+				default -> throw new AiDraftLifecycleException("Tipo de ítem de ingesta no válido.");
+			}
+		}
+	}
+
+	private void addPlatilloItem(final Ingesta ingesta, final IngestaSlotItemInput item, final String nutritionistId) {
+		if (item.platilloId() == null || item.platilloId() <= 0) {
+			throw new AiDraftLifecycleException("El platillo no es válido.");
+		}
+		final Platillo platillo = platilloRepository.findById(item.platilloId()).orElse(null);
+		if (platillo == null || !isAuthorizedPlatillo(platillo, nutritionistId)) {
+			throw new AiDraftLifecycleException("No se encontró el platillo solicitado.");
+		}
+		final PlatilloIngesta platilloIngesta = PlatilloIngestaMapping.mapPlatilloIngesta(platillo);
+		platilloIngesta.setIngesta(ingesta);
+		final int portions = resolvePortions(item.portions());
+		platilloIngesta.setPortions(portions);
+		if (platillo.getIngredientes() != null) {
+			for (final Ingrediente ingrediente : platillo.getIngredientes()) {
+				final IngredientePlatilloIngesta mapped = PlatilloIngestaMapping
+					.mapFromIngredienteToIngredientePlatilloIngesta(ingrediente);
+				mapped.setPlatillo(platilloIngesta);
+				platilloIngesta.getIngredientes().add(mapped);
+			}
+		}
+		if (portions != 1) {
+			dietaService.recalculatePlatilloIngestaNutrients(platilloIngesta, portions);
+		}
+		ingesta.getPlatillos().add(platilloIngesta);
+	}
+
+	private void addAlimentoItem(final Ingesta ingesta, final IngestaSlotItemInput item) {
+		if (item.alimentoId() == null || item.alimentoId() <= 0) {
+			throw new AiDraftLifecycleException("El alimento no es válido.");
+		}
+		final Alimento alimento = alimentosRepository.findById(item.alimentoId()).orElse(null);
+		if (alimento == null) {
+			throw new AiDraftLifecycleException("No se encontró el alimento solicitado.");
+		}
+		final AlimentoIngesta alimentoIngesta = mapAlimentoIngesta(alimento, resolvePortions(item.portions()));
+		alimentoIngesta.setIngesta(ingesta);
+		ingesta.getAlimentos().add(alimentoIngesta);
+	}
+
+	private void addRecipeItem(final Ingesta ingesta, final IngestaSlotItemInput item) {
+		if (item.ingredients() == null || item.ingredients().isEmpty()) {
+			throw new AiDraftLifecycleException("La receta inline debe incluir ingredientes.");
+		}
+		final PlatilloIngesta platilloIngesta = new PlatilloIngesta();
+		platilloIngesta.setName("Receta IA");
+		platilloIngesta.setIngesta(ingesta);
+		platilloIngesta.setPortions(resolvePortions(item.portions()));
+		for (final RecipeIngredientInput ingredientInput : item.ingredients()) {
+			final Ingrediente calculated = buildCatalogIngrediente(ingredientInput);
+			final IngredientePlatilloIngesta mapped = PlatilloIngestaMapping
+				.mapFromIngredienteToIngredientePlatilloIngesta(calculated);
+			mapped.setPlatillo(platilloIngesta);
+			platilloIngesta.getIngredientes().add(mapped);
+		}
+		dietaService.recalculatePlatilloIngestaFromIngredientes(platilloIngesta);
+		ingesta.getPlatillos().add(platilloIngesta);
+	}
+
+	private Ingrediente buildCatalogIngrediente(final RecipeIngredientInput ingredientInput) {
+		final Alimento alimento = alimentosRepository.findById(ingredientInput.alimentoId()).orElse(null);
+		if (alimento == null) {
+			throw new AiDraftLifecycleException("No se encontró el alimento solicitado.");
+		}
+		if (!AiNutrientToolSupport.isUnitSupported(alimento, ingredientInput.unidad())) {
+			throw new AiDraftLifecycleException("Unidad no compatible para el alimento " + alimento.getId() + ".");
+		}
+		final Integer pesoNeto = ingredientInput.pesoNetoG() != null ? ingredientInput.pesoNetoG()
+				: alimento.getPesoNeto();
+		if (pesoNeto == null) {
+			throw new AiDraftLifecycleException(
+					"El alimento " + alimento.getId() + " no tiene peso neto en el catálogo.");
+		}
+		final Ingrediente calculated = AiNutrientToolSupport.calculateIngredient(alimento,
+				ingredientInput.cantidad().trim(), pesoNeto);
+		if (calculated == null) {
+			throw new AiDraftLifecycleException("No se pudo calcular el alimento con id " + alimento.getId() + ".");
+		}
+		return calculated;
+	}
+
+	private static AlimentoIngesta mapAlimentoIngesta(final Alimento alimento, final int portions) {
+		final AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
+		alimentoIngesta.setName(alimento.getNombreAlimento());
+		alimentoIngesta.setAlimento(alimento);
+		alimentoIngesta.setPortions(portions);
+		alimentoIngesta.setUnidad(alimento.getUnidad());
+		if (alimento.getEnergia() != null) {
+			alimentoIngesta.setEnergia(alimento.getEnergia() * portions);
+		}
+		if (alimento.getProteina() != null) {
+			alimentoIngesta.setProteina(alimento.getProteina() * portions);
+		}
+		if (alimento.getLipidos() != null) {
+			alimentoIngesta.setLipidos(alimento.getLipidos() * portions);
+		}
+		if (alimento.getHidratosDeCarbono() != null) {
+			alimentoIngesta.setHidratosDeCarbono(alimento.getHidratosDeCarbono() * portions);
+		}
+		if (alimento.getPesoBrutoRedondeado() != null) {
+			alimentoIngesta.setPesoBrutoRedondeado(alimento.getPesoBrutoRedondeado() * portions);
+		}
+		if (alimento.getPesoNeto() != null) {
+			alimentoIngesta.setPesoNeto(alimento.getPesoNeto() * portions);
+		}
+		if (alimento.getFibra() != null) {
+			alimentoIngesta.setFibra(alimento.getFibra() * portions);
+		}
+		if (alimento.getSodio() != null) {
+			alimentoIngesta.setSodio(alimento.getSodio() * portions);
+		}
+		if (alimento.getPotasio() != null) {
+			alimentoIngesta.setPotasio(alimento.getPotasio() * portions);
+		}
+		return alimentoIngesta;
+	}
+
+	private static boolean isAuthorizedPlatillo(final Platillo platillo, final String nutritionistId) {
+		return PlatilloCatalogConstants.isSystemCatalog(platillo)
+				|| Objects.equals(nutritionistId, platillo.getUserId());
+	}
+
+	private static int resolvePortions(final Integer portions) {
+		if (portions == null || portions < 1) {
+			return 1;
+		}
+		return portions;
+	}
+
+	public static Ingesta buildIngesta(final String nombre, final int orden) {
+		final Ingesta ingesta = new Ingesta();
+		ingesta.setNombre(nombre);
+		ingesta.setOrden(orden);
+		ingesta.setPlatillos(new ArrayList<>());
+		ingesta.setAlimentos(new ArrayList<>());
+		return ingesta;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftMaterializationService.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftMaterializationService.java
@@ -1,0 +1,23 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.NonNull;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.platillos.Platillo;
+
+/**
+ * Converts accepted AI draft payloads into catalog entities (#382).
+ */
+public interface AiDraftMaterializationService {
+
+	Platillo materializeDish(@NonNull DishDraftPayload payload, @NonNull String nutritionistId,
+			@NonNull OidcUser principal);
+
+	Dieta materializeMenu(@NonNull MenuDraftPayload payload, @NonNull String nutritionistId,
+			@NonNull OidcUser principal);
+
+	Dieta materializeDietPlan(@NonNull DietPlanDraftPayload payload, @NonNull String nutritionistId,
+			@NonNull OidcUser principal);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftMaterializationServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftMaterializationServiceImpl.java
@@ -1,0 +1,225 @@
+package com.nutriconsultas.ai;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.springframework.lang.NonNull;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.alimentos.AlimentosRepository;
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.dieta.DietaAuthorization;
+import com.nutriconsultas.dieta.DietaNutritionCalculator;
+import com.nutriconsultas.dieta.DietaService;
+import com.nutriconsultas.dieta.Ingesta;
+import com.nutriconsultas.platillos.Ingrediente;
+import com.nutriconsultas.platillos.Platillo;
+import com.nutriconsultas.platillos.PlatilloAuthorization;
+import com.nutriconsultas.platillos.PlatilloService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class AiDraftMaterializationServiceImpl implements AiDraftMaterializationService {
+
+	static final String DEFAULT_MENU_NAME = "Menú del día";
+
+	static final String DEFAULT_PLAN_NAME = "Plan alimenticio";
+
+	private final PlatilloService platilloService;
+
+	private final PlatilloAuthorization platilloAuthorization;
+
+	private final DietaService dietaService;
+
+	private final DietaAuthorization dietaAuthorization;
+
+	private final AlimentosRepository alimentosRepository;
+
+	private final AiDraftIngestaMaterializer ingestaMaterializer;
+
+	public AiDraftMaterializationServiceImpl(final PlatilloService platilloService,
+			final PlatilloAuthorization platilloAuthorization, final DietaService dietaService,
+			final DietaAuthorization dietaAuthorization, final AlimentosRepository alimentosRepository,
+			final AiDraftIngestaMaterializer ingestaMaterializer) {
+		this.platilloService = platilloService;
+		this.platilloAuthorization = platilloAuthorization;
+		this.dietaService = dietaService;
+		this.dietaAuthorization = dietaAuthorization;
+		this.alimentosRepository = alimentosRepository;
+		this.ingestaMaterializer = ingestaMaterializer;
+	}
+
+	@Override
+	@Transactional
+	public Platillo materializeDish(@NonNull final DishDraftPayload payload, @NonNull final String nutritionistId,
+			@NonNull final OidcUser principal) {
+		final Platillo platillo = new Platillo();
+		platillo.setName(payload.name().trim());
+		platillo.setDescription(buildDishDescription(payload));
+		platillo.setIngestasSugeridas(payload.ingestasSugeridas());
+		platillo.setUserId(platilloAuthorization.resolveCreateUserId(principal, nutritionistId));
+		final Platillo saved = platilloService.save(platillo);
+		for (final RecipeIngredientInput ingredient : payload.ingredients()) {
+			addDishIngredient(saved.getId(), ingredient);
+		}
+		final Platillo refreshed = platilloService.findById(saved.getId());
+		platilloAuthorization.auditSystemPlatilloMutationIfNeeded(principal, refreshed, "ai.drafts.accept.dish");
+		if (log.isInfoEnabled()) {
+			log.info("AI draft materialized dish platilloId={}", refreshed.getId());
+		}
+		return refreshed;
+	}
+
+	@Override
+	@Transactional
+	public Dieta materializeMenu(@NonNull final MenuDraftPayload payload, @NonNull final String nutritionistId,
+			@NonNull final OidcUser principal) {
+		final Dieta dieta = newDieta(resolveMenuName(payload), nutritionistId, principal);
+		dieta.setIngestas(buildIngestasFromSlots(payload.ingestas(), nutritionistId, 1, 1));
+		return saveCatalogDieta(dieta, principal, "ai.drafts.accept.menu");
+	}
+
+	@Override
+	@Transactional
+	public Dieta materializeDietPlan(@NonNull final DietPlanDraftPayload payload, @NonNull final String nutritionistId,
+			@NonNull final OidcUser principal) {
+		final Dieta dieta = newDieta(resolvePlanName(payload), nutritionistId, principal);
+		final List<Ingesta> ingestas = new ArrayList<>();
+		int orden = 1;
+		final List<DietPlanDayPayload> sortedDays = payload.days()
+			.stream()
+			.sorted(Comparator.comparingInt(DietPlanDayPayload::dayIndex))
+			.toList();
+		for (final DietPlanDayPayload day : sortedDays) {
+			orden = appendDayIngestas(ingestas, day, nutritionistId, payload.days().size(), orden);
+		}
+		dieta.setIngestas(ingestas);
+		return saveCatalogDieta(dieta, principal, "ai.drafts.accept.diet_plan");
+	}
+
+	private Dieta saveCatalogDieta(final Dieta dieta, final OidcUser principal, final String auditAction) {
+		for (final Ingesta ingesta : dieta.getIngestas()) {
+			ingesta.setDieta(dieta);
+		}
+		DietaNutritionCalculator.applyCalculatedNutrients(dieta);
+		final Dieta saved = dietaService.saveDieta(dieta);
+		dietaAuthorization.auditSystemDietMutationIfNeeded(principal, saved, auditAction);
+		if (log.isInfoEnabled()) {
+			log.info("AI draft materialized dieta dietaId={}", saved.getId());
+		}
+		return saved;
+	}
+
+	private List<Ingesta> buildIngestasFromSlots(final List<IngestaSlotInput> slots, final String nutritionistId,
+			final int dayIndex, final int totalDays) {
+		final List<Ingesta> ingestas = new ArrayList<>();
+		int orden = 1;
+		for (final IngestaSlotInput slot : slots) {
+			final Ingesta ingesta = buildIngestaFromSlot(slot, nutritionistId, dayIndex, totalDays, orden);
+			orden++;
+			ingestas.add(ingesta);
+		}
+		return ingestas;
+	}
+
+	private int appendDayIngestas(final List<Ingesta> ingestas, final DietPlanDayPayload day,
+			final String nutritionistId, final int totalDays, final int startOrden) {
+		int orden = startOrden;
+		for (final IngestaSlotInput slot : day.ingestas()) {
+			ingestas.add(buildIngestaFromSlot(slot, nutritionistId, day.dayIndex(), totalDays, orden));
+			orden++;
+		}
+		return orden;
+	}
+
+	private Ingesta buildIngestaFromSlot(final IngestaSlotInput slot, final String nutritionistId, final int dayIndex,
+			final int totalDays, final int orden) {
+		final String nombre = resolveIngestaName(slot, dayIndex, totalDays);
+		final Ingesta ingesta = AiDraftIngestaMaterializer.buildIngesta(nombre, orden);
+		if (slot.items() != null && !slot.items().isEmpty()) {
+			ingestaMaterializer.addItemsToIngesta(ingesta, slot.items(), nutritionistId);
+		}
+		return ingesta;
+	}
+
+	private void addDishIngredient(final Long platilloId, final RecipeIngredientInput ingredient) {
+		final Alimento alimento = alimentosRepository.findById(ingredient.alimentoId()).orElse(null);
+		if (alimento == null) {
+			throw new AiDraftLifecycleException("No se encontró el alimento solicitado.");
+		}
+		final Integer pesoNeto = ingredient.pesoNetoG() != null ? ingredient.pesoNetoG() : alimento.getPesoNeto();
+		if (pesoNeto == null) {
+			throw new AiDraftLifecycleException(
+					"El alimento " + alimento.getId() + " no tiene peso neto en el catálogo.");
+		}
+		final Ingrediente added = platilloService.addIngrediente(platilloId, ingredient.alimentoId(),
+				ingredient.cantidad().trim(), pesoNeto);
+		if (added == null) {
+			throw new AiDraftLifecycleException("No se pudo agregar el ingrediente al platillo.");
+		}
+	}
+
+	private Dieta newDieta(final String nombre, final String nutritionistId, final OidcUser principal) {
+		final Dieta dieta = new Dieta();
+		dieta.setNombre(nombre);
+		dieta.setUserId(dietaAuthorization.resolveCreateUserId(principal, nutritionistId));
+		dieta.setPacienteId(null);
+		dieta.setIngestas(new ArrayList<>());
+		return dieta;
+	}
+
+	private static String buildDishDescription(final DishDraftPayload payload) {
+		if (!StringUtils.hasText(payload.description())
+				&& (payload.preparationSteps() == null || payload.preparationSteps().isEmpty())) {
+			return payload.description();
+		}
+		final StringBuilder builder = new StringBuilder();
+		if (StringUtils.hasText(payload.description())) {
+			builder.append(payload.description().trim());
+		}
+		if (payload.preparationSteps() != null && !payload.preparationSteps().isEmpty()) {
+			if (!builder.isEmpty()) {
+				builder.append("\n\n");
+			}
+			builder.append("Preparación:\n");
+			int step = 1;
+			for (final String preparationStep : payload.preparationSteps()) {
+				if (StringUtils.hasText(preparationStep)) {
+					builder.append(step).append(". ").append(preparationStep.trim()).append('\n');
+					step++;
+				}
+			}
+		}
+		return builder.isEmpty() ? null : builder.toString().trim();
+	}
+
+	private static String resolveMenuName(final MenuDraftPayload payload) {
+		if (StringUtils.hasText(payload.title())) {
+			return payload.title().trim();
+		}
+		return DEFAULT_MENU_NAME;
+	}
+
+	private static String resolvePlanName(final DietPlanDraftPayload payload) {
+		if (StringUtils.hasText(payload.title())) {
+			return payload.title().trim();
+		}
+		return DEFAULT_PLAN_NAME;
+	}
+
+	private static String resolveIngestaName(final IngestaSlotInput slot, final int dayIndex, final int totalDays) {
+		final String baseName = StringUtils.hasText(slot.nombre()) ? slot.nombre().trim() : "Ingesta";
+		if (totalDays <= 1) {
+			return baseName;
+		}
+		return "Día " + dayIndex + " — " + baseName;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftPayloadDeserializer.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftPayloadDeserializer.java
@@ -1,0 +1,37 @@
+package com.nutriconsultas.ai;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Deserializes persisted AI draft JSON payloads.
+ */
+public final class AiDraftPayloadDeserializer {
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	private AiDraftPayloadDeserializer() {
+	}
+
+	public static DishDraftPayload dish(final String jsonPayload) {
+		return read(jsonPayload, DishDraftPayload.class);
+	}
+
+	public static MenuDraftPayload menu(final String jsonPayload) {
+		return read(jsonPayload, MenuDraftPayload.class);
+	}
+
+	public static DietPlanDraftPayload dietPlan(final String jsonPayload) {
+		return read(jsonPayload, DietPlanDraftPayload.class);
+	}
+
+	private static <T> T read(final String jsonPayload, final Class<T> type) {
+		try {
+			return OBJECT_MAPPER.readValue(jsonPayload, type);
+		}
+		catch (JsonProcessingException ex) {
+			throw new AiDraftLifecycleException("No se pudo leer el borrador.", ex);
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftRestController.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftRestController.java
@@ -1,0 +1,107 @@
+package com.nutriconsultas.ai;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/nutritionist/ai/drafts")
+@Slf4j
+public class AiDraftRestController {
+
+	private final AiDraftAcceptanceService draftAcceptanceService;
+
+	private final AiDraftLifecycleService draftLifecycleService;
+
+	public AiDraftRestController(final AiDraftAcceptanceService draftAcceptanceService,
+			final AiDraftLifecycleService draftLifecycleService) {
+		this.draftAcceptanceService = draftAcceptanceService;
+		this.draftLifecycleService = draftLifecycleService;
+	}
+
+	@PostMapping("/{draftId}/accept")
+	public ResponseEntity<Map<String, Object>> acceptDraft(@PathVariable @NonNull final Long draftId,
+			@AuthenticationPrincipal final OidcUser principal) {
+		if (principal == null) {
+			return errorResponse(HttpStatus.UNAUTHORIZED, "Sesión no válida.");
+		}
+		try {
+			final AiDraftAcceptanceResult result = draftAcceptanceService.accept(draftId, principal.getSubject(),
+					principal);
+			final Map<String, Object> body = new LinkedHashMap<>();
+			body.put("success", true);
+			body.put("draftId", result.draftId());
+			body.put("draftType", result.draftType().name());
+			body.put("status", result.status().name());
+			body.put("createdEntityType", result.createdEntityType().name());
+			body.put("createdEntityId", result.createdEntityId());
+			body.put("summary", result.summary());
+			return ResponseEntity.ok(body);
+		}
+		catch (AiDraftLifecycleException ex) {
+			return mapLifecycleException(ex);
+		}
+	}
+
+	@PostMapping("/{draftId}/discard")
+	public ResponseEntity<Map<String, Object>> discardDraft(@PathVariable @NonNull final Long draftId,
+			@AuthenticationPrincipal final OidcUser principal) {
+		if (principal == null) {
+			return errorResponse(HttpStatus.UNAUTHORIZED, "Sesión no válida.");
+		}
+		try {
+			final AiGeneratedDraft discarded = draftLifecycleService.discardDraft(draftId, principal.getSubject());
+			final Map<String, Object> body = new LinkedHashMap<>();
+			body.put("success", true);
+			body.put("draftId", discarded.getId());
+			body.put("draftType", discarded.getDraftType().name());
+			body.put("status", discarded.getStatus().name());
+			return ResponseEntity.ok(body);
+		}
+		catch (AiDraftLifecycleException ex) {
+			return mapLifecycleException(ex);
+		}
+	}
+
+	private static ResponseEntity<Map<String, Object>> mapLifecycleException(final AiDraftLifecycleException ex) {
+		final HttpStatus status;
+		final String errorCode;
+		if (ex.getMessage() != null && ex.getMessage().contains("Borrador no encontrado")) {
+			status = HttpStatus.NOT_FOUND;
+			errorCode = AiToolErrorCode.NOT_FOUND.name();
+		}
+		else if (ex.getMessage() != null && ex.getMessage().contains("Conversación no encontrada")) {
+			status = HttpStatus.NOT_FOUND;
+			errorCode = AiToolErrorCode.NOT_FOUND.name();
+		}
+		else {
+			status = HttpStatus.BAD_REQUEST;
+			errorCode = AiToolErrorCode.VALIDATION.name();
+		}
+		final Map<String, Object> body = new LinkedHashMap<>();
+		body.put("success", false);
+		body.put("errorCode", errorCode);
+		body.put("message", ex.getMessage());
+		return ResponseEntity.status(status).body(body);
+	}
+
+	private static ResponseEntity<Map<String, Object>> errorResponse(final HttpStatus status, final String message) {
+		final Map<String, Object> body = new LinkedHashMap<>();
+		body.put("success", false);
+		body.put("errorCode", AiToolErrorCode.VALIDATION.name());
+		body.put("message", message);
+		return ResponseEntity.status(status).body(body);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiDraftAcceptanceServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftAcceptanceServiceTest.java
@@ -1,0 +1,122 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.platillos.Platillo;
+
+@ExtendWith(MockitoExtension.class)
+class AiDraftAcceptanceServiceTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	@InjectMocks
+	private AiDraftAcceptanceServiceImpl service;
+
+	@Mock
+	private AiGeneratedDraftRepository draftRepository;
+
+	@Mock
+	private AiDraftMaterializationService materializationService;
+
+	@Mock
+	private AiDraftLifecycleService draftLifecycleService;
+
+	@Test
+	void acceptMaterializesDishDraftAndMarksAccepted() {
+		final AiGeneratedDraft draft = dishDraft();
+		when(draftRepository.findByIdAndThreadNutritionistId(55L, NUTRITIONIST_ID)).thenReturn(Optional.of(draft));
+		final Platillo platillo = new Platillo();
+		platillo.setId(200L);
+		when(materializationService.materializeDish(any(), eq(NUTRITIONIST_ID), any())).thenReturn(platillo);
+		final AiGeneratedDraft accepted = dishDraft();
+		accepted.setStatus(AiDraftStatus.ACCEPTED);
+		when(draftLifecycleService.acceptDraft(55L, NUTRITIONIST_ID)).thenReturn(accepted);
+
+		final AiDraftAcceptanceResult result = service.accept(55L, NUTRITIONIST_ID, principal());
+
+		assertThat(result.createdEntityType()).isEqualTo(AiDraftCreatedEntityType.PLATILLO);
+		assertThat(result.createdEntityId()).isEqualTo(200L);
+		assertThat(result.status()).isEqualTo(AiDraftStatus.ACCEPTED);
+		verify(materializationService).materializeDish(any(), eq(NUTRITIONIST_ID), any());
+		verify(draftLifecycleService).acceptDraft(55L, NUTRITIONIST_ID);
+	}
+
+	@Test
+	void acceptRejectsUnknownDraft() {
+		when(draftRepository.findByIdAndThreadNutritionistId(55L, NUTRITIONIST_ID)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.accept(55L, NUTRITIONIST_ID, principal()))
+			.isInstanceOf(AiDraftLifecycleException.class)
+			.hasMessageContaining("Borrador no encontrado");
+	}
+
+	@Test
+	void acceptMaterializesMenuDraftAsDieta() {
+		final AiGeneratedDraft draft = menuDraft();
+		when(draftRepository.findByIdAndThreadNutritionistId(56L, NUTRITIONIST_ID)).thenReturn(Optional.of(draft));
+		final Dieta dieta = new Dieta();
+		dieta.setId(300L);
+		when(materializationService.materializeMenu(any(), eq(NUTRITIONIST_ID), any())).thenReturn(dieta);
+		final AiGeneratedDraft accepted = menuDraft();
+		accepted.setStatus(AiDraftStatus.ACCEPTED);
+		when(draftLifecycleService.acceptDraft(56L, NUTRITIONIST_ID)).thenReturn(accepted);
+
+		final AiDraftAcceptanceResult result = service.accept(56L, NUTRITIONIST_ID, principal());
+
+		assertThat(result.createdEntityType()).isEqualTo(AiDraftCreatedEntityType.DIETA);
+		assertThat(result.createdEntityId()).isEqualTo(300L);
+	}
+
+	private static AiGeneratedDraft dishDraft() {
+		final AiGeneratedDraft draft = new AiGeneratedDraft();
+		draft.setId(55L);
+		draft.setDraftType(AiDraftType.DISH);
+		draft.setStatus(AiDraftStatus.DRAFT);
+		draft.setJsonPayload(
+				"{\"name\":\"Tacos\",\"ingredients\":[{\"alimentoId\":1,\"cantidad\":\"1\"}],\"portions\":1,"
+						+ "\"nutrientsPerPortion\":{\"energiaKcal\":100,\"proteinaG\":10.0,\"lipidosG\":5.0,"
+						+ "\"hidratosDeCarbonoG\":12.0,\"fibraG\":1.0,\"sodioMg\":100.0,\"potasioMg\":200.0},"
+						+ "\"label\":\"Borrador IA\"}");
+		return draft;
+	}
+
+	private static AiGeneratedDraft menuDraft() {
+		final AiGeneratedDraft draft = new AiGeneratedDraft();
+		draft.setId(56L);
+		draft.setDraftType(AiDraftType.MENU);
+		draft.setStatus(AiDraftStatus.DRAFT);
+		draft.setJsonPayload("{\"ingestas\":[{\"nombre\":\"Desayuno\",\"orden\":1,"
+				+ "\"items\":[{\"type\":\"ALIMENTO\",\"alimentoId\":1,\"portions\":1}]}],"
+				+ "\"nutrientsTotal\":{\"energiaKcal\":500,\"proteinaG\":20.0,\"lipidosG\":10.0,"
+				+ "\"hidratosDeCarbonoG\":60.0,\"fibraG\":5.0,\"sodioMg\":400.0,\"potasioMg\":800.0},"
+				+ "\"label\":\"Borrador IA\"}");
+		return draft;
+	}
+
+	private static DefaultOidcUser principal() {
+		final Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject(NUTRITIONIST_ID).build();
+		final OidcIdToken idToken = new OidcIdToken(jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(),
+				Map.of("sub", NUTRITIONIST_ID));
+		return new DefaultOidcUser(List.of(), idToken);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiDraftRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftRestControllerTest.java
@@ -1,0 +1,73 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+
+@ExtendWith(MockitoExtension.class)
+class AiDraftRestControllerTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	@InjectMocks
+	private AiDraftRestController controller;
+
+	@Mock
+	private AiDraftAcceptanceService draftAcceptanceService;
+
+	@Mock
+	private AiDraftLifecycleService draftLifecycleService;
+
+	@Test
+	void acceptDraftReturnsCreatedEntity() {
+		when(draftAcceptanceService.accept(eq(10L), eq(NUTRITIONIST_ID), any()))
+			.thenReturn(new AiDraftAcceptanceResult(10L, AiDraftType.DISH, AiDraftStatus.ACCEPTED,
+					AiDraftCreatedEntityType.PLATILLO, 42L, "Platillo creado en catálogo (id=42)."));
+
+		final ResponseEntity<Map<String, Object>> response = controller.acceptDraft(10L, principal());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("success", true)
+			.containsEntry("createdEntityType", "PLATILLO")
+			.containsEntry("createdEntityId", 42L);
+	}
+
+	@Test
+	void discardDraftReturnsDiscardedStatus() {
+		final AiGeneratedDraft discarded = new AiGeneratedDraft();
+		discarded.setId(11L);
+		discarded.setDraftType(AiDraftType.MENU);
+		discarded.setStatus(AiDraftStatus.DISCARDED);
+		when(draftLifecycleService.discardDraft(11L, NUTRITIONIST_ID)).thenReturn(discarded);
+
+		final ResponseEntity<Map<String, Object>> response = controller.discardDraft(11L, principal());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("success", true).containsEntry("status", "DISCARDED");
+		verify(draftLifecycleService).discardDraft(11L, NUTRITIONIST_ID);
+	}
+
+	private static DefaultOidcUser principal() {
+		final Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject(NUTRITIONIST_ID).build();
+		final OidcIdToken idToken = new OidcIdToken(jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(),
+				Map.of("sub", NUTRITIONIST_ID));
+		return new DefaultOidcUser(List.of(), idToken);
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds `AiDraftMaterializationService` to convert accepted draft payloads into catalog `Platillo` (dish) or `Dieta` (menu/diet plan) records, reusing `PlatilloIngestaMapping` and authorized catalog ID checks.
- Adds `AiDraftAcceptanceService` to orchestrate materialization + `AiDraftLifecycleService.acceptDraft`, with audit hooks via existing authorization helpers.
- Exposes `POST /rest/nutritionist/ai/drafts/{draftId}/accept` and `/discard` via `AiDraftRestController`.
- Unit tests for acceptance service and REST controller.

Fixes #382. Closes epic #378 (Phase 4 complete).

## Test plan
- [x] `mvn test -Dtest=AiDraftAcceptanceServiceTest,AiDraftRestControllerTest`
- [x] `mvn pmd:check -Pci`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)