### PR TITLE
Stop and cancel in-flight AI generation (#436)

### DIFF
--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#435 — Stream assistant responses (SSE)](https://github.com/diego-torres/nutriconsultas/issues/435) (`in-progress` on `issue-435-ai-chat-streaming`). ~~#434~~ markdown merged (PR #444).
+**Current next issue:** [#436 — Stop and cancel in-flight AI generation](https://github.com/diego-torres/nutriconsultas/issues/436) (`in-progress` on `issue-436-ai-chat-cancel`). ~~#435~~ SSE merged (PR #445).
 
 **Registered backlog (2026-07-03):** Epic [#433](https://github.com/diego-torres/nutriconsultas/issues/433) chat UX (#434 markdown, #435 streaming, #436 stop, #437 edit/resubmit). Epic [#438](https://github.com/diego-torres/nutriconsultas/issues/438) prompt security (#439–#441). See registry for suggested order.
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -6,14 +6,14 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 
 | File | Purpose |
 |------|---------|
-| [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md) | `[AI Assistant]` issues #360–#442, states, dependencies |
+| [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md) | `[AI Assistant]` issues #360–#450, states, dependencies |
 | [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md) | Architecture, security, tools, milestones |
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
 **Current next issue:** [#436 — Stop and cancel in-flight AI generation](https://github.com/diego-torres/nutriconsultas/issues/436) (`in-progress` on `issue-436-ai-chat-cancel`). ~~#435~~ SSE merged (PR #445).
 
-**Registered backlog (2026-07-03):** Epic [#433](https://github.com/diego-torres/nutriconsultas/issues/433) chat UX (#434 markdown, #435 streaming, #436 stop, #437 edit/resubmit). Epic [#438](https://github.com/diego-torres/nutriconsultas/issues/438) prompt security (#439–#441). See registry for suggested order.
+**Registered backlog (2026-07-04):** Epic [#433](https://github.com/diego-torres/nutriconsultas/issues/433) chat UX (#434–#437). Epic [#438](https://github.com/diego-torres/nutriconsultas/issues/438) prompt security (#439–#441, **#447–#450** bulk scope guards). See registry for suggested order.
 
 ---
 
@@ -26,7 +26,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | **B — Display** | **#434** | Markdown rendering (chat + widget) |
 | **B — Streaming** | **#435** → **#436** | SSE tokens, then cancel/stop |
 | **C — Controls** | **#437** | Edit message and resubmit |
-| **D — Security** | **#439** → **#440** → **#441** | Injection, jailbreak, defense-in-depth |
+| **D — Security** | **#439** → **#440** → **#447** → **#449** → **#448** → **#450** → **#441** | Injection, bulk scope guards, defense-in-depth |
 | **E — Release** | **#409**, **#408**, **#397–#399** | Plan gate, checklist, observability |
 
 Wave **B** may run **#434** in parallel with **#435**. Wave **D** should complete before production `AI_ENABLED=true` (with #408).

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-07-03 — ~~#390~~ ~~#434~~ merged. **#435** in progress on `issue-435-ai-chat-streaming`.
+**Last updated:** 2026-07-04 — ~~#435~~ merged. **#436** in progress on `issue-436-ai-chat-cancel`.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -167,11 +167,11 @@ Markdown, streaming, and message controls for full-page chat and floating widget
 |---|-------|-----|-------|------------|-------|
 | **433** | Epic — AI Chat UX Enhancements (Phase 6b) | https://github.com/diego-torres/nutriconsultas/issues/433 | **open** | **387**, **390** | Parent for #434–#437 |
 | **434** | Render markdown in assistant chat responses | https://github.com/diego-torres/nutriconsultas/issues/434 | **done** | **433**, **389** | PR #444 |
-| **435** | Stream assistant responses (SSE) | https://github.com/diego-torres/nutriconsultas/issues/435 | **in-progress** | **433**, **385**, **389** | Backend SSE + incremental UI |
-| **436** | Stop and cancel in-flight AI generation | https://github.com/diego-torres/nutriconsultas/issues/436 | **open** | **433**, **389** | `AbortController`; after #435 |
+| **435** | Stream assistant responses (SSE) | https://github.com/diego-torres/nutriconsultas/issues/435 | **done** | **433**, **385**, **389** | PR #445 |
+| **436** | Stop and cancel in-flight AI generation | https://github.com/diego-torres/nutriconsultas/issues/436 | **in-progress** | **433**, **389** | AbortController + SSE cancel; after #435 |
 | **437** | Edit user message and resubmit | https://github.com/diego-torres/nutriconsultas/issues/437 | **open** | **433**, **384**, **389** | Thread truncate + SweetAlert |
 
-**Suggested order:** #434 ∥ **#435** (in progress) → #436 → #437. Epic **#387** closes when #433 children are done (or defer controls post-M3 beta).
+**Suggested order:** ~~#434~~ ~~#435~~ → **#436** (in progress) → #437. Epic **#387** closes when #433 children are done (or defer controls post-M3 beta).
 
 ---
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -216,8 +216,12 @@ Injection, jailbreak, and defense-in-depth guardrails for orchestration (#385).
 | **439** | Prompt injection input guardrails | https://github.com/diego-torres/nutriconsultas/issues/439 | **open** | **438**, **385** | Sanitize user input; `docs/ai/PROMPT-SECURITY.md` |
 | **440** | Jailbreak and role-override defenses | https://github.com/diego-torres/nutriconsultas/issues/440 | **open** | **438**, **439**, **367** | Refusal corpus + system prompt hardening |
 | **441** | Defense-in-depth prompt engineering guardrails | https://github.com/diego-torres/nutriconsultas/issues/441 | **open** | **438**, **439**, **440**, **372** | Delimiters, tool allowlist, output validation |
+| **447** | Deterministic request scope limits (bulk generation guard) | https://github.com/diego-torres/nutriconsultas/issues/447 | **open** | **438**, **385** | Java pre-check before orchestration; align with tool caps (14 days, 1 dish/turn) |
+| **448** | LLM scope classifier pre-flight | https://github.com/diego-torres/nutriconsultas/issues/448 | **open** | **438**, **447**, **366** | Structured ALLOW/REFUSE/CLARIFY before tool loop |
+| **449** | System prompt volume limits and bulk refusal corpus | https://github.com/diego-torres/nutriconsultas/issues/449 | **open** | **438**, **367**, **447** | `system-prompt-base.txt` + `FUNCTIONAL-SCOPE.md` |
+| **450** | Golden prompts for excessive bulk AI requests | https://github.com/diego-torres/nutriconsultas/issues/450 | **open** | **400**, **401**, **447** | Refuse «1000 planes» / allow «7 días» scenarios |
 
-**Suggested order:** #439 → #440 → #441; extend #401 golden prompts with security cases. Gate with #408 release checklist.
+**Suggested order:** #439 → #440 → **#447** → **#449** → **#448** → **#450** → #441; extend #401 golden prompts with security cases. Gate with #408 release checklist.
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
@@ -128,6 +128,10 @@ public class AiChatServiceImpl implements AiChatService {
 			return;
 		}
 		try {
+			final AiStreamCancellation cancellation = new AiStreamCancellation();
+			emitter.onCompletion(cancellation::cancel);
+			emitter.onTimeout(cancellation::cancel);
+			emitter.onError(ex -> cancellation.cancel());
 			final AiChatPromptContext promptContext = new AiChatPromptContext(request.patientId(), request.dietaId(),
 					request.platilloId());
 			final Long threadPatientId = transactionTemplate.execute(status -> {
@@ -138,7 +142,13 @@ public class AiChatServiceImpl implements AiChatService {
 			final AiOrchestrationContext context = buildOrchestrationContext(nutritionistId, request.threadId(),
 					mergedContext);
 			orchestrationService.processUserMessageStreaming(context, request.message().trim(),
-					streamConsumerFor(emitter));
+					streamConsumerFor(emitter, cancellation));
+			AiChatSseSupport.completeQuietly(emitter);
+		}
+		catch (final AiStreamCancelledException ex) {
+			if (log.isDebugEnabled()) {
+				log.debug("AI chat stream cancelled threadId={}", request.threadId());
+			}
 			AiChatSseSupport.completeQuietly(emitter);
 		}
 		catch (final AiChatException | AiOrchestrationException ex) {
@@ -155,8 +165,14 @@ public class AiChatServiceImpl implements AiChatService {
 		}
 	}
 
-	private AiStreamEventConsumer streamConsumerFor(final SseEmitter emitter) {
+	private AiStreamEventConsumer streamConsumerFor(final SseEmitter emitter,
+			final AiStreamCancellation cancellation) {
 		return new AiStreamEventConsumer() {
+			@Override
+			public boolean isCancelled() {
+				return cancellation.isCancelled();
+			}
+
 			@Override
 			public void onStatus(final String phase, final String message) {
 				try {

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationServiceImpl.java
@@ -95,8 +95,11 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 			throw new AiOrchestrationException("No se pudo cargar el historial de la conversación.");
 		}
 		streamConsumer.onStatus("thinking", "El asistente está pensando…");
+		streamConsumer.throwIfCancelled();
 		final ToolLoopOutcome loopOutcome = runToolLoop(context, conversation, streamConsumer);
+		streamConsumer.throwIfCancelled();
 		emitContentDeltas(loopOutcome.assistantContent(), streamConsumer);
+		streamConsumer.throwIfCancelled();
 
 		final AiOrchestrationResult result = transactionTemplate.execute(status -> {
 			final AiChatMessage assistantMessage = persistAssistantMessage(thread, loopOutcome.assistantContent());
@@ -120,6 +123,7 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 			return;
 		}
 		for (int index = 0; index < content.length(); index += STREAM_CHUNK_SIZE) {
+			streamConsumer.throwIfCancelled();
 			final int end = Math.min(index + STREAM_CHUNK_SIZE, content.length());
 			streamConsumer.onDelta(content.substring(index, end));
 		}
@@ -187,6 +191,9 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 		String assistantContent = null;
 
 		while (true) {
+			if (streamConsumer != null) {
+				streamConsumer.throwIfCancelled();
+			}
 			final OpenAiChatCompletionResponse response = openAiClientService
 				.chatCompletion(new OpenAiChatCompletionRequest(List.copyOf(conversation), toolCatalog.definitions()));
 			accumulatedUsage = mergeUsage(accumulatedUsage, response.usage());

--- a/src/main/java/com/nutriconsultas/ai/AiStreamCancellation.java
+++ b/src/main/java/com/nutriconsultas/ai/AiStreamCancellation.java
@@ -1,0 +1,26 @@
+package com.nutriconsultas.ai;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Tracks client-initiated cancellation for AI chat SSE streams (#436).
+ */
+public final class AiStreamCancellation {
+
+	private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+	public void cancel() {
+		cancelled.set(true);
+	}
+
+	public boolean isCancelled() {
+		return cancelled.get();
+	}
+
+	public void throwIfCancelled() {
+		if (cancelled.get()) {
+			throw new AiStreamCancelledException();
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiStreamCancelledException.java
+++ b/src/main/java/com/nutriconsultas/ai/AiStreamCancelledException.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Raised when an AI chat stream is cancelled before the assistant reply is persisted (#436).
+ */
+public class AiStreamCancelledException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public AiStreamCancelledException() {
+		super("Generación cancelada.");
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiStreamEventConsumer.java
+++ b/src/main/java/com/nutriconsultas/ai/AiStreamEventConsumer.java
@@ -7,6 +7,16 @@ import org.springframework.lang.Nullable;
  */
 public interface AiStreamEventConsumer {
 
+	default boolean isCancelled() {
+		return false;
+	}
+
+	default void throwIfCancelled() {
+		if (isCancelled()) {
+			throw new AiStreamCancelledException();
+		}
+	}
+
 	void onStatus(String phase, @Nullable String message);
 
 	void onDelta(String contentDelta);

--- a/src/main/resources/static/sbadmin/js/ai-assistant-widget.js
+++ b/src/main/resources/static/sbadmin/js/ai-assistant-widget.js
@@ -5,6 +5,8 @@
 
   var API_BASE = '/rest/nutritionist/ai/chat';
   var STORAGE_PREFIX = 'nutriconsultas.ai.widget.thread.';
+  var ASSISTANT_NAME = 'Mina';
+  var WELCOME_MESSAGE = 'Hola, soy Mina';
 
   var state = {
     threadId: null,
@@ -13,7 +15,9 @@
     open: false,
     context: null,
     showLoading: false,
-    loadingThread: false
+    loadingThread: false,
+    activeStreamRequest: null,
+    cancelling: false
   };
 
   function $(selector) {
@@ -57,7 +61,7 @@
       return 'Tú';
     }
     if (role === 'ASSISTANT') {
-      return 'Asistente';
+      return ASSISTANT_NAME;
     }
     return role;
   }
@@ -124,14 +128,63 @@
     if (!sendBtn) {
       return;
     }
-    sendBtn.disabled = busy;
+    var canCancel = busy && state.activeStreamRequest;
+    sendBtn.disabled = busy && !canCancel;
+    if (canCancel) {
+      sendBtn.innerHTML = '<i class="fas fa-stop" aria-hidden="true"></i><span> Detener</span>';
+      sendBtn.setAttribute('aria-busy', 'true');
+      sendBtn.setAttribute('aria-label', 'Detener generación');
+      return;
+    }
     if (busy && state.showLoading) {
       sendBtn.innerHTML = '<i class="fas fa-spinner fa-spin" aria-hidden="true"></i><span> Enviando…</span>';
       sendBtn.setAttribute('aria-busy', 'true');
+      sendBtn.setAttribute('aria-label', 'Enviando mensaje');
       return;
     }
     sendBtn.innerHTML = '<i class="fas fa-paper-plane" aria-hidden="true"></i><span> Enviar</span>';
     sendBtn.removeAttribute('aria-busy');
+    sendBtn.setAttribute('aria-label', 'Enviar mensaje');
+  }
+
+  function showCancelledNotice() {
+    if (typeof swal === 'function') {
+      swal({
+        title: 'Generación cancelada',
+        text: 'Puedes enviar un nuevo mensaje cuando quieras.',
+        type: 'info',
+        timer: 2500
+      });
+    }
+  }
+
+  function cancelActiveStream() {
+    if (!state.activeStreamRequest) {
+      return;
+    }
+    state.cancelling = true;
+    state.activeStreamRequest.abort();
+  }
+
+  function handleStreamAbort(assistantIndex) {
+    state.showLoading = false;
+    if (assistantIndex !== null && assistantIndex < state.messages.length) {
+      state.messages.splice(assistantIndex, 1);
+    }
+    state.activeStreamRequest = null;
+    state.cancelling = false;
+    setBusy(false);
+    showCancelledNotice();
+  }
+
+  function renderWelcomeMessage() {
+    return '<article class="ai-assistant-message assistant" aria-label="' + ASSISTANT_NAME + '">' +
+      '<div class="ai-assistant-bubble">' + formatMessageBubbleContent({
+        role: 'ASSISTANT',
+        content: WELCOME_MESSAGE
+      }) + '</div>' +
+      '<div class="ai-assistant-meta">' + escapeHtml(ASSISTANT_NAME) + '</div>' +
+      '</article>';
   }
 
   function setBusy(busy) {
@@ -158,8 +211,9 @@
     var loadingThread = state.loadingThread === true;
     var items = visibleMessages(state.messages);
     if (items.length === 0 && !waitingForAssistant && !loadingThread) {
-      container.innerHTML = '<p class="ai-assistant-empty">Pregunta sobre el contexto de esta pantalla. ' +
-        'El asistente usará los datos del paciente, dieta o platillo activo para redactar borradores.</p>';
+      container.innerHTML = renderWelcomeMessage() +
+        '<p class="ai-assistant-empty">Pregunta sobre el contexto de esta pantalla. ' +
+        'Usaré los datos del paciente, dieta o platillo activo para redactar borradores.</p>';
       return;
     }
 
@@ -177,7 +231,7 @@
         'aria-label="Generando respuesta">' +
         '<div class="ai-assistant-bubble ai-assistant-loading-bubble">' +
         '<i class="fas fa-spinner fa-spin ai-assistant-loading-icon" aria-hidden="true"></i>' +
-        '<span class="ai-assistant-loading-text">El asistente está pensando…</span>' +
+        '<span class="ai-assistant-loading-text">Mina está pensando…</span>' +
         '</div></article>';
     } else if (loadingThread) {
       html += '<article class="ai-assistant-message assistant loading" aria-live="polite" aria-busy="true" ' +
@@ -299,16 +353,22 @@
       .then(function (threadId) {
         payload.threadId = threadId;
         if (window.NutriAiChatStream && typeof NutriAiChatStream.streamMessage === 'function') {
-          return NutriAiChatStream.streamMessage(API_BASE + '/message/stream', payload, {
+          var streamRequest = NutriAiChatStream.streamMessage(API_BASE + '/message/stream', payload, {
             onStatus: function () {
               renderMessages();
             },
             onDelta: appendAssistantDelta,
             onDone: finalizeAssistant,
+            onAbort: function () {
+              handleStreamAbort(assistantIndex);
+            },
             onError: function (message) {
               throw new Error(message);
             }
           });
+          state.activeStreamRequest = streamRequest;
+          setBusy(true);
+          return streamRequest;
         }
         return requestJson(API_BASE + '/message', {
           method: 'POST',
@@ -319,6 +379,9 @@
         });
       })
       .catch(function (error) {
+        if (state.cancelling) {
+          return;
+        }
         state.showLoading = false;
         state.messages.pop();
         renderMessages();
@@ -326,6 +389,8 @@
       })
       .finally(function () {
         state.showLoading = false;
+        state.activeStreamRequest = null;
+        state.cancelling = false;
         setBusy(false);
         if (textarea) {
           textarea.focus();
@@ -383,6 +448,7 @@
     var closeBtn = $('#aiAssistantClose');
     var form = $('#aiAssistantForm');
     var textarea = $('#aiAssistantInput');
+    var sendBtn = $('#aiAssistantSendBtn');
     var newBtn = $('#aiAssistantNewBtn');
 
     if (toggleBtn) {
@@ -398,7 +464,19 @@
     if (form) {
       form.addEventListener('submit', function (event) {
         event.preventDefault();
+        if (state.busy && state.activeStreamRequest) {
+          cancelActiveStream();
+          return;
+        }
         sendMessage(textarea ? textarea.value : '');
+      });
+    }
+    if (sendBtn) {
+      sendBtn.addEventListener('click', function (event) {
+        if (state.busy && state.activeStreamRequest) {
+          event.preventDefault();
+          cancelActiveStream();
+        }
       });
     }
     if (textarea) {

--- a/src/main/resources/static/sbadmin/js/ai-chat-stream.js
+++ b/src/main/resources/static/sbadmin/js/ai-chat-stream.js
@@ -111,13 +111,10 @@
       throw error;
     });
 
-    function cancellablePromise(onFulfilled, onRejected) {
-      return fetchPromise.then(onFulfilled, onRejected);
-    }
-    cancellablePromise.abort = function () {
+    fetchPromise.abort = function () {
       controller.abort();
     };
-    return cancellablePromise;
+    return fetchPromise;
   }
 
   global.NutriAiChatStream = {

--- a/src/main/resources/static/sbadmin/js/ai-chat-stream.js
+++ b/src/main/resources/static/sbadmin/js/ai-chat-stream.js
@@ -1,4 +1,4 @@
-/* AI chat SSE streaming client (#435) */
+/* AI chat SSE streaming client (#435, #436) */
 
 (function (global) {
   'use strict';
@@ -47,10 +47,16 @@
     }
   }
 
+  function isAbortError(error) {
+    return error && (error.name === 'AbortError' || error.code === 20);
+  }
+
   function streamMessage(url, payload, handlers) {
-    return fetch(url, {
+    var controller = new AbortController();
+    var fetchPromise = fetch(url, {
       method: 'POST',
       credentials: 'same-origin',
+      signal: controller.signal,
       headers: {
         'Content-Type': 'application/json',
         Accept: 'text/event-stream'
@@ -95,10 +101,27 @@
       }
 
       return readNext();
+    }).catch(function (error) {
+      if (isAbortError(error)) {
+        if (handlers.onAbort) {
+          handlers.onAbort();
+        }
+        return null;
+      }
+      throw error;
     });
+
+    function cancellablePromise(onFulfilled, onRejected) {
+      return fetchPromise.then(onFulfilled, onRejected);
+    }
+    cancellablePromise.abort = function () {
+      controller.abort();
+    };
+    return cancellablePromise;
   }
 
   global.NutriAiChatStream = {
-    streamMessage: streamMessage
+    streamMessage: streamMessage,
+    isAbortError: isAbortError
   };
 })(typeof window !== 'undefined' ? window : this);

--- a/src/main/resources/static/sbadmin/js/ai-chat.js
+++ b/src/main/resources/static/sbadmin/js/ai-chat.js
@@ -15,7 +15,10 @@
     drafts: [],
     selectedDraftId: null,
     selectedPreview: null,
-    busy: false
+    busy: false,
+    showLoading: false,
+    activeStreamRequest: null,
+    cancelling: false
   };
 
   function $(selector) {
@@ -404,15 +407,53 @@
       textarea.disabled = busy;
     }
     if (sendBtn) {
-      sendBtn.disabled = busy;
-      sendBtn.innerHTML = busy
-        ? '<span class="spinner-border spinner-border-sm mr-1" role="status" aria-hidden="true"></span>Enviando…'
-        : '<i class="fas fa-paper-plane mr-1" aria-hidden="true"></i>Enviar';
+      var canCancel = busy && state.activeStreamRequest;
+      sendBtn.disabled = busy && !canCancel;
+      if (canCancel) {
+        sendBtn.innerHTML = '<i class="fas fa-stop mr-1" aria-hidden="true"></i>Detener';
+        sendBtn.setAttribute('aria-label', 'Detener generación');
+      } else if (busy) {
+        sendBtn.innerHTML = '<span class="spinner-border spinner-border-sm mr-1" role="status" aria-hidden="true"></span>Enviando…';
+        sendBtn.setAttribute('aria-label', 'Enviando mensaje al asistente');
+      } else {
+        sendBtn.innerHTML = '<i class="fas fa-paper-plane mr-1" aria-hidden="true"></i>Enviar';
+        sendBtn.setAttribute('aria-label', 'Enviar mensaje al asistente');
+      }
     }
     if (newBtn) {
       newBtn.disabled = busy;
     }
     renderMessages(state.showLoading === true);
+  }
+
+  function showCancelledNotice() {
+    if (typeof swal === 'function') {
+      swal({
+        title: 'Generación cancelada',
+        text: 'Puedes enviar un nuevo mensaje cuando quieras.',
+        type: 'info',
+        timer: 2500
+      });
+    }
+  }
+
+  function cancelActiveStream() {
+    if (!state.activeStreamRequest) {
+      return;
+    }
+    state.cancelling = true;
+    state.activeStreamRequest.abort();
+  }
+
+  function handleStreamAbort(assistantIndex) {
+    state.showLoading = false;
+    if (assistantIndex !== null && assistantIndex < state.messages.length) {
+      state.messages.splice(assistantIndex, 1);
+    }
+    state.activeStreamRequest = null;
+    state.cancelling = false;
+    setBusy(false);
+    showCancelledNotice();
   }
 
   function persistThreadId(threadId) {
@@ -583,7 +624,7 @@
     ensureThread()
       .then(function (threadId) {
         if (window.NutriAiChatStream && typeof NutriAiChatStream.streamMessage === 'function') {
-          return NutriAiChatStream.streamMessage(API_BASE + '/message/stream', {
+          var streamRequest = NutriAiChatStream.streamMessage(API_BASE + '/message/stream', {
             threadId: threadId,
             message: trimmed
           }, {
@@ -592,10 +633,16 @@
             },
             onDelta: appendAssistantDelta,
             onDone: finalizeAssistant,
+            onAbort: function () {
+              handleStreamAbort(assistantIndex);
+            },
             onError: function (message) {
               throw new Error(message);
             }
           });
+          state.activeStreamRequest = streamRequest;
+          setBusy(true);
+          return streamRequest;
         }
         return requestJson(API_BASE + '/message', {
           method: 'POST',
@@ -606,6 +653,9 @@
         });
       })
       .catch(function (error) {
+        if (state.cancelling) {
+          return;
+        }
         state.showLoading = false;
         state.messages.pop();
         renderMessages(false);
@@ -613,6 +663,8 @@
       })
       .finally(function () {
         state.showLoading = false;
+        state.activeStreamRequest = null;
+        state.cancelling = false;
         setBusy(false);
         if (textarea) {
           textarea.focus();
@@ -672,6 +724,7 @@
   function bindEvents() {
     var form = $('#aiChatForm');
     var textarea = $('#aiChatInput');
+    var sendBtn = $('#aiChatSendBtn');
     var newBtn = $('#aiChatNewBtn');
     var acceptBtn = $('#aiChatDraftAcceptBtn');
     var discardBtn = $('#aiChatDraftDiscardBtn');
@@ -679,7 +732,20 @@
     if (form) {
       form.addEventListener('submit', function (event) {
         event.preventDefault();
+        if (state.busy && state.activeStreamRequest) {
+          cancelActiveStream();
+          return;
+        }
         sendMessage(textarea ? textarea.value : '');
+      });
+    }
+
+    if (sendBtn) {
+      sendBtn.addEventListener('click', function (event) {
+        if (state.busy && state.activeStreamRequest) {
+          event.preventDefault();
+          cancelActiveStream();
+        }
       });
     }
 

--- a/src/main/resources/templates/sbadmin/fragments/ai-assistant-widget.html
+++ b/src/main/resources/templates/sbadmin/fragments/ai-assistant-widget.html
@@ -6,7 +6,7 @@
     <div id="aiAssistantPanel" hidden>
       <div id="aiAssistantHeader">
         <div id="aiAssistantHeaderText">
-          <h2 id="aiAssistantTitle">Asistente IA</h2>
+          <h2 id="aiAssistantTitle">Mina</h2>
           <p id="aiAssistantScope" th:text="${aiAssistantWidgetContext.scopeLabel()}">Contexto</p>
         </div>
         <div id="aiAssistantHeaderActions">
@@ -34,7 +34,7 @@
         </form>
       </div>
     </div>
-    <button type="button" id="aiAssistantToggle" title="Asistente de IA" aria-label="Asistente de IA">
+    <button type="button" id="aiAssistantToggle" title="Mina — asistente de IA" aria-label="Mina — asistente de IA">
       <i class="fas fa-robot fa-lg" aria-hidden="true"></i>
     </button>
   </div>

--- a/src/test/java/com/nutriconsultas/ai/AiOrchestrationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiOrchestrationServiceTest.java
@@ -237,6 +237,45 @@ class AiOrchestrationServiceTest {
 		verify(messageRepository, times(2)).save(any(AiChatMessage.class));
 	}
 
+	@Test
+	void processUserMessageStreamingSkipsPersistWhenCancelledBeforeDone() {
+		stubOperational();
+		when(threadRepository.findByIdAndNutritionistId(THREAD_ID, NUTRITIONIST_ID)).thenReturn(Optional.of(thread));
+		when(messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(THREAD_ID))
+			.thenReturn(List.of(message(AiChatMessageRole.USER, "Hola")));
+		when(openAiClientService.chatCompletion(any())).thenReturn(new OpenAiChatCompletionResponse("id-1", "assistant",
+				"Respuesta cancelada con suficiente longitud.", List.of(), "stop", null));
+
+		final int[] deltaCount = { 0 };
+		final AiStreamEventConsumer cancellingConsumer = new AiStreamEventConsumer() {
+			@Override
+			public boolean isCancelled() {
+				return deltaCount[0] > 0;
+			}
+
+			@Override
+			public void onStatus(final String phase, final String message) {
+				/* no-op */
+			}
+
+			@Override
+			public void onDelta(final String contentDelta) {
+				deltaCount[0]++;
+			}
+
+			@Override
+			public void onComplete(final AiOrchestrationResult result) {
+				/* no-op */
+			}
+		};
+
+		assertThatThrownBy(() -> service.processUserMessageStreaming(context(), "Hola", cancellingConsumer))
+			.isInstanceOf(AiStreamCancelledException.class);
+
+		verify(openAiClientService).chatCompletion(any());
+		verify(messageRepository, times(1)).save(any(AiChatMessage.class));
+	}
+
 	private static AiOrchestrationContext context() {
 		return new AiOrchestrationContext(NUTRITIONIST_ID, THREAD_ID, null, null, null);
 	}


### PR DESCRIPTION
## Summary
- Add **Detener** control during SSE streaming on full-page chat and floating widget via `AbortController`; partial assistant replies are not persisted when cancelled
- Wire server-side cancellation through `AiStreamCancellation` (client disconnect + abort) so orchestration skips assistant persistence after cancel
- Brand the floating widget assistant as **Mina** with welcome greeting "Hola, soy Mina"
- Fix `streamMessage()` to return the fetch promise (not a wrapper function) so `sendMessage().finally()` waits for the stream and **Detener** stays visible until complete or abort

Closes #436

## Test plan
- [x] `mvn test -Dtest=AiOrchestrationServiceTest,AiChatServiceTest,AiChatRestControllerTest`
- [x] `mvn pmd:check -Pci`
- [x] Browser: send message → click **Detener** → partial bubble removed, Spanish cancel notice, UI idle
- [x] Browser: floating widget shows **Hola, soy Mina** and **Mina** label on replies
- [ ] CI green

Made with [Cursor](https://cursor.com)