### PR TITLE
Add AI chat entry point to nutritionist UI (#388)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#387 — Epic Nutritionist AI Chat UI](https://github.com/diego-torres/nutriconsultas/issues/387) (`NEXT`). ~~#386~~ **done** — `AiChatRateLimiter`. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** [#389 — Build AI Chat Window](https://github.com/diego-torres/nutriconsultas/issues/389) (`NEXT`). ~~#388~~ **done** — sidebar + `/admin/ai` entry point. See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#387 — Epic Nutritionist AI Chat UI](https://github.com/diego-torres/nutriconsultas/issues/387) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#386~~ `AiChatRateLimiter` per-nutritionist on `POST /message`.
+**Current next issue:** [#389 — Build AI Chat Window](https://github.com/diego-torres/nutriconsultas/issues/389) (`NEXT` in [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md)). ~~#388~~ sidebar + dashboard button + `/admin/ai` gated by `AI_ENABLED`.
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-06-30 — ~~#386~~ AI chat rate limiting **done**. **NEXT:** #387.
+**Last updated:** 2026-07-03 — ~~#388~~ AI chat entry point **done**. **NEXT:** #389.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -149,12 +149,12 @@ Thymeleaf chat window and draft preview.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **387** | Epic — Nutritionist AI Chat UI (Phase 6) | https://github.com/diego-torres/nutriconsultas/issues/387 | **NEXT** | **384** | Milestone 3 |
-| **388** | Add AI Chat Entry Point to Nutritionist UI | https://github.com/diego-torres/nutriconsultas/issues/388 | **open** | **387**, **365** | Gated by `AI_ENABLED` |
-| **389** | Build AI Chat Window | https://github.com/diego-torres/nutriconsultas/issues/389 | **open** | **388**, **384** | Chat UI + loading/errors |
+| **387** | Epic — Nutritionist AI Chat UI (Phase 6) | https://github.com/diego-torres/nutriconsultas/issues/387 | **open** | **384** | Milestone 3 — ~~#388~~ entry point **done** |
+| **388** | Add AI Chat Entry Point to Nutritionist UI | https://github.com/diego-torres/nutriconsultas/issues/388 | **done** | **387**, **365** | Sidebar + `/admin/ai`, gated by `AI_ENABLED` |
+| **389** | Build AI Chat Window | https://github.com/diego-torres/nutriconsultas/issues/389 | **NEXT** | **388**, **384** | Chat UI + loading/errors |
 | **390** | Build Draft Preview UI | https://github.com/diego-torres/nutriconsultas/issues/390 | **open** | **389**, **382** | Accept/discard + SweetAlert |
 
-**Suggested order:** #388 → #389 → #390.
+**Suggested order:** ~~#388~~ → **#389** → #390.
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/AiChatController.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatController.java
@@ -1,0 +1,34 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nutriconsultas.controller.AbstractAuthorizedController;
+
+/**
+ * Nutritionist web entry point for the AI assistant (#388). Full chat UI follows in #389.
+ */
+@Controller
+@RequestMapping("/admin/ai")
+public class AiChatController extends AbstractAuthorizedController {
+
+	private final AiProperties aiProperties;
+
+	public AiChatController(final AiProperties aiProperties) {
+		this.aiProperties = aiProperties;
+	}
+
+	@GetMapping
+	public String chatHome(final Model model) {
+		if (!aiProperties.isEnabled()) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+		}
+		model.addAttribute("activeMenu", "ai");
+		return "sbadmin/ai/chat";
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiChatTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatTemplateValidator.java
@@ -1,0 +1,24 @@
+package com.nutriconsultas.ai;
+
+import java.util.Map;
+
+import com.nutriconsultas.validation.template.BaseTemplateValidator;
+
+public class AiChatTemplateValidator extends BaseTemplateValidator {
+
+	@Override
+	public String getTemplatePathPattern() {
+		return "sbadmin/ai/**";
+	}
+
+	@Override
+	public Map<String, Object> createMockModelVariables() {
+		final Map<String, Object> variables = super.createMockModelVariables();
+		variables.put("aiEnabled", true);
+		variables.put("platformAdmin", false);
+		variables.put("clinicDirector", false);
+		variables.put("activeMenu", "ai");
+		return variables;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiEnabledModelAdvice.java
+++ b/src/main/java/com/nutriconsultas/ai/AiEnabledModelAdvice.java
@@ -1,0 +1,27 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.stereotype.Component;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+/**
+ * Exposes the AI feature flag to admin templates (#388). Never adds API keys or OpenAI
+ * configuration — only {@code aiEnabled} from {@link AiProperties#isEnabled()}.
+ */
+@Component
+@ControllerAdvice
+public class AiEnabledModelAdvice {
+
+	private final AiProperties aiProperties;
+
+	public AiEnabledModelAdvice(final AiProperties aiProperties) {
+		this.aiProperties = aiProperties;
+	}
+
+	@ModelAttribute
+	public void addAiEnabledFlag(final Model model) {
+		model.addAttribute("aiEnabled", aiProperties.isEnabled());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/validation/template/BaseTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/validation/template/BaseTemplateValidator.java
@@ -27,6 +27,11 @@ public abstract class BaseTemplateValidator implements TemplateValidator {
 		// Common menu attribute
 		variables.put("activeMenu", "");
 
+		// Sidebar feature flags (#388, platform admin, clinic director)
+		variables.put("aiEnabled", false);
+		variables.put("platformAdmin", false);
+		variables.put("clinicDirector", false);
+
 		// Common list attributes
 		variables.put("ingestas", new ArrayList<>());
 		variables.put("platillos", new ArrayList<>());

--- a/src/main/java/com/nutriconsultas/validation/template/TemplateValidatorRegistry.java
+++ b/src/main/java/com/nutriconsultas/validation/template/TemplateValidatorRegistry.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.nutriconsultas.alimentos.AlimentoTemplateValidator;
+import com.nutriconsultas.ai.AiChatTemplateValidator;
 import com.nutriconsultas.calendar.CalendarTemplateValidator;
 import com.nutriconsultas.contact.ContactInquiryTemplateValidator;
 import com.nutriconsultas.dieta.DietaTemplateValidator;
@@ -36,6 +37,7 @@ public class TemplateValidatorRegistry {
 		register(new DietaTemplateValidator());
 		register(new AlimentoTemplateValidator());
 		register(new ReportTemplateValidator());
+		register(new AiChatTemplateValidator());
 		register(new SearchTemplateValidator());
 		register(new ProfileTemplateValidator());
 		register(new PlatformAdminTemplateValidator());

--- a/src/main/resources/templates/sbadmin/ai/chat.html
+++ b/src/main/resources/templates/sbadmin/ai/chat.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="description" content="">
+  <meta name="author" content="">
+
+  <link th:href="@{/eterna/assets/img/favicon.png}" rel="icon">
+  <link th:href="@{/eterna/assets/img/apple-touch-icon.png}" rel="apple-touch-icon">
+
+  <title>Minutriporcion - Asistente IA</title>
+
+  <link th:href="@{/sbadmin/vendor/fontawesome-free/css/all.min.css}" rel="stylesheet" type="text/css">
+  <link
+    href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
+    rel="stylesheet">
+  <link th:href="@{/sbadmin/css/sb-admin-2.min.css}" rel="stylesheet">
+
+</head>
+
+<body id="page-top">
+
+  <div id="wrapper">
+    <div th:insert="~{sbadmin/sidebar :: sidebar}"></div>
+
+    <div id="content-wrapper" class="d-flex flex-column">
+      <div id="content">
+        <div th:insert="~{sbadmin/topbar :: topbar}"></div>
+
+        <div class="container-fluid">
+          <div class="d-sm-flex align-items-center justify-content-between mb-4">
+            <h1 class="h3 mb-0 text-gray-800">
+              <i class="fas fa-robot mr-2" aria-hidden="true"></i>
+              Asistente de IA
+            </h1>
+          </div>
+
+          <div class="card shadow mb-4">
+            <div class="card-header py-3">
+              <h2 class="h6 m-0 font-weight-bold text-primary">Chat nutricional</h2>
+            </div>
+            <div class="card-body" id="ai-chat-root" aria-live="polite">
+              <p class="text-muted mb-0">
+                Usa el asistente para redactar recetas, menús y planes dietéticos como borradores.
+                El contenido generado requiere tu revisión antes de guardarse o asignarse a pacientes.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <footer class="sticky-footer bg-white">
+        <div class="container my-auto">
+          <div class="copyright text-center my-auto">
+            <span>Copyright &copy; Minutriporcion 2026</span>
+          </div>
+        </div>
+      </footer>
+    </div>
+  </div>
+
+  <a class="scroll-to-top rounded" href="#page-top">
+    <i class="fas fa-angle-up"></i>
+  </a>
+
+  <div th:insert="~{sbadmin/logout-modal :: logout}"></div>
+
+  <script th:src="@{/sbadmin/vendor/jquery/jquery.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/bootstrap/js/bootstrap.bundle.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/jquery-easing/jquery.easing.min.js}"></script>
+  <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/sbadmin/index.html
+++ b/src/main/resources/templates/sbadmin/index.html
@@ -53,8 +53,11 @@
                             <a th:href="@{/admin/calendario/nuevo}" class="d-none d-sm-inline-block btn btn-sm btn-success shadow-sm mr-2">
                                 <i class="fas fa-calendar-plus fa-sm text-white-50"></i> Nueva Cita
                             </a>
-                            <a th:href="@{/admin/dietas/nuevo}" class="d-none d-sm-inline-block btn btn-sm btn-info shadow-sm">
+                            <a th:href="@{/admin/dietas/nuevo}" class="d-none d-sm-inline-block btn btn-sm btn-info shadow-sm mr-2">
                                 <i class="fas fa-utensils fa-sm text-white-50"></i> Nueva Dieta
+                            </a>
+                            <a th:if="${aiEnabled}" th:href="@{/admin/ai}" class="d-none d-sm-inline-block btn btn-sm btn-secondary shadow-sm">
+                                <i class="fas fa-robot fa-sm text-white-50"></i> Asistente IA
                             </a>
                         </div>
                     </div>

--- a/src/main/resources/templates/sbadmin/sidebar.html
+++ b/src/main/resources/templates/sbadmin/sidebar.html
@@ -53,6 +53,11 @@
         <i class="fas fa-fw fa-file-prescription"></i>
         <span>Reportes</span></a>
     </li>
+    <li class="nav-item" th:if="${aiEnabled}" th:classappend="${activeMenu == 'ai' ? 'active' : ''}">
+      <a class="nav-link" th:href="@{/admin/ai}">
+        <i class="fas fa-fw fa-robot"></i>
+        <span>Asistente IA</span></a>
+    </li>
     <li class="nav-item" th:classappend="${activeMenu == 'perfil' ? 'active' : ''}">
       <a class="nav-link" th:href="@{/admin/perfil}">
         <i class="fas fa-fw fa-user-md"></i>

--- a/src/test/java/com/nutriconsultas/ai/AiChatControllerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatControllerTest.java
@@ -1,0 +1,46 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.web.server.ResponseStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class AiChatControllerTest {
+
+	@InjectMocks
+	private AiChatController controller;
+
+	@Mock
+	private AiProperties aiProperties;
+
+	@Test
+	void chatHomeReturnsViewWhenEnabled() {
+		when(aiProperties.isEnabled()).thenReturn(true);
+		final ExtendedModelMap model = new ExtendedModelMap();
+
+		final String view = controller.chatHome(model);
+
+		assertThat(view).isEqualTo("sbadmin/ai/chat");
+		assertThat(model.getAttribute("activeMenu")).isEqualTo("ai");
+		assertThat(model.asMap()).doesNotContainKeys("openaiApiKey", "openaiModel", "apiKey");
+	}
+
+	@Test
+	void chatHomeReturnsNotFoundWhenDisabled() {
+		when(aiProperties.isEnabled()).thenReturn(false);
+
+		assertThatThrownBy(() -> controller.chatHome(new ExtendedModelMap()))
+			.isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode().value())
+			.isEqualTo(404);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiEnabledModelAdviceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiEnabledModelAdviceTest.java
@@ -1,0 +1,46 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AiEnabledModelAdviceTest {
+
+	@InjectMocks
+	private AiEnabledModelAdvice advice;
+
+	@Mock
+	private AiProperties aiProperties;
+
+	@Test
+	void addsAiEnabledWhenFeatureFlagOn() {
+		when(aiProperties.isEnabled()).thenReturn(true);
+		final Model model = new ExtendedModelMap();
+
+		advice.addAiEnabledFlag(model);
+
+		assertThat(model.getAttribute("aiEnabled")).isEqualTo(true);
+		assertThat(model.asMap()).doesNotContainKey("openaiApiKey");
+		assertThat(model.asMap()).doesNotContainKey("openaiModel");
+	}
+
+	@Test
+	void addsAiEnabledFalseWhenFeatureFlagOff() {
+		when(aiProperties.isEnabled()).thenReturn(false);
+		final Model model = new ExtendedModelMap();
+
+		advice.addAiEnabledFlag(model);
+
+		assertThat(model.getAttribute("aiEnabled")).isEqualTo(false);
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds `AiEnabledModelAdvice` to expose only the `aiEnabled` flag (no API keys) to admin templates
- Sidebar **Asistente IA** link and dashboard quick-action button, visible when `AI_ENABLED=true`
- `GET /admin/ai` placeholder page (`sbadmin/ai/chat.html`) — full chat UI follows in #389
- Returns 404 when AI is disabled (direct URL access blocked)
- Template validator + base mock variables for sidebar feature flags

## Test plan
- [x] `AiEnabledModelAdviceTest` — flag on/off, no secrets in model
- [x] `AiChatControllerTest` — view when enabled, 404 when disabled
- [x] `ThymeleafTemplateValidationTest` — includes new `sbadmin/ai/chat.html`


Made with [Cursor](https://cursor.com)