### PR TITLE
Allow editing and resubmitting AI chat messages (#437)

### DIFF
--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#436 — Stop and cancel in-flight AI generation](https://github.com/diego-torres/nutriconsultas/issues/436) (`in-progress` on `issue-436-ai-chat-cancel`). ~~#435~~ SSE merged (PR #445).
+**Current next issue:** [#437 — Edit user message and resubmit](https://github.com/diego-torres/nutriconsultas/issues/437) (`in-progress` on `issue-437-ai-chat-edit-resubmit`). ~~#436~~ merged (PR #446).
 
 **Registered backlog (2026-07-04):** Epic [#433](https://github.com/diego-torres/nutriconsultas/issues/433) chat UX (#434–#437). Epic [#438](https://github.com/diego-torres/nutriconsultas/issues/438) prompt security (#439–#441, **#447–#450** bulk scope guards). See registry for suggested order.
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-07-04 — ~~#435~~ merged. **#436** in progress on `issue-436-ai-chat-cancel`.
+**Last updated:** 2026-07-04 — ~~#436~~ merged (PR #446). **#437** in progress on `issue-437-ai-chat-edit-resubmit`.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -168,10 +168,10 @@ Markdown, streaming, and message controls for full-page chat and floating widget
 | **433** | Epic — AI Chat UX Enhancements (Phase 6b) | https://github.com/diego-torres/nutriconsultas/issues/433 | **open** | **387**, **390** | Parent for #434–#437 |
 | **434** | Render markdown in assistant chat responses | https://github.com/diego-torres/nutriconsultas/issues/434 | **done** | **433**, **389** | PR #444 |
 | **435** | Stream assistant responses (SSE) | https://github.com/diego-torres/nutriconsultas/issues/435 | **done** | **433**, **385**, **389** | PR #445 |
-| **436** | Stop and cancel in-flight AI generation | https://github.com/diego-torres/nutriconsultas/issues/436 | **in-progress** | **433**, **389** | AbortController + SSE cancel; after #435 |
-| **437** | Edit user message and resubmit | https://github.com/diego-torres/nutriconsultas/issues/437 | **open** | **433**, **384**, **389** | Thread truncate + SweetAlert |
+| **436** | Stop and cancel in-flight AI generation | https://github.com/diego-torres/nutriconsultas/issues/436 | **done** | **433**, **389** | PR #446 |
+| **437** | Edit user message and resubmit | https://github.com/diego-torres/nutriconsultas/issues/437 | **in-progress** | **433**, **384**, **389** | Thread truncate + SweetAlert |
 
-**Suggested order:** ~~#434~~ ~~#435~~ → **#436** (in progress) → #437. Epic **#387** closes when #433 children are done (or defer controls post-M3 beta).
+**Suggested order:** ~~#434~~ ~~#435~~ ~~#436~~ → **#437** (in progress). Epic **#387** closes when #433 children are done (or defer controls post-M3 beta).
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/AiChatMessageRepository.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatMessageRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,5 +15,10 @@ public interface AiChatMessageRepository extends JpaRepository<AiChatMessage, Lo
 	@Query("SELECT m FROM AiChatMessage m JOIN m.thread t WHERE m.id = :messageId AND t.nutritionistId = :nutritionistId")
 	Optional<AiChatMessage> findByIdAndThreadNutritionistId(@Param("messageId") Long messageId,
 			@Param("nutritionistId") String nutritionistId);
+
+	@Modifying
+	@Query("DELETE FROM AiChatMessage m WHERE m.thread.id = :threadId AND m.id >= :fromMessageId")
+	int deleteByThreadIdAndIdGreaterThanEqual(@Param("threadId") Long threadId,
+			@Param("fromMessageId") Long fromMessageId);
 
 }

--- a/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
@@ -81,13 +81,7 @@ public class AiChatRestController {
 			final AiOrchestrationResult result = aiChatRateLimiter.executeMessage(nutritionistId, () -> chatService
 				.sendMessage(nutritionistId, request.threadId(), request.message(), promptContext));
 			final Map<String, Object> response = successBody();
-			response.put("threadId", result.threadId());
-			response.put("assistantMessageId", result.assistantMessage().getId());
-			response.put("content", result.assistantMessage().getContent());
-			response.put("toolCallsExecuted", result.toolCallsExecuted());
-			if (result.tokenUsage() != null) {
-				response.put("tokenUsage", tokenUsageMap(result.tokenUsage()));
-			}
+			putOrchestrationFields(response, result);
 			return ResponseEntity.ok(response);
 		}
 		catch (final AiChatException ex) {
@@ -137,6 +131,78 @@ public class AiChatRestController {
 		catch (final RuntimeException ex) {
 			if (log.isWarnEnabled()) {
 				log.warn("AI chat stream failed unexpectedly", ex);
+			}
+			completeStreamError(emitter, "No se pudo completar la solicitud.");
+		}
+		return emitter;
+	}
+
+	@PostMapping("/message/edit")
+	public ResponseEntity<Map<String, Object>> editMessage(@RequestBody final AiEditMessageRequest request,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String nutritionistId = nutritionistId(principal);
+		if (nutritionistId == null) {
+			return unauthorized();
+		}
+		if (request == null) {
+			return errorResponse(HttpStatus.BAD_REQUEST, AiToolErrorCode.VALIDATION, "Solicitud no válida.");
+		}
+		try {
+			final AiEditResubmitResult result = aiChatRateLimiter.executeMessage(nutritionistId,
+					() -> chatService.editAndResubmitMessage(nutritionistId, request));
+			final Map<String, Object> response = successBody();
+			putOrchestrationFields(response, result.orchestration());
+			response.put("truncatedMessageCount", result.truncatedMessageCount());
+			response.put("discardedDraftIds", result.discardedDraftIds());
+			return ResponseEntity.ok(response);
+		}
+		catch (final AiChatException ex) {
+			return errorResponse(ex);
+		}
+		catch (final AiOrchestrationException ex) {
+			return errorResponse(HttpStatus.SERVICE_UNAVAILABLE, AiToolErrorCode.VALIDATION, ex.getMessage());
+		}
+		catch (final OpenAiClientException ex) {
+			return mapOpenAiException(ex);
+		}
+		catch (final RequestNotPermitted ex) {
+			if (log.isDebugEnabled()) {
+				log.debug("AI chat edit rate limit exceeded");
+			}
+			return errorResponse(HttpStatus.TOO_MANY_REQUESTS, AiToolErrorCode.RATE_LIMIT,
+					AiChatRateLimiter.RATE_LIMIT_USER_MESSAGE);
+		}
+	}
+
+	@PostMapping(value = "/message/edit/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public SseEmitter streamEditMessage(@RequestBody final AiEditMessageRequest request,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final SseEmitter emitter = new SseEmitter(300_000L);
+		emitter.onTimeout(emitter::complete);
+		final String nutritionistId = nutritionistId(principal);
+		if (nutritionistId == null) {
+			completeStreamError(emitter, "Sesión no válida.");
+			return emitter;
+		}
+		if (request == null) {
+			completeStreamError(emitter, "Solicitud no válida.");
+			return emitter;
+		}
+		try {
+			aiChatRateLimiter.executeMessage(nutritionistId, () -> {
+				chatService.streamEditMessage(nutritionistId, request, emitter);
+				return null;
+			});
+		}
+		catch (final RequestNotPermitted ex) {
+			if (log.isDebugEnabled()) {
+				log.debug("AI chat edit stream rate limit exceeded");
+			}
+			completeStreamError(emitter, AiChatRateLimiter.RATE_LIMIT_USER_MESSAGE);
+		}
+		catch (final RuntimeException ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("AI chat edit stream failed unexpectedly", ex);
 			}
 			completeStreamError(emitter, "No se pudo completar la solicitud.");
 		}
@@ -243,6 +309,16 @@ public class AiChatRestController {
 		map.put("completionTokens", usage.completionTokens());
 		map.put("totalTokens", usage.totalTokens());
 		return map;
+	}
+
+	private static void putOrchestrationFields(final Map<String, Object> response, final AiOrchestrationResult result) {
+		response.put("threadId", result.threadId());
+		response.put("assistantMessageId", result.assistantMessage().getId());
+		response.put("content", result.assistantMessage().getContent());
+		response.put("toolCallsExecuted", result.toolCallsExecuted());
+		if (result.tokenUsage() != null) {
+			response.put("tokenUsage", tokenUsageMap(result.tokenUsage()));
+		}
 	}
 
 	private static List<Map<String, Object>> toMessageMaps(final List<AiChatMessageView> messages) {

--- a/src/main/java/com/nutriconsultas/ai/AiChatService.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatService.java
@@ -20,4 +20,8 @@ public interface AiChatService {
 
 	void streamMessage(String nutritionistId, AiSendMessageRequest request, SseEmitter emitter);
 
+	AiEditResubmitResult editAndResubmitMessage(String nutritionistId, AiEditMessageRequest request);
+
+	void streamEditMessage(String nutritionistId, AiEditMessageRequest request, SseEmitter emitter);
+
 }

--- a/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
@@ -47,8 +47,8 @@ public class AiChatServiceImpl implements AiChatService {
 			final AiOrchestrationService orchestrationService,
 			final AiPatientPromptContextResolver patientContextResolver,
 			final AiDietaPromptContextResolver dietaContextResolver,
-			final AiPlatilloPromptContextResolver platilloContextResolver,
-			final PacienteRepository pacienteRepository, final TransactionTemplate transactionTemplate) {
+			final AiPlatilloPromptContextResolver platilloContextResolver, final PacienteRepository pacienteRepository,
+			final TransactionTemplate transactionTemplate) {
 		this.threadRepository = threadRepository;
 		this.messageRepository = messageRepository;
 		this.draftRepository = draftRepository;
@@ -165,8 +165,91 @@ public class AiChatServiceImpl implements AiChatService {
 		}
 	}
 
-	private AiStreamEventConsumer streamConsumerFor(final SseEmitter emitter,
-			final AiStreamCancellation cancellation) {
+	@Override
+	@Transactional
+	public AiEditResubmitResult editAndResubmitMessage(@NonNull final String nutritionistId,
+			final AiEditMessageRequest request) {
+		assertNutritionistId(nutritionistId);
+		assertEditRequest(request);
+		final AiChatPromptContext promptContext = new AiChatPromptContext(request.patientId(), request.dietaId(),
+				request.platilloId());
+		final TruncateOutcome truncateOutcome = truncateThreadFromMessage(nutritionistId, request.threadId(),
+				request.messageId());
+		final AiChatThread thread = loadOwnedThread(request.threadId(), nutritionistId);
+		final AiChatPromptContext mergedContext = mergePromptContext(promptContext, patientId(thread));
+		final AiOrchestrationContext context = buildOrchestrationContext(nutritionistId, request.threadId(),
+				mergedContext);
+		final AiOrchestrationResult orchestration = orchestrationService.processUserMessage(context,
+				request.message().trim());
+		return new AiEditResubmitResult(orchestration, truncateOutcome.truncatedMessageCount(),
+				truncateOutcome.discardedDraftIds());
+	}
+
+	@Override
+	public void streamEditMessage(@NonNull final String nutritionistId, final AiEditMessageRequest request,
+			final SseEmitter emitter) {
+		assertNutritionistId(nutritionistId);
+		if (request == null) {
+			completeStreamWithError(emitter, "Solicitud no válida.");
+			return;
+		}
+		try {
+			assertEditRequest(request);
+		}
+		catch (final AiChatException ex) {
+			completeStreamWithError(emitter, ex.getMessage());
+			return;
+		}
+		try {
+			final AiStreamCancellation cancellation = new AiStreamCancellation();
+			emitter.onCompletion(cancellation::cancel);
+			emitter.onTimeout(cancellation::cancel);
+			emitter.onError(ex -> cancellation.cancel());
+			final AiChatPromptContext promptContext = new AiChatPromptContext(request.patientId(), request.dietaId(),
+					request.platilloId());
+			final TruncateOutcome truncateOutcome = transactionTemplate
+				.execute(status -> truncateThreadFromMessage(nutritionistId, request.threadId(), request.messageId()));
+			if (truncateOutcome == null) {
+				completeStreamWithError(emitter, "No se pudo actualizar la conversación.");
+				return;
+			}
+			final Long threadPatientId = transactionTemplate.execute(status -> {
+				final AiChatThread ownedThread = loadOwnedThread(request.threadId(), nutritionistId);
+				return patientId(ownedThread);
+			});
+			final AiChatPromptContext mergedContext = mergePromptContext(promptContext, threadPatientId);
+			final AiOrchestrationContext context = buildOrchestrationContext(nutritionistId, request.threadId(),
+					mergedContext);
+			orchestrationService.processUserMessageStreaming(context, request.message().trim(),
+					streamConsumerFor(emitter, cancellation));
+			if (log.isInfoEnabled()) {
+				log.info("AI chat edit-resubmit stream threadId={} truncatedMessages={} discardedDrafts={}",
+						request.threadId(), truncateOutcome.truncatedMessageCount(),
+						truncateOutcome.discardedDraftIds().size());
+			}
+			AiChatSseSupport.completeQuietly(emitter);
+		}
+		catch (final AiStreamCancelledException ex) {
+			if (log.isDebugEnabled()) {
+				log.debug("AI chat edit-resubmit stream cancelled threadId={}", request.threadId());
+			}
+			AiChatSseSupport.completeQuietly(emitter);
+		}
+		catch (final AiChatException | AiOrchestrationException ex) {
+			completeStreamWithError(emitter, ex.getMessage());
+		}
+		catch (final OpenAiClientException ex) {
+			completeStreamWithError(emitter, ex.getUserMessage());
+		}
+		catch (final AiStreamDeliveryException ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("AI chat edit-resubmit stream delivery failed threadId={}", request.threadId());
+			}
+			AiChatSseSupport.completeQuietly(emitter);
+		}
+	}
+
+	private AiStreamEventConsumer streamConsumerFor(final SseEmitter emitter, final AiStreamCancellation cancellation) {
 		return new AiStreamEventConsumer() {
 			@Override
 			public boolean isCancelled() {
@@ -282,6 +365,51 @@ public class AiChatServiceImpl implements AiChatService {
 			throw new AiChatException(org.springframework.http.HttpStatus.UNAUTHORIZED, AiToolErrorCode.VALIDATION,
 					"Sesión no válida.");
 		}
+	}
+
+	private static void assertEditRequest(final AiEditMessageRequest request) {
+		if (request == null) {
+			throw new AiChatException(org.springframework.http.HttpStatus.BAD_REQUEST, AiToolErrorCode.VALIDATION,
+					"Solicitud no válida.");
+		}
+		if (!StringUtils.hasText(request.message())) {
+			throw new AiChatException(org.springframework.http.HttpStatus.BAD_REQUEST, AiToolErrorCode.VALIDATION,
+					"El mensaje no puede estar vacío.");
+		}
+	}
+
+	private TruncateOutcome truncateThreadFromMessage(final String nutritionistId, final long threadId,
+			final long messageId) {
+		final AiChatMessage anchor = messageRepository.findByIdAndThreadNutritionistId(messageId, nutritionistId)
+			.orElseThrow(() -> new AiChatException(org.springframework.http.HttpStatus.NOT_FOUND,
+					AiToolErrorCode.NOT_FOUND, "No se encontró el mensaje."));
+		if (anchor.getThread() == null || anchor.getThread().getId() == null
+				|| anchor.getThread().getId() != threadId) {
+			throw new AiChatException(org.springframework.http.HttpStatus.BAD_REQUEST, AiToolErrorCode.VALIDATION,
+					"El mensaje no pertenece a esta conversación.");
+		}
+		if (anchor.getRole() != AiChatMessageRole.USER) {
+			throw new AiChatException(org.springframework.http.HttpStatus.BAD_REQUEST, AiToolErrorCode.VALIDATION,
+					"Solo puedes editar mensajes enviados por ti.");
+		}
+		final java.time.Instant anchorCreatedAt = anchor.getCreatedAt();
+		final List<Long> discardedDraftIds = new ArrayList<>();
+		for (final AiGeneratedDraft draft : draftRepository
+			.findByThreadIdAndStatusAndCreatedAtGreaterThanEqual(threadId, AiDraftStatus.DRAFT, anchorCreatedAt)) {
+			draft.setStatus(AiDraftStatus.DISCARDED);
+			draftRepository.save(draft);
+			discardedDraftIds.add(draft.getId());
+		}
+		final int truncatedMessageCount = messageRepository.deleteByThreadIdAndIdGreaterThanEqual(threadId,
+				anchor.getId());
+		if (log.isInfoEnabled()) {
+			log.info("AI chat truncated threadId={} fromMessageId={} removedMessages={} discardedDrafts={}", threadId,
+					messageId, truncatedMessageCount, discardedDraftIds.size());
+		}
+		return new TruncateOutcome(truncatedMessageCount, List.copyOf(discardedDraftIds));
+	}
+
+	private record TruncateOutcome(int truncatedMessageCount, List<Long> discardedDraftIds) {
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/ai/AiEditMessageRequest.java
+++ b/src/main/java/com/nutriconsultas/ai/AiEditMessageRequest.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Request body for edit-and-resubmit AI chat endpoints (#437).
+ */
+public record AiEditMessageRequest(long threadId, long messageId, String message, @Nullable Long patientId,
+		@Nullable Long dietaId, @Nullable Long platilloId) {
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiEditResubmitResult.java
+++ b/src/main/java/com/nutriconsultas/ai/AiEditResubmitResult.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+/**
+ * Outcome of truncating a thread and resubmitting an edited user message (#437).
+ */
+public record AiEditResubmitResult(AiOrchestrationResult orchestration, int truncatedMessageCount,
+		List<Long> discardedDraftIds) {
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiGeneratedDraftRepository.java
+++ b/src/main/java/com/nutriconsultas/ai/AiGeneratedDraftRepository.java
@@ -1,5 +1,6 @@
 package com.nutriconsultas.ai;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,5 +17,8 @@ public interface AiGeneratedDraftRepository extends JpaRepository<AiGeneratedDra
 			@Param("nutritionistId") String nutritionistId);
 
 	List<AiGeneratedDraft> findByThreadIdAndStatusOrderByCreatedAtDescIdDesc(Long threadId, AiDraftStatus status);
+
+	List<AiGeneratedDraft> findByThreadIdAndStatusAndCreatedAtGreaterThanEqual(Long threadId, AiDraftStatus status,
+			Instant createdAt);
 
 }

--- a/src/main/java/com/nutriconsultas/ai/AiStreamCancelledException.java
+++ b/src/main/java/com/nutriconsultas/ai/AiStreamCancelledException.java
@@ -1,7 +1,8 @@
 package com.nutriconsultas.ai;
 
 /**
- * Raised when an AI chat stream is cancelled before the assistant reply is persisted (#436).
+ * Raised when an AI chat stream is cancelled before the assistant reply is persisted
+ * (#436).
  */
 public class AiStreamCancelledException extends RuntimeException {
 

--- a/src/main/resources/static/sbadmin/js/ai-assistant-widget.js
+++ b/src/main/resources/static/sbadmin/js/ai-assistant-widget.js
@@ -17,7 +17,9 @@
     showLoading: false,
     loadingThread: false,
     activeStreamRequest: null,
-    cancelling: false
+    cancelling: false,
+    editingMessageId: null,
+    editingMessageIndex: null
   };
 
   function $(selector) {
@@ -70,6 +72,67 @@
     return (messages || []).filter(function (message) {
       return message.role === 'USER' || message.role === 'ASSISTANT';
     });
+  }
+
+  function findMessageIndexById(messageId) {
+    var items = visibleMessages(state.messages);
+    for (var i = 0; i < items.length; i++) {
+      if (items[i].id === messageId) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  function cancelEditMessage() {
+    state.editingMessageId = null;
+    state.editingMessageIndex = null;
+    var textarea = $('#aiAssistantInput');
+    if (textarea) {
+      textarea.value = '';
+      textarea.placeholder = 'Pide un borrador usando el contexto de esta pantalla…';
+    }
+    renderMessages();
+  }
+
+  function startEditMessage(messageId) {
+    if (state.busy || !messageId) {
+      return;
+    }
+    var index = findMessageIndexById(messageId);
+    if (index < 0) {
+      return;
+    }
+    var message = visibleMessages(state.messages)[index];
+    state.editingMessageId = messageId;
+    state.editingMessageIndex = index;
+    var textarea = $('#aiAssistantInput');
+    if (textarea) {
+      textarea.value = message.content || '';
+      textarea.placeholder = 'Edita tu mensaje y reenvía…';
+      textarea.focus();
+    }
+    renderMessages();
+  }
+
+  function confirmResubmit(onConfirm) {
+    if (typeof swal === 'function') {
+      swal({
+        title: '¿Reenviar mensaje editado?',
+        text: 'Se eliminarán este mensaje, las respuestas posteriores y los borradores pendientes generados después.',
+        type: 'warning',
+        showCancelButton: true,
+        confirmButtonText: 'Sí, reenviar',
+        cancelButtonText: 'Cancelar',
+        closeOnConfirm: true
+      }, function (isConfirm) {
+        if (isConfirm) {
+          onConfirm();
+        }
+      });
+    } else if (window.confirm('¿Reenviar mensaje editado?')) {
+      onConfirm();
+    }
   }
 
   function requestJson(url, options) {
@@ -219,10 +282,15 @@
 
     var html = items.map(function (message) {
       var roleClass = message.role === 'USER' ? 'user' : 'assistant';
+      var editControl = '';
+      if (message.role === 'USER' && message.id && !state.busy && !state.editingMessageId) {
+        editControl = ' <button type="button" class="btn btn-link btn-sm ai-assistant-edit-btn p-0 ml-1" ' +
+          'data-message-id="' + message.id + '" aria-label="Editar mensaje">Editar</button>';
+      }
       return '<article class="ai-assistant-message ' + roleClass + '" aria-label="' + roleLabel(message.role) + '">' +
         '<div class="ai-assistant-bubble">' + formatMessageBubbleContent(message) + '</div>' +
         '<div class="ai-assistant-meta">' + escapeHtml(roleLabel(message.role)) +
-        (message.createdAt ? ' · ' + formatTime(message.createdAt) : '') + '</div>' +
+        (message.createdAt ? ' · ' + formatTime(message.createdAt) : '') + editControl + '</div>' +
         '</article>';
     }).join('');
 
@@ -294,6 +362,41 @@
   }
 
   function sendMessage(text) {
+    if (state.editingMessageId) {
+      resubmitEditedMessage(text);
+      return;
+    }
+    executeAssistantStream(text, API_BASE + '/message/stream', null);
+  }
+
+  function resubmitEditedMessage(text) {
+    var trimmed = (text || '').trim();
+    if (!trimmed || state.busy || !state.editingMessageId || state.threadId == null) {
+      return;
+    }
+    var editIndex = state.editingMessageIndex;
+    var messageId = state.editingMessageId;
+    var hasLaterMessages = editIndex >= 0 &&
+      editIndex < visibleMessages(state.messages).length - 1;
+
+    function performResubmit() {
+      state.messages = state.messages.slice(0, editIndex);
+      cancelEditMessage();
+      var payload = promptContextPayload();
+      payload.threadId = state.threadId;
+      payload.messageId = messageId;
+      payload.message = trimmed;
+      executeAssistantStream(trimmed, API_BASE + '/message/edit/stream', payload);
+    }
+
+    if (hasLaterMessages) {
+      confirmResubmit(performResubmit);
+      return;
+    }
+    performResubmit();
+  }
+
+  function executeAssistantStream(text, streamUrl, payloadOverride) {
     var trimmed = (text || '').trim();
     if (!trimmed || state.busy) {
       return;
@@ -307,11 +410,12 @@
     });
     if (textarea) {
       textarea.value = '';
+      textarea.placeholder = 'Pide un borrador usando el contexto de esta pantalla…';
     }
     state.showLoading = true;
     setBusy(true);
 
-    var payload = promptContextPayload();
+    var payload = payloadOverride || promptContextPayload();
     payload.message = trimmed;
     var assistantIndex = null;
 
@@ -351,9 +455,11 @@
 
     ensureThread()
       .then(function (threadId) {
-        payload.threadId = threadId;
+        if (!payload.threadId) {
+          payload.threadId = threadId;
+        }
         if (window.NutriAiChatStream && typeof NutriAiChatStream.streamMessage === 'function') {
-          var streamRequest = NutriAiChatStream.streamMessage(API_BASE + '/message/stream', payload, {
+          var streamRequest = NutriAiChatStream.streamMessage(streamUrl, payload, {
             onStatus: function () {
               renderMessages();
             },
@@ -370,7 +476,7 @@
           setBusy(true);
           return streamRequest;
         }
-        return requestJson(API_BASE + '/message', {
+        return requestJson(streamUrl.replace('/stream', ''), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
@@ -401,6 +507,7 @@
   function resetConversation() {
     persistThreadId(null);
     state.messages = [];
+    cancelEditMessage();
     renderMessages();
   }
 
@@ -481,9 +588,27 @@
     }
     if (textarea) {
       textarea.addEventListener('keydown', function (event) {
+        if (event.key === 'Escape' && state.editingMessageId) {
+          event.preventDefault();
+          cancelEditMessage();
+          return;
+        }
         if (event.key === 'Enter' && !event.shiftKey) {
           event.preventDefault();
           sendMessage(textarea.value);
+        }
+      });
+    }
+    var messagesContainer = $('#aiAssistantMessages');
+    if (messagesContainer) {
+      messagesContainer.addEventListener('click', function (event) {
+        var target = event.target;
+        if (!target || !target.classList || !target.classList.contains('ai-assistant-edit-btn')) {
+          return;
+        }
+        var messageId = Number(target.getAttribute('data-message-id'));
+        if (messageId) {
+          startEditMessage(messageId);
         }
       });
     }

--- a/src/main/resources/static/sbadmin/js/ai-chat.js
+++ b/src/main/resources/static/sbadmin/js/ai-chat.js
@@ -18,7 +18,9 @@
     busy: false,
     showLoading: false,
     activeStreamRequest: null,
-    cancelling: false
+    cancelling: false,
+    editingMessageId: null,
+    editingMessageIndex: null
   };
 
   function $(selector) {
@@ -71,6 +73,67 @@
     return (messages || []).filter(function (message) {
       return message.role === 'USER' || message.role === 'ASSISTANT';
     });
+  }
+
+  function findMessageIndexById(messageId) {
+    var items = visibleMessages(state.messages);
+    for (var i = 0; i < items.length; i++) {
+      if (items[i].id === messageId) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  function updateComposerForEditMode() {
+    var textarea = $('#aiChatInput');
+    var hint = document.querySelector('.ai-chat-hint');
+    if (state.editingMessageId) {
+      if (textarea) {
+        textarea.placeholder = 'Edita tu mensaje y reenvía…';
+      }
+      if (hint) {
+        hint.textContent = 'Editando un mensaje anterior. Los mensajes posteriores se descartarán al reenviar.';
+      }
+    } else {
+      if (textarea) {
+        textarea.placeholder = 'Describe la receta, menú o plan que necesitas…';
+      }
+      if (hint) {
+        hint.textContent = 'Enter para enviar · Shift+Enter para nueva línea · Los borradores requieren tu revisión antes de usarse.';
+      }
+    }
+  }
+
+  function cancelEditMessage() {
+    state.editingMessageId = null;
+    state.editingMessageIndex = null;
+    var textarea = $('#aiChatInput');
+    if (textarea) {
+      textarea.value = '';
+    }
+    updateComposerForEditMode();
+    renderMessages(state.showLoading === true);
+  }
+
+  function startEditMessage(messageId) {
+    if (state.busy || !messageId) {
+      return;
+    }
+    var index = findMessageIndexById(messageId);
+    if (index < 0) {
+      return;
+    }
+    var message = visibleMessages(state.messages)[index];
+    state.editingMessageId = messageId;
+    state.editingMessageIndex = index;
+    var textarea = $('#aiChatInput');
+    if (textarea) {
+      textarea.value = message.content || '';
+      textarea.focus();
+    }
+    updateComposerForEditMode();
+    renderMessages(state.showLoading === true);
   }
 
   function requestJson(url, options) {
@@ -498,10 +561,15 @@
 
     var html = items.map(function (message) {
       var roleClass = message.role === 'USER' ? 'user' : 'assistant';
+      var editControl = '';
+      if (message.role === 'USER' && message.id && !state.busy && !state.editingMessageId) {
+        editControl = ' <button type="button" class="btn btn-link btn-sm ai-chat-edit-btn p-0 ml-2" ' +
+          'data-message-id="' + message.id + '" aria-label="Editar mensaje">Editar</button>';
+      }
       return '<article class="ai-chat-message ' + roleClass + '" aria-label="' + roleLabel(message.role) + '">' +
         '<div class="ai-chat-bubble">' + formatMessageBubbleContent(message) + '</div>' +
         '<div class="ai-chat-meta">' + escapeHtml(roleLabel(message.role)) +
-        (message.createdAt ? ' · ' + formatTime(message.createdAt) : '') + '</div>' +
+        (message.createdAt ? ' · ' + formatTime(message.createdAt) : '') + editControl + '</div>' +
         '</article>';
     }).join('');
 
@@ -566,12 +634,7 @@
     return startThread();
   }
 
-  function sendMessage(text) {
-    var trimmed = (text || '').trim();
-    if (!trimmed || state.busy) {
-      return;
-    }
-
+  function executeAssistantStream(threadId, trimmed, streamUrl, payload, onAfterTruncate) {
     var textarea = $('#aiChatInput');
     state.messages.push({
       role: 'USER',
@@ -621,13 +684,12 @@
       renderMessages(false);
     }
 
-    ensureThread()
-      .then(function (threadId) {
+    return ensureThread()
+      .then(function (resolvedThreadId) {
+        var effectiveThreadId = threadId || resolvedThreadId;
+        var body = payload || { threadId: effectiveThreadId, message: trimmed };
         if (window.NutriAiChatStream && typeof NutriAiChatStream.streamMessage === 'function') {
-          var streamRequest = NutriAiChatStream.streamMessage(API_BASE + '/message/stream', {
-            threadId: threadId,
-            message: trimmed
-          }, {
+          var streamRequest = NutriAiChatStream.streamMessage(streamUrl, body, {
             onStatus: function () {
               renderMessages(true);
             },
@@ -644,10 +706,10 @@
           setBusy(true);
           return streamRequest;
         }
-        return requestJson(API_BASE + '/message', {
+        return requestJson(streamUrl.replace('/stream', ''), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ threadId: threadId, message: trimmed })
+          body: JSON.stringify(body)
         }).then(function (data) {
           finalizeAssistant(data);
         });
@@ -666,10 +728,57 @@
         state.activeStreamRequest = null;
         state.cancelling = false;
         setBusy(false);
+        if (typeof onAfterTruncate === 'function') {
+          onAfterTruncate();
+        }
         if (textarea) {
           textarea.focus();
         }
       });
+  }
+
+  function resubmitEditedMessage(text) {
+    var trimmed = (text || '').trim();
+    if (!trimmed || state.busy || !state.editingMessageId || state.threadId == null) {
+      return;
+    }
+    var editIndex = state.editingMessageIndex;
+    var messageId = state.editingMessageId;
+    var hasLaterMessages = editIndex >= 0 &&
+      editIndex < visibleMessages(state.messages).length - 1;
+
+    function performResubmit() {
+      state.messages = state.messages.slice(0, editIndex);
+      cancelEditMessage();
+      executeAssistantStream(state.threadId, trimmed, API_BASE + '/message/edit/stream', {
+        threadId: state.threadId,
+        messageId: messageId,
+        message: trimmed
+      });
+    }
+
+    if (hasLaterMessages) {
+      confirmDraftAction({
+        title: '¿Reenviar mensaje editado?',
+        text: 'Se eliminarán este mensaje, las respuestas posteriores y los borradores pendientes generados después.',
+        confirmText: 'Sí, reenviar',
+        confirmColor: '#4e73df'
+      }, performResubmit);
+      return;
+    }
+    performResubmit();
+  }
+
+  function sendMessage(text) {
+    if (state.editingMessageId) {
+      resubmitEditedMessage(text);
+      return;
+    }
+    var trimmed = (text || '').trim();
+    if (!trimmed || state.busy) {
+      return;
+    }
+    executeAssistantStream(null, trimmed, API_BASE + '/message/stream', null);
   }
 
   function startNewConversation() {
@@ -699,6 +808,7 @@
     persistThreadId(null);
     state.messages = [];
     state.drafts = [];
+    cancelEditMessage();
     hideDraftPreview();
     renderDraftList();
     updateThreadTitle(null);
@@ -749,15 +859,6 @@
       });
     }
 
-    if (textarea) {
-      textarea.addEventListener('keydown', function (event) {
-        if (event.key === 'Enter' && !event.shiftKey) {
-          event.preventDefault();
-          sendMessage(textarea.value);
-        }
-      });
-    }
-
     if (newBtn) {
       newBtn.addEventListener('click', startNewConversation);
     }
@@ -766,6 +867,34 @@
     }
     if (discardBtn) {
       discardBtn.addEventListener('click', discardSelectedDraft);
+    }
+
+    var messagesContainer = $('#aiChatMessages');
+    if (messagesContainer) {
+      messagesContainer.addEventListener('click', function (event) {
+        var target = event.target;
+        if (!target || !target.classList || !target.classList.contains('ai-chat-edit-btn')) {
+          return;
+        }
+        var messageId = Number(target.getAttribute('data-message-id'));
+        if (messageId) {
+          startEditMessage(messageId);
+        }
+      });
+    }
+
+    if (textarea) {
+      textarea.addEventListener('keydown', function (event) {
+        if (event.key === 'Escape' && state.editingMessageId) {
+          event.preventDefault();
+          cancelEditMessage();
+          return;
+        }
+        if (event.key === 'Enter' && !event.shiftKey) {
+          event.preventDefault();
+          sendMessage(textarea.value);
+        }
+      });
     }
   }
 

--- a/src/test/java/com/nutriconsultas/ai/AiChatPersistenceRepositoryTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatPersistenceRepositoryTest.java
@@ -13,9 +13,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
 @ActiveProfiles("test")
+@Transactional
 class AiChatPersistenceRepositoryTest {
 
 	private static final String NUTRITIONIST_A = "auth0|nutritionist-ai-a";
@@ -110,6 +112,34 @@ class AiChatPersistenceRepositoryTest {
 
 		assertThat(threads).hasSizeGreaterThanOrEqualTo(2);
 		assertThat(threads.getFirst().getTitle()).isEqualTo("Reciente");
+	}
+
+	@Test
+	void deleteByThreadIdAndIdGreaterThanEqualRemovesAnchorAndLaterMessages() {
+		final AiChatThread thread = threadRepository.saveAndFlush(sampleThread(NUTRITIONIST_A, "Editar mensaje"));
+		final AiChatMessage firstUser = persistMessage(thread, AiChatMessageRole.USER, "Primero");
+		final AiChatMessage firstAssistant = persistMessage(thread, AiChatMessageRole.ASSISTANT, "Respuesta 1");
+		final AiChatMessage secondUser = persistMessage(thread, AiChatMessageRole.USER, "Segundo");
+
+		messageRepository.deleteByThreadIdAndIdGreaterThanEqual(thread.getId(), secondUser.getId());
+		entityManager.flush();
+		entityManager.clear();
+
+		final List<AiChatMessage> remaining = messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(thread.getId());
+		assertThat(remaining).hasSize(2);
+		assertThat(remaining.get(0).getContent()).isEqualTo("Primero");
+		assertThat(remaining.get(1).getContent()).isEqualTo("Respuesta 1");
+		assertThat(firstAssistant.getId()).isGreaterThan(firstUser.getId());
+		assertThat(secondUser.getId()).isGreaterThan(firstAssistant.getId());
+	}
+
+	private AiChatMessage persistMessage(final AiChatThread thread, final AiChatMessageRole role,
+			final String content) {
+		final AiChatMessage message = new AiChatMessage();
+		message.setThread(thread);
+		message.setRole(role);
+		message.setContent(content);
+		return messageRepository.saveAndFlush(message);
 	}
 
 	private static AiChatThread sampleThread(final String nutritionistId, final String title) {

--- a/src/test/java/com/nutriconsultas/ai/AiChatRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatRestControllerTest.java
@@ -164,6 +164,43 @@ class AiChatRestControllerTest {
 	}
 
 	@Test
+	void editMessageReturnsAssistantReply() throws Exception {
+		final AiChatMessage assistant = new AiChatMessage();
+		assistant.setId(99L);
+		assistant.setRole(AiChatMessageRole.ASSISTANT);
+		assistant.setContent("Respuesta editada.");
+		when(chatService.editAndResubmitMessage(eq(NUTRITIONIST_ID), any(AiEditMessageRequest.class)))
+			.thenReturn(new AiEditResubmitResult(new AiOrchestrationResult(5L, assistant, 0, null), 2, List.of(11L)));
+		when(aiChatRateLimiter.executeMessage(eq(NUTRITIONIST_ID), any())).thenAnswer(invocation -> {
+			final Callable<?> callable = invocation.getArgument(1);
+			return callable.call();
+		});
+
+		final ResponseEntity<Map<String, Object>> response = controller.editMessage(
+				new AiEditMessageRequest(5L, 10L, "Texto editado", null, null, null), principal(NUTRITIONIST_ID));
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("assistantMessageId", 99L)
+			.containsEntry("truncatedMessageCount", 2)
+			.containsEntry("discardedDraftIds", List.of(11L));
+	}
+
+	@Test
+	void streamEditMessageReturnsSseEmitter() throws Exception {
+		when(aiChatRateLimiter.executeMessage(eq(NUTRITIONIST_ID), any())).thenAnswer(invocation -> {
+			final Callable<?> callable = invocation.getArgument(1);
+			return callable.call();
+		});
+
+		final SseEmitter emitter = controller.streamEditMessage(
+				new AiEditMessageRequest(5L, 10L, "Texto editado", null, null, null), principal(NUTRITIONIST_ID));
+
+		assertThat(emitter).isNotNull();
+		verify(chatService).streamEditMessage(eq(NUTRITIONIST_ID), any(AiEditMessageRequest.class),
+				any(SseEmitter.class));
+	}
+
+	@Test
 	void startChatRequiresAuthentication() {
 		final ResponseEntity<Map<String, Object>> response = controller.startChat(null, null);
 

--- a/src/test/java/com/nutriconsultas/ai/AiChatServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatServiceTest.java
@@ -160,6 +160,60 @@ class AiChatServiceTest {
 		verify(orchestrationService, never()).processUserMessage(any(), any());
 	}
 
+	@Test
+	void editAndResubmitTruncatesAndDelegatesToOrchestration() {
+		final AiChatThread thread = sampleThread(5L, NUTRITIONIST_ID);
+		when(threadRepository.findByIdAndNutritionistId(5L, NUTRITIONIST_ID)).thenReturn(Optional.of(thread));
+		final AiChatMessage anchor = message(10L, AiChatMessageRole.USER, "Original");
+		anchor.setThread(thread);
+		anchor.setCreatedAt(Instant.parse("2026-06-30T12:00:00Z"));
+		when(messageRepository.findByIdAndThreadNutritionistId(10L, NUTRITIONIST_ID)).thenReturn(Optional.of(anchor));
+		when(draftRepository.findByThreadIdAndStatusAndCreatedAtGreaterThanEqual(5L, AiDraftStatus.DRAFT,
+				anchor.getCreatedAt()))
+			.thenReturn(List.of());
+		when(messageRepository.deleteByThreadIdAndIdGreaterThanEqual(5L, 10L)).thenReturn(3);
+		final AiChatMessage assistant = message(99L, AiChatMessageRole.ASSISTANT, "Nueva respuesta");
+		when(patientContextResolver.resolve(null, NUTRITIONIST_ID)).thenReturn(Optional.empty());
+		when(dietaContextResolver.resolve(null, NUTRITIONIST_ID)).thenReturn(Optional.empty());
+		when(platilloContextResolver.resolve(null, NUTRITIONIST_ID)).thenReturn(Optional.empty());
+		when(orchestrationService.processUserMessage(any(), eq("Texto editado")))
+			.thenReturn(new AiOrchestrationResult(5L, assistant, 1, null));
+
+		final AiEditResubmitResult result = service.editAndResubmitMessage(NUTRITIONIST_ID,
+				new AiEditMessageRequest(5L, 10L, "Texto editado", null, null, null));
+
+		assertThat(result.truncatedMessageCount()).isEqualTo(3);
+		assertThat(result.orchestration().assistantMessage().getContent()).isEqualTo("Nueva respuesta");
+		verify(orchestrationService).processUserMessage(any(), eq("Texto editado"));
+	}
+
+	@Test
+	void editAndResubmitRejectsAssistantAnchor() {
+		final AiChatThread thread = sampleThread(5L, NUTRITIONIST_ID);
+		final AiChatMessage anchor = message(10L, AiChatMessageRole.ASSISTANT, "Respuesta");
+		anchor.setThread(thread);
+		when(messageRepository.findByIdAndThreadNutritionistId(10L, NUTRITIONIST_ID)).thenReturn(Optional.of(anchor));
+
+		assertThatThrownBy(() -> service.editAndResubmitMessage(NUTRITIONIST_ID,
+				new AiEditMessageRequest(5L, 10L, "Texto editado", null, null, null)))
+			.isInstanceOf(AiChatException.class)
+			.extracting(ex -> ((AiChatException) ex).getHttpStatus())
+			.isEqualTo(HttpStatus.BAD_REQUEST);
+		verify(orchestrationService, never()).processUserMessage(any(), any());
+	}
+
+	@Test
+	void editAndResubmitDeniesForeignMessage() {
+		when(messageRepository.findByIdAndThreadNutritionistId(10L, OTHER_NUTRITIONIST_ID))
+			.thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.editAndResubmitMessage(OTHER_NUTRITIONIST_ID,
+				new AiEditMessageRequest(5L, 10L, "Texto editado", null, null, null)))
+			.isInstanceOf(AiChatException.class)
+			.extracting(ex -> ((AiChatException) ex).getHttpStatus())
+			.isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
 	private static AiChatThread sampleThread(final long id, final String nutritionistId) {
 		final AiChatThread thread = new AiChatThread();
 		thread.setId(id);


### PR DESCRIPTION
## Summary
- Add `POST /rest/ai/chat/message/edit` and `/message/edit/stream` to edit a user message and resubmit with thread truncation from that message onward
- Auto-discard pending `DRAFT` records created after the edited anchor message
- Expose **Editar** on user bubbles in full-page chat (`ai-chat.js`) and the Mina floating widget (`ai-assistant-widget.js`), with SweetAlert confirmation when later messages would be removed

## Test plan
- [x] `./lint.sh` (checkstyle, spotbugs, pmd, tests, Thymeleaf validation)
- [x] `mvn pmd:check`
- [x] `AiChatServiceTest`, `AiChatRestControllerTest`, `AiChatPersistenceRepositoryTest`
- [x] Browser: `/admin/ai` edit → confirm → truncate + stream
- [x] Browser: `/admin/dietas` widget edit → confirm → resubmit

Closes #437

Made with [Cursor](https://cursor.com)