### PR TITLE
Add AI chat REST controller (#384)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#384 — Create AI Chat Controller](https://github.com/diego-torres/nutriconsultas/issues/384) (`NEXT`). ~~#385~~ **done** — `AiOrchestrationService` tool loop. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#386 — Add Rate Limiting for AI Chat](https://github.com/diego-torres/nutriconsultas/issues/386) (`NEXT`). ~~#384~~ **done** — `AiChatRestController`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#384 — Create AI Chat Controller](https://github.com/diego-torres/nutriconsultas/issues/384) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#385~~ `AiOrchestrationService` + tool dispatcher.
+**Current next issue:** [#386 — Add Rate Limiting for AI Chat](https://github.com/diego-torres/nutriconsultas/issues/386) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#384~~ `AiChatRestController` + patient context resolver.
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#385~~ AI orchestration service **done**. **NEXT:** #384.
+**Last updated:** 2026-06-30 — ~~#384~~ AI chat REST controller **done**. **NEXT:** #386.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -124,7 +124,7 @@ Draft-creation tools and acceptance flow (no direct patient assignment).
 | **381** | Implement Diet Plan Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/381 | **done** | **378**, **371** | `create_diet_plan_draft` |
 | **382** | Implement Draft Acceptance Flow | https://github.com/diego-torres/nutriconsultas/issues/382 | **done** | **379**, **380**, **381** | Convert draft → real record |
 
-**Phase 4 complete.** Epic #383 **open** — ~~#385~~ orchestration **done**. **NEXT:** #384.
+**Phase 4 complete.** Epic #383 **open** — ~~#384~~ chat REST **done**. **NEXT:** #386.
 
 ---
 
@@ -135,11 +135,11 @@ Authenticated endpoints for chat and draft management.
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
 | **383** | Epic — AI Chat REST API (Phase 5) | https://github.com/diego-torres/nutriconsultas/issues/383 | **open** | **366**, **382** | Milestone 3 |
-| **384** | Create AI Chat Controller | https://github.com/diego-torres/nutriconsultas/issues/384 | **NEXT** | **383**, **385** | `/nutritionist/ai/**` |
+| **384** | Create AI Chat Controller | https://github.com/diego-torres/nutriconsultas/issues/384 | **done** | **383**, **385** | `AiChatRestController` |
 | **385** | Implement AI Orchestration Service | https://github.com/diego-torres/nutriconsultas/issues/385 | **done** | **366**, **372**, **378** | `AiOrchestrationService` |
-| **386** | Add Rate Limiting for AI Chat | https://github.com/diego-torres/nutriconsultas/issues/386 | **open** | **385** | Resilience4j |
+| **386** | Add Rate Limiting for AI Chat | https://github.com/diego-torres/nutriconsultas/issues/386 | **NEXT** | **385** | Resilience4j |
 
-**Suggested order:** ~~#385~~ → **#384** + #386.
+**Suggested order:** ~~#384~~ → **#386**.
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/AiChatDraftList.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatDraftList.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.ai;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Draft list for a chat thread (#384).
+ */
+public record AiChatDraftList(long threadId, List<AiChatDraftSummary> drafts) {
+}

--- a/src/main/java/com/nutriconsultas/ai/AiChatDraftList.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatDraftList.java
@@ -1,6 +1,5 @@
 package com.nutriconsultas.ai;
 
-import java.time.Instant;
 import java.util.List;
 
 /**

--- a/src/main/java/com/nutriconsultas/ai/AiChatDraftSummary.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatDraftSummary.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.ai;
+
+import java.time.Instant;
+
+/**
+ * Draft summary for chat REST responses (#384).
+ */
+public record AiChatDraftSummary(long draftId, AiDraftType draftType, AiDraftStatus status, String summary,
+		Instant createdAt) {
+}

--- a/src/main/java/com/nutriconsultas/ai/AiChatException.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatException.java
@@ -1,0 +1,30 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Nutritionist AI chat REST errors (#384).
+ */
+public class AiChatException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final HttpStatus httpStatus;
+
+	private final AiToolErrorCode errorCode;
+
+	public AiChatException(final HttpStatus httpStatus, final AiToolErrorCode errorCode, final String message) {
+		super(message);
+		this.httpStatus = httpStatus;
+		this.errorCode = errorCode;
+	}
+
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
+
+	public AiToolErrorCode getErrorCode() {
+		return errorCode;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiChatMessageView.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatMessageView.java
@@ -1,0 +1,9 @@
+package com.nutriconsultas.ai;
+
+import java.time.Instant;
+
+/**
+ * User-visible chat message for REST responses (#384).
+ */
+public record AiChatMessageView(long id, AiChatMessageRole role, String content, Instant createdAt) {
+}

--- a/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
@@ -1,0 +1,211 @@
+package com.nutriconsultas.ai;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/nutritionist/ai/chat")
+@Slf4j
+public class AiChatRestController {
+
+	private final AiChatService chatService;
+
+	public AiChatRestController(final AiChatService chatService) {
+		this.chatService = chatService;
+	}
+
+	@PostMapping("/start")
+	public ResponseEntity<Map<String, Object>> startChat(
+			@RequestBody(required = false) final AiStartChatRequest request,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String nutritionistId = nutritionistId(principal);
+		if (nutritionistId == null) {
+			return unauthorized();
+		}
+		final AiStartChatRequest body = request != null ? request : new AiStartChatRequest(null, null, null);
+		try {
+			final AiChatThread thread = chatService.startThread(nutritionistId, body.title(), body.patientId(),
+					body.clinicId());
+			final Map<String, Object> response = successBody();
+			response.put("threadId", thread.getId());
+			response.put("title", thread.getTitle());
+			response.put("patientId", thread.getPatient() != null ? thread.getPatient().getId() : null);
+			response.put("clinicId", thread.getClinicId());
+			response.put("createdAt", thread.getCreatedAt());
+			response.put("updatedAt", thread.getUpdatedAt());
+			return ResponseEntity.status(HttpStatus.CREATED).body(response);
+		}
+		catch (final AiChatException ex) {
+			return errorResponse(ex);
+		}
+	}
+
+	@PostMapping("/message")
+	public ResponseEntity<Map<String, Object>> sendMessage(@RequestBody final AiSendMessageRequest request,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String nutritionistId = nutritionistId(principal);
+		if (nutritionistId == null) {
+			return unauthorized();
+		}
+		if (request == null) {
+			return errorResponse(HttpStatus.BAD_REQUEST, AiToolErrorCode.VALIDATION, "Solicitud no válida.");
+		}
+		try {
+			final AiOrchestrationResult result = chatService.sendMessage(nutritionistId, request.threadId(),
+					request.message());
+			final Map<String, Object> response = successBody();
+			response.put("threadId", result.threadId());
+			response.put("assistantMessageId", result.assistantMessage().getId());
+			response.put("content", result.assistantMessage().getContent());
+			response.put("toolCallsExecuted", result.toolCallsExecuted());
+			if (result.tokenUsage() != null) {
+				response.put("tokenUsage", tokenUsageMap(result.tokenUsage()));
+			}
+			return ResponseEntity.ok(response);
+		}
+		catch (final AiChatException ex) {
+			return errorResponse(ex);
+		}
+		catch (final AiOrchestrationException ex) {
+			return errorResponse(HttpStatus.SERVICE_UNAVAILABLE, AiToolErrorCode.VALIDATION, ex.getMessage());
+		}
+		catch (final OpenAiClientException ex) {
+			return mapOpenAiException(ex);
+		}
+	}
+
+	@GetMapping("/{threadId}")
+	public ResponseEntity<Map<String, Object>> getThread(@PathVariable @NonNull final Long threadId,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String nutritionistId = nutritionistId(principal);
+		if (nutritionistId == null) {
+			return unauthorized();
+		}
+		try {
+			final AiChatThreadDetail detail = chatService.getThread(nutritionistId, threadId);
+			final Map<String, Object> response = successBody();
+			response.put("threadId", detail.threadId());
+			response.put("title", detail.title());
+			response.put("patientId", detail.patientId());
+			response.put("clinicId", detail.clinicId());
+			response.put("createdAt", detail.createdAt());
+			response.put("updatedAt", detail.updatedAt());
+			response.put("messages", toMessageMaps(detail.messages()));
+			return ResponseEntity.ok(response);
+		}
+		catch (final AiChatException ex) {
+			return errorResponse(ex);
+		}
+	}
+
+	@GetMapping("/{threadId}/drafts")
+	public ResponseEntity<Map<String, Object>> listDrafts(@PathVariable @NonNull final Long threadId,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String nutritionistId = nutritionistId(principal);
+		if (nutritionistId == null) {
+			return unauthorized();
+		}
+		try {
+			final AiChatDraftList draftList = chatService.listDrafts(nutritionistId, threadId);
+			final Map<String, Object> response = successBody();
+			response.put("threadId", draftList.threadId());
+			response.put("drafts", toDraftMaps(draftList.drafts()));
+			return ResponseEntity.ok(response);
+		}
+		catch (final AiChatException ex) {
+			return errorResponse(ex);
+		}
+	}
+
+	private static String nutritionistId(final OidcUser principal) {
+		if (principal == null || principal.getSubject() == null || principal.getSubject().isBlank()) {
+			return null;
+		}
+		return principal.getSubject();
+	}
+
+	private static ResponseEntity<Map<String, Object>> unauthorized() {
+		return errorResponse(HttpStatus.UNAUTHORIZED, AiToolErrorCode.VALIDATION, "Sesión no válida.");
+	}
+
+	private static Map<String, Object> successBody() {
+		final Map<String, Object> body = new LinkedHashMap<>();
+		body.put("success", true);
+		return body;
+	}
+
+	private static ResponseEntity<Map<String, Object>> errorResponse(final AiChatException ex) {
+		return errorResponse(ex.getHttpStatus(), ex.getErrorCode(), ex.getMessage());
+	}
+
+	private static ResponseEntity<Map<String, Object>> errorResponse(final HttpStatus status,
+			final AiToolErrorCode errorCode, final String message) {
+		final Map<String, Object> body = new LinkedHashMap<>();
+		body.put("success", false);
+		body.put("errorCode", errorCode.name());
+		body.put("message", message);
+		return ResponseEntity.status(status).body(body);
+	}
+
+	private static ResponseEntity<Map<String, Object>> mapOpenAiException(final OpenAiClientException ex) {
+		final HttpStatus status = switch (ex.getKind()) {
+			case NOT_CONFIGURED -> HttpStatus.SERVICE_UNAVAILABLE;
+			case RATE_LIMIT -> HttpStatus.TOO_MANY_REQUESTS;
+			case TIMEOUT -> HttpStatus.GATEWAY_TIMEOUT;
+			default -> HttpStatus.BAD_GATEWAY;
+		};
+		return errorResponse(status, AiToolErrorCode.VALIDATION, ex.getUserMessage());
+	}
+
+	private static Map<String, Object> tokenUsageMap(final OpenAiTokenUsage usage) {
+		final Map<String, Object> map = new LinkedHashMap<>();
+		map.put("promptTokens", usage.promptTokens());
+		map.put("completionTokens", usage.completionTokens());
+		map.put("totalTokens", usage.totalTokens());
+		return map;
+	}
+
+	private static List<Map<String, Object>> toMessageMaps(final List<AiChatMessageView> messages) {
+		final List<Map<String, Object>> maps = new ArrayList<>();
+		for (final AiChatMessageView message : messages) {
+			final Map<String, Object> map = new LinkedHashMap<>();
+			map.put("id", message.id());
+			map.put("role", message.role().name());
+			map.put("content", message.content());
+			map.put("createdAt", message.createdAt());
+			maps.add(map);
+		}
+		return maps;
+	}
+
+	private static List<Map<String, Object>> toDraftMaps(final List<AiChatDraftSummary> drafts) {
+		final List<Map<String, Object>> maps = new ArrayList<>();
+		for (final AiChatDraftSummary draft : drafts) {
+			final Map<String, Object> map = new LinkedHashMap<>();
+			map.put("draftId", draft.draftId());
+			map.put("draftType", draft.draftType().name());
+			map.put("status", draft.status().name());
+			map.put("summary", draft.summary());
+			map.put("createdAt", draft.createdAt());
+			maps.add(map);
+		}
+		return maps;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiChatService.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatService.java
@@ -1,0 +1,20 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Nutritionist-scoped AI chat thread operations (#384).
+ */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
+public interface AiChatService {
+
+	AiChatThread startThread(String nutritionistId, @Nullable String title, @Nullable Long patientId,
+			@Nullable Long clinicId);
+
+	AiChatThreadDetail getThread(String nutritionistId, long threadId);
+
+	AiChatDraftList listDrafts(String nutritionistId, long threadId);
+
+	AiOrchestrationResult sendMessage(String nutritionistId, long threadId, String message);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiChatService.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatService.java
@@ -5,7 +5,6 @@ import org.springframework.lang.Nullable;
 /**
  * Nutritionist-scoped AI chat thread operations (#384).
  */
-@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface AiChatService {
 
 	AiChatThread startThread(String nutritionistId, @Nullable String title, @Nullable Long patientId,

--- a/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
@@ -1,0 +1,155 @@
+package com.nutriconsultas.ai;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class AiChatServiceImpl implements AiChatService {
+
+	private static final int MAX_TITLE_LENGTH = 200;
+
+	private static final String DEFAULT_TITLE = "Nueva conversación";
+
+	private final AiChatThreadRepository threadRepository;
+
+	private final AiChatMessageRepository messageRepository;
+
+	private final AiGeneratedDraftRepository draftRepository;
+
+	private final AiOrchestrationService orchestrationService;
+
+	private final AiPatientPromptContextResolver patientContextResolver;
+
+	private final PacienteRepository pacienteRepository;
+
+	public AiChatServiceImpl(final AiChatThreadRepository threadRepository,
+			final AiChatMessageRepository messageRepository, final AiGeneratedDraftRepository draftRepository,
+			final AiOrchestrationService orchestrationService,
+			final AiPatientPromptContextResolver patientContextResolver, final PacienteRepository pacienteRepository) {
+		this.threadRepository = threadRepository;
+		this.messageRepository = messageRepository;
+		this.draftRepository = draftRepository;
+		this.orchestrationService = orchestrationService;
+		this.patientContextResolver = patientContextResolver;
+		this.pacienteRepository = pacienteRepository;
+	}
+
+	@Override
+	@Transactional
+	public AiChatThread startThread(@NonNull final String nutritionistId, @Nullable final String title,
+			@Nullable final Long patientId, @Nullable final Long clinicId) {
+		assertNutritionistId(nutritionistId);
+		final Paciente patient = resolveOwnedPatient(patientId, nutritionistId);
+		final AiChatThread thread = new AiChatThread();
+		thread.setNutritionistId(nutritionistId);
+		thread.setTitle(resolveTitle(title));
+		thread.setClinicId(clinicId);
+		thread.setPatient(patient);
+		final AiChatThread saved = threadRepository.save(thread);
+		if (log.isInfoEnabled()) {
+			log.info("AI chat thread created id={} patientLinked={}", saved.getId(), patient != null);
+		}
+		return saved;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public AiChatThreadDetail getThread(@NonNull final String nutritionistId, final long threadId) {
+		assertNutritionistId(nutritionistId);
+		final AiChatThread thread = loadOwnedThread(threadId, nutritionistId);
+		final List<AiChatMessageView> messages = toVisibleMessages(
+				messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(threadId));
+		return new AiChatThreadDetail(thread.getId(), thread.getTitle(), patientId(thread), thread.getClinicId(),
+				thread.getCreatedAt(), thread.getUpdatedAt(), messages);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public AiChatDraftList listDrafts(@NonNull final String nutritionistId, final long threadId) {
+		assertNutritionistId(nutritionistId);
+		loadOwnedThread(threadId, nutritionistId);
+		final List<AiChatDraftSummary> drafts = new ArrayList<>();
+		for (final AiGeneratedDraft draft : draftRepository.findByThreadIdOrderByCreatedAtDescIdDesc(threadId)) {
+			drafts.add(new AiChatDraftSummary(draft.getId(), draft.getDraftType(), draft.getStatus(),
+					AiDraftSummaryExtractor.summarize(draft), draft.getCreatedAt()));
+		}
+		return new AiChatDraftList(threadId, List.copyOf(drafts));
+	}
+
+	@Override
+	@Transactional
+	public AiOrchestrationResult sendMessage(@NonNull final String nutritionistId, final long threadId,
+			final String message) {
+		assertNutritionistId(nutritionistId);
+		if (!StringUtils.hasText(message)) {
+			throw new AiChatException(org.springframework.http.HttpStatus.BAD_REQUEST, AiToolErrorCode.VALIDATION,
+					"El mensaje no puede estar vacío.");
+		}
+		final AiChatThread thread = loadOwnedThread(threadId, nutritionistId);
+		final AiPatientPromptContext patientContext = patientContextResolver.resolve(patientId(thread), nutritionistId)
+			.orElse(null);
+		final AiOrchestrationContext context = new AiOrchestrationContext(nutritionistId, threadId, patientContext);
+		return orchestrationService.processUserMessage(context, message.trim());
+	}
+
+	private AiChatThread loadOwnedThread(final long threadId, final String nutritionistId) {
+		return threadRepository.findByIdAndNutritionistId(threadId, nutritionistId)
+			.orElseThrow(() -> new AiChatException(org.springframework.http.HttpStatus.NOT_FOUND,
+					AiToolErrorCode.NOT_FOUND, "No se encontró la conversación."));
+	}
+
+	private Paciente resolveOwnedPatient(@Nullable final Long patientId, final String nutritionistId) {
+		if (patientId == null) {
+			return null;
+		}
+		return pacienteRepository.findByIdAndUserId(patientId, nutritionistId)
+			.orElseThrow(() -> new AiChatException(org.springframework.http.HttpStatus.NOT_FOUND,
+					AiToolErrorCode.NOT_FOUND, "No se encontró el paciente."));
+	}
+
+	private static Long patientId(final AiChatThread thread) {
+		return thread.getPatient() != null ? thread.getPatient().getId() : null;
+	}
+
+	private static List<AiChatMessageView> toVisibleMessages(final List<AiChatMessage> persisted) {
+		final List<AiChatMessageView> messages = new ArrayList<>();
+		for (final AiChatMessage message : persisted) {
+			if (message.getRole() == AiChatMessageRole.USER || message.getRole() == AiChatMessageRole.ASSISTANT) {
+				messages.add(new AiChatMessageView(message.getId(), message.getRole(), message.getContent(),
+						message.getCreatedAt()));
+			}
+		}
+		return List.copyOf(messages);
+	}
+
+	private static String resolveTitle(@Nullable final String title) {
+		if (!StringUtils.hasText(title)) {
+			return DEFAULT_TITLE;
+		}
+		final String trimmed = title.trim();
+		if (trimmed.length() <= MAX_TITLE_LENGTH) {
+			return trimmed;
+		}
+		return trimmed.substring(0, MAX_TITLE_LENGTH);
+	}
+
+	private static void assertNutritionistId(final String nutritionistId) {
+		if (!StringUtils.hasText(nutritionistId)) {
+			throw new AiChatException(org.springframework.http.HttpStatus.UNAUTHORIZED, AiToolErrorCode.VALIDATION,
+					"Sesión no válida.");
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiChatThreadDetail.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatThreadDetail.java
@@ -1,0 +1,13 @@
+package com.nutriconsultas.ai;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Thread detail for chat REST responses (#384).
+ */
+public record AiChatThreadDetail(long threadId, String title, @Nullable Long patientId, @Nullable Long clinicId,
+		Instant createdAt, Instant updatedAt, List<AiChatMessageView> messages) {
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftSummaryExtractor.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftSummaryExtractor.java
@@ -1,0 +1,55 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Human-readable draft summaries for chat REST responses (#384).
+ */
+public final class AiDraftSummaryExtractor {
+
+	private static final String DEFAULT_LABEL = "Borrador IA — revisión del nutriólogo requerida";
+
+	private AiDraftSummaryExtractor() {
+	}
+
+	public static String summarize(final AiGeneratedDraft draft) {
+		if (draft == null || draft.getDraftType() == null) {
+			return DEFAULT_LABEL;
+		}
+		try {
+			return switch (draft.getDraftType()) {
+				case DISH -> summarizeDish(draft);
+				case MENU -> summarizeMenu(draft);
+				case DIET_PLAN -> summarizeDietPlan(draft);
+			};
+		}
+		catch (final AiDraftLifecycleException ex) {
+			return DEFAULT_LABEL;
+		}
+	}
+
+	private static String summarizeDish(final AiGeneratedDraft draft) {
+		final DishDraftPayload payload = AiDraftPayloadDeserializer.dish(draft.getJsonPayload());
+		if (StringUtils.hasText(payload.name())) {
+			return DEFAULT_LABEL + ": " + payload.name().trim();
+		}
+		return DEFAULT_LABEL;
+	}
+
+	private static String summarizeMenu(final AiGeneratedDraft draft) {
+		final MenuDraftPayload payload = AiDraftPayloadDeserializer.menu(draft.getJsonPayload());
+		if (StringUtils.hasText(payload.title())) {
+			return DEFAULT_LABEL + ": " + payload.title().trim();
+		}
+		return DEFAULT_LABEL;
+	}
+
+	private static String summarizeDietPlan(final AiGeneratedDraft draft) {
+		final DietPlanDraftPayload payload = AiDraftPayloadDeserializer.dietPlan(draft.getJsonPayload());
+		if (StringUtils.hasText(payload.title())) {
+			return DEFAULT_LABEL + ": " + payload.title().trim();
+		}
+		return DEFAULT_LABEL;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiPatientPromptContextResolver.java
+++ b/src/main/java/com/nutriconsultas/ai/AiPatientPromptContextResolver.java
@@ -1,0 +1,15 @@
+package com.nutriconsultas.ai;
+
+import java.util.Optional;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Builds redacted patient prompt context for owned patients (#384, #367).
+ */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
+public interface AiPatientPromptContextResolver {
+
+	Optional<AiPatientPromptContext> resolve(@Nullable Long patientId, String nutritionistId);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiPatientPromptContextResolverImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiPatientPromptContextResolverImpl.java
@@ -1,0 +1,90 @@
+package com.nutriconsultas.ai;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.satellite.PacienteMedicalHistory;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class AiPatientPromptContextResolverImpl implements AiPatientPromptContextResolver {
+
+	private static final int MAX_ALERGIAS_CHARS = 500;
+
+	private final PacienteRepository pacienteRepository;
+
+	public AiPatientPromptContextResolverImpl(final PacienteRepository pacienteRepository) {
+		this.pacienteRepository = pacienteRepository;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Optional<AiPatientPromptContext> resolve(@Nullable final Long patientId, final String nutritionistId) {
+		if (patientId == null || !StringUtils.hasText(nutritionistId)) {
+			return Optional.empty();
+		}
+		return pacienteRepository.findByIdAndUserId(patientId, nutritionistId).map(this::toPromptContext);
+	}
+
+	private AiPatientPromptContext toPromptContext(final Paciente paciente) {
+		final PacienteMedicalHistory history = paciente.getMedicalHistory();
+		final String activityLevel = paciente.getPhysicalActivityLevel() != null
+				? paciente.getPhysicalActivityLevel().name() : null;
+		return new AiPatientPromptContext(paciente.getId(), resolveRequerimientoKcal(paciente),
+				paciente.getFinalTotalKcal(), paciente.getPhysiologicalStressActive(), paciente.getGender(),
+				paciente.getPregnancy(), nivelPesoLabel(paciente), paciente.getImc(), pathologyFlags(history),
+				sanitizeAlergias(history != null ? history.getAlergias() : null), activityLevel);
+	}
+
+	private static String nivelPesoLabel(final Paciente paciente) {
+		return paciente.getNivelPeso() != null ? paciente.getNivelPeso().name() : null;
+	}
+
+	private static Double resolveRequerimientoKcal(final Paciente paciente) {
+		if (paciente.getTotalAdjustedKcal() != null) {
+			return paciente.getTotalAdjustedKcal();
+		}
+		return paciente.getGetKcal();
+	}
+
+	private static Map<String, Boolean> pathologyFlags(final PacienteMedicalHistory history) {
+		final Map<String, Boolean> flags = new LinkedHashMap<>();
+		if (history == null) {
+			return flags;
+		}
+		flags.put("hipertension", history.getHipertension());
+		flags.put("diabetes", history.getDiabetes());
+		flags.put("hipotiroidismo", history.getHipotiroidismo());
+		flags.put("obesidad", history.getObesidad());
+		flags.put("anemia", history.getAnemia());
+		flags.put("bulimia", history.getBulimia());
+		flags.put("anorexia", history.getAnorexia());
+		flags.put("enfermedadesHepaticas", history.getEnfermedadesHepaticas());
+		return flags;
+	}
+
+	private static String sanitizeAlergias(@Nullable final String alergias) {
+		if (!StringUtils.hasText(alergias)) {
+			return null;
+		}
+		final String trimmed = alergias.replaceAll("\\p{Cntrl}", " ").trim();
+		if (trimmed.isEmpty()) {
+			return null;
+		}
+		if (trimmed.length() <= MAX_ALERGIAS_CHARS) {
+			return trimmed;
+		}
+		return trimmed.substring(0, MAX_ALERGIAS_CHARS);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiSendMessageRequest.java
+++ b/src/main/java/com/nutriconsultas/ai/AiSendMessageRequest.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Request body for {@code POST /rest/nutritionist/ai/chat/message} (#384).
+ */
+public record AiSendMessageRequest(long threadId, String message) {
+}

--- a/src/main/java/com/nutriconsultas/ai/AiStartChatRequest.java
+++ b/src/main/java/com/nutriconsultas/ai/AiStartChatRequest.java
@@ -1,0 +1,9 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Request body for {@code POST /rest/nutritionist/ai/chat/start} (#384).
+ */
+public record AiStartChatRequest(@Nullable String title, @Nullable Long patientId, @Nullable Long clinicId) {
+}

--- a/src/test/java/com/nutriconsultas/ai/AiChatRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatRestControllerTest.java
@@ -1,0 +1,134 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+
+@ExtendWith(MockitoExtension.class)
+class AiChatRestControllerTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	private static final String OTHER_NUTRITIONIST_ID = "auth0|nutritionist-b";
+
+	@InjectMocks
+	private AiChatRestController controller;
+
+	@Mock
+	private AiChatService chatService;
+
+	@Test
+	void startChatReturnsCreatedThread() {
+		final AiChatThread thread = new AiChatThread();
+		thread.setId(5L);
+		thread.setTitle("Menú semanal");
+		thread.setNutritionistId(NUTRITIONIST_ID);
+		thread.setCreatedAt(Instant.parse("2026-06-30T12:00:00Z"));
+		thread.setUpdatedAt(Instant.parse("2026-06-30T12:00:00Z"));
+		when(chatService.startThread(eq(NUTRITIONIST_ID), eq("Menú semanal"), eq(10L), eq(null))).thenReturn(thread);
+
+		final ResponseEntity<Map<String, Object>> response = controller
+			.startChat(new AiStartChatRequest("Menú semanal", 10L, null), principal(NUTRITIONIST_ID));
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+		assertThat(response.getBody()).containsEntry("success", true).containsEntry("threadId", 5L);
+	}
+
+	@Test
+	void sendMessageReturnsAssistantReply() {
+		final AiChatMessage assistant = new AiChatMessage();
+		assistant.setId(99L);
+		assistant.setRole(AiChatMessageRole.ASSISTANT);
+		assistant.setContent("Aquí tienes una sugerencia.");
+		when(chatService.sendMessage(NUTRITIONIST_ID, 5L, "Hola"))
+			.thenReturn(new AiOrchestrationResult(5L, assistant, 1, new OpenAiTokenUsage(10, 8, 18)));
+
+		final ResponseEntity<Map<String, Object>> response = controller
+			.sendMessage(new AiSendMessageRequest(5L, "Hola"), principal(NUTRITIONIST_ID));
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("assistantMessageId", 99L).containsEntry("toolCallsExecuted", 1);
+		verify(chatService).sendMessage(NUTRITIONIST_ID, 5L, "Hola");
+	}
+
+	@Test
+	void getThreadReturnsMessages() {
+		final Instant now = Instant.parse("2026-06-30T12:00:00Z");
+		final AiChatThreadDetail detail = new AiChatThreadDetail(5L, "Menú", 10L, null, now, now,
+				List.of(new AiChatMessageView(1L, AiChatMessageRole.USER, "Hola", now)));
+		when(chatService.getThread(NUTRITIONIST_ID, 5L)).thenReturn(detail);
+
+		final ResponseEntity<Map<String, Object>> response = controller.getThread(5L, principal(NUTRITIONIST_ID));
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("threadId", 5L).containsKey("messages");
+	}
+
+	@Test
+	void listDraftsReturnsSummaries() {
+		final Instant now = Instant.parse("2026-06-30T12:00:00Z");
+		when(chatService.listDrafts(NUTRITIONIST_ID, 5L)).thenReturn(new AiChatDraftList(5L,
+				List.of(new AiChatDraftSummary(11L, AiDraftType.DISH, AiDraftStatus.DRAFT, "Borrador", now))));
+
+		final ResponseEntity<Map<String, Object>> response = controller.listDrafts(5L, principal(NUTRITIONIST_ID));
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("threadId", 5L).containsKey("drafts");
+	}
+
+	@Test
+	void getThreadReturnsNotFoundForOtherNutritionist() {
+		when(chatService.getThread(OTHER_NUTRITIONIST_ID, 5L)).thenThrow(new AiChatException(HttpStatus.NOT_FOUND,
+				AiToolErrorCode.NOT_FOUND, "No se encontró la conversación."));
+
+		final ResponseEntity<Map<String, Object>> response = controller.getThread(5L, principal(OTHER_NUTRITIONIST_ID));
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(response.getBody()).containsEntry("success", false);
+	}
+
+	@Test
+	void sendMessageMapsOpenAiRateLimit() {
+		when(chatService.sendMessage(any(), eq(5L), any()))
+			.thenThrow(new OpenAiClientException(OpenAiClientException.ErrorKind.RATE_LIMIT,
+					HttpStatus.TOO_MANY_REQUESTS, "El servicio de IA está saturado.", "rate limit", null));
+
+		final ResponseEntity<Map<String, Object>> response = controller
+			.sendMessage(new AiSendMessageRequest(5L, "Hola"), principal(NUTRITIONIST_ID));
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+	}
+
+	@Test
+	void startChatRequiresAuthentication() {
+		final ResponseEntity<Map<String, Object>> response = controller.startChat(null, null);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+	}
+
+	private static DefaultOidcUser principal(final String subject) {
+		final Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject(subject).build();
+		final OidcIdToken idToken = new OidcIdToken(jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(),
+				Map.of("sub", subject));
+		return new DefaultOidcUser(List.of(), idToken);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiChatServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatServiceTest.java
@@ -1,0 +1,166 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AiChatServiceTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	private static final String OTHER_NUTRITIONIST_ID = "auth0|nutritionist-b";
+
+	@InjectMocks
+	private AiChatServiceImpl service;
+
+	@Mock
+	private AiChatThreadRepository threadRepository;
+
+	@Mock
+	private AiChatMessageRepository messageRepository;
+
+	@Mock
+	private AiGeneratedDraftRepository draftRepository;
+
+	@Mock
+	private AiOrchestrationService orchestrationService;
+
+	@Mock
+	private AiPatientPromptContextResolver patientContextResolver;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Test
+	void startThreadPersistsOwnedPatient() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(10L);
+		when(pacienteRepository.findByIdAndUserId(10L, NUTRITIONIST_ID)).thenReturn(Optional.of(paciente));
+		when(threadRepository.save(any(AiChatThread.class))).thenAnswer(invocation -> {
+			final AiChatThread thread = invocation.getArgument(0);
+			thread.setId(5L);
+			thread.setCreatedAt(Instant.now());
+			thread.setUpdatedAt(Instant.now());
+			return thread;
+		});
+
+		final AiChatThread thread = service.startThread(NUTRITIONIST_ID, "Menú", 10L, null);
+
+		assertThat(thread.getId()).isEqualTo(5L);
+		assertThat(thread.getPatient()).isNotNull();
+		assertThat(thread.getPatient().getId()).isEqualTo(10L);
+	}
+
+	@Test
+	void startThreadRejectsForeignPatient() {
+		when(pacienteRepository.findByIdAndUserId(10L, NUTRITIONIST_ID)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.startThread(NUTRITIONIST_ID, null, 10L, null))
+			.isInstanceOf(AiChatException.class)
+			.extracting(ex -> ((AiChatException) ex).getHttpStatus())
+			.isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	void getThreadFiltersToolMessages() {
+		final AiChatThread thread = sampleThread(5L, NUTRITIONIST_ID);
+		when(threadRepository.findByIdAndNutritionistId(5L, NUTRITIONIST_ID)).thenReturn(Optional.of(thread));
+		final AiChatMessage user = message(1L, AiChatMessageRole.USER, "Hola");
+		final AiChatMessage assistant = message(2L, AiChatMessageRole.ASSISTANT, "Respuesta");
+		final AiChatMessage tool = message(3L, AiChatMessageRole.TOOL, "{\"success\":true}");
+		when(messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(5L)).thenReturn(List.of(user, assistant, tool));
+
+		final AiChatThreadDetail detail = service.getThread(NUTRITIONIST_ID, 5L);
+
+		assertThat(detail.messages()).hasSize(2);
+		assertThat(detail.messages()).extracting(AiChatMessageView::role)
+			.containsExactly(AiChatMessageRole.USER, AiChatMessageRole.ASSISTANT);
+	}
+
+	@Test
+	void getThreadDeniesCrossTenantAccess() {
+		when(threadRepository.findByIdAndNutritionistId(5L, OTHER_NUTRITIONIST_ID)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.getThread(OTHER_NUTRITIONIST_ID, 5L)).isInstanceOf(AiChatException.class)
+			.extracting(ex -> ((AiChatException) ex).getHttpStatus())
+			.isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	void sendMessageDelegatesToOrchestration() {
+		final AiChatThread thread = sampleThread(5L, NUTRITIONIST_ID);
+		when(threadRepository.findByIdAndNutritionistId(5L, NUTRITIONIST_ID)).thenReturn(Optional.of(thread));
+		final AiChatMessage assistant = message(99L, AiChatMessageRole.ASSISTANT, "Listo");
+		when(orchestrationService.processUserMessage(any(), eq("Crea un menú")))
+			.thenReturn(new AiOrchestrationResult(5L, assistant, 2, null));
+
+		final AiOrchestrationResult result = service.sendMessage(NUTRITIONIST_ID, 5L, "Crea un menú");
+
+		assertThat(result.toolCallsExecuted()).isEqualTo(2);
+		verify(orchestrationService).processUserMessage(any(), eq("Crea un menú"));
+	}
+
+	@Test
+	void listDraftsReturnsSummaries() {
+		final AiChatThread thread = sampleThread(5L, NUTRITIONIST_ID);
+		when(threadRepository.findByIdAndNutritionistId(5L, NUTRITIONIST_ID)).thenReturn(Optional.of(thread));
+		final AiGeneratedDraft draft = new AiGeneratedDraft();
+		draft.setId(11L);
+		draft.setDraftType(AiDraftType.DISH);
+		draft.setStatus(AiDraftStatus.DRAFT);
+		draft.setJsonPayload(
+				"{\"name\":\"Tacos\",\"ingredients\":[],\"portions\":1,\"nutrientsPerPortion\":{\"energiaKcal\":0,\"proteinaG\":0.0,\"lipidosG\":0.0,\"hidratosDeCarbonoG\":0.0,\"fibraG\":0.0,\"sodioMg\":0.0,\"potasioMg\":0.0},\"label\":\"Borrador IA\"}");
+		draft.setCreatedAt(Instant.now());
+		when(draftRepository.findByThreadIdOrderByCreatedAtDescIdDesc(5L)).thenReturn(List.of(draft));
+
+		final AiChatDraftList list = service.listDrafts(NUTRITIONIST_ID, 5L);
+
+		assertThat(list.drafts()).hasSize(1);
+		assertThat(list.drafts().get(0).summary()).contains("Tacos");
+	}
+
+	@Test
+	void sendMessageRejectsBlankMessage() {
+		assertThatThrownBy(() -> service.sendMessage(NUTRITIONIST_ID, 5L, "  ")).isInstanceOf(AiChatException.class);
+		verify(orchestrationService, never()).processUserMessage(any(), any());
+	}
+
+	private static AiChatThread sampleThread(final long id, final String nutritionistId) {
+		final AiChatThread thread = new AiChatThread();
+		thread.setId(id);
+		thread.setNutritionistId(nutritionistId);
+		thread.setTitle("Test");
+		thread.setCreatedAt(Instant.now());
+		thread.setUpdatedAt(Instant.now());
+		return thread;
+	}
+
+	private static AiChatMessage message(final long id, final AiChatMessageRole role, final String content) {
+		final AiChatMessage message = new AiChatMessage();
+		message.setId(id);
+		message.setRole(role);
+		message.setContent(content);
+		message.setCreatedAt(Instant.now());
+		return message;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiPatientPromptContextResolverTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiPatientPromptContextResolverTest.java
@@ -1,0 +1,67 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.paciente.NivelPeso;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.calculation.PhysicalActivityLevel;
+import com.nutriconsultas.paciente.embeddable.PacienteBodySnapshot;
+import com.nutriconsultas.paciente.satellite.PacienteMedicalHistory;
+
+@ExtendWith(MockitoExtension.class)
+class AiPatientPromptContextResolverTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	@InjectMocks
+	private AiPatientPromptContextResolverImpl resolver;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Test
+	void resolveBuildsRedactedContext() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(42L);
+		paciente.setGender("F");
+		paciente.setPregnancy(false);
+		paciente.setBodySnapshot(new PacienteBodySnapshot());
+		paciente.getBodySnapshot().setImc(23.5);
+		paciente.getBodySnapshot().setNivelPeso(NivelPeso.NORMAL);
+		paciente.getBodySnapshot().setGetKcal(1800.0);
+		paciente.getBodySnapshot().setFinalTotalKcal(2000.0);
+		paciente.setPhysicalActivityLevel(PhysicalActivityLevel.MODERATE);
+		paciente.setPhysiologicalStressActive(true);
+		final PacienteMedicalHistory history = new PacienteMedicalHistory();
+		history.setHipertension(true);
+		history.setAlergias("Mariscos");
+		paciente.setMedicalHistory(history);
+		when(pacienteRepository.findByIdAndUserId(42L, NUTRITIONIST_ID)).thenReturn(Optional.of(paciente));
+
+		final Optional<AiPatientPromptContext> context = resolver.resolve(42L, NUTRITIONIST_ID);
+
+		assertThat(context).isPresent();
+		assertThat(context.get().patientId()).isEqualTo(42L);
+		assertThat(context.get().requerimientoKcal()).isEqualTo(1800.0);
+		assertThat(context.get().alergias()).isEqualTo("Mariscos");
+		assertThat(context.get().pathologyFlags()).containsEntry("hipertension", true);
+	}
+
+	@Test
+	void resolveEmptyWhenPatientNotOwned() {
+		when(pacienteRepository.findByIdAndUserId(99L, NUTRITIONIST_ID)).thenReturn(Optional.empty());
+
+		assertThat(resolver.resolve(99L, NUTRITIONIST_ID)).isEmpty();
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds `AiChatRestController` with authenticated endpoints: start thread, send message (orchestration), get thread history, list drafts.
- Introduces `AiChatService`, `AiPatientPromptContextResolver`, and `AiDraftSummaryExtractor` for tenant-scoped patient context and draft summaries.
- Maps OpenAI client errors to Spanish HTTP responses; filters TOOL audit messages from chat history.

Fixes #384

## Test plan
- [x] `mvn verify`
- [x] `AiChatRestControllerTest` — start, message, get thread, list drafts, auth, rate limit mapping, IDOR 404
- [x] `AiChatServiceTest` — patient ownership, cross-tenant denial, orchestration delegation, draft summaries
- [x] `AiPatientPromptContextResolverTest` — redacted patient context


Made with [Cursor](https://cursor.com)