### PR TITLE
Add rate limiting for AI chat (#386)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#386 — Add Rate Limiting for AI Chat](https://github.com/diego-torres/nutriconsultas/issues/386) (`NEXT`). ~~#384~~ **done** — `AiChatRestController`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#387 — Epic Nutritionist AI Chat UI](https://github.com/diego-torres/nutriconsultas/issues/387) (`NEXT`). ~~#386~~ **done** — `AiChatRateLimiter`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#386 — Add Rate Limiting for AI Chat](https://github.com/diego-torres/nutriconsultas/issues/386) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#384~~ `AiChatRestController` + patient context resolver.
+**Current next issue:** [#387 — Epic Nutritionist AI Chat UI](https://github.com/diego-torres/nutriconsultas/issues/387) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#386~~ `AiChatRateLimiter` per-nutritionist on `POST /message`.
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#384~~ AI chat REST controller **done**. **NEXT:** #386.
+**Last updated:** 2026-06-30 — ~~#386~~ AI chat rate limiting **done**. **NEXT:** #387.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -124,7 +124,7 @@ Draft-creation tools and acceptance flow (no direct patient assignment).
 | **381** | Implement Diet Plan Draft Creation Tool | https://github.com/diego-torres/nutriconsultas/issues/381 | **done** | **378**, **371** | `create_diet_plan_draft` |
 | **382** | Implement Draft Acceptance Flow | https://github.com/diego-torres/nutriconsultas/issues/382 | **done** | **379**, **380**, **381** | Convert draft → real record |
 
-**Phase 4 complete.** Epic #383 **open** — ~~#384~~ chat REST **done**. **NEXT:** #386.
+**Phase 4 complete.** Epic #383 **done** — ~~#384–#386~~ REST API complete. **NEXT:** #387.
 
 ---
 
@@ -134,12 +134,12 @@ Authenticated endpoints for chat and draft management.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **383** | Epic — AI Chat REST API (Phase 5) | https://github.com/diego-torres/nutriconsultas/issues/383 | **open** | **366**, **382** | Milestone 3 |
+| **383** | Epic — AI Chat REST API (Phase 5) | https://github.com/diego-torres/nutriconsultas/issues/383 | **done** | **366**, **382** | Milestone 3 — ~~#384–#386~~ |
 | **384** | Create AI Chat Controller | https://github.com/diego-torres/nutriconsultas/issues/384 | **done** | **383**, **385** | `AiChatRestController` |
 | **385** | Implement AI Orchestration Service | https://github.com/diego-torres/nutriconsultas/issues/385 | **done** | **366**, **372**, **378** | `AiOrchestrationService` |
-| **386** | Add Rate Limiting for AI Chat | https://github.com/diego-torres/nutriconsultas/issues/386 | **NEXT** | **385** | Resilience4j |
+| **386** | Add Rate Limiting for AI Chat | https://github.com/diego-torres/nutriconsultas/issues/386 | **done** | **385** | `AiChatRateLimiter` |
 
-**Suggested order:** ~~#384~~ → **#386**.
+**Suggested order:** ~~#386~~ → **#387**.
 
 ---
 
@@ -149,7 +149,7 @@ Thymeleaf chat window and draft preview.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **387** | Epic — Nutritionist AI Chat UI (Phase 6) | https://github.com/diego-torres/nutriconsultas/issues/387 | **open** | **384** | Milestone 3 |
+| **387** | Epic — Nutritionist AI Chat UI (Phase 6) | https://github.com/diego-torres/nutriconsultas/issues/387 | **NEXT** | **384** | Milestone 3 |
 | **388** | Add AI Chat Entry Point to Nutritionist UI | https://github.com/diego-torres/nutriconsultas/issues/388 | **open** | **387**, **365** | Gated by `AI_ENABLED` |
 | **389** | Build AI Chat Window | https://github.com/diego-torres/nutriconsultas/issues/389 | **open** | **388**, **384** | Chat UI + loading/errors |
 | **390** | Build Draft Preview UI | https://github.com/diego-torres/nutriconsultas/issues/390 | **open** | **389**, **382** | Accept/discard + SweetAlert |

--- a/src/main/java/com/nutriconsultas/ai/AiChatRateLimiter.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatRateLimiter.java
@@ -1,0 +1,48 @@
+package com.nutriconsultas.ai;
+
+import java.util.concurrent.Callable;
+
+import org.springframework.stereotype.Component;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+
+/**
+ * Per-nutritionist rate limiting for AI chat message orchestration (#386).
+ */
+@Component
+public final class AiChatRateLimiter {
+
+	public static final String AI_CHAT_MESSAGE = "aiChatMessage";
+
+	public static final String RATE_LIMIT_USER_MESSAGE = "Has alcanzado el límite de mensajes del asistente de IA. "
+			+ "Intenta de nuevo en unos minutos.";
+
+	private final RateLimiterRegistry rateLimiterRegistry;
+
+	public AiChatRateLimiter(final RateLimiterRegistry rateLimiterRegistry) {
+		this.rateLimiterRegistry = rateLimiterRegistry;
+	}
+
+	public <T> T executeMessage(final String nutritionistId, final Callable<T> callable) {
+		return execute(AI_CHAT_MESSAGE, nutritionistId, callable);
+	}
+
+	private <T> T execute(final String instanceName, final String nutritionistId, final Callable<T> callable) {
+		final RateLimiter templateLimiter = rateLimiterRegistry.rateLimiter(instanceName);
+		final RateLimiterConfig config = templateLimiter.getRateLimiterConfig();
+		final RateLimiter limiter = rateLimiterRegistry.rateLimiter(instanceName + ":" + nutritionistId, config);
+		try {
+			return RateLimiter.decorateCallable(limiter, callable).call();
+		}
+		catch (RequestNotPermitted ex) {
+			throw ex;
+		}
+		catch (Exception ex) {
+			throw new IllegalStateException("Rate-limited AI chat call failed", ex);
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
@@ -26,8 +27,11 @@ public class AiChatRestController {
 
 	private final AiChatService chatService;
 
-	public AiChatRestController(final AiChatService chatService) {
+	private final AiChatRateLimiter aiChatRateLimiter;
+
+	public AiChatRestController(final AiChatService chatService, final AiChatRateLimiter aiChatRateLimiter) {
 		this.chatService = chatService;
+		this.aiChatRateLimiter = aiChatRateLimiter;
 	}
 
 	@PostMapping("/start")
@@ -67,8 +71,8 @@ public class AiChatRestController {
 			return errorResponse(HttpStatus.BAD_REQUEST, AiToolErrorCode.VALIDATION, "Solicitud no válida.");
 		}
 		try {
-			final AiOrchestrationResult result = chatService.sendMessage(nutritionistId, request.threadId(),
-					request.message());
+			final AiOrchestrationResult result = aiChatRateLimiter.executeMessage(nutritionistId,
+					() -> chatService.sendMessage(nutritionistId, request.threadId(), request.message()));
 			final Map<String, Object> response = successBody();
 			response.put("threadId", result.threadId());
 			response.put("assistantMessageId", result.assistantMessage().getId());
@@ -87,6 +91,13 @@ public class AiChatRestController {
 		}
 		catch (final OpenAiClientException ex) {
 			return mapOpenAiException(ex);
+		}
+		catch (final RequestNotPermitted ex) {
+			if (log.isDebugEnabled()) {
+				log.debug("AI chat message rate limit exceeded");
+			}
+			return errorResponse(HttpStatus.TOO_MANY_REQUESTS, AiToolErrorCode.RATE_LIMIT,
+					AiChatRateLimiter.RATE_LIMIT_USER_MESSAGE);
 		}
 	}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -61,6 +61,10 @@ resilience4j.ratelimiter.instances.patientInvitationRedeem.timeout-duration=0s
 resilience4j.ratelimiter.instances.patientAuth.limit-for-period=10
 resilience4j.ratelimiter.instances.patientAuth.limit-refresh-period=1m
 resilience4j.ratelimiter.instances.patientAuth.timeout-duration=0s
+# AI chat message rate limits (#386) — per nutritionist, configurable via env
+resilience4j.ratelimiter.instances.aiChatMessage.limit-for-period=${AI_CHAT_MESSAGE_RATE_LIMIT:20}
+resilience4j.ratelimiter.instances.aiChatMessage.limit-refresh-period=${AI_CHAT_MESSAGE_RATE_WINDOW:1h}
+resilience4j.ratelimiter.instances.aiChatMessage.timeout-duration=0s
 # Auth0 Management API — optional; enables patient mobile linkage by email (#109)
 app.auth0.management.client-id=${AUTH0_MGMT_CLIENT_ID:}
 app.auth0.management.client-secret=${AUTH0_MGMT_CLIENT_SECRET:}

--- a/src/test/java/com/nutriconsultas/ai/AiChatRateLimiterTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatRateLimiterTest.java
@@ -1,0 +1,50 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+
+class AiChatRateLimiterTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|rate-limit-nutritionist";
+
+	@Test
+	void executeMessageRunsCallableWhenPermitAvailable() throws Exception {
+		final RateLimiterRegistry registry = registryWithLimit(1);
+		final AiChatRateLimiter liveLimiter = new AiChatRateLimiter(registry);
+
+		final String result = liveLimiter.executeMessage(NUTRITIONIST_ID, () -> "ok");
+
+		assertThat(result).isEqualTo("ok");
+	}
+
+	@Test
+	void executeMessageUsesPerNutritionistKey() throws Exception {
+		final RateLimiterRegistry registry = registryWithLimit(1);
+		final AiChatRateLimiter liveLimiter = new AiChatRateLimiter(registry);
+
+		liveLimiter.executeMessage(NUTRITIONIST_ID, () -> "first");
+		assertThatThrownBy(() -> liveLimiter.executeMessage(NUTRITIONIST_ID, () -> "second"))
+			.isInstanceOf(RequestNotPermitted.class);
+
+		final String otherResult = liveLimiter.executeMessage("auth0|other-nutritionist", () -> "other");
+		assertThat(otherResult).isEqualTo("other");
+	}
+
+	private static RateLimiterRegistry registryWithLimit(final int limitForPeriod) {
+		final RateLimiterConfig config = RateLimiterConfig.custom()
+			.limitForPeriod(limitForPeriod)
+			.limitRefreshPeriod(Duration.ofMinutes(1))
+			.timeoutDuration(Duration.ZERO)
+			.build();
+		return RateLimiterRegistry.of(config);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiChatRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatRestControllerTest.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +22,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 
 @ExtendWith(MockitoExtension.class)
 class AiChatRestControllerTest {
@@ -34,6 +37,9 @@ class AiChatRestControllerTest {
 
 	@Mock
 	private AiChatService chatService;
+
+	@Mock
+	private AiChatRateLimiter aiChatRateLimiter;
 
 	@Test
 	void startChatReturnsCreatedThread() {
@@ -53,13 +59,17 @@ class AiChatRestControllerTest {
 	}
 
 	@Test
-	void sendMessageReturnsAssistantReply() {
+	void sendMessageReturnsAssistantReply() throws Exception {
 		final AiChatMessage assistant = new AiChatMessage();
 		assistant.setId(99L);
 		assistant.setRole(AiChatMessageRole.ASSISTANT);
 		assistant.setContent("Aquí tienes una sugerencia.");
 		when(chatService.sendMessage(NUTRITIONIST_ID, 5L, "Hola"))
 			.thenReturn(new AiOrchestrationResult(5L, assistant, 1, new OpenAiTokenUsage(10, 8, 18)));
+		when(aiChatRateLimiter.executeMessage(eq(NUTRITIONIST_ID), any())).thenAnswer(invocation -> {
+			final Callable<?> callable = invocation.getArgument(1);
+			return callable.call();
+		});
 
 		final ResponseEntity<Map<String, Object>> response = controller
 			.sendMessage(new AiSendMessageRequest(5L, "Hola"), principal(NUTRITIONIST_ID));
@@ -106,15 +116,33 @@ class AiChatRestControllerTest {
 	}
 
 	@Test
-	void sendMessageMapsOpenAiRateLimit() {
+	void sendMessageMapsOpenAiRateLimit() throws Exception {
 		when(chatService.sendMessage(any(), eq(5L), any()))
 			.thenThrow(new OpenAiClientException(OpenAiClientException.ErrorKind.RATE_LIMIT,
 					HttpStatus.TOO_MANY_REQUESTS, "El servicio de IA está saturado.", "rate limit", null));
+		when(aiChatRateLimiter.executeMessage(eq(NUTRITIONIST_ID), any())).thenAnswer(invocation -> {
+			final Callable<?> callable = invocation.getArgument(1);
+			return callable.call();
+		});
 
 		final ResponseEntity<Map<String, Object>> response = controller
 			.sendMessage(new AiSendMessageRequest(5L, "Hola"), principal(NUTRITIONIST_ID));
 
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+	}
+
+	@Test
+	void sendMessageReturns429WhenAppRateLimitExceeded() {
+		when(aiChatRateLimiter.executeMessage(eq(NUTRITIONIST_ID), any())).thenThrow(RequestNotPermitted
+			.createRequestNotPermitted(io.github.resilience4j.ratelimiter.RateLimiter.ofDefaults("aiChatMessage")));
+
+		final ResponseEntity<Map<String, Object>> response = controller
+			.sendMessage(new AiSendMessageRequest(5L, "Hola"), principal(NUTRITIONIST_ID));
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+		assertThat(response.getBody()).containsEntry("success", false)
+			.containsEntry("errorCode", AiToolErrorCode.RATE_LIMIT.name())
+			.containsEntry("message", AiChatRateLimiter.RATE_LIMIT_USER_MESSAGE);
 	}
 
 	@Test

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -42,6 +42,10 @@ resilience4j.ratelimiter.instances.patientInvitationPreview.timeout-duration=0s
 resilience4j.ratelimiter.instances.patientInvitationRedeem.limit-for-period=2
 resilience4j.ratelimiter.instances.patientInvitationRedeem.limit-refresh-period=1m
 resilience4j.ratelimiter.instances.patientInvitationRedeem.timeout-duration=0s
+# AI chat message rate limits (#386) — low limit for integration tests
+resilience4j.ratelimiter.instances.aiChatMessage.limit-for-period=1
+resilience4j.ratelimiter.instances.aiChatMessage.limit-refresh-period=1m
+resilience4j.ratelimiter.instances.aiChatMessage.timeout-duration=0s
 # OpenAPI spec generation in tests (#112)
 springdoc.api-docs.enabled=true
 springdoc.swagger-ui.enabled=true


### PR DESCRIPTION
## Summary
- Adds `AiChatRateLimiter` with per-nutritionist Resilience4j limits on `POST /rest/nutritionist/ai/chat/message`
- Configurable via `AI_CHAT_MESSAGE_RATE_LIMIT` / `AI_CHAT_MESSAGE_RATE_WINDOW` (default 20/hour)
- Returns HTTP 429 with Spanish message and `RATE_LIMIT` error code when quota exceeded
- Closes Phase 5 REST API epic (#383); next up is #387 (chat UI)

## Test plan
- [x] `AiChatRateLimiterTest` — permit available, per-nutritionist isolation
- [x] `AiChatRestControllerTest` — 429 on `RequestNotPermitted`, existing OpenAI rate-limit mapping unchanged
- [x] `mvn checkstyle:check pmd:check`


Made with [Cursor](https://cursor.com)