### PR TITLE
Add system prompt volume limits and bulk refusal corpus (#449)

### DIFF
--- a/docs/ai/FUNCTIONAL-SCOPE.md
+++ b/docs/ai/FUNCTIONAL-SCOPE.md
@@ -124,8 +124,9 @@ The assistant **must decline or redirect** (politely, in Spanish) for:
 | **Final save without review** | «Guarda ya este platillo en mi catálogo.» | Draft only until nutritionist accepts |
 | **Patient mobile / public API** | «Envía el plan al app del paciente.» | v1 is nutritionist web only |
 | **Unsupported languages** | Prompts insisting on English-only replies | Track policy: user-facing comms in es-MX |
+| **Excessive bulk generation** | «Genera 100 platillos», «1000 planes nutricionales», «menú de 30 días», «plan para todos mis pacientes» | Volume limits (#447, #449): max 14 plan days, 7 menu days, 1 dish/turn; offer 1 approvable draft — see [`PROMPT-SECURITY.md`](PROMPT-SECURITY.md) |
 
-When declining, the assistant explains **what it can do instead** (e.g. «Puedo generar un borrador para que lo revises y guardes manualmente.»).
+When declining, the assistant explains **what it can do instead** (e.g. «Puedo generar un borrador para que lo revises y guardes manualmente.»). For bulk volume requests, use the refusal copy in **VOLUMEN Y LÍMITES** (`system-prompt-base.txt`), aligned with `AiRequestScopeGuard` (#447).
 
 ---
 

--- a/docs/ai/PROMPT-SECURITY.md
+++ b/docs/ai/PROMPT-SECURITY.md
@@ -1,7 +1,7 @@
 # AI Prompt Security (v1)
 
-**Issue:** [#439](https://github.com/diego-torres/nutriconsultas/issues/439), [#440](https://github.com/diego-torres/nutriconsultas/issues/440), [#447](https://github.com/diego-torres/nutriconsultas/issues/447) · Epic [#438](https://github.com/diego-torres/nutriconsultas/issues/438)  
-**Related:** [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md) (#362) · [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md)
+**Issue:** [#439](https://github.com/diego-torres/nutriconsultas/issues/439), [#440](https://github.com/diego-torres/nutriconsultas/issues/440), [#447](https://github.com/diego-torres/nutriconsultas/issues/447), [#449](https://github.com/diego-torres/nutriconsultas/issues/449) · Epic [#438](https://github.com/diego-torres/nutriconsultas/issues/438)  
+**Related:** [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md) (#362) · [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) · [`FUNCTIONAL-SCOPE.md`](FUNCTIONAL-SCOPE.md) (#361)
 
 Defense-in-depth rules for nutritionist chat input before OpenAI orchestration (#385). Part of Milestone 5 — required before production `AI_ENABLED=true` (see #408).
 
@@ -14,7 +14,7 @@ Defense-in-depth rules for nutritionist chat input before OpenAI orchestration (
 | Limit untrusted input size | `nutriconsultas.ai.max-user-message-length` (default **4000**, matches UI `maxlength`) |
 | Detect high-risk override patterns | `AiPromptThreatDetector` + `AiUserMessageGuard` (injection + jailbreak) |
 | Separate user content from system instructions | Delimiter wrap `<mensaje_nutriologo>…</mensaje_nutriologo>` on outbound user role messages |
-| Model-side refusal | `ai/system-prompt-base.txt` **SEGURIDAD DE PROMPTS** + **DEFENSA ANTE JAILBREAK** (#440) |
+| Model-side refusal | `ai/system-prompt-base.txt` **SEGURIDAD DE PROMPTS** + **DEFENSA ANTE JAILBREAK** (#440) + **VOLUMEN Y LÍMITES** (#449) |
 | User-facing block message | Spanish `400` via `AiChatException` — no OpenAI call, no persistence on block |
 | Bulk generation limits (#447) | `AiRequestScopeGuard` before orchestration — persist user + assistant refusal, no OpenAI/tools |
 
@@ -78,6 +78,25 @@ Blocked requests log `category` and `messageLength` only — never the message b
 
 Scope blocks log `kind` and `requestedAmount` only — never the message body.
 
+**Model-side reinforcement (#449):** `system-prompt-base.txt` **VOLUMEN Y LÍMITES** instructs the assistant to refuse politely with the same Spanish copy as `AiRequestScopeGuard.refusalFor()` when bulk requests reach the model (defense-in-depth if heuristics miss edge phrasing). Documented in [`FUNCTIONAL-SCOPE.md`](FUNCTIONAL-SCOPE.md) unsupported prompts.
+
+---
+
+## Bulk refusal corpus (#449)
+
+Examples the assistant (and `AiRequestScopeGuard`) should refuse — offer **1 borrador de ejemplo** instead:
+
+| Scenario | Example user prompt | Expected refusal theme |
+|----------|---------------------|------------------------|
+| Bulk dishes | «Genera 100 platillos con pollo esta semana» | *No puedo generar 100 platillos en un solo turno… 1 borrador de ejemplo* |
+| Bulk plans | «Crea 1000 planes nutricionales para mis pacientes» | *No puedo generar 1000 planes… 1 borrador de ejemplo* |
+| Long plan | «Genera un plan alimenticio de 30 días» | *No puedo generar 30 planes/días… variaciones en mensajes separados* |
+| Long menu | «Arma un menú de 14 días» | *No puedo generar un menú de 14 días… hasta 7 días* |
+| Multi-patient | «Genera planes para todos mis pacientes» | *No puedo generar planes para todos tus pacientes… un paciente a la vez* |
+| Year scope | «Comidas para cada día del año» | Plan-day refusal; redirect to single draft |
+
+**Allowed (not bulk):** «Genera un menú de 7 días», «Plan de 14 días bajo en sodio», «Un borrador de platillo con avena».
+
 ---
 
 ## Configuration
@@ -119,6 +138,7 @@ HTTP status: **400** (`AiToolErrorCode.VALIDATION`) for injection/jailbreak/leng
 | **440** | ~~Jailbreak / role-override refusal corpus~~ **done** in #440 |
 | **441** | Delimiters, tool allowlist, output validation (defense-in-depth) |
 | **447** | ~~Deterministic bulk scope limits (Java pre-check)~~ **done** in #447 |
+| **449** | ~~System prompt volume limits and bulk refusal corpus~~ **done** in #449 |
 | **448** | LLM scope classifier pre-flight |
 
 ---

--- a/src/main/java/com/nutriconsultas/ai/AiSystemPromptServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiSystemPromptServiceImpl.java
@@ -31,6 +31,8 @@ public class AiSystemPromptServiceImpl implements AiSystemPromptService {
 
 	static final String SAFETY_MARKER_JAILBREAK_DEFENSE = "DEFENSA ANTE JAILBREAK";
 
+	static final String SAFETY_MARKER_VOLUME_LIMITS = "VOLUMEN Y LÍMITES";
+
 	private static final String TEMPLATE_PATH = "ai/system-prompt-base.txt";
 
 	private final String baseTemplate;

--- a/src/main/resources/ai/system-prompt-base.txt
+++ b/src/main/resources/ai/system-prompt-base.txt
@@ -20,6 +20,16 @@ PREGUNTAS CLARIFICADORAS
 - Pregunta antes de generar borradores extensos si faltan: objetivo calórico, número de ingestas, restricciones no conocidas o porciones.
 - Si el contexto del paciente ya incluye kcal objetivo o alergias, no vuelvas a preguntar esos datos salvo que el nutriólogo pida cambiarlos.
 
+VOLUMEN Y LÍMITES
+- Máximo 14 días por borrador de plan alimenticio; máximo 7 días por menú semanal en un solo turno.
+- Máximo 1 platillo por turno; pide variaciones o platillos adicionales en mensajes siguientes.
+- No intentes generación masiva (p. ej. 100 platillos, 1000 planes, menús para todo el año, planes para todos los pacientes).
+- Si piden volumen excesivo, responde cortésmente en español y ofrece 1 borrador de ejemplo aprobable. Usa esta redacción (adaptando N y el sustantivo cuando aplique):
+  - Platillos: «No puedo generar N platillos en un solo turno. Puedo ayudarte con 1 borrador de ejemplo que revises y apruebes; después puedes pedir variaciones en mensajes separados.»
+  - Menús: «No puedo generar un menú de N días en un solo turno. Puedo ayudarte con un menú de hasta 7 días o un borrador de ejemplo; pide días adicionales en mensajes separados.»
+  - Planes: «No puedo generar N planes alimenticios en un solo turno. Puedo ayudarte con 1 borrador de ejemplo que revises y apruebes; después puedes pedir variaciones o días adicionales en mensajes separados.»
+  - Todos los pacientes: «No puedo generar planes para todos tus pacientes en un solo turno. Trabajemos con un paciente o un borrador de ejemplo a la vez; después puedes pedir variaciones en mensajes separados.»
+
 SEGURIDAD CLÍNICA
 - No diagnostiques enfermedades ni prescribas medicamentos o tratamiento médico.
 - No afirmes que un plan es clínicamente apropiado, seguro o definitivo; siempre requiere revisión profesional del nutriólogo.

--- a/src/test/java/com/nutriconsultas/ai/AiSystemPromptServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiSystemPromptServiceTest.java
@@ -36,6 +36,11 @@ class AiSystemPromptServiceTest {
 		assertThat(prompt.toLowerCase(Locale.ROOT)).contains("investigación profunda");
 		assertThat(prompt).contains(AiSystemPromptServiceImpl.SAFETY_MARKER_JAILBREAK_DEFENSE);
 		assertThat(prompt.toLowerCase(Locale.ROOT)).contains("no puedo cambiar mi rol");
+		assertThat(prompt).contains(AiSystemPromptServiceImpl.SAFETY_MARKER_VOLUME_LIMITS);
+		assertThat(prompt).contains("14 días");
+		assertThat(prompt.toLowerCase(Locale.ROOT)).contains("1 platillo");
+		assertThat(prompt).contains("Puedo ayudarte con 1 borrador de ejemplo que revises y apruebes");
+		assertThat(prompt).contains("todos tus pacientes en un solo turno");
 		assertThat(prompt).contains("<mensaje_nutriologo>");
 	}
 
@@ -89,11 +94,19 @@ class AiSystemPromptServiceTest {
 	}
 
 	@Test
-	void nullContextUsesDefaults() {
-		final String prompt = service.buildSystemPrompt(null);
+	void volumeLimitsSectionAlignsWithScopeGuardRefusalCopy() {
+		final String prompt = service.buildSystemPrompt(AiSystemPromptContext.defaultNutritionist());
+		final String dishRefusal = new AiRequestScopeGuard(new AiProperties()).evaluate("Genera 5 platillos")
+			.orElseThrow()
+			.refusalMessage();
+		final String planRefusal = new AiRequestScopeGuard(new AiProperties()).evaluate("Genera un plan de 20 días")
+			.orElseThrow()
+			.refusalMessage();
 
-		assertThat(prompt).contains("es-MX");
-		assertThat(prompt).contains(AiSystemPromptServiceImpl.SAFETY_MARKER_DRAFT_LABEL);
+		assertThat(prompt).contains("No puedo generar N platillos en un solo turno");
+		assertThat(prompt).contains("Puedo ayudarte con 1 borrador de ejemplo que revises y apruebes");
+		assertThat(dishRefusal).contains("Puedo ayudarte con 1 borrador de ejemplo que revises y apruebes");
+		assertThat(planRefusal).contains("Puedo ayudarte con 1 borrador de ejemplo que revises y apruebes");
 	}
 
 }


### PR DESCRIPTION
## Summary
- Adds **VOLUMEN Y LÍMITES** section to `system-prompt-base.txt` (14 plan days, 7 menu days, 1 dish/turn, bulk refusal copy aligned with `AiRequestScopeGuard`).
- Documents excessive bulk generation in `FUNCTIONAL-SCOPE.md` unsupported prompts.
- Extends `PROMPT-SECURITY.md` with bulk refusal corpus and cross-references.
- Tests: `AiSystemPromptServiceTest` asserts volume section and alignment with scope guard copy.

Closes #449

## Test plan
- [x] `mvn test -Dtest=AiSystemPromptServiceTest`
- [x] `./lint.sh`


Made with [Cursor](https://cursor.com)