### PR TITLE
Implement AI orchestration service (#385)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#383 — Epic AI Chat REST API](https://github.com/diego-torres/nutriconsultas/issues/383) (`NEXT`). ~~#382~~ **done** — draft acceptance flow; Phase 4 **complete**. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#384 — Create AI Chat Controller](https://github.com/diego-torres/nutriconsultas/issues/384) (`NEXT`). ~~#385~~ **done** — `AiOrchestrationService` tool loop. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#383 — Epic AI Chat REST API](https://github.com/diego-torres/nutriconsultas/issues/383) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#382~~ `AiDraftAcceptanceService` + REST accept/discard.
+**Current next issue:** [#384 — Create AI Chat Controller](https://github.com/diego-torres/nutriconsultas/issues/384) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#385~~ `AiOrchestrationService` + tool dispatcher.
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#382~~ draft acceptance flow **done**. **NEXT:** #383.
+**Last updated:** 2026-06-30 — ~~#385~~ AI orchestration service **done**. **NEXT:** #384.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -124,7 +124,7 @@ Draft-creation tools and acceptance flow (no direct patient assignment).
 | **381** | Implement Diet Plan Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/381 | **done** | **378**, **371** | `create_diet_plan_draft` |
 | **382** | Implement Draft Acceptance Flow | https://github.com/diego-torres/nutriconsultas/issues/382 | **done** | **379**, **380**, **381** | Convert draft → real record |
 
-**Phase 4 complete.** **NEXT:** #383 (AI Chat REST API epic).
+**Phase 4 complete.** Epic #383 **open** — ~~#385~~ orchestration **done**. **NEXT:** #384.
 
 ---
 
@@ -135,11 +135,11 @@ Authenticated endpoints for chat and draft management.
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
 | **383** | Epic — AI Chat REST API (Phase 5) | https://github.com/diego-torres/nutriconsultas/issues/383 | **open** | **366**, **382** | Milestone 3 |
-| **384** | Create AI Chat Controller | https://github.com/diego-torres/nutriconsultas/issues/384 | **open** | **383**, **385** | `/nutritionist/ai/**` |
-| **385** | Implement AI Orchestration Service | https://github.com/diego-torres/nutriconsultas/issues/385 | **open** | **366**, **372**, **378** | OpenAI + tools |
+| **384** | Create AI Chat Controller | https://github.com/diego-torres/nutriconsultas/issues/384 | **NEXT** | **383**, **385** | `/nutritionist/ai/**` |
+| **385** | Implement AI Orchestration Service | https://github.com/diego-torres/nutriconsultas/issues/385 | **done** | **366**, **372**, **378** | `AiOrchestrationService` |
 | **386** | Add Rate Limiting for AI Chat | https://github.com/diego-torres/nutriconsultas/issues/386 | **open** | **385** | Resilience4j |
 
-**Suggested order:** #385 → #384 + #386.
+**Suggested order:** ~~#385~~ → **#384** + #386.
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/AiOpenAiToolCatalog.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOpenAiToolCatalog.java
@@ -1,0 +1,144 @@
+package com.nutriconsultas.ai;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * OpenAI function definitions for implemented nutrition tools (#385).
+ */
+@Component
+public final class AiOpenAiToolCatalog {
+
+	public List<OpenAiToolDefinition> definitions() {
+		return List.of(searchFoodCatalog(), getFoodNutrients(), searchDishCatalog(), calculateRecipeNutrients(),
+				validatePlanConstraints(), createDishDraft(), createMenuDraft(), createDietPlanDraft());
+	}
+
+	private static OpenAiToolDefinition searchFoodCatalog() {
+		return new OpenAiToolDefinition(SearchFoodCatalogToolService.TOOL_NAME,
+				"Busca alimentos en el catálogo autorizado por nombre o clasificación. "
+						+ "Devuelve IDs para consultar nutrientes. No inventes alimentos.",
+				objectSchema(Map.of("query", stringProperty("Texto de búsqueda (nombre o clasificación)", 2, 120),
+						"clasificacion", optionalStringProperty("Filtro opcional por clasificación", 80), "limit",
+						integerProperty("Cantidad máxima de resultados", 1, 25)), List.of("query")));
+	}
+
+	private static OpenAiToolDefinition getFoodNutrients() {
+		return new OpenAiToolDefinition(GetFoodNutrientsToolService.TOOL_NAME,
+				"Obtiene nutrientes calculados de un alimento del catálogo para una cantidad y unidad específicas. "
+						+ "Usa siempre este tool en lugar de estimar.",
+				objectSchema(Map.of("alimentoId", Map.of("type", "integer"), "cantidad",
+						Map.of("type", "string", "description", "Cantidad fraccionaria, ej. 1, 1/2, 2"), "pesoNetoG",
+						Map.of("type", "integer", "minimum", 1), "portions",
+						Map.of("type", "integer", "minimum", 1, "default", 1), "unidad",
+						Map.of("type", "string", "maxLength", 40)), List.of("alimentoId", "cantidad")));
+	}
+
+	private static OpenAiToolDefinition searchDishCatalog() {
+		return new OpenAiToolDefinition(SearchDishCatalogToolService.TOOL_NAME,
+				"Busca platillos del catálogo del sistema y del nutriólogo autenticado. "
+						+ "Devuelve IDs para leer recetas.",
+				objectSchema(Map.of("query", stringProperty("Texto de búsqueda", 2, 120), "ingestasSugeridas",
+						optionalStringProperty("Filtro opcional, ej. Desayuno, Comida", 80), "limit",
+						integerProperty("Cantidad máxima de resultados", 1, 25)), List.of("query")));
+	}
+
+	private static OpenAiToolDefinition calculateRecipeNutrients() {
+		return new OpenAiToolDefinition(CalculateRecipeNutrientsToolService.TOOL_NAME,
+				"Calcula nutrientes totales y por porción de una lista de ingredientes del catálogo. "
+						+ "Usa antes de proponer un platillo o validar un menú.",
+				objectSchema(Map.of("ingredients", recipeIngredientArrayProperty(), "portions",
+						Map.of("type", "integer", "minimum", 1, "default", 1), "label",
+						Map.of("type", "string", "maxLength", 120)), List.of("ingredients")));
+	}
+
+	private static OpenAiToolDefinition validatePlanConstraints() {
+		final Map<String, Object> properties = new LinkedHashMap<>();
+		properties.put("planType", Map.of("type", "string", "enum", List.of("MENU", "DIET_PLAN", "DISH")));
+		properties.put("targetKcal", Map.of("type", "number", "minimum", 500, "maximum", 10000));
+		properties.put("targetProteinaG", Map.of("type", "number", "minimum", 0));
+		properties.put("targetLipidosG", Map.of("type", "number", "minimum", 0));
+		properties.put("targetHidratosG", Map.of("type", "number", "minimum", 0));
+		properties.put("maxSodioMg", Map.of("type", "number", "minimum", 0));
+		properties.put("excludedAlimentoIds", Map.of("type", "array", "items", Map.of("type", "integer")));
+		properties.put("menu", Map.of("type", "object"));
+		properties.put("dietPlan", Map.of("type", "object"));
+		properties.put("dish", Map.of("type", "object"));
+		properties.put("toleranceKcal", Map.of("type", "number", "minimum", 0, "default", 50));
+		return new OpenAiToolDefinition(ValidatePlanConstraintsToolService.TOOL_NAME,
+				"Valida un borrador de menú o plan contra objetivos calóricos, macros, alergias del paciente "
+						+ "vinculado y restricciones declaradas. Devuelve cumplimiento y advertencias en español.",
+				objectSchema(properties, List.of("planType")));
+	}
+
+	private static OpenAiToolDefinition createDishDraft() {
+		final Map<String, Object> properties = new LinkedHashMap<>();
+		properties.put("name", stringProperty("Nombre del platillo", 2, 120));
+		properties.put("description", optionalStringProperty("Descripción", 2000));
+		properties.put("preparationSteps",
+				Map.of("type", "array", "maxItems", 30, "items", Map.of("type", "string", "maxLength", 500)));
+		properties.put("ingestasSugeridas", optionalStringProperty("Ingesta sugerida", 80));
+		properties.put("ingredients", recipeIngredientArrayProperty());
+		properties.put("portions", Map.of("type", "integer", "minimum", 1, "default", 1));
+		properties.put("nutrientsPerPortion", Map.of("type", "object"));
+		properties.put("assumptions", stringArrayProperty());
+		properties.put("warnings", stringArrayProperty());
+		return new OpenAiToolDefinition(CreateDishDraftToolService.TOOL_NAME,
+				"Guarda un borrador de platillo/receta para revisión del nutriólogo. "
+						+ "No guarda en el catálogo final.",
+				objectSchema(properties, List.of("name", "ingredients")));
+	}
+
+	private static OpenAiToolDefinition createMenuDraft() {
+		return new OpenAiToolDefinition(CreateMenuDraftToolService.TOOL_NAME,
+				"Guarda un borrador de menú de un día (varias ingestas). No asigna al paciente.",
+				objectSchema(Map.of("title", optionalStringProperty("Título del menú", 120), "targetKcal",
+						Map.of("type", "number"), "ingestas",
+						Map.of("type", "array", "minItems", 1, "maxItems", 12, "items", Map.of("type", "object")),
+						"validationSummary", optionalStringProperty("Resumen de validación", 1000), "assumptions",
+						stringArrayProperty(), "warnings", stringArrayProperty()), List.of("ingestas")));
+	}
+
+	private static OpenAiToolDefinition createDietPlanDraft() {
+		return new OpenAiToolDefinition(CreateDietPlanDraftToolService.TOOL_NAME,
+				"Guarda un borrador de plan alimenticio multi-día. No asigna al paciente.",
+				objectSchema(Map.of("title", optionalStringProperty("Título del plan", 120), "dayCount",
+						Map.of("type", "integer", "minimum", 1, "maximum", 14), "targetKcalPerDay",
+						Map.of("type", "number"), "days",
+						Map.of("type", "array", "minItems", 1, "maxItems", 14, "items", Map.of("type", "object")),
+						"validationSummary", optionalStringProperty("Resumen de validación", 2000), "assumptions",
+						stringArrayProperty(), "warnings", stringArrayProperty()), List.of("days")));
+	}
+
+	private static Map<String, Object> objectSchema(final Map<String, Object> properties, final List<String> required) {
+		return Map.of("type", "object", "properties", properties, "required", required, "additionalProperties", false);
+	}
+
+	private static Map<String, Object> stringProperty(final String description, final int minLength,
+			final int maxLength) {
+		return Map.of("type", "string", "description", description, "minLength", minLength, "maxLength", maxLength);
+	}
+
+	private static Map<String, Object> optionalStringProperty(final String description, final int maxLength) {
+		return Map.of("type", "string", "description", description, "maxLength", maxLength);
+	}
+
+	private static Map<String, Object> integerProperty(final String description, final int minimum, final int maximum) {
+		return Map.of("type", "integer", "description", description, "minimum", minimum, "maximum", maximum);
+	}
+
+	private static Map<String, Object> recipeIngredientArrayProperty() {
+		return Map.of("type", "array", "minItems", 1, "maxItems", 40, "items", Map.of("type", "object", "properties",
+				Map.of("alimentoId", Map.of("type", "integer"), "cantidad", Map.of("type", "string"), "pesoNetoG",
+						Map.of("type", "integer", "minimum", 1), "unidad", Map.of("type", "string", "maxLength", 40)),
+				"required", List.of("alimentoId", "cantidad"), "additionalProperties", false));
+	}
+
+	private static Map<String, Object> stringArrayProperty() {
+		return Map.of("type", "array", "items", Map.of("type", "string", "maxLength", 300));
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiOpenAiToolCatalog.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOpenAiToolCatalog.java
@@ -58,7 +58,7 @@ public final class AiOpenAiToolCatalog {
 	private static OpenAiToolDefinition validatePlanConstraints() {
 		final Map<String, Object> properties = new LinkedHashMap<>();
 		properties.put("planType", Map.of("type", "string", "enum", List.of("MENU", "DIET_PLAN", "DISH")));
-		properties.put("targetKcal", Map.of("type", "number", "minimum", 500, "maximum", 10000));
+		properties.put("targetKcal", Map.of("type", "number", "minimum", 500, "maximum", 10_000));
 		properties.put("targetProteinaG", Map.of("type", "number", "minimum", 0));
 		properties.put("targetLipidosG", Map.of("type", "number", "minimum", 0));
 		properties.put("targetHidratosG", Map.of("type", "number", "minimum", 0));

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationContext.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationContext.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Server-injected context for a single orchestration turn (#385).
+ */
+public record AiOrchestrationContext(String nutritionistId, long threadId,
+		@Nullable AiPatientPromptContext patientContext) {
+}

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationException.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationException.java
@@ -1,0 +1,18 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Orchestration errors for the AI chat tool loop (#385).
+ */
+public class AiOrchestrationException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public AiOrchestrationException(final String message) {
+		super(message);
+	}
+
+	public AiOrchestrationException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationResult.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationResult.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Outcome of processing one nutritionist chat turn (#385).
+ */
+public record AiOrchestrationResult(long threadId, AiChatMessage assistantMessage, int toolCallsExecuted,
+		@Nullable OpenAiTokenUsage tokenUsage) {
+}

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationService.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationService.java
@@ -1,0 +1,17 @@
+package com.nutriconsultas.ai;
+
+/**
+ * OpenAI chat orchestration for nutritionist AI assistant (#385).
+ */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
+public interface AiOrchestrationService {
+
+	/**
+	 * Processes one user turn: persists the message, runs the tool loop, and stores the
+	 * assistant reply.
+	 * @throws AiOrchestrationException when the thread is missing or AI is misconfigured
+	 * @throws OpenAiClientException when OpenAI returns an error
+	 */
+	AiOrchestrationResult processUserMessage(AiOrchestrationContext context, String userMessage);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationServiceImpl.java
@@ -1,0 +1,228 @@
+package com.nutriconsultas.ai;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class AiOrchestrationServiceImpl implements AiOrchestrationService {
+
+	private static final int TOOL_AUDIT_MAX_CHARS = 2_000;
+
+	private static final String TOOL_LIMIT_MESSAGE = "Alcancé el límite de consultas al catálogo en este turno. "
+			+ "Responde con la información disponible hasta ahora.";
+
+	private final AiProperties properties;
+
+	private final OpenAiClientService openAiClientService;
+
+	private final AiSystemPromptService systemPromptService;
+
+	private final AiChatThreadRepository threadRepository;
+
+	private final AiChatMessageRepository messageRepository;
+
+	private final AiOpenAiToolCatalog toolCatalog;
+
+	private final AiOrchestrationToolDispatcher toolDispatcher;
+
+	public AiOrchestrationServiceImpl(final AiProperties properties, final OpenAiClientService openAiClientService,
+			final AiSystemPromptService systemPromptService, final AiChatThreadRepository threadRepository,
+			final AiChatMessageRepository messageRepository, final AiOpenAiToolCatalog toolCatalog,
+			final AiOrchestrationToolDispatcher toolDispatcher) {
+		this.properties = properties;
+		this.openAiClientService = openAiClientService;
+		this.systemPromptService = systemPromptService;
+		this.threadRepository = threadRepository;
+		this.messageRepository = messageRepository;
+		this.toolCatalog = toolCatalog;
+		this.toolDispatcher = toolDispatcher;
+	}
+
+	@Override
+	@Transactional
+	public AiOrchestrationResult processUserMessage(final AiOrchestrationContext context, final String userMessage) {
+		assertOperational();
+		validateUserMessage(userMessage);
+		final AiChatThread thread = loadThread(context);
+		persistUserMessage(thread, userMessage.trim());
+
+		final List<OpenAiChatMessage> conversation = buildConversation(context, thread);
+		final ToolLoopOutcome loopOutcome = runToolLoop(context, conversation);
+		final AiChatMessage assistantMessage = persistAssistantMessage(thread, loopOutcome.assistantContent());
+		persistToolAuditMessages(thread, loopOutcome.toolAuditEntries());
+		touchThread(thread);
+
+		if (log.isInfoEnabled()) {
+			log.info("AI orchestration threadId={} toolCalls={}", thread.getId(), loopOutcome.toolCallsExecuted());
+		}
+		return new AiOrchestrationResult(thread.getId(), assistantMessage, loopOutcome.toolCallsExecuted(),
+				loopOutcome.tokenUsage());
+	}
+
+	private void assertOperational() {
+		if (!properties.isOperational()) {
+			if (properties.isEnabledButMisconfigured()) {
+				throw new AiOrchestrationException(properties.getMisconfigurationUserMessage());
+			}
+			throw new AiOrchestrationException("El asistente de IA no está habilitado.");
+		}
+		if (!openAiClientService.isAvailable()) {
+			throw new AiOrchestrationException(properties.getMisconfigurationUserMessage());
+		}
+	}
+
+	private void validateUserMessage(final String userMessage) {
+		if (!StringUtils.hasText(userMessage)) {
+			throw new AiOrchestrationException("El mensaje no puede estar vacío.");
+		}
+	}
+
+	private AiChatThread loadThread(final AiOrchestrationContext context) {
+		return threadRepository.findByIdAndNutritionistId(context.threadId(), context.nutritionistId())
+			.orElseThrow(() -> new AiOrchestrationException("No se encontró la conversación."));
+	}
+
+	private void persistUserMessage(final AiChatThread thread, final String content) {
+		final AiChatMessage message = new AiChatMessage();
+		message.setThread(thread);
+		message.setRole(AiChatMessageRole.USER);
+		message.setContent(content);
+		messageRepository.save(message);
+	}
+
+	private List<OpenAiChatMessage> buildConversation(final AiOrchestrationContext context, final AiChatThread thread) {
+		final AiSystemPromptContext promptContext = new AiSystemPromptContext(
+				Locale.forLanguageTag(AiSystemPromptContext.DEFAULT_LOCALE_TAG),
+				"El nutriólogo autenticado es el único dueño de los datos y borradores de esta sesión.",
+				context.patientContext());
+		final List<OpenAiChatMessage> messages = new ArrayList<>();
+		messages.add(OpenAiChatMessage.system(systemPromptService.buildSystemPrompt(promptContext)));
+		appendPersistedHistory(messages, thread.getId());
+		return messages;
+	}
+
+	private void appendPersistedHistory(final List<OpenAiChatMessage> messages, final long threadId) {
+		final List<AiChatMessage> persisted = messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(threadId);
+		for (final AiChatMessage message : persisted) {
+			if (message.getRole() == AiChatMessageRole.USER) {
+				messages.add(OpenAiChatMessage.user(message.getContent()));
+			}
+			else if (message.getRole() == AiChatMessageRole.ASSISTANT) {
+				messages.add(OpenAiChatMessage.assistant(message.getContent()));
+			}
+		}
+	}
+
+	private ToolLoopOutcome runToolLoop(final AiOrchestrationContext context,
+			final List<OpenAiChatMessage> conversation) {
+		int toolCallsExecuted = 0;
+		OpenAiTokenUsage accumulatedUsage = null;
+		final List<ToolAuditEntry> toolAuditEntries = new ArrayList<>();
+		String assistantContent = null;
+
+		while (true) {
+			final OpenAiChatCompletionResponse response = openAiClientService
+				.chatCompletion(new OpenAiChatCompletionRequest(List.copyOf(conversation), toolCatalog.definitions()));
+			accumulatedUsage = mergeUsage(accumulatedUsage, response.usage());
+			assistantContent = response.content();
+
+			if (!response.hasToolCalls()) {
+				break;
+			}
+			if (toolCallsExecuted >= properties.getMaxToolCalls()) {
+				assistantContent = TOOL_LIMIT_MESSAGE;
+				if (log.isWarnEnabled()) {
+					log.warn("AI orchestration threadId={} reached maxToolCalls={}", context.threadId(),
+							properties.getMaxToolCalls());
+				}
+				break;
+			}
+
+			conversation.add(OpenAiChatMessage.assistantWithToolCalls(response.content(), response.toolCalls()));
+			for (final OpenAiToolCall toolCall : response.toolCalls()) {
+				if (toolCallsExecuted >= properties.getMaxToolCalls()) {
+					break;
+				}
+				final String toolResultJson = executeToolCall(context, toolCall);
+				conversation.add(OpenAiChatMessage.tool(toolCall.id(), toolCall.name(), toolResultJson));
+				toolAuditEntries.add(new ToolAuditEntry(toolCall.name(), toolResultJson));
+				toolCallsExecuted++;
+			}
+		}
+
+		if (!StringUtils.hasText(assistantContent)) {
+			assistantContent = "No pude generar una respuesta en este momento. Intenta reformular tu solicitud.";
+		}
+		return new ToolLoopOutcome(assistantContent, toolCallsExecuted, accumulatedUsage, toolAuditEntries);
+	}
+
+	private String executeToolCall(final AiOrchestrationContext context, final OpenAiToolCall toolCall) {
+		try {
+			return toolDispatcher.dispatch(context, toolCall.name(), toolCall.argumentsJson());
+		}
+		catch (final AiOrchestrationException ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("AI tool dispatch failed tool={} threadId={}", toolCall.name(), context.threadId());
+			}
+			return AiToolJsonSerializer.toJson(AiToolResult.error(AiToolErrorCode.VALIDATION, ex.getMessage()));
+		}
+	}
+
+	private AiChatMessage persistAssistantMessage(final AiChatThread thread, final String content) {
+		final AiChatMessage message = new AiChatMessage();
+		message.setThread(thread);
+		message.setRole(AiChatMessageRole.ASSISTANT);
+		message.setContent(content);
+		return messageRepository.save(message);
+	}
+
+	private void persistToolAuditMessages(final AiChatThread thread, final List<ToolAuditEntry> entries) {
+		for (final ToolAuditEntry entry : entries) {
+			final AiChatMessage message = new AiChatMessage();
+			message.setThread(thread);
+			message.setRole(AiChatMessageRole.TOOL);
+			message.setToolName(entry.toolName());
+			message.setContent(truncateForAudit(entry.resultJson()));
+			messageRepository.save(message);
+		}
+	}
+
+	private void touchThread(final AiChatThread thread) {
+		threadRepository.save(thread);
+	}
+
+	private static String truncateForAudit(final String json) {
+		if (json.length() <= TOOL_AUDIT_MAX_CHARS) {
+			return json;
+		}
+		return json.substring(0, TOOL_AUDIT_MAX_CHARS) + "...";
+	}
+
+	private static OpenAiTokenUsage mergeUsage(final OpenAiTokenUsage accumulated, final OpenAiTokenUsage latest) {
+		if (latest == null) {
+			return accumulated;
+		}
+		if (accumulated == null) {
+			return latest;
+		}
+		return new OpenAiTokenUsage(accumulated.promptTokens() + latest.promptTokens(),
+				accumulated.completionTokens() + latest.completionTokens(),
+				accumulated.totalTokens() + latest.totalTokens());
+	}
+
+	private record ToolAuditEntry(String toolName, String resultJson) {
+	}
+
+	private record ToolLoopOutcome(String assistantContent, int toolCallsExecuted, OpenAiTokenUsage tokenUsage,
+			List<ToolAuditEntry> toolAuditEntries) {
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcher.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcher.java
@@ -1,0 +1,178 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Dispatches OpenAI tool calls to registered nutrition tool services (#385).
+ */
+@Service
+public class AiOrchestrationToolDispatcher {
+
+	private final SearchFoodCatalogToolService searchFoodCatalogToolService;
+
+	private final GetFoodNutrientsToolService getFoodNutrientsToolService;
+
+	private final SearchDishCatalogToolService searchDishCatalogToolService;
+
+	private final CalculateRecipeNutrientsToolService calculateRecipeNutrientsToolService;
+
+	private final ValidatePlanConstraintsToolService validatePlanConstraintsToolService;
+
+	private final CreateDishDraftToolService createDishDraftToolService;
+
+	private final CreateMenuDraftToolService createMenuDraftToolService;
+
+	private final CreateDietPlanDraftToolService createDietPlanDraftToolService;
+
+	public AiOrchestrationToolDispatcher(final SearchFoodCatalogToolService searchFoodCatalogToolService,
+			final GetFoodNutrientsToolService getFoodNutrientsToolService,
+			final SearchDishCatalogToolService searchDishCatalogToolService,
+			final CalculateRecipeNutrientsToolService calculateRecipeNutrientsToolService,
+			final ValidatePlanConstraintsToolService validatePlanConstraintsToolService,
+			final CreateDishDraftToolService createDishDraftToolService,
+			final CreateMenuDraftToolService createMenuDraftToolService,
+			final CreateDietPlanDraftToolService createDietPlanDraftToolService) {
+		this.searchFoodCatalogToolService = searchFoodCatalogToolService;
+		this.getFoodNutrientsToolService = getFoodNutrientsToolService;
+		this.searchDishCatalogToolService = searchDishCatalogToolService;
+		this.calculateRecipeNutrientsToolService = calculateRecipeNutrientsToolService;
+		this.validatePlanConstraintsToolService = validatePlanConstraintsToolService;
+		this.createDishDraftToolService = createDishDraftToolService;
+		this.createMenuDraftToolService = createMenuDraftToolService;
+		this.createDietPlanDraftToolService = createDietPlanDraftToolService;
+	}
+
+	public String dispatch(final AiOrchestrationContext context, final String toolName, final String argumentsJson) {
+		final Object result = execute(context, toolName, argumentsJson);
+		return AiToolJsonSerializer.toJson(result);
+	}
+
+	private Object execute(final AiOrchestrationContext context, final String toolName, final String argumentsJson) {
+		if (SearchFoodCatalogToolService.TOOL_NAME.equals(toolName)) {
+			return searchFoodCatalog(context, argumentsJson);
+		}
+		if (GetFoodNutrientsToolService.TOOL_NAME.equals(toolName)) {
+			return getFoodNutrients(context, argumentsJson);
+		}
+		if (SearchDishCatalogToolService.TOOL_NAME.equals(toolName)) {
+			return searchDishCatalog(context, argumentsJson);
+		}
+		if (CalculateRecipeNutrientsToolService.TOOL_NAME.equals(toolName)) {
+			return calculateRecipeNutrients(context, argumentsJson);
+		}
+		if (ValidatePlanConstraintsToolService.TOOL_NAME.equals(toolName)) {
+			return validatePlanConstraints(context, argumentsJson);
+		}
+		if (CreateDishDraftToolService.TOOL_NAME.equals(toolName)) {
+			return createDishDraft(context, argumentsJson);
+		}
+		if (CreateMenuDraftToolService.TOOL_NAME.equals(toolName)) {
+			return createMenuDraft(context, argumentsJson);
+		}
+		if (CreateDietPlanDraftToolService.TOOL_NAME.equals(toolName)) {
+			return createDietPlanDraft(context, argumentsJson);
+		}
+		return AiToolResult.error(AiToolErrorCode.VALIDATION, "Herramienta no reconocida: " + toolName);
+	}
+
+	private AiToolResult<FoodCatalogSearchData> searchFoodCatalog(final AiOrchestrationContext context,
+			final String argumentsJson) {
+		final JsonNode root = AiToolJsonSerializer.parseJson(argumentsJson);
+		final String query = requiredText(root, "query");
+		return searchFoodCatalogToolService.search(context.nutritionistId(), query, optionalText(root, "clasificacion"),
+				optionalInteger(root, "limit"));
+	}
+
+	private AiToolResult<FoodNutrientsData> getFoodNutrients(final AiOrchestrationContext context,
+			final String argumentsJson) {
+		final JsonNode root = AiToolJsonSerializer.parseJson(argumentsJson);
+		final long alimentoId = requiredLong(root, "alimentoId");
+		final String cantidad = requiredText(root, "cantidad");
+		return getFoodNutrientsToolService.getNutrients(context.nutritionistId(), alimentoId, cantidad,
+				optionalInteger(root, "pesoNetoG"), optionalInteger(root, "portions"), optionalText(root, "unidad"));
+	}
+
+	private AiToolResult<DishCatalogSearchData> searchDishCatalog(final AiOrchestrationContext context,
+			final String argumentsJson) {
+		final JsonNode root = AiToolJsonSerializer.parseJson(argumentsJson);
+		final String query = requiredText(root, "query");
+		return searchDishCatalogToolService.search(context.nutritionistId(), query,
+				optionalText(root, "ingestasSugeridas"), optionalInteger(root, "limit"));
+	}
+
+	private AiToolResult<RecipeNutrientsData> calculateRecipeNutrients(final AiOrchestrationContext context,
+			final String argumentsJson) {
+		final JsonNode root = AiToolJsonSerializer.parseJson(argumentsJson);
+		final JsonNode ingredientsNode = root.get("ingredients");
+		if (ingredientsNode == null || !ingredientsNode.isArray()) {
+			throw new AiOrchestrationException("La lista de ingredientes es obligatoria.");
+		}
+		final List<RecipeIngredientInput> ingredients = AiToolJsonSerializer.convertList(ingredientsNode,
+				RecipeIngredientInput.class);
+		return calculateRecipeNutrientsToolService.calculate(context.nutritionistId(), ingredients,
+				optionalInteger(root, "portions"), optionalText(root, "label"));
+	}
+
+	private AiToolResult<PlanConstraintValidationData> validatePlanConstraints(final AiOrchestrationContext context,
+			final String argumentsJson) {
+		final ValidatePlanConstraintsRequest request = AiToolJsonSerializer.fromJson(argumentsJson,
+				ValidatePlanConstraintsRequest.class);
+		return validatePlanConstraintsToolService.validate(context.nutritionistId(), request, context.patientContext());
+	}
+
+	private AiToolResult<AiDraftCreationData> createDishDraft(final AiOrchestrationContext context,
+			final String argumentsJson) {
+		final DishDraftInput input = AiToolJsonSerializer.fromJson(argumentsJson, DishDraftInput.class);
+		return createDishDraftToolService.createDraft(context.nutritionistId(), context.threadId(), input);
+	}
+
+	private AiToolResult<AiDraftCreationData> createMenuDraft(final AiOrchestrationContext context,
+			final String argumentsJson) {
+		final MenuDraftInput input = AiToolJsonSerializer.fromJson(argumentsJson, MenuDraftInput.class);
+		return createMenuDraftToolService.createDraft(context.nutritionistId(), context.threadId(), input);
+	}
+
+	private AiToolResult<AiDraftCreationData> createDietPlanDraft(final AiOrchestrationContext context,
+			final String argumentsJson) {
+		final DietPlanDraftInput input = AiToolJsonSerializer.fromJson(argumentsJson, DietPlanDraftInput.class);
+		return createDietPlanDraftToolService.createDraft(context.nutritionistId(), context.threadId(), input);
+	}
+
+	private static String requiredText(final JsonNode root, final String field) {
+		final JsonNode node = root.get(field);
+		if (node == null || node.isNull() || !node.isTextual() || node.asText().isBlank()) {
+			throw new AiOrchestrationException("El campo '" + field + "' es obligatorio.");
+		}
+		return node.asText();
+	}
+
+	private static String optionalText(final JsonNode root, final String field) {
+		final JsonNode node = root.get(field);
+		if (node == null || node.isNull() || !node.isTextual()) {
+			return null;
+		}
+		final String value = node.asText();
+		return value.isBlank() ? null : value;
+	}
+
+	private static Integer optionalInteger(final JsonNode root, final String field) {
+		final JsonNode node = root.get(field);
+		if (node == null || node.isNull() || !node.isNumber()) {
+			return null;
+		}
+		return node.intValue();
+	}
+
+	private static long requiredLong(final JsonNode root, final String field) {
+		final JsonNode node = root.get(field);
+		if (node == null || node.isNull() || !node.isNumber()) {
+			throw new AiOrchestrationException("El campo '" + field + "' es obligatorio.");
+		}
+		return node.longValue();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiToolJsonSerializer.java
+++ b/src/main/java/com/nutriconsultas/ai/AiToolJsonSerializer.java
@@ -1,0 +1,66 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Serializes AI tool results to JSON for OpenAI tool responses.
+ */
+public final class AiToolJsonSerializer {
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	private AiToolJsonSerializer() {
+	}
+
+	public static String toJson(final Object value) {
+		try {
+			return OBJECT_MAPPER.writeValueAsString(value);
+		}
+		catch (JsonProcessingException ex) {
+			throw new AiOrchestrationException("No se pudo serializar la respuesta de la herramienta.", ex);
+		}
+	}
+
+	public static JsonNode parseJson(final String json) {
+		try {
+			return OBJECT_MAPPER.readTree(json);
+		}
+		catch (JsonProcessingException ex) {
+			throw new AiOrchestrationException("Argumentos de herramienta no válidos.", ex);
+		}
+	}
+
+	public static <T> T fromJson(final String json, final Class<T> type) {
+		try {
+			return OBJECT_MAPPER.readValue(json, type);
+		}
+		catch (JsonProcessingException ex) {
+			throw new AiOrchestrationException("Argumentos de herramienta no válidos.", ex);
+		}
+	}
+
+	public static <T> T convert(final JsonNode node, final Class<T> type) {
+		try {
+			return OBJECT_MAPPER.treeToValue(node, type);
+		}
+		catch (JsonProcessingException ex) {
+			throw new AiOrchestrationException("Argumentos de herramienta no válidos.", ex);
+		}
+	}
+
+	public static <T> List<T> convertList(final JsonNode arrayNode, final Class<T> elementType) {
+		try {
+			return OBJECT_MAPPER.readerForListOf(elementType).readValue(arrayNode);
+		}
+		catch (IOException ex) {
+			throw new AiOrchestrationException("Argumentos de herramienta no válidos.", ex);
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/OpenAiChatMessage.java
+++ b/src/main/java/com/nutriconsultas/ai/OpenAiChatMessage.java
@@ -1,33 +1,43 @@
 package com.nutriconsultas.ai;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
  * Chat message for OpenAI chat completions (#366).
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record OpenAiChatMessage(String role, String content, String toolCallId, String name) {
+public record OpenAiChatMessage(String role, String content, String toolCallId, String name,
+		List<OpenAiToolCall> toolCalls) {
 
 	public OpenAiChatMessage {
 		if (role == null || role.isBlank()) {
 			throw new IllegalArgumentException("role is required");
 		}
+		if (toolCalls != null && !toolCalls.isEmpty()) {
+			toolCalls = List.copyOf(toolCalls);
+		}
 	}
 
 	public static OpenAiChatMessage system(final String content) {
-		return new OpenAiChatMessage("system", content, null, null);
+		return new OpenAiChatMessage("system", content, null, null, null);
 	}
 
 	public static OpenAiChatMessage user(final String content) {
-		return new OpenAiChatMessage("user", content, null, null);
+		return new OpenAiChatMessage("user", content, null, null, null);
 	}
 
 	public static OpenAiChatMessage assistant(final String content) {
-		return new OpenAiChatMessage("assistant", content, null, null);
+		return new OpenAiChatMessage("assistant", content, null, null, null);
+	}
+
+	public static OpenAiChatMessage assistantWithToolCalls(final String content, final List<OpenAiToolCall> toolCalls) {
+		return new OpenAiChatMessage("assistant", content, null, null, toolCalls);
 	}
 
 	public static OpenAiChatMessage tool(final String toolCallId, final String name, final String content) {
-		return new OpenAiChatMessage("tool", content, toolCallId, name);
+		return new OpenAiChatMessage("tool", content, toolCallId, name, null);
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/ai/OpenAiClientServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/OpenAiClientServiceImpl.java
@@ -77,7 +77,16 @@ public class OpenAiClientServiceImpl implements OpenAiClientService {
 	private OpenAiApiRequest toApiRequest(final OpenAiChatCompletionRequest request) {
 		final List<OpenAiApiMessage> messages = new ArrayList<>();
 		for (final OpenAiChatMessage message : request.messages()) {
-			messages.add(new OpenAiApiMessage(message.role(), message.content(), message.toolCallId(), message.name()));
+			List<OpenAiApiToolCall> apiToolCalls = null;
+			if (message.toolCalls() != null && !message.toolCalls().isEmpty()) {
+				apiToolCalls = new ArrayList<>();
+				for (final OpenAiToolCall toolCall : message.toolCalls()) {
+					apiToolCalls.add(new OpenAiApiToolCall(toolCall.id(), "function",
+							new OpenAiApiFunctionCall(toolCall.name(), toolCall.argumentsJson())));
+				}
+			}
+			messages.add(new OpenAiApiMessage(message.role(), message.content(), message.toolCallId(), message.name(),
+					apiToolCalls));
 		}
 		final List<OpenAiApiTool> tools = new ArrayList<>();
 		for (final OpenAiToolDefinition tool : request.tools()) {
@@ -129,7 +138,15 @@ public class OpenAiClientServiceImpl implements OpenAiClientService {
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private record OpenAiApiMessage(String role, String content, @JsonProperty("tool_call_id") String toolCallId,
-			String name) {
+			String name, @JsonProperty("tool_calls") List<OpenAiApiToolCall> toolCalls) {
+	}
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private record OpenAiApiToolCall(String id, String type, @JsonProperty("function") OpenAiApiFunctionCall function) {
+	}
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private record OpenAiApiFunctionCall(String name, String arguments) {
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/test/java/com/nutriconsultas/ai/AiOrchestrationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiOrchestrationServiceTest.java
@@ -1,0 +1,206 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AiOrchestrationServiceTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	private static final long THREAD_ID = 10L;
+
+	@InjectMocks
+	private AiOrchestrationServiceImpl service;
+
+	@Mock
+	private AiProperties properties;
+
+	@Mock
+	private OpenAiClientService openAiClientService;
+
+	@Mock
+	private AiSystemPromptService systemPromptService;
+
+	@Mock
+	private AiChatThreadRepository threadRepository;
+
+	@Mock
+	private AiChatMessageRepository messageRepository;
+
+	@Mock
+	private AiOpenAiToolCatalog toolCatalog;
+
+	@Mock
+	private AiOrchestrationToolDispatcher toolDispatcher;
+
+	private AiChatThread thread;
+
+	@BeforeEach
+	void setUp() {
+		thread = new AiChatThread();
+		thread.setId(THREAD_ID);
+		thread.setNutritionistId(NUTRITIONIST_ID);
+	}
+
+	private void stubAiEnabled() {
+		when(properties.isOperational()).thenReturn(true);
+		when(openAiClientService.isAvailable()).thenReturn(true);
+	}
+
+	private void stubOperational() {
+		stubAiEnabled();
+		when(systemPromptService.buildSystemPrompt(any())).thenReturn("Eres un asistente nutricional.");
+		when(toolCatalog.definitions()).thenReturn(List.of());
+		when(messageRepository.save(any(AiChatMessage.class))).thenAnswer(invocation -> {
+			final AiChatMessage message = invocation.getArgument(0);
+			if (message.getId() == null) {
+				message.setId(100L);
+			}
+			return message;
+		});
+	}
+
+	@Test
+	void processUserMessageReturnsAssistantReply() {
+		stubOperational();
+		when(threadRepository.findByIdAndNutritionistId(THREAD_ID, NUTRITIONIST_ID)).thenReturn(Optional.of(thread));
+		when(messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(THREAD_ID))
+			.thenReturn(List.of(message(AiChatMessageRole.USER, "Necesito un menú bajo en sodio")));
+		when(openAiClientService.chatCompletion(any())).thenReturn(new OpenAiChatCompletionResponse("id-1", "assistant",
+				"Aquí tienes una sugerencia.", List.of(), "stop", new OpenAiTokenUsage(20, 10, 30)));
+
+		final AiOrchestrationResult result = service.processUserMessage(context(), "Necesito un menú bajo en sodio");
+
+		assertThat(result.threadId()).isEqualTo(THREAD_ID);
+		assertThat(result.toolCallsExecuted()).isZero();
+		assertThat(result.assistantMessage().getRole()).isEqualTo(AiChatMessageRole.ASSISTANT);
+		assertThat(result.assistantMessage().getContent()).isEqualTo("Aquí tienes una sugerencia.");
+		assertThat(result.tokenUsage().totalTokens()).isEqualTo(30);
+		verify(messageRepository, times(2)).save(any(AiChatMessage.class));
+	}
+
+	@Test
+	void processUserMessageExecutesToolLoop() {
+		stubOperational();
+		when(properties.getMaxToolCalls()).thenReturn(8);
+		when(threadRepository.findByIdAndNutritionistId(THREAD_ID, NUTRITIONIST_ID)).thenReturn(Optional.of(thread));
+		when(messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(THREAD_ID))
+			.thenReturn(List.of(message(AiChatMessageRole.USER, "Busca avena")));
+		when(openAiClientService.chatCompletion(any()))
+			.thenReturn(new OpenAiChatCompletionResponse("id-tools", "assistant", null,
+					List.of(new OpenAiToolCall("call_1", SearchFoodCatalogToolService.TOOL_NAME,
+							"{\"query\":\"avena\"}")),
+					"tool_calls", new OpenAiTokenUsage(15, 5, 20)))
+			.thenReturn(new OpenAiChatCompletionResponse("id-final", "assistant",
+					"Encontré avena en el catálogo con esos datos.", List.of(), "stop",
+					new OpenAiTokenUsage(40, 20, 60)));
+		when(toolDispatcher.dispatch(any(), eq(SearchFoodCatalogToolService.TOOL_NAME), any()))
+			.thenReturn("{\"success\":true,\"data\":{\"items\":[]}}");
+
+		final AiOrchestrationResult result = service.processUserMessage(context(), "Busca avena");
+
+		assertThat(result.toolCallsExecuted()).isEqualTo(1);
+		assertThat(result.assistantMessage().getContent()).contains("Encontré avena");
+		assertThat(result.tokenUsage().totalTokens()).isEqualTo(80);
+		verify(toolDispatcher).dispatch(any(), eq(SearchFoodCatalogToolService.TOOL_NAME), any());
+		verify(messageRepository, times(3)).save(any(AiChatMessage.class));
+	}
+
+	@Test
+	void processUserMessageEnforcesMaxToolCalls() {
+		stubOperational();
+		when(properties.getMaxToolCalls()).thenReturn(1);
+		when(threadRepository.findByIdAndNutritionistId(THREAD_ID, NUTRITIONIST_ID)).thenReturn(Optional.of(thread));
+		when(messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(THREAD_ID))
+			.thenReturn(List.of(message(AiChatMessageRole.USER, "Compara alimentos")));
+		when(openAiClientService.chatCompletion(any())).thenReturn(new OpenAiChatCompletionResponse("id-tools",
+				"assistant", null,
+				List.of(new OpenAiToolCall("call_1", SearchFoodCatalogToolService.TOOL_NAME, "{\"query\":\"avena\"}"),
+						new OpenAiToolCall("call_2", SearchFoodCatalogToolService.TOOL_NAME, "{\"query\":\"arroz\"}")),
+				"tool_calls", null))
+			.thenReturn(
+					new OpenAiChatCompletionResponse(
+							"id-more", "assistant", null, List.of(new OpenAiToolCall("call_3",
+									SearchFoodCatalogToolService.TOOL_NAME, "{\"query\":\"frijol\"}")),
+							"tool_calls", null));
+		when(toolDispatcher.dispatch(any(), any(), any())).thenReturn("{\"success\":true}");
+
+		final AiOrchestrationResult result = service.processUserMessage(context(), "Compara alimentos");
+
+		assertThat(result.toolCallsExecuted()).isEqualTo(1);
+		assertThat(result.assistantMessage().getContent()).contains("límite de consultas");
+		verify(toolDispatcher, times(1)).dispatch(any(), any(), any());
+	}
+
+	@Test
+	void processUserMessageWhenThreadNotFound() {
+		stubAiEnabled();
+		when(threadRepository.findByIdAndNutritionistId(THREAD_ID, NUTRITIONIST_ID)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.processUserMessage(context(), "Hola"))
+			.isInstanceOf(AiOrchestrationException.class)
+			.hasMessageContaining("No se encontró la conversación");
+	}
+
+	@Test
+	void processUserMessageWhenNotOperational() {
+		when(properties.isOperational()).thenReturn(false);
+		when(properties.isEnabledButMisconfigured()).thenReturn(true);
+		when(properties.getMisconfigurationUserMessage()).thenReturn("El asistente de IA no está disponible.");
+
+		assertThatThrownBy(() -> service.processUserMessage(context(), "Hola"))
+			.isInstanceOf(AiOrchestrationException.class)
+			.hasMessageContaining("no está disponible");
+	}
+
+	@Test
+	void processUserMessageIncludesPersistedHistory() {
+		stubOperational();
+		final AiChatMessage priorUser = message(AiChatMessageRole.USER, "Mensaje anterior");
+		final AiChatMessage priorAssistant = message(AiChatMessageRole.ASSISTANT, "Respuesta anterior");
+		when(threadRepository.findByIdAndNutritionistId(THREAD_ID, NUTRITIONIST_ID)).thenReturn(Optional.of(thread));
+		when(messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(THREAD_ID))
+			.thenReturn(List.of(priorUser, priorAssistant, message(AiChatMessageRole.USER, "Siguiente pregunta")));
+		when(openAiClientService.chatCompletion(any())).thenReturn(
+				new OpenAiChatCompletionResponse("id-1", "assistant", "Continuación.", List.of(), "stop", null));
+
+		service.processUserMessage(context(), "Siguiente pregunta");
+
+		final ArgumentCaptor<OpenAiChatCompletionRequest> requestCaptor = ArgumentCaptor
+			.forClass(OpenAiChatCompletionRequest.class);
+		verify(openAiClientService).chatCompletion(requestCaptor.capture());
+		final List<OpenAiChatMessage> messages = requestCaptor.getValue().messages();
+		assertThat(messages).anyMatch(message -> "Mensaje anterior".equals(message.content()));
+		assertThat(messages).anyMatch(message -> "Respuesta anterior".equals(message.content()));
+		assertThat(messages).anyMatch(message -> "Siguiente pregunta".equals(message.content()));
+	}
+
+	private static AiOrchestrationContext context() {
+		return new AiOrchestrationContext(NUTRITIONIST_ID, THREAD_ID, null);
+	}
+
+	private static AiChatMessage message(final AiChatMessageRole role, final String content) {
+		final AiChatMessage message = new AiChatMessage();
+		message.setRole(role);
+		message.setContent(content);
+		return message;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcherTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcherTest.java
@@ -1,0 +1,73 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AiOrchestrationToolDispatcherTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	private static final long THREAD_ID = 7L;
+
+	@InjectMocks
+	private AiOrchestrationToolDispatcher dispatcher;
+
+	@Mock
+	private SearchFoodCatalogToolService searchFoodCatalogToolService;
+
+	@Mock
+	private GetFoodNutrientsToolService getFoodNutrientsToolService;
+
+	@Mock
+	private SearchDishCatalogToolService searchDishCatalogToolService;
+
+	@Mock
+	private CalculateRecipeNutrientsToolService calculateRecipeNutrientsToolService;
+
+	@Mock
+	private ValidatePlanConstraintsToolService validatePlanConstraintsToolService;
+
+	@Mock
+	private CreateDishDraftToolService createDishDraftToolService;
+
+	@Mock
+	private CreateMenuDraftToolService createMenuDraftToolService;
+
+	@Mock
+	private CreateDietPlanDraftToolService createDietPlanDraftToolService;
+
+	@Test
+	void dispatchSearchFoodCatalog() {
+		final FoodCatalogSearchData data = new FoodCatalogSearchData(java.util.List.of(), 0, false);
+		when(searchFoodCatalogToolService.search(eq(NUTRITIONIST_ID), eq("avena"), eq(null), eq(5)))
+			.thenReturn(AiToolResult.success(data));
+
+		final String json = dispatcher.dispatch(context(), SearchFoodCatalogToolService.TOOL_NAME,
+				"{\"query\":\"avena\",\"limit\":5}");
+
+		assertThat(json).contains("\"success\":true");
+		verify(searchFoodCatalogToolService).search(NUTRITIONIST_ID, "avena", null, 5);
+	}
+
+	@Test
+	void dispatchUnknownToolReturnsValidationError() {
+		final String json = dispatcher.dispatch(context(), "unknown_tool", "{}");
+
+		assertThat(json).contains("\"success\":false");
+		assertThat(json).contains("Herramienta no reconocida");
+	}
+
+	private static AiOrchestrationContext context() {
+		return new AiOrchestrationContext(NUTRITIONIST_ID, THREAD_ID, null);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/OpenAiClientServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/OpenAiClientServiceTest.java
@@ -90,6 +90,51 @@ class OpenAiClientServiceTest {
 	}
 
 	@Test
+	void chatCompletionSerializesAssistantToolCallsInRequest() {
+		final String responseJson = """
+				{
+				  "id": "chatcmpl-echo",
+				  "choices": [{
+				    "message": {
+				      "role": "assistant",
+				      "content": "Listo."
+				    },
+				    "finish_reason": "stop"
+				  }]
+				}
+				""";
+		mockServer.expect(requestTo("https://api.openai.com/v1/chat/completions"))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(content().json("""
+					{
+					  "model": "gpt-test",
+					  "messages": [
+					    {
+					      "role": "assistant",
+					      "tool_calls": [{
+					        "id": "call_abc",
+					        "type": "function",
+					        "function": {
+					          "name": "search_food_catalog",
+					          "arguments": "{\\"query\\":\\"avena\\"}"
+					        }
+					      }]
+					    }
+					  ],
+					  "store": false
+					}
+					""", false))
+			.andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
+
+		service.chatCompletion(new OpenAiChatCompletionRequest(
+				List.of(OpenAiChatMessage.assistantWithToolCalls(null,
+						List.of(new OpenAiToolCall("call_abc", "search_food_catalog", "{\"query\":\"avena\"}")))),
+				List.of()));
+
+		mockServer.verify();
+	}
+
+	@Test
 	void chatCompletionReturnsToolCalls() {
 		final String responseJson = """
 				{


### PR DESCRIPTION
## Summary
- Adds `AiOrchestrationService` to process nutritionist chat turns: persist user message, call OpenAI with system prompt + history, run the tool loop, and store assistant/tool audit messages.
- Registers all eight nutrition tools via `AiOpenAiToolCatalog` and routes calls through `AiOrchestrationToolDispatcher`.
- Extends `OpenAiChatMessage` / `OpenAiClientServiceImpl` to serialize assistant `tool_calls` for multi-turn tool loops; enforces `nutriconsultas.ai.max-tool-calls`.

Fixes #385

## Test plan
- [x] `mvn verify` (checkstyle, PMD, SpotBugs, Thymeleaf, tests)
- [x] `AiOrchestrationServiceTest` — happy path, tool loop, max tool calls, thread not found, misconfiguration
- [x] `AiOrchestrationToolDispatcherTest` — dispatch + unknown tool
- [x] `OpenAiClientServiceTest` — assistant `tool_calls` request serialization


Made with [Cursor](https://cursor.com)