### PR TITLE
Stream AI assistant responses over SSE (#435)

### DIFF
--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#434 — Render markdown in assistant chat responses](https://github.com/diego-torres/nutriconsultas/issues/434) (`in-progress` on `issue-434-ai-chat-markdown`). ~~#390~~ draft preview merged (PR #443).
+**Current next issue:** [#435 — Stream assistant responses (SSE)](https://github.com/diego-torres/nutriconsultas/issues/435) (`in-progress` on `issue-435-ai-chat-streaming`). ~~#434~~ markdown merged (PR #444).
 
 **Registered backlog (2026-07-03):** Epic [#433](https://github.com/diego-torres/nutriconsultas/issues/433) chat UX (#434 markdown, #435 streaming, #436 stop, #437 edit/resubmit). Epic [#438](https://github.com/diego-torres/nutriconsultas/issues/438) prompt security (#439–#441). See registry for suggested order.
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-07-03 — ~~#389~~ ~~#390~~ ~~#442~~ merged. **#434** in progress on `issue-434-ai-chat-markdown`.
+**Last updated:** 2026-07-03 — ~~#390~~ ~~#434~~ merged. **#435** in progress on `issue-435-ai-chat-streaming`.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -166,12 +166,12 @@ Markdown, streaming, and message controls for full-page chat and floating widget
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
 | **433** | Epic — AI Chat UX Enhancements (Phase 6b) | https://github.com/diego-torres/nutriconsultas/issues/433 | **open** | **387**, **390** | Parent for #434–#437 |
-| **434** | Render markdown in assistant chat responses | https://github.com/diego-torres/nutriconsultas/issues/434 | **in-progress** | **433**, **389** | XSS-safe MD in chat + widget |
-| **435** | Stream assistant responses (SSE) | https://github.com/diego-torres/nutriconsultas/issues/435 | **open** | **433**, **385**, **389** | Backend SSE + incremental UI |
+| **434** | Render markdown in assistant chat responses | https://github.com/diego-torres/nutriconsultas/issues/434 | **done** | **433**, **389** | PR #444 |
+| **435** | Stream assistant responses (SSE) | https://github.com/diego-torres/nutriconsultas/issues/435 | **in-progress** | **433**, **385**, **389** | Backend SSE + incremental UI |
 | **436** | Stop and cancel in-flight AI generation | https://github.com/diego-torres/nutriconsultas/issues/436 | **open** | **433**, **389** | `AbortController`; after #435 |
 | **437** | Edit user message and resubmit | https://github.com/diego-torres/nutriconsultas/issues/437 | **open** | **433**, **384**, **389** | Thread truncate + SweetAlert |
 
-**Suggested order:** #434 ∥ #435 → #436 → #437. Epic **#387** closes when #390 and #433 children are done (or defer controls post-M3 beta).
+**Suggested order:** #434 ∥ **#435** (in progress) → #436 → #437. Epic **#387** closes when #433 children are done (or defer controls post-M3 beta).
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
@@ -136,7 +136,7 @@ public class AiChatRestController {
 		}
 		catch (final RuntimeException ex) {
 			if (log.isWarnEnabled()) {
-				log.warn("AI chat stream failed unexpectedly");
+				log.warn("AI chat stream failed unexpectedly", ex);
 			}
 			completeStreamError(emitter, "No se pudo completar la solicitud.");
 		}

--- a/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.NonNull;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import lombok.extern.slf4j.Slf4j;
@@ -104,6 +106,52 @@ public class AiChatRestController {
 			return errorResponse(HttpStatus.TOO_MANY_REQUESTS, AiToolErrorCode.RATE_LIMIT,
 					AiChatRateLimiter.RATE_LIMIT_USER_MESSAGE);
 		}
+	}
+
+	@PostMapping(value = "/message/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public SseEmitter streamMessage(@RequestBody final AiSendMessageRequest request,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final SseEmitter emitter = new SseEmitter(300_000L);
+		emitter.onTimeout(emitter::complete);
+		final String nutritionistId = nutritionistId(principal);
+		if (nutritionistId == null) {
+			completeStreamError(emitter, "Sesión no válida.");
+			return emitter;
+		}
+		if (request == null) {
+			completeStreamError(emitter, "Solicitud no válida.");
+			return emitter;
+		}
+		try {
+			aiChatRateLimiter.executeMessage(nutritionistId, () -> {
+				chatService.streamMessage(nutritionistId, request, emitter);
+				return null;
+			});
+		}
+		catch (final RequestNotPermitted ex) {
+			if (log.isDebugEnabled()) {
+				log.debug("AI chat stream rate limit exceeded");
+			}
+			completeStreamError(emitter, AiChatRateLimiter.RATE_LIMIT_USER_MESSAGE);
+		}
+		catch (final RuntimeException ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("AI chat stream failed unexpectedly");
+			}
+			completeStreamError(emitter, "No se pudo completar la solicitud.");
+		}
+		return emitter;
+	}
+
+	private static void completeStreamError(final SseEmitter emitter, final String message) {
+		try {
+			AiChatSseSupport.sendError(emitter, message);
+		}
+		catch (Exception ex) {
+			emitter.completeWithError(ex);
+			return;
+		}
+		AiChatSseSupport.completeQuietly(emitter);
 	}
 
 	@GetMapping("/{threadId}")

--- a/src/main/java/com/nutriconsultas/ai/AiChatService.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatService.java
@@ -1,6 +1,7 @@
 package com.nutriconsultas.ai;
 
 import org.springframework.lang.Nullable;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 /**
  * Nutritionist-scoped AI chat thread operations (#384).
@@ -16,5 +17,7 @@ public interface AiChatService {
 
 	AiOrchestrationResult sendMessage(String nutritionistId, long threadId, String message,
 			AiChatPromptContext promptContext);
+
+	void streamMessage(String nutritionistId, AiSendMessageRequest request, SseEmitter emitter);
 
 }

--- a/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -39,13 +40,15 @@ public class AiChatServiceImpl implements AiChatService {
 
 	private final PacienteRepository pacienteRepository;
 
+	private final TransactionTemplate transactionTemplate;
+
 	public AiChatServiceImpl(final AiChatThreadRepository threadRepository,
 			final AiChatMessageRepository messageRepository, final AiGeneratedDraftRepository draftRepository,
 			final AiOrchestrationService orchestrationService,
 			final AiPatientPromptContextResolver patientContextResolver,
 			final AiDietaPromptContextResolver dietaContextResolver,
 			final AiPlatilloPromptContextResolver platilloContextResolver,
-			final PacienteRepository pacienteRepository) {
+			final PacienteRepository pacienteRepository, final TransactionTemplate transactionTemplate) {
 		this.threadRepository = threadRepository;
 		this.messageRepository = messageRepository;
 		this.draftRepository = draftRepository;
@@ -54,6 +57,7 @@ public class AiChatServiceImpl implements AiChatService {
 		this.dietaContextResolver = dietaContextResolver;
 		this.platilloContextResolver = platilloContextResolver;
 		this.pacienteRepository = pacienteRepository;
+		this.transactionTemplate = transactionTemplate;
 	}
 
 	@Override
@@ -126,8 +130,11 @@ public class AiChatServiceImpl implements AiChatService {
 		try {
 			final AiChatPromptContext promptContext = new AiChatPromptContext(request.patientId(), request.dietaId(),
 					request.platilloId());
-			final AiChatThread thread = loadOwnedThread(request.threadId(), nutritionistId);
-			final AiChatPromptContext mergedContext = mergePromptContext(promptContext, patientId(thread));
+			final Long threadPatientId = transactionTemplate.execute(status -> {
+				final AiChatThread ownedThread = loadOwnedThread(request.threadId(), nutritionistId);
+				return patientId(ownedThread);
+			});
+			final AiChatPromptContext mergedContext = mergePromptContext(promptContext, threadPatientId);
 			final AiOrchestrationContext context = buildOrchestrationContext(nutritionistId, request.threadId(),
 					mergedContext);
 			orchestrationService.processUserMessageStreaming(context, request.message().trim(),

--- a/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
@@ -112,6 +113,84 @@ public class AiChatServiceImpl implements AiChatService {
 		final AiChatPromptContext mergedContext = mergePromptContext(promptContext, patientId(thread));
 		final AiOrchestrationContext context = buildOrchestrationContext(nutritionistId, threadId, mergedContext);
 		return orchestrationService.processUserMessage(context, message.trim());
+	}
+
+	@Override
+	public void streamMessage(@NonNull final String nutritionistId, final AiSendMessageRequest request,
+			final SseEmitter emitter) {
+		assertNutritionistId(nutritionistId);
+		if (request == null || !StringUtils.hasText(request.message())) {
+			completeStreamWithError(emitter, "El mensaje no puede estar vacío.");
+			return;
+		}
+		try {
+			final AiChatPromptContext promptContext = new AiChatPromptContext(request.patientId(), request.dietaId(),
+					request.platilloId());
+			final AiChatThread thread = loadOwnedThread(request.threadId(), nutritionistId);
+			final AiChatPromptContext mergedContext = mergePromptContext(promptContext, patientId(thread));
+			final AiOrchestrationContext context = buildOrchestrationContext(nutritionistId, request.threadId(),
+					mergedContext);
+			orchestrationService.processUserMessageStreaming(context, request.message().trim(),
+					streamConsumerFor(emitter));
+			AiChatSseSupport.completeQuietly(emitter);
+		}
+		catch (final AiChatException | AiOrchestrationException ex) {
+			completeStreamWithError(emitter, ex.getMessage());
+		}
+		catch (final OpenAiClientException ex) {
+			completeStreamWithError(emitter, ex.getUserMessage());
+		}
+		catch (final AiStreamDeliveryException ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("AI chat stream delivery failed threadId={}", request.threadId());
+			}
+			AiChatSseSupport.completeQuietly(emitter);
+		}
+	}
+
+	private AiStreamEventConsumer streamConsumerFor(final SseEmitter emitter) {
+		return new AiStreamEventConsumer() {
+			@Override
+			public void onStatus(final String phase, final String message) {
+				try {
+					AiChatSseSupport.sendStatus(emitter, phase, message);
+				}
+				catch (Exception ex) {
+					throw new AiStreamDeliveryException("Stream status failed", ex);
+				}
+			}
+
+			@Override
+			public void onDelta(final String contentDelta) {
+				try {
+					AiChatSseSupport.sendDelta(emitter, contentDelta);
+				}
+				catch (Exception ex) {
+					throw new AiStreamDeliveryException("Stream delta failed", ex);
+				}
+			}
+
+			@Override
+			public void onComplete(final AiOrchestrationResult result) {
+				try {
+					AiChatSseSupport.sendDone(emitter, result);
+				}
+				catch (Exception ex) {
+					throw new AiStreamDeliveryException("Stream done failed", ex);
+				}
+			}
+		};
+	}
+
+	private static void completeStreamWithError(final SseEmitter emitter, final String message) {
+		try {
+			AiChatSseSupport.sendError(emitter, message);
+		}
+		catch (Exception ex) {
+			emitter.completeWithError(ex);
+			return;
+		}
+		AiChatSseSupport.completeQuietly(emitter);
 	}
 
 	private AiOrchestrationContext buildOrchestrationContext(final String nutritionistId, final long threadId,

--- a/src/main/java/com/nutriconsultas/ai/AiChatSseSupport.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatSseSupport.java
@@ -1,0 +1,69 @@
+package com.nutriconsultas.ai;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * Helpers for AI chat Server-Sent Events (#435).
+ */
+public final class AiChatSseSupport {
+
+	private AiChatSseSupport() {
+	}
+
+	public static void sendStatus(final SseEmitter emitter, final String phase, final String message)
+			throws IOException {
+		final Map<String, Object> payload = new LinkedHashMap<>();
+		payload.put("phase", phase);
+		if (message != null) {
+			payload.put("message", message);
+		}
+		emitter.send(SseEmitter.event().name("status").data(AiToolJsonSerializer.toJson(payload)));
+	}
+
+	public static void sendDelta(final SseEmitter emitter, final String content) throws IOException {
+		final Map<String, Object> payload = Map.of("content", content);
+		emitter.send(SseEmitter.event().name("delta").data(AiToolJsonSerializer.toJson(payload)));
+	}
+
+	public static void sendDone(final SseEmitter emitter, final AiOrchestrationResult result) throws IOException {
+		final Map<String, Object> payload = new LinkedHashMap<>();
+		payload.put("success", true);
+		payload.put("threadId", result.threadId());
+		payload.put("assistantMessageId", result.assistantMessage().getId());
+		payload.put("content", result.assistantMessage().getContent());
+		payload.put("toolCallsExecuted", result.toolCallsExecuted());
+		if (result.tokenUsage() != null) {
+			payload.put("tokenUsage", tokenUsageMap(result.tokenUsage()));
+		}
+		emitter.send(SseEmitter.event().name("done").data(AiToolJsonSerializer.toJson(payload)));
+	}
+
+	public static void sendError(final SseEmitter emitter, final String message) throws IOException {
+		final Map<String, Object> payload = new LinkedHashMap<>();
+		payload.put("success", false);
+		payload.put("message", message);
+		emitter.send(SseEmitter.event().name("error").data(AiToolJsonSerializer.toJson(payload)));
+	}
+
+	public static void completeQuietly(final SseEmitter emitter) {
+		try {
+			emitter.complete();
+		}
+		catch (Exception ex) {
+			emitter.completeWithError(ex);
+		}
+	}
+
+	private static Map<String, Object> tokenUsageMap(final OpenAiTokenUsage usage) {
+		final Map<String, Object> map = new LinkedHashMap<>();
+		map.put("promptTokens", usage.promptTokens());
+		map.put("completionTokens", usage.completionTokens());
+		map.put("totalTokens", usage.totalTokens());
+		return map;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationService.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationService.java
@@ -14,4 +14,11 @@ public interface AiOrchestrationService {
 	 */
 	AiOrchestrationResult processUserMessage(AiOrchestrationContext context, String userMessage);
 
+	/**
+	 * Processes one user turn and emits assistant text incrementally after the tool loop
+	 * completes (#435).
+	 */
+	void processUserMessageStreaming(AiOrchestrationContext context, String userMessage,
+			AiStreamEventConsumer streamConsumer);
+
 }

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationService.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationService.java
@@ -3,7 +3,6 @@ package com.nutriconsultas.ai;
 /**
  * OpenAI chat orchestration for nutritionist AI assistant (#385).
  */
-@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface AiOrchestrationService {
 
 	/**

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationServiceImpl.java
@@ -87,7 +87,13 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 			throw new AiOrchestrationException("No se pudo guardar el mensaje.");
 		}
 
-		final List<OpenAiChatMessage> conversation = buildConversation(context, thread);
+		final List<OpenAiChatMessage> conversation = transactionTemplate.execute(status -> {
+			final AiChatThread loadedThread = loadThread(context);
+			return buildConversation(context, loadedThread);
+		});
+		if (conversation == null) {
+			throw new AiOrchestrationException("No se pudo cargar el historial de la conversación.");
+		}
 		streamConsumer.onStatus("thinking", "El asistente está pensando…");
 		final ToolLoopOutcome loopOutcome = runToolLoop(context, conversation, streamConsumer);
 		emitContentDeltas(loopOutcome.assistantContent(), streamConsumer);

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.Locale;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.StringUtils;
 
 import lombok.extern.slf4j.Slf4j;
@@ -33,10 +34,14 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 
 	private final AiOrchestrationToolDispatcher toolDispatcher;
 
+	private final TransactionTemplate transactionTemplate;
+
+	private static final int STREAM_CHUNK_SIZE = 32;
+
 	public AiOrchestrationServiceImpl(final AiProperties properties, final OpenAiClientService openAiClientService,
 			final AiSystemPromptService systemPromptService, final AiChatThreadRepository threadRepository,
 			final AiChatMessageRepository messageRepository, final AiOpenAiToolCatalog toolCatalog,
-			final AiOrchestrationToolDispatcher toolDispatcher) {
+			final AiOrchestrationToolDispatcher toolDispatcher, final TransactionTemplate transactionTemplate) {
 		this.properties = properties;
 		this.openAiClientService = openAiClientService;
 		this.systemPromptService = systemPromptService;
@@ -44,6 +49,7 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 		this.messageRepository = messageRepository;
 		this.toolCatalog = toolCatalog;
 		this.toolDispatcher = toolDispatcher;
+		this.transactionTemplate = transactionTemplate;
 	}
 
 	@Override
@@ -55,7 +61,7 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 		persistUserMessage(thread, userMessage.trim());
 
 		final List<OpenAiChatMessage> conversation = buildConversation(context, thread);
-		final ToolLoopOutcome loopOutcome = runToolLoop(context, conversation);
+		final ToolLoopOutcome loopOutcome = runToolLoop(context, conversation, null);
 		final AiChatMessage assistantMessage = persistAssistantMessage(thread, loopOutcome.assistantContent());
 		persistToolAuditMessages(thread, loopOutcome.toolAuditEntries());
 		touchThread(thread);
@@ -65,6 +71,52 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 		}
 		return new AiOrchestrationResult(thread.getId(), assistantMessage, loopOutcome.toolCallsExecuted(),
 				loopOutcome.tokenUsage());
+	}
+
+	@Override
+	public void processUserMessageStreaming(final AiOrchestrationContext context, final String userMessage,
+			final AiStreamEventConsumer streamConsumer) {
+		assertOperational();
+		validateUserMessage(userMessage);
+		final AiChatThread thread = transactionTemplate.execute(status -> {
+			final AiChatThread loaded = loadThread(context);
+			persistUserMessage(loaded, userMessage.trim());
+			return loaded;
+		});
+		if (thread == null) {
+			throw new AiOrchestrationException("No se pudo guardar el mensaje.");
+		}
+
+		final List<OpenAiChatMessage> conversation = buildConversation(context, thread);
+		streamConsumer.onStatus("thinking", "El asistente está pensando…");
+		final ToolLoopOutcome loopOutcome = runToolLoop(context, conversation, streamConsumer);
+		emitContentDeltas(loopOutcome.assistantContent(), streamConsumer);
+
+		final AiOrchestrationResult result = transactionTemplate.execute(status -> {
+			final AiChatMessage assistantMessage = persistAssistantMessage(thread, loopOutcome.assistantContent());
+			persistToolAuditMessages(thread, loopOutcome.toolAuditEntries());
+			touchThread(thread);
+			if (log.isInfoEnabled()) {
+				log.info("AI streaming orchestration threadId={} toolCalls={}", thread.getId(),
+						loopOutcome.toolCallsExecuted());
+			}
+			return new AiOrchestrationResult(thread.getId(), assistantMessage, loopOutcome.toolCallsExecuted(),
+					loopOutcome.tokenUsage());
+		});
+		if (result == null) {
+			throw new AiOrchestrationException("No se pudo guardar la respuesta del asistente.");
+		}
+		streamConsumer.onComplete(result);
+	}
+
+	private void emitContentDeltas(final String content, final AiStreamEventConsumer streamConsumer) {
+		if (!StringUtils.hasText(content)) {
+			return;
+		}
+		for (int index = 0; index < content.length(); index += STREAM_CHUNK_SIZE) {
+			final int end = Math.min(index + STREAM_CHUNK_SIZE, content.length());
+			streamConsumer.onDelta(content.substring(index, end));
+		}
 	}
 
 	private void assertOperational() {
@@ -122,7 +174,7 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 	}
 
 	private ToolLoopOutcome runToolLoop(final AiOrchestrationContext context,
-			final List<OpenAiChatMessage> conversation) {
+			final List<OpenAiChatMessage> conversation, final AiStreamEventConsumer streamConsumer) {
 		int toolCallsExecuted = 0;
 		OpenAiTokenUsage accumulatedUsage = null;
 		final List<ToolAuditEntry> toolAuditEntries = new ArrayList<>();
@@ -136,6 +188,9 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 
 			if (!response.hasToolCalls()) {
 				break;
+			}
+			if (streamConsumer != null) {
+				streamConsumer.onStatus("tools", "Consultando catálogo nutricional…");
 			}
 			if (toolCallsExecuted >= properties.getMaxToolCalls()) {
 				assistantContent = TOOL_LIMIT_MESSAGE;

--- a/src/main/java/com/nutriconsultas/ai/AiStreamDeliveryException.java
+++ b/src/main/java/com/nutriconsultas/ai/AiStreamDeliveryException.java
@@ -5,6 +5,8 @@ package com.nutriconsultas.ai;
  */
 public class AiStreamDeliveryException extends RuntimeException {
 
+	private static final long serialVersionUID = 1L;
+
 	public AiStreamDeliveryException(final String message, final Throwable cause) {
 		super(message, cause);
 	}

--- a/src/main/java/com/nutriconsultas/ai/AiStreamDeliveryException.java
+++ b/src/main/java/com/nutriconsultas/ai/AiStreamDeliveryException.java
@@ -1,0 +1,12 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Signals a failure while delivering AI chat SSE events (#435).
+ */
+public class AiStreamDeliveryException extends RuntimeException {
+
+	public AiStreamDeliveryException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiStreamEventConsumer.java
+++ b/src/main/java/com/nutriconsultas/ai/AiStreamEventConsumer.java
@@ -1,0 +1,16 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Callbacks for streaming AI orchestration events to nutritionist clients (#435).
+ */
+public interface AiStreamEventConsumer {
+
+	void onStatus(String phase, @Nullable String message);
+
+	void onDelta(String contentDelta);
+
+	void onComplete(AiOrchestrationResult result);
+
+}

--- a/src/main/resources/static/sbadmin/js/ai-assistant-widget.js
+++ b/src/main/resources/static/sbadmin/js/ai-assistant-widget.js
@@ -259,25 +259,64 @@
 
     var payload = promptContextPayload();
     payload.message = trimmed;
+    var assistantIndex = null;
+
+    function appendAssistantDelta(content) {
+      state.showLoading = false;
+      if (assistantIndex === null) {
+        state.messages.push({
+          role: 'ASSISTANT',
+          content: content,
+          createdAt: new Date().toISOString()
+        });
+        assistantIndex = state.messages.length - 1;
+      } else {
+        state.messages[assistantIndex].content += content;
+      }
+      renderMessages();
+    }
+
+    function finalizeAssistant(data) {
+      state.showLoading = false;
+      if (data && data.content != null) {
+        if (assistantIndex === null) {
+          state.messages.push({
+            role: 'ASSISTANT',
+            content: data.content,
+            createdAt: new Date().toISOString()
+          });
+        } else {
+          state.messages[assistantIndex].content = data.content;
+        }
+      }
+      if (data && data.threadId) {
+        persistThreadId(data.threadId);
+      }
+      renderMessages();
+    }
 
     ensureThread()
       .then(function (threadId) {
         payload.threadId = threadId;
+        if (window.NutriAiChatStream && typeof NutriAiChatStream.streamMessage === 'function') {
+          return NutriAiChatStream.streamMessage(API_BASE + '/message/stream', payload, {
+            onStatus: function () {
+              renderMessages();
+            },
+            onDelta: appendAssistantDelta,
+            onDone: finalizeAssistant,
+            onError: function (message) {
+              throw new Error(message);
+            }
+          });
+        }
         return requestJson(API_BASE + '/message', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
+        }).then(function (data) {
+          finalizeAssistant(data);
         });
-      })
-      .then(function (data) {
-        state.showLoading = false;
-        persistThreadId(data.threadId);
-        state.messages.push({
-          role: 'ASSISTANT',
-          content: data.content,
-          createdAt: new Date().toISOString()
-        });
-        renderMessages();
       })
       .catch(function (error) {
         state.showLoading = false;

--- a/src/main/resources/static/sbadmin/js/ai-chat-stream.js
+++ b/src/main/resources/static/sbadmin/js/ai-chat-stream.js
@@ -1,0 +1,104 @@
+/* AI chat SSE streaming client (#435) */
+
+(function (global) {
+  'use strict';
+
+  function parseEventBlock(block) {
+    var lines = block.split('\n');
+    var eventName = 'message';
+    var dataLines = [];
+    lines.forEach(function (line) {
+      if (line.indexOf('event:') === 0) {
+        eventName = line.slice(6).trim();
+      } else if (line.indexOf('data:') === 0) {
+        dataLines.push(line.slice(5).trim());
+      }
+    });
+    if (dataLines.length === 0) {
+      return null;
+    }
+    var raw = dataLines.join('\n');
+    try {
+      return { event: eventName, data: JSON.parse(raw) };
+    } catch (e) {
+      return { event: eventName, data: { raw: raw } };
+    }
+  }
+
+  function dispatchEvent(parsed, handlers) {
+    if (!parsed) {
+      return;
+    }
+    if (parsed.event === 'status' && handlers.onStatus) {
+      handlers.onStatus(parsed.data);
+      return;
+    }
+    if (parsed.event === 'delta' && handlers.onDelta && parsed.data && parsed.data.content) {
+      handlers.onDelta(parsed.data.content);
+      return;
+    }
+    if (parsed.event === 'done' && handlers.onDone) {
+      handlers.onDone(parsed.data);
+      return;
+    }
+    if (parsed.event === 'error' && handlers.onError) {
+      var message = parsed.data && parsed.data.message ? parsed.data.message : 'No se pudo completar la solicitud.';
+      handlers.onError(message);
+    }
+  }
+
+  function streamMessage(url, payload, handlers) {
+    return fetch(url, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream'
+      },
+      body: JSON.stringify(payload)
+    }).then(function (response) {
+      var contentType = response.headers.get('content-type') || '';
+      if (!response.ok) {
+        if (contentType.indexOf('application/json') >= 0) {
+          return response.json().then(function (data) {
+            throw new Error(data.message || 'No se pudo completar la solicitud.');
+          });
+        }
+        throw new Error('No se pudo completar la solicitud.');
+      }
+      if (!response.body || !response.body.getReader) {
+        throw new Error('Streaming no disponible en este navegador.');
+      }
+
+      var reader = response.body.getReader();
+      var decoder = new TextDecoder('utf-8');
+      var buffer = '';
+
+      function readNext() {
+        return reader.read().then(function (result) {
+          if (result.done) {
+            if (buffer.trim()) {
+              buffer.split(/\n\n/).forEach(function (block) {
+                dispatchEvent(parseEventBlock(block.trim()), handlers);
+              });
+            }
+            return null;
+          }
+          buffer += decoder.decode(result.value, { stream: true });
+          var parts = buffer.split(/\n\n/);
+          buffer = parts.pop() || '';
+          parts.forEach(function (block) {
+            dispatchEvent(parseEventBlock(block.trim()), handlers);
+          });
+          return readNext();
+        });
+      }
+
+      return readNext();
+    });
+  }
+
+  global.NutriAiChatStream = {
+    streamMessage: streamMessage
+  };
+})(typeof window !== 'undefined' ? window : this);

--- a/src/main/resources/static/sbadmin/js/ai-chat.js
+++ b/src/main/resources/static/sbadmin/js/ai-chat.js
@@ -543,24 +543,67 @@
     state.showLoading = true;
     setBusy(true);
 
+    var assistantIndex = null;
+
+    function appendAssistantDelta(content) {
+      state.showLoading = false;
+      if (assistantIndex === null) {
+        state.messages.push({
+          role: 'ASSISTANT',
+          content: content,
+          createdAt: new Date().toISOString()
+        });
+        assistantIndex = state.messages.length - 1;
+      } else {
+        state.messages[assistantIndex].content += content;
+      }
+      renderMessages(false);
+    }
+
+    function finalizeAssistant(data) {
+      state.showLoading = false;
+      if (data && data.content != null) {
+        if (assistantIndex === null) {
+          state.messages.push({
+            role: 'ASSISTANT',
+            content: data.content,
+            createdAt: new Date().toISOString()
+          });
+        } else {
+          state.messages[assistantIndex].content = data.content;
+        }
+      }
+      if (data && data.threadId) {
+        persistThreadId(data.threadId);
+        loadDrafts(data.threadId);
+      }
+      renderMessages(false);
+    }
+
     ensureThread()
       .then(function (threadId) {
+        if (window.NutriAiChatStream && typeof NutriAiChatStream.streamMessage === 'function') {
+          return NutriAiChatStream.streamMessage(API_BASE + '/message/stream', {
+            threadId: threadId,
+            message: trimmed
+          }, {
+            onStatus: function () {
+              renderMessages(true);
+            },
+            onDelta: appendAssistantDelta,
+            onDone: finalizeAssistant,
+            onError: function (message) {
+              throw new Error(message);
+            }
+          });
+        }
         return requestJson(API_BASE + '/message', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ threadId: threadId, message: trimmed })
+        }).then(function (data) {
+          finalizeAssistant(data);
         });
-      })
-      .then(function (data) {
-        state.showLoading = false;
-        persistThreadId(data.threadId);
-        state.messages.push({
-          role: 'ASSISTANT',
-          content: data.content,
-          createdAt: new Date().toISOString()
-        });
-        renderMessages(false);
-        loadDrafts(data.threadId);
       })
       .catch(function (error) {
         state.showLoading = false;

--- a/src/main/resources/templates/sbadmin/ai/chat.html
+++ b/src/main/resources/templates/sbadmin/ai/chat.html
@@ -133,6 +133,7 @@
   <script th:src="@{/sbadmin/vendor/marked/marked.min.js}"></script>
   <script th:src="@{/sbadmin/vendor/dompurify/purify.min.js}"></script>
   <script th:src="@{/sbadmin/js/ai-markdown.js}"></script>
+  <script th:src="@{/sbadmin/js/ai-chat-stream.js}"></script>
   <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
   <script th:src="@{/sbadmin/js/ai-chat.js}"></script>
 

--- a/src/main/resources/templates/sbadmin/fragments/ai-assistant-widget.html
+++ b/src/main/resources/templates/sbadmin/fragments/ai-assistant-widget.html
@@ -51,5 +51,6 @@
   <script th:src="@{/sbadmin/vendor/marked/marked.min.js}"></script>
   <script th:src="@{/sbadmin/vendor/dompurify/purify.min.js}"></script>
   <script th:src="@{/sbadmin/js/ai-markdown.js}"></script>
+  <script th:src="@{/sbadmin/js/ai-chat-stream.js}"></script>
   <script th:src="@{/sbadmin/js/ai-assistant-widget.js}" defer></script>
 </div>

--- a/src/test/java/com/nutriconsultas/ai/AiChatRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatRestControllerTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
@@ -146,6 +147,20 @@ class AiChatRestControllerTest {
 		assertThat(response.getBody()).containsEntry("success", false)
 			.containsEntry("errorCode", AiToolErrorCode.RATE_LIMIT.name())
 			.containsEntry("message", AiChatRateLimiter.RATE_LIMIT_USER_MESSAGE);
+	}
+
+	@Test
+	void streamMessageReturnsSseEmitter() throws Exception {
+		when(aiChatRateLimiter.executeMessage(eq(NUTRITIONIST_ID), any())).thenAnswer(invocation -> {
+			final Callable<?> callable = invocation.getArgument(1);
+			return callable.call();
+		});
+
+		final SseEmitter emitter = controller.streamMessage(new AiSendMessageRequest(5L, "Hola"),
+				principal(NUTRITIONIST_ID));
+
+		assertThat(emitter).isNotNull();
+		verify(chatService).streamMessage(eq(NUTRITIONIST_ID), any(AiSendMessageRequest.class), any(SseEmitter.class));
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/AiChatServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
@@ -55,6 +56,9 @@ class AiChatServiceTest {
 
 	@Mock
 	private PacienteRepository pacienteRepository;
+
+	@Mock
+	private TransactionTemplate transactionTemplate;
 
 	@Test
 	void startThreadPersistsOwnedPatient() {

--- a/src/test/java/com/nutriconsultas/ai/AiMarkdownStaticAssetsTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiMarkdownStaticAssetsTest.java
@@ -15,6 +15,7 @@ class AiMarkdownStaticAssetsTest {
 		assertThat(new ClassPathResource("static/sbadmin/vendor/marked/marked.min.js").exists()).isTrue();
 		assertThat(new ClassPathResource("static/sbadmin/vendor/dompurify/purify.min.js").exists()).isTrue();
 		assertThat(new ClassPathResource("static/sbadmin/js/ai-markdown.js").exists()).isTrue();
+		assertThat(new ClassPathResource("static/sbadmin/js/ai-chat-stream.js").exists()).isTrue();
 		assertThat(new ClassPathResource("static/sbadmin/css/ai-markdown.css").exists()).isTrue();
 	}
 

--- a/src/test/java/com/nutriconsultas/ai/AiOrchestrationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiOrchestrationServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -18,6 +19,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @ExtendWith(MockitoExtension.class)
 class AiOrchestrationServiceTest {
@@ -50,6 +53,9 @@ class AiOrchestrationServiceTest {
 	@Mock
 	private AiOrchestrationToolDispatcher toolDispatcher;
 
+	@Mock
+	private TransactionTemplate transactionTemplate;
+
 	private AiChatThread thread;
 
 	@BeforeEach
@@ -57,6 +63,11 @@ class AiOrchestrationServiceTest {
 		thread = new AiChatThread();
 		thread.setId(THREAD_ID);
 		thread.setNutritionistId(NUTRITIONIST_ID);
+		lenient().when(transactionTemplate.execute(org.mockito.ArgumentMatchers.<TransactionCallback<Object>>any()))
+			.thenAnswer(invocation -> {
+				final TransactionCallback<?> callback = invocation.getArgument(0);
+				return callback.doInTransaction(null);
+			});
 	}
 
 	private void stubAiEnabled() {
@@ -190,6 +201,40 @@ class AiOrchestrationServiceTest {
 		assertThat(messages).anyMatch(message -> "Mensaje anterior".equals(message.content()));
 		assertThat(messages).anyMatch(message -> "Respuesta anterior".equals(message.content()));
 		assertThat(messages).anyMatch(message -> "Siguiente pregunta".equals(message.content()));
+	}
+
+	@Test
+	void processUserMessageStreamingEmitsDeltasAndCompletes() {
+		stubOperational();
+		when(threadRepository.findByIdAndNutritionistId(THREAD_ID, NUTRITIONIST_ID)).thenReturn(Optional.of(thread));
+		when(messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(THREAD_ID))
+			.thenReturn(List.of(message(AiChatMessageRole.USER, "Hola")));
+		when(openAiClientService.chatCompletion(any())).thenReturn(new OpenAiChatCompletionResponse("id-1", "assistant",
+				"Respuesta en streaming para prueba.", List.of(), "stop", null));
+
+		final StringBuilder deltas = new StringBuilder();
+		final AiOrchestrationResult[] completed = new AiOrchestrationResult[1];
+		service.processUserMessageStreaming(context(), "Hola", new AiStreamEventConsumer() {
+			@Override
+			public void onStatus(final String phase, final String message) {
+				/* no-op for test */
+			}
+
+			@Override
+			public void onDelta(final String contentDelta) {
+				deltas.append(contentDelta);
+			}
+
+			@Override
+			public void onComplete(final AiOrchestrationResult result) {
+				completed[0] = result;
+			}
+		});
+
+		assertThat(deltas.toString()).isEqualTo("Respuesta en streaming para prueba.");
+		assertThat(completed[0]).isNotNull();
+		assertThat(completed[0].assistantMessage().getContent()).isEqualTo("Respuesta en streaming para prueba.");
+		verify(messageRepository, times(2)).save(any(AiChatMessage.class));
 	}
 
 	private static AiOrchestrationContext context() {


### PR DESCRIPTION
## Summary
- Add `POST /rest/nutritionist/ai/chat/message/stream` (SSE) with `status`, `delta`, `done`, and `error` events; tool loop runs non-streaming first, then chunks and streams the final assistant text (#385)
- Wire full-page chat and floating widget to `NutriAiChatStream` for incremental rendering; non-streaming `/message` remains as fallback
- Fix PostgreSQL `@Lob` history reads during streaming by loading thread ownership and conversation history inside `TransactionTemplate`

Closes #435

## Test plan
- [x] `mvn test -Dtest=AiOrchestrationServiceTest,AiChatServiceTest,AiChatRestControllerTest`
- [x] Browser: `/admin/ai` — send message, verify loading → streamed bubble → markdown (`**negrita**`, lists)
- [x] Browser: floating widget on `/admin/dietas` — send message, verify streaming + markdown
- [ ] CI green


Made with [Cursor](https://cursor.com)