### PR TITLE
Build AI draft preview UI with accept and discard (#390)

### DIFF
--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-07-03 — ~~#389~~ AI chat window **done**. **NEXT:** #390. Registered **#433–#442** (chat UX enhancements + prompt security + floating widget).
+**Last updated:** 2026-07-03 — ~~#389~~ ~~#442~~ merged. **#390** in progress on `issue-390-draft-preview-ui`.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -152,8 +152,8 @@ Thymeleaf chat window and draft preview.
 | **387** | Epic — Nutritionist AI Chat UI (Phase 6) | https://github.com/diego-torres/nutriconsultas/issues/387 | **open** | **384** | ~~#388–#389~~ |
 | **388** | Add AI Chat Entry Point to Nutritionist UI | https://github.com/diego-torres/nutriconsultas/issues/388 | **done** | **387**, **365** | Sidebar + `/admin/ai`, gated by `AI_ENABLED` |
 | **389** | Build AI Chat Window | https://github.com/diego-torres/nutriconsultas/issues/389 | **done** | **388**, **384** | `ai-chat.js` + REST integration |
-| **390** | Build Draft Preview UI | https://github.com/diego-torres/nutriconsultas/issues/390 | **NEXT** | **389**, **382** | Accept/discard + SweetAlert |
-| **442** | Floating context-aware AI assistant widget | https://github.com/diego-torres/nutriconsultas/issues/442 | **in-progress** | **388**, **384**, **389** | PR #432; patient/dieta/platillo context |
+| **390** | Build Draft Preview UI | https://github.com/diego-torres/nutriconsultas/issues/390 | **in-progress** | **389**, **382** | Accept/discard + SweetAlert |
+| **442** | Floating context-aware AI assistant widget | https://github.com/diego-torres/nutriconsultas/issues/442 | **done** | **388**, **384**, **389** | Merged with PR #432 |
 
 **Suggested order:** ~~#389~~ → **#390** → close **#442** when PR #432 merges → epic **#433**.
 

--- a/src/main/java/com/nutriconsultas/ai/AiDraftPreviewService.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftPreviewService.java
@@ -5,6 +5,7 @@ import org.springframework.lang.NonNull;
 /**
  * Builds nutritionist-facing draft previews (#390).
  */
+@FunctionalInterface
 public interface AiDraftPreviewService {
 
 	AiDraftPreviewView getPreview(long draftId, @NonNull String nutritionistId);

--- a/src/main/java/com/nutriconsultas/ai/AiDraftPreviewService.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftPreviewService.java
@@ -1,0 +1,12 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.NonNull;
+
+/**
+ * Builds nutritionist-facing draft previews (#390).
+ */
+public interface AiDraftPreviewService {
+
+	AiDraftPreviewView getPreview(long draftId, @NonNull String nutritionistId);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftPreviewServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftPreviewServiceImpl.java
@@ -1,0 +1,140 @@
+package com.nutriconsultas.ai;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class AiDraftPreviewServiceImpl implements AiDraftPreviewService {
+
+	private final AiGeneratedDraftRepository draftRepository;
+
+	public AiDraftPreviewServiceImpl(final AiGeneratedDraftRepository draftRepository) {
+		this.draftRepository = draftRepository;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public AiDraftPreviewView getPreview(final long draftId, @NonNull final String nutritionistId) {
+		final AiGeneratedDraft draft = draftRepository.findByIdAndThreadNutritionistId(draftId, nutritionistId)
+			.orElseThrow(() -> new AiDraftLifecycleException("Borrador no encontrado."));
+		return toPreviewView(draft);
+	}
+
+	private AiDraftPreviewView toPreviewView(final AiGeneratedDraft draft) {
+		final String summary = AiDraftSummaryExtractor.summarize(draft);
+		return switch (draft.getDraftType()) {
+			case DISH -> fromDish(draft, summary);
+			case MENU -> fromMenu(draft, summary);
+			case DIET_PLAN -> fromDietPlan(draft, summary);
+		};
+	}
+
+	private AiDraftPreviewView fromDish(final AiGeneratedDraft draft, final String summary) {
+		final DishDraftPayload payload = AiDraftPayloadDeserializer.dish(draft.getJsonPayload());
+		final String reviewLabel = StringUtils.hasText(payload.label()) ? payload.label()
+				: AiDraftSummaryExtractor.REVIEW_LABEL;
+		return new AiDraftPreviewView(draft.getId(), draft.getThread().getId(), draft.getDraftType(), draft.getStatus(),
+				"Platillo (receta)", reviewLabel, payload.name(), summary, payload.portions(), null,
+				payload.nutrientsPerPortion(), toIngredientLines(payload.ingredients()), List.of(),
+				safeList(payload.preparationSteps()), safeList(payload.assumptions()), safeList(payload.warnings()),
+				null);
+	}
+
+	private AiDraftPreviewView fromMenu(final AiGeneratedDraft draft, final String summary) {
+		final MenuDraftPayload payload = AiDraftPayloadDeserializer.menu(draft.getJsonPayload());
+		final String reviewLabel = StringUtils.hasText(payload.label()) ? payload.label()
+				: AiDraftSummaryExtractor.REVIEW_LABEL;
+		return new AiDraftPreviewView(draft.getId(), draft.getThread().getId(), draft.getDraftType(), draft.getStatus(),
+				"Menú", reviewLabel, payload.title(), summary, null, null, payload.nutrientsTotal(), List.of(),
+				toMealSlots(payload.ingestas()), List.of(), safeList(payload.assumptions()),
+				safeList(payload.warnings()), payload.validationSummary());
+	}
+
+	private AiDraftPreviewView fromDietPlan(final AiGeneratedDraft draft, final String summary) {
+		final DietPlanDraftPayload payload = AiDraftPayloadDeserializer.dietPlan(draft.getJsonPayload());
+		final String reviewLabel = StringUtils.hasText(payload.label()) ? payload.label()
+				: AiDraftSummaryExtractor.REVIEW_LABEL;
+		final List<Map<String, Object>> mealSlots = new ArrayList<>();
+		if (payload.days() != null) {
+			for (final DietPlanDayPayload day : payload.days()) {
+				final Map<String, Object> dayMap = new LinkedHashMap<>();
+				dayMap.put("dayIndex", day.dayIndex());
+				dayMap.put("label", day.label());
+				dayMap.put("ingestas", toMealSlots(day.ingestas()));
+				dayMap.put("nutrients", day.nutrientsTotal());
+				mealSlots.add(dayMap);
+			}
+		}
+		return new AiDraftPreviewView(draft.getId(), draft.getThread().getId(), draft.getDraftType(), draft.getStatus(),
+				"Plan alimentario", reviewLabel, payload.title(), summary, null, payload.dayCount(),
+				payload.weeklyAverageNutrients(), List.of(), mealSlots, List.of(), safeList(payload.assumptions()),
+				safeList(payload.warnings()), payload.validationSummary());
+	}
+
+	private static List<Map<String, String>> toIngredientLines(final List<RecipeIngredientInput> ingredients) {
+		final List<Map<String, String>> lines = new ArrayList<>();
+		if (ingredients == null) {
+			return lines;
+		}
+		for (final RecipeIngredientInput ingredient : ingredients) {
+			final Map<String, String> line = new LinkedHashMap<>();
+			line.put("alimentoId", String.valueOf(ingredient.alimentoId()));
+			line.put("cantidad", ingredient.cantidad());
+			line.put("unidad", ingredient.unidad() != null ? ingredient.unidad() : "");
+			if (ingredient.pesoNetoG() != null) {
+				line.put("pesoNetoG", String.valueOf(ingredient.pesoNetoG()));
+			}
+			lines.add(line);
+		}
+		return lines;
+	}
+
+	private static List<Map<String, Object>> toMealSlots(final List<IngestaSlotInput> ingestas) {
+		final List<Map<String, Object>> slots = new ArrayList<>();
+		if (ingestas == null) {
+			return slots;
+		}
+		for (final IngestaSlotInput ingesta : ingestas) {
+			final Map<String, Object> slot = new LinkedHashMap<>();
+			slot.put("nombre", ingesta.nombre());
+			slot.put("orden", ingesta.orden());
+			slot.put("items", toMealItems(ingesta.items()));
+			slots.add(slot);
+		}
+		return slots;
+	}
+
+	private static List<Map<String, String>> toMealItems(final List<IngestaSlotItemInput> items) {
+		final List<Map<String, String>> result = new ArrayList<>();
+		if (items == null) {
+			return result;
+		}
+		for (final IngestaSlotItemInput item : items) {
+			final Map<String, String> map = new LinkedHashMap<>();
+			map.put("type", item.type());
+			if (item.platilloId() != null) {
+				map.put("platilloId", String.valueOf(item.platilloId()));
+			}
+			if (item.alimentoId() != null) {
+				map.put("alimentoId", String.valueOf(item.alimentoId()));
+			}
+			if (item.portions() != null) {
+				map.put("portions", String.valueOf(item.portions()));
+			}
+			result.add(map);
+		}
+		return result;
+	}
+
+	private static List<String> safeList(final List<String> values) {
+		return values != null ? List.copyOf(values) : List.of();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftPreviewView.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftPreviewView.java
@@ -1,0 +1,16 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Structured draft preview for nutritionist review UI (#390).
+ */
+public record AiDraftPreviewView(long draftId, long threadId, AiDraftType draftType, AiDraftStatus status,
+		String draftTypeLabel, String reviewLabel, @Nullable String title, String summary, @Nullable Integer portions,
+		@Nullable Integer dayCount, @Nullable NutrientSummary nutrients, List<Map<String, String>> ingredients,
+		List<Map<String, Object>> mealSlots, List<String> preparationSteps, List<String> assumptions,
+		List<String> warnings, @Nullable String validationSummary) {
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftRestController.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftRestController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.lang.NonNull;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,10 +25,47 @@ public class AiDraftRestController {
 
 	private final AiDraftLifecycleService draftLifecycleService;
 
+	private final AiDraftPreviewService draftPreviewService;
+
 	public AiDraftRestController(final AiDraftAcceptanceService draftAcceptanceService,
-			final AiDraftLifecycleService draftLifecycleService) {
+			final AiDraftLifecycleService draftLifecycleService, final AiDraftPreviewService draftPreviewService) {
 		this.draftAcceptanceService = draftAcceptanceService;
 		this.draftLifecycleService = draftLifecycleService;
+		this.draftPreviewService = draftPreviewService;
+	}
+
+	@GetMapping("/{draftId}")
+	public ResponseEntity<Map<String, Object>> getDraftPreview(@PathVariable @NonNull final Long draftId,
+			@AuthenticationPrincipal final OidcUser principal) {
+		if (principal == null) {
+			return errorResponse(HttpStatus.UNAUTHORIZED, "Sesión no válida.");
+		}
+		try {
+			final AiDraftPreviewView preview = draftPreviewService.getPreview(draftId, principal.getSubject());
+			final Map<String, Object> body = new LinkedHashMap<>();
+			body.put("success", true);
+			body.put("draftId", preview.draftId());
+			body.put("threadId", preview.threadId());
+			body.put("draftType", preview.draftType().name());
+			body.put("status", preview.status().name());
+			body.put("draftTypeLabel", preview.draftTypeLabel());
+			body.put("reviewLabel", preview.reviewLabel());
+			body.put("title", preview.title());
+			body.put("summary", preview.summary());
+			body.put("portions", preview.portions());
+			body.put("dayCount", preview.dayCount());
+			body.put("nutrients", preview.nutrients());
+			body.put("ingredients", preview.ingredients());
+			body.put("mealSlots", preview.mealSlots());
+			body.put("preparationSteps", preview.preparationSteps());
+			body.put("assumptions", preview.assumptions());
+			body.put("warnings", preview.warnings());
+			body.put("validationSummary", preview.validationSummary());
+			return ResponseEntity.ok(body);
+		}
+		catch (AiDraftLifecycleException ex) {
+			return mapLifecycleException(ex);
+		}
 	}
 
 	@PostMapping("/{draftId}/accept")

--- a/src/main/java/com/nutriconsultas/ai/AiDraftSummaryExtractor.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftSummaryExtractor.java
@@ -7,7 +7,9 @@ import org.springframework.util.StringUtils;
  */
 public final class AiDraftSummaryExtractor {
 
-	private static final String DEFAULT_LABEL = "Borrador IA — revisión del nutriólogo requerida";
+	public static final String REVIEW_LABEL = "Borrador IA — revisión del nutriólogo requerida";
+
+	private static final String DEFAULT_LABEL = REVIEW_LABEL;
 
 	private AiDraftSummaryExtractor() {
 	}

--- a/src/main/resources/static/sbadmin/css/ai-chat.css
+++ b/src/main/resources/static/sbadmin/css/ai-chat.css
@@ -119,6 +119,125 @@
   margin-top: 0.5rem;
 }
 
+.ai-chat-columns {
+  min-height: 28rem;
+}
+
+.ai-chat-main {
+  display: flex;
+  flex-direction: column;
+  min-height: 28rem;
+}
+
+.ai-chat-drafts-column {
+  margin-top: 1rem;
+}
+
+.ai-chat-drafts-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 20rem;
+  max-height: calc(100vh - 14rem);
+  border: 1px solid #e3e6f0;
+  border-radius: 0.35rem;
+  background: #fff;
+  padding: 0.85rem;
+}
+
+.ai-chat-drafts-header {
+  margin-bottom: 0.75rem;
+}
+
+.ai-chat-drafts-subtitle {
+  font-size: 0.75rem;
+  color: #e74a3b;
+  font-weight: 600;
+}
+
+.ai-chat-draft-list {
+  flex: 1;
+  overflow-y: auto;
+  margin-bottom: 0.75rem;
+}
+
+.ai-chat-draft-card {
+  width: 100%;
+  text-align: left;
+  border: 1px solid #e3e6f0;
+  border-radius: 0.35rem;
+  background: #f8f9fc;
+  padding: 0.55rem 0.65rem;
+  margin-bottom: 0.5rem;
+  cursor: pointer;
+}
+
+.ai-chat-draft-card:hover,
+.ai-chat-draft-card.active {
+  border-color: #4e73df;
+  background: #fff;
+}
+
+.ai-chat-draft-card-title {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #3a3b45;
+  margin: 0 0 0.15rem;
+}
+
+.ai-chat-draft-card-meta {
+  font-size: 0.72rem;
+  color: #858796;
+}
+
+.ai-chat-draft-preview {
+  border-top: 1px solid #e3e6f0;
+  padding-top: 0.75rem;
+  overflow-y: auto;
+  max-height: 55%;
+}
+
+.ai-chat-draft-review-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #e74a3b;
+  margin-bottom: 0.35rem;
+}
+
+.ai-chat-draft-section {
+  margin-bottom: 0.65rem;
+  font-size: 0.85rem;
+}
+
+.ai-chat-draft-section h5 {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #5a5c69;
+  margin-bottom: 0.25rem;
+}
+
+.ai-chat-draft-section ul {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.ai-chat-draft-empty {
+  color: #858796;
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 1rem 0.5rem;
+}
+
+.ai-chat-draft-actions .btn {
+  margin-right: 0.35rem;
+}
+
+@media (min-width: 992px) {
+  .ai-chat-drafts-column {
+    margin-top: 0;
+  }
+}
+
 @media (max-width: 576px) {
   .ai-chat-layout {
     max-height: none;

--- a/src/main/resources/static/sbadmin/js/ai-chat.js
+++ b/src/main/resources/static/sbadmin/js/ai-chat.js
@@ -4,12 +4,17 @@
   'use strict';
 
   var API_BASE = '/rest/nutritionist/ai/chat';
+  var DRAFT_API = '/rest/nutritionist/ai/drafts';
   var STORAGE_KEY = 'nutriconsultas.ai.threadId';
+  var REVIEW_LABEL = 'Borrador IA — revisión del nutriólogo requerida';
 
   var state = {
     threadId: null,
     threadTitle: null,
     messages: [],
+    drafts: [],
+    selectedDraftId: null,
+    selectedPreview: null,
     busy: false
   };
 
@@ -80,6 +85,304 @@
     } else {
       window.alert(message);
     }
+  }
+
+  function draftTypeLabel(type) {
+    if (type === 'DISH') {
+      return 'Platillo (receta)';
+    }
+    if (type === 'MENU') {
+      return 'Menú';
+    }
+    if (type === 'DIET_PLAN') {
+      return 'Plan alimentario';
+    }
+    return type;
+  }
+
+  function draftStatusLabel(status) {
+    if (status === 'DRAFT') {
+      return 'Pendiente de revisión';
+    }
+    if (status === 'ACCEPTED') {
+      return 'Aceptado';
+    }
+    if (status === 'DISCARDED') {
+      return 'Descartado';
+    }
+    return status;
+  }
+
+  function formatNutrients(nutrients) {
+    if (!nutrients) {
+      return '';
+    }
+    var parts = [];
+    if (nutrients.energiaKcal != null) {
+      parts.push(nutrients.energiaKcal + ' kcal');
+    }
+    if (nutrients.proteinaG != null) {
+      parts.push('Proteína ' + nutrients.proteinaG + ' g');
+    }
+    if (nutrients.lipidosG != null) {
+      parts.push('Lípidos ' + nutrients.lipidosG + ' g');
+    }
+    if (nutrients.hidratosDeCarbonoG != null) {
+      parts.push('H. de carbono ' + nutrients.hidratosDeCarbonoG + ' g');
+    }
+    return parts.join(' · ');
+  }
+
+  function renderListSection(title, items) {
+    if (!items || items.length === 0) {
+      return '';
+    }
+    return '<section class="ai-chat-draft-section"><h5>' + escapeHtml(title) + '</h5><ul>' +
+      items.map(function (item) {
+        return '<li>' + escapeHtml(String(item)) + '</li>';
+      }).join('') +
+      '</ul></section>';
+  }
+
+  function renderDraftList() {
+    var container = $('#aiChatDraftList');
+    if (!container) {
+      return;
+    }
+    if (!state.threadId) {
+      container.innerHTML = '<p class="ai-chat-draft-empty">Inicia una conversación para ver borradores.</p>';
+      hideDraftPreview();
+      return;
+    }
+    if (!state.drafts || state.drafts.length === 0) {
+      container.innerHTML = '<p class="ai-chat-draft-empty">Aún no hay borradores en esta conversación.</p>';
+      hideDraftPreview();
+      return;
+    }
+    container.innerHTML = state.drafts.map(function (draft) {
+      var active = state.selectedDraftId === draft.draftId ? ' active' : '';
+      var title = draft.summary || draftTypeLabel(draft.draftType);
+      return '<button type="button" class="ai-chat-draft-card' + active + '" data-draft-id="' + draft.draftId + '">' +
+        '<p class="ai-chat-draft-card-title">' + escapeHtml(title) + '</p>' +
+        '<p class="ai-chat-draft-card-meta">' + escapeHtml(draftTypeLabel(draft.draftType)) +
+        ' · ' + escapeHtml(draftStatusLabel(draft.status)) + '</p></button>';
+    }).join('');
+    container.querySelectorAll('[data-draft-id]').forEach(function (button) {
+      button.addEventListener('click', function () {
+        selectDraft(Number(button.getAttribute('data-draft-id')));
+      });
+    });
+  }
+
+  function hideDraftPreview() {
+    state.selectedDraftId = null;
+    state.selectedPreview = null;
+    var panel = $('#aiChatDraftPreview');
+    if (panel) {
+      panel.hidden = true;
+    }
+  }
+
+  function renderDraftPreview(preview) {
+    var panel = $('#aiChatDraftPreview');
+    var body = $('#aiChatDraftPreviewBody');
+    var reviewLabel = $('#aiChatDraftReviewLabel');
+    var titleEl = $('#aiChatDraftPreviewTitle');
+    var typeEl = $('#aiChatDraftPreviewType');
+    var actions = $('#aiChatDraftActions');
+    if (!panel || !body) {
+      return;
+    }
+    panel.hidden = false;
+    if (reviewLabel) {
+      reviewLabel.textContent = preview.reviewLabel || REVIEW_LABEL;
+    }
+    if (titleEl) {
+      titleEl.textContent = preview.title || preview.summary || draftTypeLabel(preview.draftType);
+    }
+    if (typeEl) {
+      typeEl.textContent = (preview.draftTypeLabel || draftTypeLabel(preview.draftType)) +
+        ' · ' + draftStatusLabel(preview.status);
+    }
+
+    var html = '';
+    if (preview.portions != null) {
+      html += '<section class="ai-chat-draft-section"><h5>Porciones</h5><p>' +
+        escapeHtml(String(preview.portions)) + '</p></section>';
+    }
+    if (preview.dayCount != null) {
+      html += '<section class="ai-chat-draft-section"><h5>Días</h5><p>' +
+        escapeHtml(String(preview.dayCount)) + '</p></section>';
+    }
+    var nutrientsText = formatNutrients(preview.nutrients);
+    if (nutrientsText) {
+      html += '<section class="ai-chat-draft-section"><h5>Nutrientes</h5><p>' +
+        escapeHtml(nutrientsText) + '</p></section>';
+    }
+    if (preview.ingredients && preview.ingredients.length > 0) {
+      html += '<section class="ai-chat-draft-section"><h5>Ingredientes</h5><ul>' +
+        preview.ingredients.map(function (line) {
+          var text = 'Alimento #' + line.alimentoId + ': ' + line.cantidad;
+          if (line.unidad) {
+            text += ' ' + line.unidad;
+          }
+          return '<li>' + escapeHtml(text) + '</li>';
+        }).join('') + '</ul></section>';
+    }
+    if (preview.mealSlots && preview.mealSlots.length > 0) {
+      html += '<section class="ai-chat-draft-section"><h5>Ingestas / comidas</h5><ul>' +
+        preview.mealSlots.map(function (slot) {
+          if (slot.ingestas) {
+            var dayLabel = slot.label || ('Día ' + slot.dayIndex);
+            return '<li>' + escapeHtml(String(dayLabel)) + ': ' + slot.ingestas.length + ' ingestas</li>';
+          }
+          var ingestaName = slot.nombre || ('Ingesta ' + (slot.orden != null ? slot.orden : ''));
+          var itemCount = slot.items ? slot.items.length : 0;
+          return '<li>' + escapeHtml(String(ingestaName)) + ' (' + itemCount + ' ítems)</li>';
+        }).join('') + '</ul></section>';
+    }
+    html += renderListSection('Pasos de preparación', preview.preparationSteps);
+    html += renderListSection('Supuestos', preview.assumptions);
+    html += renderListSection('Advertencias', preview.warnings);
+    if (preview.validationSummary) {
+      html += '<section class="ai-chat-draft-section"><h5>Validación</h5><p>' +
+        escapeHtml(preview.validationSummary) + '</p></section>';
+    }
+    body.innerHTML = html;
+
+    if (actions) {
+      actions.hidden = preview.status !== 'DRAFT';
+    }
+  }
+
+  function loadDrafts(threadId) {
+    if (!threadId) {
+      state.drafts = [];
+      renderDraftList();
+      return Promise.resolve();
+    }
+    return requestJson(API_BASE + '/' + threadId + '/drafts', { method: 'GET' })
+      .then(function (data) {
+        state.drafts = data.drafts || [];
+        if (state.selectedDraftId && !state.drafts.some(function (d) {
+          return d.draftId === state.selectedDraftId;
+        })) {
+          hideDraftPreview();
+        }
+        renderDraftList();
+        if (state.selectedDraftId) {
+          return loadDraftPreview(state.selectedDraftId);
+        }
+        return null;
+      })
+      .catch(function (error) {
+        showError(error.message);
+      });
+  }
+
+  function loadDraftPreview(draftId) {
+    return requestJson(DRAFT_API + '/' + draftId, { method: 'GET' })
+      .then(function (preview) {
+        state.selectedDraftId = draftId;
+        state.selectedPreview = preview;
+        renderDraftList();
+        renderDraftPreview(preview);
+      })
+      .catch(function (error) {
+        showError(error.message);
+      });
+  }
+
+  function selectDraft(draftId) {
+    if (state.busy) {
+      return;
+    }
+    loadDraftPreview(draftId);
+  }
+
+  function confirmDraftAction(options, onConfirm) {
+    if (typeof swal === 'function') {
+      swal({
+        title: options.title,
+        text: options.text,
+        type: 'warning',
+        showCancelButton: true,
+        confirmButtonColor: options.confirmColor || '#1cc88a',
+        confirmButtonText: options.confirmText,
+        cancelButtonText: 'Cancelar',
+        closeOnConfirm: true
+      }, function (isConfirm) {
+        if (isConfirm) {
+          onConfirm();
+        }
+      });
+    } else if (window.confirm(options.text)) {
+      onConfirm();
+    }
+  }
+
+  function acceptSelectedDraft() {
+    if (!state.selectedDraftId || !state.selectedPreview || state.selectedPreview.status !== 'DRAFT') {
+      return;
+    }
+    confirmDraftAction({
+      title: '¿Aceptar borrador?',
+      text: 'Se creará un registro en tu catálogo a partir de este borrador. Revisa que los datos sean correctos.',
+      confirmText: 'Sí, aceptar',
+      confirmColor: '#1cc88a'
+    }, function () {
+      setBusy(true);
+      requestJson(DRAFT_API + '/' + state.selectedDraftId + '/accept', { method: 'POST' })
+        .then(function (data) {
+          if (typeof swal === 'function') {
+            swal({
+              title: 'Borrador aceptado',
+              text: data.summary || 'El borrador se guardó en tu catálogo.',
+              type: 'success',
+              timer: 2500
+            });
+          }
+          return loadDrafts(state.threadId);
+        })
+        .catch(function (error) {
+          showError(error.message);
+        })
+        .finally(function () {
+          setBusy(false);
+        });
+    });
+  }
+
+  function discardSelectedDraft() {
+    if (!state.selectedDraftId || !state.selectedPreview || state.selectedPreview.status !== 'DRAFT') {
+      return;
+    }
+    confirmDraftAction({
+      title: '¿Descartar borrador?',
+      text: 'Esta acción no se puede deshacer.',
+      confirmText: 'Sí, descartar',
+      confirmColor: '#e74a3b'
+    }, function () {
+      setBusy(true);
+      requestJson(DRAFT_API + '/' + state.selectedDraftId + '/discard', { method: 'POST' })
+        .then(function () {
+          if (typeof swal === 'function') {
+            swal({
+              title: 'Borrador descartado',
+              type: 'success',
+              timer: 2000
+            });
+          }
+          hideDraftPreview();
+          return loadDrafts(state.threadId);
+        })
+        .catch(function (error) {
+          showError(error.message);
+        })
+        .finally(function () {
+          setBusy(false);
+        });
+    });
   }
 
   function setBusy(busy) {
@@ -167,6 +470,7 @@
     updateThreadTitle(data.title);
     state.messages = data.messages || [];
     renderMessages(false);
+    loadDrafts(data.threadId);
   }
 
   function loadThread(threadId) {
@@ -246,6 +550,7 @@
           createdAt: new Date().toISOString()
         });
         renderMessages(false);
+        loadDrafts(data.threadId);
       })
       .catch(function (error) {
         state.showLoading = false;
@@ -288,6 +593,9 @@
   function resetConversation() {
     persistThreadId(null);
     state.messages = [];
+    state.drafts = [];
+    hideDraftPreview();
+    renderDraftList();
     updateThreadTitle(null);
     renderMessages(false);
     var textarea = $('#aiChatInput');
@@ -312,6 +620,8 @@
     var form = $('#aiChatForm');
     var textarea = $('#aiChatInput');
     var newBtn = $('#aiChatNewBtn');
+    var acceptBtn = $('#aiChatDraftAcceptBtn');
+    var discardBtn = $('#aiChatDraftDiscardBtn');
 
     if (form) {
       form.addEventListener('submit', function (event) {
@@ -332,6 +642,12 @@
     if (newBtn) {
       newBtn.addEventListener('click', startNewConversation);
     }
+    if (acceptBtn) {
+      acceptBtn.addEventListener('click', acceptSelectedDraft);
+    }
+    if (discardBtn) {
+      discardBtn.addEventListener('click', discardSelectedDraft);
+    }
   }
 
   function init() {
@@ -341,6 +657,7 @@
       loadThread(threadId);
     } else {
       renderMessages(false);
+      renderDraftList();
     }
   }
 

--- a/src/main/resources/templates/sbadmin/ai/chat.html
+++ b/src/main/resources/templates/sbadmin/ai/chat.html
@@ -50,27 +50,55 @@
               </button>
             </div>
             <div class="card-body ai-chat-layout">
-              <div class="ai-chat-toolbar">
-                <p class="ai-chat-thread-title mb-0" id="aiChatThreadTitle">Nueva conversación</p>
-              </div>
+              <div class="row ai-chat-columns">
+                <div class="col-lg-7 ai-chat-main">
+                  <div class="ai-chat-toolbar">
+                    <p class="ai-chat-thread-title mb-0" id="aiChatThreadTitle">Nueva conversación</p>
+                  </div>
 
-              <div id="aiChatMessages" class="ai-chat-messages" role="log" aria-live="polite"
-                aria-relevant="additions" aria-label="Mensajes del chat">
-              </div>
+                  <div id="aiChatMessages" class="ai-chat-messages" role="log" aria-live="polite"
+                    aria-relevant="additions" aria-label="Mensajes del chat">
+                  </div>
 
-              <form id="aiChatForm" class="ai-chat-composer" novalidate>
-                <label class="sr-only" for="aiChatInput">Mensaje para el asistente de IA</label>
-                <textarea id="aiChatInput" class="form-control" rows="2"
-                  placeholder="Describe la receta, menú o plan que necesitas…"
-                  aria-label="Mensaje para el asistente de IA" maxlength="4000" required></textarea>
-                <button type="submit" class="btn btn-primary btn-send" id="aiChatSendBtn"
-                  aria-label="Enviar mensaje al asistente">
-                  <i class="fas fa-paper-plane mr-1" aria-hidden="true"></i>Enviar
-                </button>
-              </form>
-              <p class="ai-chat-hint mb-0">
-                Enter para enviar · Shift+Enter para nueva línea · Los borradores requieren tu revisión antes de usarse.
-              </p>
+                  <form id="aiChatForm" class="ai-chat-composer" novalidate>
+                    <label class="sr-only" for="aiChatInput">Mensaje para el asistente de IA</label>
+                    <textarea id="aiChatInput" class="form-control" rows="2"
+                      placeholder="Describe la receta, menú o plan que necesitas…"
+                      aria-label="Mensaje para el asistente de IA" maxlength="4000" required></textarea>
+                    <button type="submit" class="btn btn-primary btn-send" id="aiChatSendBtn"
+                      aria-label="Enviar mensaje al asistente">
+                      <i class="fas fa-paper-plane mr-1" aria-hidden="true"></i>Enviar
+                    </button>
+                  </form>
+                  <p class="ai-chat-hint mb-0">
+                    Enter para enviar · Shift+Enter para nueva línea · Los borradores requieren tu revisión antes de usarse.
+                  </p>
+                </div>
+
+                <div class="col-lg-5 ai-chat-drafts-column">
+                  <aside id="aiChatDraftsPanel" class="ai-chat-drafts-panel" aria-label="Borradores generados por IA">
+                    <div class="ai-chat-drafts-header">
+                      <h3 class="h6 font-weight-bold text-primary mb-0">Borradores IA</h3>
+                      <p class="ai-chat-drafts-subtitle mb-0">Borrador IA — revisión del nutriólogo requerida</p>
+                    </div>
+                    <div id="aiChatDraftList" class="ai-chat-draft-list"></div>
+                    <div id="aiChatDraftPreview" class="ai-chat-draft-preview" hidden>
+                      <p class="ai-chat-draft-review-label" id="aiChatDraftReviewLabel"></p>
+                      <h4 class="h6 font-weight-bold mb-1" id="aiChatDraftPreviewTitle"></h4>
+                      <p class="ai-chat-draft-type text-muted mb-2" id="aiChatDraftPreviewType"></p>
+                      <div id="aiChatDraftPreviewBody"></div>
+                      <div class="ai-chat-draft-actions mt-3" id="aiChatDraftActions">
+                        <button type="button" class="btn btn-success btn-sm" id="aiChatDraftAcceptBtn">
+                          <i class="fas fa-check mr-1" aria-hidden="true"></i>Aceptar
+                        </button>
+                        <button type="button" class="btn btn-outline-danger btn-sm" id="aiChatDraftDiscardBtn">
+                          <i class="fas fa-times mr-1" aria-hidden="true"></i>Descartar
+                        </button>
+                      </div>
+                    </div>
+                  </aside>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/test/java/com/nutriconsultas/ai/AiDraftPreviewServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftPreviewServiceTest.java
@@ -1,0 +1,73 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+class AiDraftPreviewServiceTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	@InjectMocks
+	private AiDraftPreviewServiceImpl service;
+
+	@Mock
+	private AiGeneratedDraftRepository draftRepository;
+
+	@Test
+	void getPreviewReturnsDishDetails() throws Exception {
+		final AiGeneratedDraft draft = dishDraft();
+		when(draftRepository.findByIdAndThreadNutritionistId(10L, NUTRITIONIST_ID)).thenReturn(Optional.of(draft));
+
+		final AiDraftPreviewView preview = service.getPreview(10L, NUTRITIONIST_ID);
+
+		assertThat(preview.draftType()).isEqualTo(AiDraftType.DISH);
+		assertThat(preview.title()).isEqualTo("Tacos de pollo");
+		assertThat(preview.reviewLabel()).isEqualTo(AiDraftSummaryExtractor.REVIEW_LABEL);
+		assertThat(preview.ingredients()).hasSize(1);
+		assertThat(preview.preparationSteps()).containsExactly("Cocinar el pollo");
+		assertThat(preview.assumptions()).containsExactly("Porción estándar");
+		assertThat(preview.warnings()).containsExactly("Revisar sodio");
+		assertThat(preview.portions()).isEqualTo(2);
+		assertThat(preview.nutrients().energiaKcal()).isEqualTo(250);
+	}
+
+	@Test
+	void getPreviewRejectsUnknownDraft() {
+		when(draftRepository.findByIdAndThreadNutritionistId(99L, NUTRITIONIST_ID)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.getPreview(99L, NUTRITIONIST_ID)).isInstanceOf(AiDraftLifecycleException.class)
+			.hasMessageContaining("Borrador no encontrado");
+	}
+
+	private static AiGeneratedDraft dishDraft() throws Exception {
+		final DishDraftPayload payload = new DishDraftPayload("Tacos de pollo", "Receta ligera",
+				List.of("Cocinar el pollo"), "Comida", List.of(new RecipeIngredientInput(1L, "1", null, "pz")), 2,
+				new NutrientSummary(250, 20.0, 8.0, 30.0, 4.0, 300.0, 500.0), List.of("Porción estándar"),
+				List.of("Revisar sodio"), AiDraftSummaryExtractor.REVIEW_LABEL);
+		final AiChatThread thread = new AiChatThread();
+		thread.setId(42L);
+		final AiGeneratedDraft draft = new AiGeneratedDraft();
+		draft.setId(10L);
+		draft.setThread(thread);
+		draft.setDraftType(AiDraftType.DISH);
+		draft.setStatus(AiDraftStatus.DRAFT);
+		draft.setJsonPayload(OBJECT_MAPPER.writeValueAsString(payload));
+		return draft;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiDraftRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftRestControllerTest.java
@@ -34,6 +34,27 @@ class AiDraftRestControllerTest {
 	@Mock
 	private AiDraftLifecycleService draftLifecycleService;
 
+	@Mock
+	private AiDraftPreviewService draftPreviewService;
+
+	@Test
+	void getDraftPreviewReturnsStructuredBody() {
+		final AiDraftPreviewView preview = new AiDraftPreviewView(10L, 5L, AiDraftType.DISH, AiDraftStatus.DRAFT,
+				"Platillo (receta)", AiDraftSummaryExtractor.REVIEW_LABEL, "Tacos", "Resumen", 2, null,
+				new NutrientSummary(250, 20.0, 8.0, 30.0, null, null, null), List.of(), List.of(), List.of("Paso 1"),
+				List.of("Supuesto"), List.of("Advertencia"), null);
+		when(draftPreviewService.getPreview(10L, NUTRITIONIST_ID)).thenReturn(preview);
+
+		final ResponseEntity<Map<String, Object>> response = controller.getDraftPreview(10L, principal());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("success", true)
+			.containsEntry("draftId", 10L)
+			.containsEntry("draftType", "DISH")
+			.containsEntry("reviewLabel", AiDraftSummaryExtractor.REVIEW_LABEL)
+			.containsEntry("title", "Tacos");
+	}
+
 	@Test
 	void acceptDraftReturnsCreatedEntity() {
 		when(draftAcceptanceService.accept(eq(10L), eq(NUTRITIONIST_ID), any()))


### PR DESCRIPTION
## Summary
- Adds `GET /rest/nutritionist/ai/drafts/{draftId}` and `AiDraftPreviewService` to return structured dish/menu/plan preview data for nutritionist review.
- Extends `/admin/ai` with a **Borradores IA** sidebar: draft list, detail preview (portions, nutrients, ingredients, steps, assumptions, warnings), and **Aceptar** / **Descartar** actions via SweetAlert confirmations.
- Includes service/controller tests and Thymeleaf-compatible chat layout/CSS updates.

## Test plan
- [x] `mvn test` — `AiDraftPreviewServiceTest`, `AiDraftRestControllerTest`
- [x] Browser UI on `/admin/ai`: empty state, draft list, preview detail, discard confirmation + success flow
- [ ] CI lint + full test suite

Closes #390


Made with [Cursor](https://cursor.com)