### PR TITLE
Add LLM scope classifier pre-flight for AI chat (#448)

### DIFF
--- a/docs/ai/PROMPT-SECURITY.md
+++ b/docs/ai/PROMPT-SECURITY.md
@@ -1,6 +1,6 @@
 # AI Prompt Security (v1)
 
-**Issue:** [#439](https://github.com/diego-torres/nutriconsultas/issues/439), [#440](https://github.com/diego-torres/nutriconsultas/issues/440), [#447](https://github.com/diego-torres/nutriconsultas/issues/447), [#449](https://github.com/diego-torres/nutriconsultas/issues/449) · Epic [#438](https://github.com/diego-torres/nutriconsultas/issues/438)  
+**Issue:** [#439](https://github.com/diego-torres/nutriconsultas/issues/439), [#440](https://github.com/diego-torres/nutriconsultas/issues/440), [#447](https://github.com/diego-torres/nutriconsultas/issues/447), [#448](https://github.com/diego-torres/nutriconsultas/issues/448), [#449](https://github.com/diego-torres/nutriconsultas/issues/449) · Epic [#438](https://github.com/diego-torres/nutriconsultas/issues/438)  
 **Related:** [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md) (#362) · [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) · [`FUNCTIONAL-SCOPE.md`](FUNCTIONAL-SCOPE.md) (#361)
 
 Defense-in-depth rules for nutritionist chat input before OpenAI orchestration (#385). Part of Milestone 5 — required before production `AI_ENABLED=true` (see #408).
@@ -17,6 +17,7 @@ Defense-in-depth rules for nutritionist chat input before OpenAI orchestration (
 | Model-side refusal | `ai/system-prompt-base.txt` **SEGURIDAD DE PROMPTS** + **DEFENSA ANTE JAILBREAK** (#440) + **VOLUMEN Y LÍMITES** (#449) |
 | User-facing block message | Spanish `400` via `AiChatException` — no OpenAI call, no persistence on block |
 | Bulk generation limits (#447) | `AiRequestScopeGuard` before orchestration — persist user + assistant refusal, no OpenAI/tools |
+| Ambiguous bulk scope (#448) | `AiRequestScopeClassifier` — cheap JSON OpenAI call after deterministic guard passes |
 
 ---
 
@@ -29,8 +30,10 @@ flowchart LR
   B -->|allowed| D[Persist sanitized text in ai_chat_message]
   D --> S[AiRequestScopeGuard.evaluate]
   S -->|scope exceeded| R[Persist assistant refusal — no OpenAI]
-  S -->|allowed| E[buildConversation wraps USER rows]
-  E --> F[OpenAI chat completion]
+  S -->|allowed| C[AiRequestScopeClassifier.evaluate]
+  C -->|REFUSE/CLARIFY| R
+  C -->|ALLOW/disabled| E[buildConversation wraps USER rows]
+  E --> F[OpenAI chat completion + tools]
 ```
 
 **Edit/resubmit (#437):** validation runs **before** thread truncation so a blocked edit cannot delete history.
@@ -99,6 +102,27 @@ Examples the assistant (and `AiRequestScopeGuard`) should refuse — offer **1 b
 
 ---
 
+## LLM scope classifier (#448)
+
+`AiRequestScopeClassifier` runs **after** `AiRequestScopeGuard` passes and **before** the main tool loop. Skipped when the deterministic guard already refused (no double pre-flight cost for obvious bulk).
+
+| Setting | Env | Default |
+|---------|-----|---------|
+| `nutriconsultas.ai.scope-classifier-enabled` | `AI_SCOPE_CLASSIFIER_ENABLED` | `true` |
+| `nutriconsultas.ai.scope-classifier-max-tokens` | `AI_SCOPE_CLASSIFIER_MAX_TOKENS` | `200` |
+
+Single OpenAI call: **no tools**, temperature **0**, JSON object response (`ALLOW` \| `REFUSE` \| `CLARIFY`). Prompt: `ai/scope-classifier-prompt.txt`.
+
+| Decision | Behavior |
+|----------|----------|
+| **ALLOW** | Proceed to orchestration |
+| **REFUSE** | Spanish refusal aligned with #447 (`refusalMessageForUnits`) |
+| **CLARIFY** | One follow-up question (`suggestedPrompt`); no drafts yet |
+
+Classifier failures **fail open** (allow request) with warn log. Decisions log `decision` + unit counts only — never message body.
+
+---
+
 ## Configuration
 
 | Property | Env | Default |
@@ -107,6 +131,8 @@ Examples the assistant (and `AiRequestScopeGuard`) should refuse — offer **1 b
 | `nutriconsultas.ai.max-days-per-turn` | `AI_MAX_DAYS_PER_TURN` | `14` |
 | `nutriconsultas.ai.max-dishes-per-turn` | `AI_MAX_DISHES_PER_TURN` | `1` |
 | `nutriconsultas.ai.max-menu-days-per-turn` | `AI_MAX_MENU_DAYS_PER_TURN` | `7` |
+| `nutriconsultas.ai.scope-classifier-enabled` | `AI_SCOPE_CLASSIFIER_ENABLED` | `true` |
+| `nutriconsultas.ai.scope-classifier-max-tokens` | `AI_SCOPE_CLASSIFIER_MAX_TOKENS` | `200` |
 
 ---
 
@@ -125,9 +151,9 @@ HTTP status: **400** (`AiToolErrorCode.VALIDATION`) for injection/jailbreak/leng
 
 ## Testing
 
-- **Unit:** `AiPromptThreatDetectorTest`, `AiUserMessageGuardTest`, `AiRequestScopeGuardTest`, `AiOpenAiToolCatalogTest` — fixtures only, no live OpenAI
-- **Integration:** `AiOrchestrationServiceTest` — wrapped user content; scope refusal without OpenAI
-- **Future:** #450 golden prompts for bulk/abuse scenarios; #448 LLM scope classifier
+- **Unit:** `AiPromptThreatDetectorTest`, `AiUserMessageGuardTest`, `AiRequestScopeGuardTest`, `AiRequestScopeClassifierTest`, `AiOpenAiToolCatalogTest` — fixtures only, no live OpenAI
+- **Integration:** `AiOrchestrationServiceTest` — wrapped user content; scope/classifier short-circuit without tool loop
+- **Future:** #450 golden prompts for bulk/abuse scenarios
 
 ---
 
@@ -139,7 +165,7 @@ HTTP status: **400** (`AiToolErrorCode.VALIDATION`) for injection/jailbreak/leng
 | **441** | Delimiters, tool allowlist, output validation (defense-in-depth) |
 | **447** | ~~Deterministic bulk scope limits (Java pre-check)~~ **done** in #447 |
 | **449** | ~~System prompt volume limits and bulk refusal corpus~~ **done** in #449 |
-| **448** | LLM scope classifier pre-flight |
+| **448** | ~~LLM scope classifier pre-flight~~ **done** in #448 |
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/AiChatPersistence.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatPersistence.java
@@ -1,0 +1,37 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Shared chat persistence collaborators for {@link AiOrchestrationServiceImpl}.
+ */
+@Component
+public class AiChatPersistence {
+
+	private final AiChatThreadRepository threads;
+
+	private final AiChatMessageRepository messages;
+
+	private final TransactionTemplate transactions;
+
+	public AiChatPersistence(final AiChatThreadRepository threads, final AiChatMessageRepository messages,
+			final TransactionTemplate transactions) {
+		this.threads = threads;
+		this.messages = messages;
+		this.transactions = transactions;
+	}
+
+	public AiChatThreadRepository getThreadRepository() {
+		return threads;
+	}
+
+	public AiChatMessageRepository getMessageRepository() {
+		return messages;
+	}
+
+	public TransactionTemplate getTransactionTemplate() {
+		return transactions;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationServiceImpl.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.StringUtils;
 
 import lombok.extern.slf4j.Slf4j;
@@ -27,37 +26,27 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 
 	private final AiSystemPromptService systemPromptService;
 
-	private final AiChatThreadRepository threadRepository;
+	private final AiChatPersistence chatPersistence;
 
-	private final AiChatMessageRepository messageRepository;
-
-	private final AiOpenAiToolCatalog toolCatalog;
-
-	private final AiOrchestrationToolDispatcher toolDispatcher;
-
-	private final TransactionTemplate transactionTemplate;
+	private final AiOrchestrationTools orchestrationTools;
 
 	private final AiUserMessageGuard userMessageGuard;
 
-	private final AiRequestScopeGuard requestScopeGuard;
+	private final AiRequestScopePipeline requestScopePipeline;
 
 	private static final int STREAM_CHUNK_SIZE = 32;
 
 	public AiOrchestrationServiceImpl(final AiProperties properties, final OpenAiClientService openAiClientService,
-			final AiSystemPromptService systemPromptService, final AiChatThreadRepository threadRepository,
-			final AiChatMessageRepository messageRepository, final AiOpenAiToolCatalog toolCatalog,
-			final AiOrchestrationToolDispatcher toolDispatcher, final TransactionTemplate transactionTemplate,
-			final AiUserMessageGuard userMessageGuard, final AiRequestScopeGuard requestScopeGuard) {
+			final AiSystemPromptService systemPromptService, final AiChatPersistence chatPersistence,
+			final AiOrchestrationTools orchestrationTools, final AiUserMessageGuard userMessageGuard,
+			final AiRequestScopePipeline requestScopePipeline) {
 		this.properties = properties;
 		this.openAiClientService = openAiClientService;
 		this.systemPromptService = systemPromptService;
-		this.threadRepository = threadRepository;
-		this.messageRepository = messageRepository;
-		this.toolCatalog = toolCatalog;
-		this.toolDispatcher = toolDispatcher;
-		this.transactionTemplate = transactionTemplate;
+		this.chatPersistence = chatPersistence;
+		this.orchestrationTools = orchestrationTools;
 		this.userMessageGuard = userMessageGuard;
-		this.requestScopeGuard = requestScopeGuard;
+		this.requestScopePipeline = requestScopePipeline;
 	}
 
 	@Override
@@ -68,9 +57,10 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 		final AiChatThread thread = loadThread(context);
 		persistUserMessage(thread, sanitizedMessage);
 
-		final Optional<AiRequestScopeViolation> scopeViolation = requestScopeGuard.evaluate(sanitizedMessage);
-		if (scopeViolation.isPresent()) {
-			return completeScopeRefusal(thread, scopeViolation.get());
+		final Optional<AiRequestScopePipeline.ScopeShortCircuit> scopeShortCircuit = requestScopePipeline
+			.evaluate(sanitizedMessage);
+		if (scopeShortCircuit.isPresent()) {
+			return completeScopeShortCircuit(thread, scopeShortCircuit.get());
 		}
 
 		final List<OpenAiChatMessage> conversation = buildConversation(context, thread);
@@ -91,7 +81,7 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 			final AiStreamEventConsumer streamConsumer) {
 		assertOperational();
 		final String sanitizedMessage = validateUserMessage(userMessage);
-		final AiChatThread thread = transactionTemplate.execute(status -> {
+		final AiChatThread thread = chatPersistence.getTransactionTemplate().execute(status -> {
 			final AiChatThread loaded = loadThread(context);
 			persistUserMessage(loaded, sanitizedMessage);
 			return loaded;
@@ -100,17 +90,19 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 			throw new AiOrchestrationException("No se pudo guardar el mensaje.");
 		}
 
-		final List<OpenAiChatMessage> conversation = transactionTemplate.execute(status -> {
+		final Optional<AiRequestScopePipeline.ScopeShortCircuit> scopeShortCircuit = requestScopePipeline
+			.evaluate(sanitizedMessage);
+		if (scopeShortCircuit.isPresent()) {
+			completeScopeShortCircuitStreaming(thread, scopeShortCircuit.get(), streamConsumer);
+			return;
+		}
+
+		final List<OpenAiChatMessage> conversation = chatPersistence.getTransactionTemplate().execute(status -> {
 			final AiChatThread loadedThread = loadThread(context);
 			return buildConversation(context, loadedThread);
 		});
 		if (conversation == null) {
 			throw new AiOrchestrationException("No se pudo cargar el historial de la conversación.");
-		}
-		final Optional<AiRequestScopeViolation> scopeViolation = requestScopeGuard.evaluate(sanitizedMessage);
-		if (scopeViolation.isPresent()) {
-			completeScopeRefusalStreaming(thread, scopeViolation.get(), streamConsumer);
-			return;
 		}
 		streamConsumer.onStatus("thinking", "El asistente está pensando…");
 		streamConsumer.throwIfCancelled();
@@ -119,7 +111,7 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 		emitContentDeltas(loopOutcome.assistantContent(), streamConsumer);
 		streamConsumer.throwIfCancelled();
 
-		final AiOrchestrationResult result = transactionTemplate.execute(status -> {
+		final AiOrchestrationResult result = chatPersistence.getTransactionTemplate().execute(status -> {
 			final AiChatMessage assistantMessage = persistAssistantMessage(thread, loopOutcome.assistantContent());
 			persistToolAuditMessages(thread, loopOutcome.toolAuditEntries());
 			touchThread(thread);
@@ -163,26 +155,34 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 		return userMessageGuard.validateAndSanitize(userMessage);
 	}
 
-	private AiOrchestrationResult completeScopeRefusal(final AiChatThread thread,
-			final AiRequestScopeViolation violation) {
-		final AiChatMessage assistantMessage = persistAssistantMessage(thread, violation.refusalMessage());
+	private AiOrchestrationResult completeScopeShortCircuit(final AiChatThread thread,
+			final AiRequestScopePipeline.ScopeShortCircuit shortCircuit) {
+		final AiChatMessage assistantMessage = persistAssistantMessage(thread, shortCircuit.assistantMessage());
 		touchThread(thread);
 		if (log.isInfoEnabled()) {
-			log.info("AI orchestration scope refusal threadId={} kind={}", thread.getId(), violation.kind());
+			log.info("AI orchestration {} short-circuit threadId={} detail={}", shortCircuit.sourceLabel(),
+					thread.getId(), shortCircuit.sourceDetail());
 		}
 		return new AiOrchestrationResult(thread.getId(), assistantMessage, 0, null);
 	}
 
-	private void completeScopeRefusalStreaming(final AiChatThread thread, final AiRequestScopeViolation violation,
-			final AiStreamEventConsumer streamConsumer) {
+	private void completeScopeShortCircuitStreaming(final AiChatThread thread,
+			final AiRequestScopePipeline.ScopeShortCircuit shortCircuit, final AiStreamEventConsumer streamConsumer) {
+		completePreOrchestrationReplyStreaming(thread, shortCircuit.assistantMessage(), shortCircuit.sourceLabel(),
+				shortCircuit.sourceDetail(), streamConsumer);
+	}
+
+	private void completePreOrchestrationReplyStreaming(final AiChatThread thread, final String assistantContent,
+			final String sourceLabel, final Object sourceDetail, final AiStreamEventConsumer streamConsumer) {
 		streamConsumer.throwIfCancelled();
-		emitContentDeltas(violation.refusalMessage(), streamConsumer);
+		emitContentDeltas(assistantContent, streamConsumer);
 		streamConsumer.throwIfCancelled();
-		final AiOrchestrationResult result = transactionTemplate.execute(status -> {
-			final AiChatMessage assistantMessage = persistAssistantMessage(thread, violation.refusalMessage());
+		final AiOrchestrationResult result = chatPersistence.getTransactionTemplate().execute(status -> {
+			final AiChatMessage assistantMessage = persistAssistantMessage(thread, assistantContent);
 			touchThread(thread);
 			if (log.isInfoEnabled()) {
-				log.info("AI streaming scope refusal threadId={} kind={}", thread.getId(), violation.kind());
+				log.info("AI streaming {} short-circuit threadId={} detail={}", sourceLabel, thread.getId(),
+						sourceDetail);
 			}
 			return new AiOrchestrationResult(thread.getId(), assistantMessage, 0, null);
 		});
@@ -193,7 +193,7 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 	}
 
 	private AiChatThread loadThread(final AiOrchestrationContext context) {
-		return threadRepository.findByIdAndNutritionistId(context.threadId(), context.nutritionistId())
+		return chatPersistence.getThreadRepository().findByIdAndNutritionistId(context.threadId(), context.nutritionistId())
 			.orElseThrow(() -> new AiOrchestrationException("No se encontró la conversación."));
 	}
 
@@ -202,7 +202,7 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 		message.setThread(thread);
 		message.setRole(AiChatMessageRole.USER);
 		message.setContent(content);
-		messageRepository.save(message);
+		chatPersistence.getMessageRepository().save(message);
 	}
 
 	private List<OpenAiChatMessage> buildConversation(final AiOrchestrationContext context, final AiChatThread thread) {
@@ -217,7 +217,8 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 	}
 
 	private void appendPersistedHistory(final List<OpenAiChatMessage> messages, final long threadId) {
-		final List<AiChatMessage> persisted = messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(threadId);
+		final List<AiChatMessage> persisted = chatPersistence.getMessageRepository()
+			.findByThreadIdOrderByCreatedAtAscIdAsc(threadId);
 		for (final AiChatMessage message : persisted) {
 			if (message.getRole() == AiChatMessageRole.USER) {
 				messages.add(OpenAiChatMessage.user(userMessageGuard.wrapForModel(message.getContent())));
@@ -240,7 +241,8 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 				streamConsumer.throwIfCancelled();
 			}
 			final OpenAiChatCompletionResponse response = openAiClientService
-				.chatCompletion(new OpenAiChatCompletionRequest(List.copyOf(conversation), toolCatalog.definitions()));
+				.chatCompletion(new OpenAiChatCompletionRequest(List.copyOf(conversation),
+						orchestrationTools.getToolCatalog().definitions()));
 			accumulatedUsage = mergeUsage(accumulatedUsage, response.usage());
 			assistantContent = response.content();
 
@@ -279,7 +281,7 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 
 	private String executeToolCall(final AiOrchestrationContext context, final OpenAiToolCall toolCall) {
 		try {
-			return toolDispatcher.dispatch(context, toolCall.name(), toolCall.argumentsJson());
+			return orchestrationTools.getToolDispatcher().dispatch(context, toolCall.name(), toolCall.argumentsJson());
 		}
 		catch (final AiOrchestrationException ex) {
 			if (log.isWarnEnabled()) {
@@ -294,7 +296,7 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 		message.setThread(thread);
 		message.setRole(AiChatMessageRole.ASSISTANT);
 		message.setContent(content);
-		return messageRepository.save(message);
+		return chatPersistence.getMessageRepository().save(message);
 	}
 
 	private void persistToolAuditMessages(final AiChatThread thread, final List<ToolAuditEntry> entries) {
@@ -304,12 +306,12 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 			message.setRole(AiChatMessageRole.TOOL);
 			message.setToolName(entry.toolName());
 			message.setContent(truncateForAudit(entry.resultJson()));
-			messageRepository.save(message);
+			chatPersistence.getMessageRepository().save(message);
 		}
 	}
 
 	private void touchThread(final AiChatThread thread) {
-		threadRepository.save(thread);
+		chatPersistence.getThreadRepository().save(thread);
 	}
 
 	private static String truncateForAudit(final String json) {

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationTools.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationTools.java
@@ -1,0 +1,28 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Tool catalog and dispatcher for {@link AiOrchestrationServiceImpl}.
+ */
+@Component
+public class AiOrchestrationTools {
+
+	private final AiOpenAiToolCatalog catalog;
+
+	private final AiOrchestrationToolDispatcher dispatcher;
+
+	public AiOrchestrationTools(final AiOpenAiToolCatalog catalog, final AiOrchestrationToolDispatcher dispatcher) {
+		this.catalog = catalog;
+		this.dispatcher = dispatcher;
+	}
+
+	public AiOpenAiToolCatalog getToolCatalog() {
+		return catalog;
+	}
+
+	public AiOrchestrationToolDispatcher getToolDispatcher() {
+		return dispatcher;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiProperties.java
+++ b/src/main/java/com/nutriconsultas/ai/AiProperties.java
@@ -32,6 +32,10 @@ public class AiProperties {
 
 	private int maxMenuDaysPerTurn = 7;
 
+	private boolean scopeClassifierEnabled = true;
+
+	private int scopeClassifierMaxTokens = 200;
+
 	public boolean isEnabled() {
 		return enabled;
 	}
@@ -94,6 +98,22 @@ public class AiProperties {
 
 	public void setMaxMenuDaysPerTurn(final int maxMenuDaysPerTurn) {
 		this.maxMenuDaysPerTurn = clampScopeLimit(maxMenuDaysPerTurn, 1, CreateDietPlanDraftToolServiceImpl.MAX_DAYS);
+	}
+
+	public boolean isScopeClassifierEnabled() {
+		return scopeClassifierEnabled;
+	}
+
+	public void setScopeClassifierEnabled(final boolean scopeClassifierEnabled) {
+		this.scopeClassifierEnabled = scopeClassifierEnabled;
+	}
+
+	public int getScopeClassifierMaxTokens() {
+		return scopeClassifierMaxTokens;
+	}
+
+	public void setScopeClassifierMaxTokens(final int scopeClassifierMaxTokens) {
+		this.scopeClassifierMaxTokens = clampScopeLimit(scopeClassifierMaxTokens, 64, 512);
 	}
 
 	private static int clampScopeLimit(final int value, final int minimum, final int maximum) {

--- a/src/main/java/com/nutriconsultas/ai/AiRequestScopeClassifier.java
+++ b/src/main/java/com/nutriconsultas/ai/AiRequestScopeClassifier.java
@@ -1,0 +1,17 @@
+package com.nutriconsultas.ai;
+
+import java.util.Optional;
+
+/**
+ * Optional LLM pre-flight scope evaluation before the main orchestration tool loop (#448).
+ */
+@FunctionalInterface
+public interface AiRequestScopeClassifier {
+
+	/**
+	 * @return empty when {@link AiRequestScopeDecision#ALLOW}, disabled, or classifier fails
+	 *         open; present with assistant message for REFUSE/CLARIFY
+	 */
+	Optional<AiRequestScopeClassifierOutcome> evaluate(String sanitizedUserMessage);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiRequestScopeClassifierImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiRequestScopeClassifierImpl.java
@@ -1,0 +1,182 @@
+package com.nutriconsultas.ai;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Lightweight OpenAI scope classifier before main orchestration (#448).
+ */
+@Component
+@Slf4j
+public class AiRequestScopeClassifierImpl implements AiRequestScopeClassifier {
+
+	private static final String PROMPT_PATH = "ai/scope-classifier-prompt.txt";
+
+	private static final String DEFAULT_CLARIFY_MESSAGE = "¿Podrías indicar cuántos días, platillos o pacientes "
+			+ "quieres abordar en este turno? Puedo ayudarte con un borrador de ejemplo a la vez.";
+
+	private static final String GENERIC_REFUSAL_MESSAGE = "No puedo generar esa cantidad en un solo turno. "
+			+ "Puedo ayudarte con 1 borrador de ejemplo que revises y apruebes; "
+			+ "después puedes pedir variaciones en mensajes separados.";
+
+	private final AiProperties properties;
+
+	private final OpenAiClientService openAiClientService;
+
+	private final AiRequestScopeGuard requestScopeGuard;
+
+	private final String classifierPrompt;
+
+	public AiRequestScopeClassifierImpl(final AiProperties properties, final OpenAiClientService openAiClientService,
+			final AiRequestScopeGuard requestScopeGuard) {
+		this.properties = properties;
+		this.openAiClientService = openAiClientService;
+		this.requestScopeGuard = requestScopeGuard;
+		this.classifierPrompt = loadClassifierPrompt();
+	}
+
+	@Override
+	public Optional<AiRequestScopeClassifierOutcome> evaluate(final String sanitizedUserMessage) {
+		if (!properties.isScopeClassifierEnabled() || !StringUtils.hasText(sanitizedUserMessage)) {
+			return Optional.empty();
+		}
+		try {
+			final OpenAiChatCompletionResponse response = openAiClientService.chatCompletion(
+					new OpenAiChatCompletionRequest(
+							List.of(OpenAiChatMessage.system(classifierPrompt),
+									OpenAiChatMessage.user(sanitizedUserMessage)),
+							List.of(), OpenAiCompletionParameters.scopeClassifier(properties.getScopeClassifierMaxTokens())));
+			final ParsedClassification parsed = parseClassification(response.content());
+			if (parsed.decision() == AiRequestScopeDecision.ALLOW) {
+				if (log.isInfoEnabled()) {
+					log.info("AI scope classifier decision=ALLOW");
+				}
+				return Optional.empty();
+			}
+			final String assistantMessage = buildAssistantMessage(parsed);
+			if (log.isInfoEnabled()) {
+				log.info("AI scope classifier decision={} days={} dishes={} plans={} patients={}",
+						parsed.decision(), parsed.requestedUnits().days(), parsed.requestedUnits().dishes(),
+						parsed.requestedUnits().plans(), parsed.requestedUnits().patients());
+			}
+			return Optional.of(new AiRequestScopeClassifierOutcome(parsed.decision(), assistantMessage,
+					parsed.requestedUnits()));
+		}
+		catch (final RuntimeException ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("AI scope classifier failed, allowing request");
+			}
+			return Optional.empty();
+		}
+	}
+
+	private String buildAssistantMessage(final ParsedClassification parsed) {
+		if (parsed.decision() == AiRequestScopeDecision.CLARIFY) {
+			if (StringUtils.hasText(parsed.suggestedPrompt())) {
+				return parsed.suggestedPrompt().trim();
+			}
+			if (StringUtils.hasText(parsed.reason())) {
+				return parsed.reason().trim();
+			}
+			return DEFAULT_CLARIFY_MESSAGE;
+		}
+		final Optional<String> refusalFromUnits = requestScopeGuard
+			.refusalMessageForUnits(parsed.requestedUnits());
+		if (refusalFromUnits.isPresent()) {
+			return refusalFromUnits.get();
+		}
+		if (StringUtils.hasText(parsed.reason())) {
+			return parsed.reason().trim();
+		}
+		return GENERIC_REFUSAL_MESSAGE;
+	}
+
+	private ParsedClassification parseClassification(final String content) {
+		if (!StringUtils.hasText(content)) {
+			throw new AiOrchestrationException("Classifier response empty");
+		}
+		final JsonNode root = AiToolJsonSerializer.parseJson(stripCodeFence(content.trim()));
+		final AiRequestScopeDecision decision = parseDecision(root.path("decision").asText(null));
+		final AiRequestScopeRequestedUnits units = parseRequestedUnits(root.path("requestedUnits"));
+		final String reason = nullableText(root.path("reason"));
+		final String suggestedPrompt = nullableText(root.path("suggestedPrompt"));
+		return new ParsedClassification(decision, units, reason, suggestedPrompt);
+	}
+
+	private static AiRequestScopeDecision parseDecision(final String rawDecision) {
+		if (!StringUtils.hasText(rawDecision)) {
+			throw new AiOrchestrationException("Classifier decision missing");
+		}
+		try {
+			return AiRequestScopeDecision.valueOf(rawDecision.trim().toUpperCase(Locale.ROOT));
+		}
+		catch (final IllegalArgumentException ex) {
+			throw new AiOrchestrationException("Classifier decision invalid", ex);
+		}
+	}
+
+	private static AiRequestScopeRequestedUnits parseRequestedUnits(final JsonNode node) {
+		if (node == null || node.isMissingNode() || node.isNull()) {
+			return AiRequestScopeRequestedUnits.empty();
+		}
+		return new AiRequestScopeRequestedUnits(nullableInteger(node.path("days")),
+				nullableInteger(node.path("dishes")), nullableInteger(node.path("plans")),
+				nullableInteger(node.path("patients")));
+	}
+
+	private static Integer nullableInteger(final JsonNode node) {
+		if (node == null || node.isMissingNode() || node.isNull()) {
+			return null;
+		}
+		if (node.isNumber()) {
+			return node.intValue();
+		}
+		return null;
+	}
+
+	private static String nullableText(final JsonNode node) {
+		if (node == null || node.isMissingNode() || node.isNull()) {
+			return null;
+		}
+		final String text = node.asText(null);
+		return StringUtils.hasText(text) ? text : null;
+	}
+
+	private static String stripCodeFence(final String content) {
+		if (content.startsWith("```")) {
+			final int firstNewline = content.indexOf('\n');
+			final int closingFence = content.lastIndexOf("```");
+			if (firstNewline >= 0 && closingFence > firstNewline) {
+				return content.substring(firstNewline + 1, closingFence).trim();
+			}
+		}
+		return content;
+	}
+
+	private static String loadClassifierPrompt() {
+		final ClassPathResource resource = new ClassPathResource(PROMPT_PATH);
+		try (InputStream inputStream = resource.getInputStream()) {
+			return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+		}
+		catch (final IOException ex) {
+			throw new IllegalStateException("Missing AI scope classifier prompt: " + PROMPT_PATH, ex);
+		}
+	}
+
+	private record ParsedClassification(AiRequestScopeDecision decision, AiRequestScopeRequestedUnits requestedUnits,
+			String reason, String suggestedPrompt) {
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiRequestScopeClassifierOutcome.java
+++ b/src/main/java/com/nutriconsultas/ai/AiRequestScopeClassifierOutcome.java
@@ -1,0 +1,9 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Pre-orchestration scope decision that short-circuits the tool loop (#448).
+ */
+public record AiRequestScopeClassifierOutcome(AiRequestScopeDecision decision, String assistantMessage,
+		AiRequestScopeRequestedUnits requestedUnits) {
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiRequestScopeDecision.java
+++ b/src/main/java/com/nutriconsultas/ai/AiRequestScopeDecision.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.ai;
+
+/**
+ * LLM scope classifier outcome (#448).
+ */
+public enum AiRequestScopeDecision {
+
+	ALLOW, REFUSE, CLARIFY
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiRequestScopeGuard.java
+++ b/src/main/java/com/nutriconsultas/ai/AiRequestScopeGuard.java
@@ -243,4 +243,35 @@ public class AiRequestScopeGuard {
 				+ "después puedes pedir variaciones o días adicionales en mensajes separados.";
 	}
 
+	/**
+	 * Builds deterministic refusal copy from classifier-estimated units (#448).
+	 */
+	public Optional<String> refusalMessageForUnits(final AiRequestScopeRequestedUnits units) {
+		if (units == null) {
+			return Optional.empty();
+		}
+		if (units.patients() != null && units.patients() > 1) {
+			return Optional.of("No puedo generar planes para " + units.patients() + " pacientes en un solo turno. "
+					+ "Trabajemos con un paciente o un borrador de ejemplo a la vez.");
+		}
+		if (units.patients() != null && units.patients() == 0) {
+			return Optional.of("No puedo generar planes para todos tus pacientes en un solo turno. "
+					+ "Trabajemos con un paciente o un borrador de ejemplo a la vez; "
+					+ "después puedes pedir variaciones en mensajes separados.");
+		}
+		if (units.dishes() != null && units.dishes() > properties.getMaxDishesPerTurn()) {
+			return Optional.of(refusalFor(AiRequestScopeKind.DISH_COUNT, units.dishes(), "platillos"));
+		}
+		if (units.plans() != null && units.plans() > 1) {
+			return Optional.of(refusalFor(AiRequestScopeKind.DIET_PLAN_DAYS, units.plans(), "planes nutricionales"));
+		}
+		if (units.days() != null && units.days() > properties.getMaxDaysPerTurn()) {
+			return Optional.of(refusalFor(AiRequestScopeKind.DIET_PLAN_DAYS, units.days(), "planes alimenticios"));
+		}
+		if (units.days() != null && units.days() > properties.getMaxMenuDaysPerTurn()) {
+			return Optional.of(refusalFor(AiRequestScopeKind.MENU_DAYS, units.days(), "menús"));
+		}
+		return Optional.empty();
+	}
+
 }

--- a/src/main/java/com/nutriconsultas/ai/AiRequestScopePipeline.java
+++ b/src/main/java/com/nutriconsultas/ai/AiRequestScopePipeline.java
@@ -1,0 +1,45 @@
+package com.nutriconsultas.ai;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Deterministic scope guard plus optional LLM classifier (#447, #448).
+ */
+@Component
+public class AiRequestScopePipeline {
+
+	/**
+	 * Short-circuit reply before main orchestration.
+	 */
+	public record ScopeShortCircuit(String assistantMessage, String sourceLabel, Object sourceDetail) {
+	}
+
+	private final AiRequestScopeGuard deterministicGuard;
+
+	private final AiRequestScopeClassifier classifier;
+
+	public AiRequestScopePipeline(final AiRequestScopeGuard deterministicGuard,
+			final AiRequestScopeClassifier classifier) {
+		this.deterministicGuard = deterministicGuard;
+		this.classifier = classifier;
+	}
+
+	public Optional<ScopeShortCircuit> evaluate(final String sanitizedUserMessage) {
+		final Optional<AiRequestScopeViolation> violation = deterministicGuard.evaluate(sanitizedUserMessage);
+		if (violation.isPresent()) {
+			final AiRequestScopeViolation scopeViolation = violation.get();
+			return Optional.of(new ScopeShortCircuit(scopeViolation.refusalMessage(), "scope refusal",
+					scopeViolation.kind()));
+		}
+		final Optional<AiRequestScopeClassifierOutcome> classifierOutcome = classifier.evaluate(sanitizedUserMessage);
+		if (classifierOutcome.isPresent()) {
+			final AiRequestScopeClassifierOutcome outcome = classifierOutcome.get();
+			return Optional.of(
+					new ScopeShortCircuit(outcome.assistantMessage(), "classifier", outcome.decision()));
+		}
+		return Optional.empty();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiRequestScopeRequestedUnits.java
+++ b/src/main/java/com/nutriconsultas/ai/AiRequestScopeRequestedUnits.java
@@ -1,0 +1,12 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Estimated bulk units from the scope classifier (#448).
+ */
+public record AiRequestScopeRequestedUnits(Integer days, Integer dishes, Integer plans, Integer patients) {
+
+	public static AiRequestScopeRequestedUnits empty() {
+		return new AiRequestScopeRequestedUnits(null, null, null, null);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/OpenAiChatCompletionRequest.java
+++ b/src/main/java/com/nutriconsultas/ai/OpenAiChatCompletionRequest.java
@@ -5,7 +5,13 @@ import java.util.List;
 /**
  * Request to {@link OpenAiClientService#chatCompletion(OpenAiChatCompletionRequest)}.
  */
-public record OpenAiChatCompletionRequest(List<OpenAiChatMessage> messages, List<OpenAiToolDefinition> tools) {
+public record OpenAiChatCompletionRequest(List<OpenAiChatMessage> messages, List<OpenAiToolDefinition> tools,
+		OpenAiCompletionParameters parameters) {
+
+	public OpenAiChatCompletionRequest(final List<OpenAiChatMessage> messages,
+			final List<OpenAiToolDefinition> tools) {
+		this(messages, tools, OpenAiCompletionParameters.none());
+	}
 
 	public OpenAiChatCompletionRequest {
 		if (messages == null || messages.isEmpty()) {
@@ -13,6 +19,9 @@ public record OpenAiChatCompletionRequest(List<OpenAiChatMessage> messages, List
 		}
 		messages = List.copyOf(messages);
 		tools = tools == null ? List.of() : List.copyOf(tools);
+		if (parameters == null) {
+			parameters = OpenAiCompletionParameters.none();
+		}
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/ai/OpenAiClientServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/OpenAiClientServiceImpl.java
@@ -97,7 +97,15 @@ public class OpenAiClientServiceImpl implements OpenAiClientService {
 			tools.add(new OpenAiApiTool("function", function));
 		}
 		return new OpenAiApiRequest(properties.getOpenai().getModel(), messages, tools.isEmpty() ? null : tools,
-				properties.getOpenai().isStore());
+				properties.getOpenai().isStore(), request.parameters().temperature(),
+				request.parameters().maxTokens(), responseFormat(request.parameters().responseFormatType()));
+	}
+
+	private static Map<String, String> responseFormat(final String type) {
+		if (!org.springframework.util.StringUtils.hasText(type)) {
+			return null;
+		}
+		return Map.of("type", type);
 	}
 
 	private OpenAiChatCompletionResponse toCompletionResponse(final OpenAiApiResponse response) {
@@ -133,7 +141,8 @@ public class OpenAiClientServiceImpl implements OpenAiClientService {
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private record OpenAiApiRequest(String model, List<OpenAiApiMessage> messages, List<OpenAiApiTool> tools,
-			boolean store) {
+			boolean store, Double temperature, @JsonProperty("max_tokens") Integer maxTokens,
+			@JsonProperty("response_format") Map<String, String> responseFormat) {
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/com/nutriconsultas/ai/OpenAiCompletionParameters.java
+++ b/src/main/java/com/nutriconsultas/ai/OpenAiCompletionParameters.java
@@ -1,0 +1,16 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Optional OpenAI chat completion tuning (#448 scope classifier).
+ */
+public record OpenAiCompletionParameters(Double temperature, Integer maxTokens, String responseFormatType) {
+
+	public static OpenAiCompletionParameters none() {
+		return new OpenAiCompletionParameters(null, null, null);
+	}
+
+	public static OpenAiCompletionParameters scopeClassifier(final int maxTokens) {
+		return new OpenAiCompletionParameters(0.0, maxTokens, "json_object");
+	}
+
+}

--- a/src/main/resources/ai/scope-classifier-prompt.txt
+++ b/src/main/resources/ai/scope-classifier-prompt.txt
@@ -1,0 +1,24 @@
+Eres un clasificador de alcance para el asistente nutricional Minutriporcion.
+Evalúa UN mensaje del nutriólogo y responde SOLO con JSON válido (sin markdown ni texto adicional).
+
+Política por turno:
+- Máximo 14 días por borrador de plan alimenticio
+- Máximo 7 días por menú semanal
+- Máximo 1 platillo por turno (más variaciones en mensajes siguientes)
+- Solo borradores; nunca asignación final ni generación masiva para todos los pacientes del consultorio
+
+Decisiones:
+- ALLOW: la solicitud cabe en los límites, es conversacional, búsqueda de catálogo o aclaración sin generación masiva
+- REFUSE: pide volumen excesivo, múltiples pacientes, todo el consultorio/año, o generación masiva aunque esté redactada de forma indirecta
+- CLARIFY: falta precisar días, platillos o pacientes antes de proponer borradores extensos
+
+Responde con este JSON:
+{
+  "decision": "ALLOW" | "REFUSE" | "CLARIFY",
+  "requestedUnits": { "days": number|null, "dishes": number|null, "plans": number|null, "patients": number|null },
+  "reason": "breve explicación en español",
+  "suggestedPrompt": "una pregunta de aclaración en español cuando decision=CLARIFY; cadena vacía si no aplica"
+}
+
+Interpreta de forma conservadora frases como «todo el consultorio», «cada paciente», «plan muy completo para todos».
+Estima requestedUnits con números explícitos o inferidos (p. ej. «todo el año» => days 365).

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -134,5 +134,7 @@ nutriconsultas.ai.max-user-message-length=${AI_MAX_USER_MESSAGE_LENGTH:4000}
 nutriconsultas.ai.max-days-per-turn=${AI_MAX_DAYS_PER_TURN:14}
 nutriconsultas.ai.max-dishes-per-turn=${AI_MAX_DISHES_PER_TURN:1}
 nutriconsultas.ai.max-menu-days-per-turn=${AI_MAX_MENU_DAYS_PER_TURN:7}
+nutriconsultas.ai.scope-classifier-enabled=${AI_SCOPE_CLASSIFIER_ENABLED:true}
+nutriconsultas.ai.scope-classifier-max-tokens=${AI_SCOPE_CLASSIFIER_MAX_TOKENS:200}
 #logging.level.org.hibernate.SQL=debug
 #logging.level.org.hibernate.type.descriptor.sql=trace

--- a/src/test/java/com/nutriconsultas/ai/AiOrchestrationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiOrchestrationServiceTest.java
@@ -61,7 +61,13 @@ class AiOrchestrationServiceTest {
 	private AiUserMessageGuard userMessageGuard;
 
 	@Mock
-	private AiRequestScopeGuard requestScopeGuard;
+	private AiChatPersistence chatPersistence;
+
+	@Mock
+	private AiOrchestrationTools orchestrationTools;
+
+	@Mock
+	private AiRequestScopePipeline requestScopePipeline;
 
 	private AiUserMessageGuard realUserMessageGuard;
 
@@ -81,8 +87,21 @@ class AiOrchestrationServiceTest {
 			.thenAnswer(invocation -> realUserMessageGuard.validateAndSanitize(invocation.getArgument(0)));
 		lenient().when(userMessageGuard.wrapForModel(any(String.class)))
 			.thenAnswer(invocation -> realUserMessageGuard.wrapForModel(invocation.getArgument(0)));
-		lenient().when(requestScopeGuard.evaluate(any(String.class)))
-			.thenAnswer(invocation -> realRequestScopeGuard.evaluate(invocation.getArgument(0)));
+		lenient().when(chatPersistence.getThreadRepository()).thenReturn(threadRepository);
+		lenient().when(chatPersistence.getMessageRepository()).thenReturn(messageRepository);
+		lenient().when(chatPersistence.getTransactionTemplate()).thenReturn(transactionTemplate);
+		lenient().when(orchestrationTools.getToolCatalog()).thenReturn(toolCatalog);
+		lenient().when(orchestrationTools.getToolDispatcher()).thenReturn(toolDispatcher);
+		lenient().when(requestScopePipeline.evaluate(any(String.class))).thenAnswer(invocation -> {
+			final Optional<AiRequestScopeViolation> violation = realRequestScopeGuard
+				.evaluate(invocation.getArgument(0));
+			if (violation.isPresent()) {
+				final AiRequestScopeViolation scopeViolation = violation.get();
+				return Optional.of(new AiRequestScopePipeline.ScopeShortCircuit(scopeViolation.refusalMessage(),
+						"scope refusal", scopeViolation.kind()));
+			}
+			return Optional.empty();
+		});
 		lenient().when(transactionTemplate.execute(org.mockito.ArgumentMatchers.<TransactionCallback<Object>>any()))
 			.thenAnswer(invocation -> {
 				final TransactionCallback<?> callback = invocation.getArgument(0);
@@ -297,6 +316,47 @@ class AiOrchestrationServiceTest {
 		assertThat(completed[0].assistantMessage().getContent()).contains("30");
 		verify(openAiClientService, never()).chatCompletion(any());
 		verify(messageRepository, times(2)).save(any(AiChatMessage.class));
+	}
+
+	@Test
+	void processUserMessageClassifierRefusalPersistsWithoutToolLoop() {
+		stubAiEnabled();
+		when(threadRepository.findByIdAndNutritionistId(THREAD_ID, NUTRITIONIST_ID)).thenReturn(Optional.of(thread));
+		when(messageRepository.save(any(AiChatMessage.class))).thenAnswer(invocation -> {
+			final AiChatMessage message = invocation.getArgument(0);
+			if (message.getId() == null) {
+				message.setId(100L);
+			}
+			return message;
+		});
+		when(requestScopePipeline.evaluate("Plan muy completo para todo el consultorio"))
+			.thenReturn(Optional.of(new AiRequestScopePipeline.ScopeShortCircuit(
+					"No puedo generar planes para todos tus pacientes en un solo turno.", "classifier",
+					AiRequestScopeDecision.REFUSE)));
+
+		final AiOrchestrationResult result = service.processUserMessage(context(),
+				"Plan muy completo para todo el consultorio");
+
+		assertThat(result.toolCallsExecuted()).isZero();
+		assertThat(result.assistantMessage().getContent()).contains("todos tus pacientes");
+		verify(openAiClientService, never()).chatCompletion(any());
+		verify(messageRepository, times(2)).save(any(AiChatMessage.class));
+	}
+
+	@Test
+	void processUserMessageClassifierAllowProceedsToToolLoop() {
+		stubOperational();
+		when(threadRepository.findByIdAndNutritionistId(THREAD_ID, NUTRITIONIST_ID)).thenReturn(Optional.of(thread));
+		when(messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(THREAD_ID))
+			.thenReturn(List.of(message(AiChatMessageRole.USER, "Menú de 7 días")));
+		when(requestScopePipeline.evaluate("Menú de 7 días")).thenReturn(Optional.empty());
+		when(openAiClientService.chatCompletion(any())).thenReturn(new OpenAiChatCompletionResponse("id-1", "assistant",
+				"Aquí tienes el borrador.", List.of(), "stop", null));
+
+		final AiOrchestrationResult result = service.processUserMessage(context(), "Menú de 7 días");
+
+		assertThat(result.assistantMessage().getContent()).contains("borrador");
+		verify(openAiClientService).chatCompletion(any());
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/AiRequestScopeClassifierTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiRequestScopeClassifierTest.java
@@ -1,0 +1,128 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AiRequestScopeClassifierTest {
+
+	private AiRequestScopeClassifierImpl classifier;
+
+	@Mock
+	private OpenAiClientService openAiClientService;
+
+	private AiRequestScopeGuard requestScopeGuard;
+
+	@BeforeEach
+	void setUp() {
+		final AiProperties properties = new AiProperties();
+		properties.setScopeClassifierEnabled(true);
+		requestScopeGuard = new AiRequestScopeGuard(properties);
+		classifier = new AiRequestScopeClassifierImpl(properties, openAiClientService, requestScopeGuard);
+	}
+
+	@Test
+	void returnsEmptyWhenDisabled() {
+		final AiProperties properties = new AiProperties();
+		properties.setScopeClassifierEnabled(false);
+		final AiRequestScopeClassifierImpl disabledClassifier = new AiRequestScopeClassifierImpl(properties,
+				openAiClientService, requestScopeGuard);
+
+		assertThat(disabledClassifier.evaluate("Genera variaciones para cada paciente")).isEmpty();
+
+		verify(openAiClientService, never()).chatCompletion(any());
+	}
+
+	@Test
+	void allowDecisionProceedsWithoutOutcome() {
+		when(openAiClientService.chatCompletion(any())).thenReturn(classifierResponse("""
+				{
+				  "decision": "ALLOW",
+				  "requestedUnits": { "days": 7, "dishes": 1, "plans": 1, "patients": 1 },
+				  "reason": "Dentro de límites",
+				  "suggestedPrompt": ""
+				}
+				"""));
+
+		assertThat(classifier.evaluate("Genera un menú de 7 días")).isEmpty();
+	}
+
+	@Test
+	void refuseDecisionUsesDeterministicCopyFromUnits() {
+		when(openAiClientService.chatCompletion(any())).thenReturn(classifierResponse("""
+				{
+				  "decision": "REFUSE",
+				  "requestedUnits": { "days": null, "dishes": 5, "plans": null, "patients": null },
+				  "reason": "Demasiados platillos",
+				  "suggestedPrompt": ""
+				}
+				"""));
+
+		final AiRequestScopeClassifierOutcome outcome = classifier
+			.evaluate("Genera variaciones de platillos para todo el consultorio")
+			.orElseThrow();
+
+		assertThat(outcome.decision()).isEqualTo(AiRequestScopeDecision.REFUSE);
+		assertThat(outcome.assistantMessage()).contains("5 platillos").contains("borrador de ejemplo");
+	}
+
+	@Test
+	void clarifyDecisionUsesSuggestedPrompt() {
+		when(openAiClientService.chatCompletion(any())).thenReturn(classifierResponse("""
+				{
+				  "decision": "CLARIFY",
+				  "requestedUnits": { "days": null, "dishes": null, "plans": null, "patients": null },
+				  "reason": "Falta precisar alcance",
+				  "suggestedPrompt": "¿Para cuántos días quieres el borrador?"
+				}
+				"""));
+
+		final AiRequestScopeClassifierOutcome outcome = classifier.evaluate("Arma un plan muy completo").orElseThrow();
+
+		assertThat(outcome.decision()).isEqualTo(AiRequestScopeDecision.CLARIFY);
+		assertThat(outcome.assistantMessage()).isEqualTo("¿Para cuántos días quieres el borrador?");
+	}
+
+	@Test
+	void usesLowTemperatureJsonCompletionRequest() {
+		when(openAiClientService.chatCompletion(any())).thenReturn(classifierResponse("""
+				{"decision":"ALLOW","requestedUnits":{},"reason":"","suggestedPrompt":""}
+				"""));
+
+		classifier.evaluate("Busca avena en el catálogo");
+
+		final ArgumentCaptor<OpenAiChatCompletionRequest> captor = ArgumentCaptor
+			.forClass(OpenAiChatCompletionRequest.class);
+		verify(openAiClientService).chatCompletion(captor.capture());
+		assertThat(captor.getValue().parameters().temperature()).isEqualTo(0.0);
+		assertThat(captor.getValue().parameters().maxTokens()).isEqualTo(200);
+		assertThat(captor.getValue().parameters().responseFormatType()).isEqualTo("json_object");
+		assertThat(captor.getValue().tools()).isEmpty();
+	}
+
+	@Test
+	void failsOpenOnInvalidJson() {
+		when(openAiClientService.chatCompletion(any()))
+			.thenReturn(new OpenAiChatCompletionResponse("id", "assistant", "not json", List.of(), "stop", null));
+
+		assertThat(classifier.evaluate("Plan ambiguo para el consultorio")).isEmpty();
+	}
+
+	private static OpenAiChatCompletionResponse classifierResponse(final String json) {
+		return new OpenAiChatCompletionResponse("id-classifier", "assistant", json, List.of(), "stop", null);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiRequestScopeGuardTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiRequestScopeGuardTest.java
@@ -57,6 +57,16 @@ class AiRequestScopeGuardTest {
 		assertThat(violation.requestedAmount()).isEqualTo(5);
 	}
 
+	@Test
+	void refusalMessageForUnitsMatchesRefusalFor() {
+		final AiProperties properties = new AiProperties();
+		final AiRequestScopeGuard scopeGuard = new AiRequestScopeGuard(properties);
+
+		assertThat(scopeGuard.refusalMessageForUnits(new AiRequestScopeRequestedUnits(null, 5, null, null)))
+			.get()
+			.isEqualTo(AiRequestScopeGuard.refusalFor(AiRequestScopeKind.DISH_COUNT, 5, "platillos"));
+	}
+
 	@ParameterizedTest
 	@ValueSource(strings = { "Genera 100 platillos para la semana", "Crea cien recetas de desayuno",
 			"Genera 1000 planes nutricionales", "Genera un plan para todos mis pacientes" })

--- a/src/test/java/com/nutriconsultas/ai/OpenAiClientServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/OpenAiClientServiceTest.java
@@ -212,17 +212,32 @@ class OpenAiClientServiceTest {
 	}
 
 	@Test
-	void chatCompletionMapsModelNotFound() {
+	void chatCompletionSerializesOptionalParameters() {
 		mockServer.expect(requestTo("https://api.openai.com/v1/chat/completions"))
-			.andRespond(withStatus(HttpStatus.NOT_FOUND).body("""
-					{"error":{"message":"The model gpt-test does not exist","type":"invalid_request_error"}}
-					"""));
+			.andExpect(content().json("""
+					{
+					  "model": "gpt-test",
+					  "messages": [{"role":"user","content":"Clasifica"}],
+					  "store": false,
+					  "temperature": 0.0,
+					  "max_tokens": 200,
+					  "response_format": {"type":"json_object"}
+					}
+					""", false))
+			.andRespond(withSuccess("""
+					{
+					  "id": "chatcmpl-json",
+					  "choices": [{
+					    "message": {"role":"assistant","content":"{\\"decision\\":\\"ALLOW\\"}"},
+					    "finish_reason": "stop"
+					  }]
+					}
+					""", MediaType.APPLICATION_JSON));
 
-		assertThatThrownBy(() -> service
-			.chatCompletion(new OpenAiChatCompletionRequest(List.of(OpenAiChatMessage.user("Hola")), List.of())))
-			.isInstanceOf(OpenAiClientException.class)
-			.extracting(ex -> ((OpenAiClientException) ex).getKind())
-			.isEqualTo(OpenAiClientException.ErrorKind.MODEL_NOT_FOUND);
+		service.chatCompletion(new OpenAiChatCompletionRequest(List.of(OpenAiChatMessage.user("Clasifica")), List.of(),
+				OpenAiCompletionParameters.scopeClassifier(200)));
+
+		mockServer.verify();
 	}
 
 }


### PR DESCRIPTION
## Summary
- Adds `AiRequestScopeClassifier` — cheap OpenAI JSON call (no tools, temp 0) after `AiRequestScopeGuard` passes.
- **REFUSE** / **CLARIFY** short-circuit orchestration with persisted assistant reply; **ALLOW** proceeds to tool loop.
- Config: `AI_SCOPE_CLASSIFIER_ENABLED` (default true), `AI_SCOPE_CLASSIFIER_MAX_TOKENS` (200).
- Fail-open on classifier errors; logs decision + unit counts only.
- Extends `OpenAiChatCompletionRequest` with optional temperature/max_tokens/JSON response format.

Closes #448

## Test plan
- [x] `mvn test -Dtest=AiRequestScopeClassifierTest,AiOrchestrationServiceTest,OpenAiClientServiceTest`
- [x] `./lint.sh`
- [ ] Manual: ambiguous «plan para todo el consultorio» → clarify/refuse without tool calls


Made with [Cursor](https://cursor.com)