### PR TITLE
[AI Assistant] Add Golden Prompt Test Cases (#401)

### DIFF
--- a/docs/ai/BULK-SCOPE-GOLDEN-PROMPTS.md
+++ b/docs/ai/BULK-SCOPE-GOLDEN-PROMPTS.md
@@ -65,4 +65,4 @@ mvn test -Dtest=AiBulkScopeGoldenPromptTest
 2. Extend `AiBulkScopeGoldenPromptTest` if a new expectation type is needed.
 3. Prefer phrasing that matches production guard/classifier policy in [`PROMPT-SECURITY.md`](PROMPT-SECURITY.md).
 
-Future [#401](https://github.com/diego-torres/nutriconsultas/issues/401) golden prompts for nutrition workflows should reuse this fixture pattern.
+Future nutrition workflow scenarios: [`NUTRITION-GOLDEN-PROMPTS.md`](NUTRITION-GOLDEN-PROMPTS.md) (#401).

--- a/docs/ai/NUTRITION-GOLDEN-PROMPTS.md
+++ b/docs/ai/NUTRITION-GOLDEN-PROMPTS.md
@@ -1,0 +1,84 @@
+# Nutrition golden prompts (#401)
+
+**Issue:** [#401](https://github.com/diego-torres/nutriconsultas/issues/401) · Epic [#400](https://github.com/diego-torres/nutriconsultas/issues/400)  
+**Related:** [`FUNCTIONAL-SCOPE.md`](FUNCTIONAL-SCOPE.md) (#361) · [`TOOL-CONTRACT.md`](TOOL-CONTRACT.md) (#363) · [`BULK-SCOPE-GOLDEN-PROMPTS.md`](BULK-SCOPE-GOLDEN-PROMPTS.md) (#450)
+
+Documented evaluation scenarios for **supported nutrition workflows** in Spanish (es-MX). Tests run in CI **without live OpenAI** — mocked orchestration simulates expected tool usage and warning copy.
+
+---
+
+## Scenario matrix
+
+| ID | Prompt (es-MX) | Category | Expectation | Expected tools |
+|----|----------------|----------|-------------|----------------|
+| `high-protein-breakfast` | Genera un desayuno alto en proteína usando alimentos de mi catálogo. | DISH | Use tools | `search_food_catalog` → `calculate_recipe_nutrients` → `create_dish_draft` |
+| `low-sodium-day-menu` | Menú bajo en sodio de un día: desayuno, comida, cena y dos colaciones. | MENU_DAILY | Use tools | `search_food_catalog`, `search_dish_catalog`, `validate_plan_constraints`, `create_menu_draft` |
+| `7-day-weight-loss-menu` | Menú semanal de 7 días para pérdida de peso, 1600 kcal. | MENU_WEEKLY | Use tools | `search_food_catalog`, `search_dish_catalog`, `validate_plan_constraints`, `create_diet_plan_draft` |
+| `egg-allergy-plan` | Plan de 7 días sin huevo para el paciente vinculado. | DIET_PLAN | Use tools + patient context | `search_food_catalog`, `validate_plan_constraints`, `create_diet_plan_draft` |
+| `diabetic-friendly-menu` | Menú de un día amigable para diabetes, 1800 kcal, bajo índice glucémico. | MENU_DAILY | Use tools | `search_food_catalog`, `search_dish_catalog`, `validate_plan_constraints`, `create_menu_draft` |
+| `vegetarian-weekly-plan` | Plan semanal vegetariano de 7 días, lunes a viernes iguales. | MENU_WEEKLY | Use tools | `search_food_catalog`, `search_dish_catalog`, `create_diet_plan_draft` |
+| `unsupported-ingredient` | Receta con pitahaya del catálogo. | CATALOG_LOOKUP | Search only | `search_food_catalog` (no draft if missing) |
+| `menu-missing-calorie-target` | Arma un menú de un día con desayuno, comida y cena. | CLARIFY | Ask first | *(none on first turn)* |
+
+---
+
+## Expected warnings (Spanish)
+
+| ID | Warning themes |
+|----|----------------|
+| `high-protein-breakfast` | *Borrador IA*, *revisión del nutriólogo* |
+| `low-sodium-day-menu` | *sodio*, draft label |
+| `7-day-weight-loss-menu` | Calorie target echoed (*1600*), draft label |
+| `egg-allergy-plan` | *huevo*, *alergia*, draft label |
+| `diabetic-friendly-menu` | *revisión profesional* (no diagnosis), draft label |
+| `vegetarian-weekly-plan` | *vegetariano*, *supuesto*, draft label |
+| `unsupported-ingredient` | *catálogo*, *no se encontró*, *sustituto* — must not invent foods |
+| `menu-missing-calorie-target` | Ask for *objetivo calórico* / *kcal* before generating |
+
+---
+
+## Assertions (automated)
+
+| Check | Implementation |
+|-------|----------------|
+| In scope (#447) | All prompts pass `AiRequestScopeGuard` |
+| Valid tool names | Expected tools ⊆ `AiToolAllowlist` |
+| Tool loop (MUST_USE_TOOLS) | Mocked OpenAI returns tool calls; `AiOrchestrationToolDispatcher` invoked for each |
+| Clarify (MUST_CLARIFY) | No tool dispatch; assistant asks for missing kcal |
+| Catalog miss (MUST_SEARCH_CATALOG) | Search only; no `create_dish_draft` when ingredient absent |
+
+---
+
+## Test classes
+
+| Class | Role |
+|-------|------|
+| `AiNutritionGoldenPrompt` | Scenario fixtures (ids, prompts, tools, warnings) |
+| `AiNutritionGoldenPromptTest` | Parameterized golden evaluation (#401) |
+
+Run:
+
+```bash
+mvn test -Dtest=AiNutritionGoldenPromptTest
+```
+
+---
+
+## Manual evaluation (optional)
+
+For live OpenAI smoke tests (not CI), use the prompts above in `/admin/ai` with `AI_ENABLED=true` and verify:
+
+1. Assistant responds in **Spanish**.
+2. Tool audit rows match expected tools (or clarifying question when applicable).
+3. Draft preview shows **Borrador IA — revisión del nutriólogo requerida**.
+4. No patient assignment or catalog save without accept flow (#382).
+
+---
+
+## Adding scenarios
+
+1. Add a row to the matrix and a `Scenario` in `AiNutritionGoldenPrompt.java`.
+2. Reference tool names from [`TOOL-CONTRACT.md`](TOOL-CONTRACT.md).
+3. Extend `AiNutritionGoldenPromptTest` if a new `Expectation` type is needed.
+
+Security and bulk-scope scenarios live in [`SECURITY-GOLDEN-PROMPTS.md`](SECURITY-GOLDEN-PROMPTS.md) and [`BULK-SCOPE-GOLDEN-PROMPTS.md`](BULK-SCOPE-GOLDEN-PROMPTS.md).

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -11,6 +11,7 @@ Documentation for the **AI Nutrition Assistant** track.
 | [`PROMPT-SECURITY.md`](PROMPT-SECURITY.md) | Input guardrails, delimiter wrap, injection block list (#439–#441) |
 | [`BULK-SCOPE-GOLDEN-PROMPTS.md`](BULK-SCOPE-GOLDEN-PROMPTS.md) | Golden prompt evaluation for bulk scope (#450) |
 | [`SECURITY-GOLDEN-PROMPTS.md`](SECURITY-GOLDEN-PROMPTS.md) | Golden prompt evaluation for defense-in-depth (#441) |
+| [`NUTRITION-GOLDEN-PROMPTS.md`](NUTRITION-GOLDEN-PROMPTS.md) | Golden prompt evaluation for nutrition workflows (#401) |
 | [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) | Architecture, security, tools, milestones, definition of done |
 | [`../../ISSUE-AI-ASSISTANT.md`](../../ISSUE-AI-ASSISTANT.md) | GitHub issue registry (#360–#408) |
 | [`../../AI-ASSISTANT-WORKFLOW.md`](../../AI-ASSISTANT-WORKFLOW.md) | Agent implementation workflow |

--- a/docs/ai/SECURITY-GOLDEN-PROMPTS.md
+++ b/docs/ai/SECURITY-GOLDEN-PROMPTS.md
@@ -44,4 +44,4 @@ System prompt **SEGURIDAD DE PROMPTS** instructs the model to treat delimiter bl
 | `AiToolResultSanitizerTest` | Indirect injection in tool JSON |
 | `AiAssistantOutputValidatorTest` | Secret / PII redaction |
 
-Future [#401](https://github.com/diego-torres/nutriconsultas/issues/401) nutrition workflow golden prompts should reuse this fixture pattern alongside bulk scope cases (#450).
+Nutrition workflow scenarios: [`NUTRITION-GOLDEN-PROMPTS.md`](NUTRITION-GOLDEN-PROMPTS.md) (#401).

--- a/src/test/java/com/nutriconsultas/ai/AiNutritionGoldenPrompt.java
+++ b/src/test/java/com/nutriconsultas/ai/AiNutritionGoldenPrompt.java
@@ -1,0 +1,99 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Golden prompt fixtures for supported nutrition workflows (#401). Scenarios align with
+ * {@code docs/ai/FUNCTIONAL-SCOPE.md} and {@code docs/ai/NUTRITION-GOLDEN-PROMPTS.md}.
+ */
+final class AiNutritionGoldenPrompt {
+
+	enum Category {
+
+		DISH, MENU_DAILY, MENU_WEEKLY, DIET_PLAN, CATALOG_LOOKUP, CLARIFY
+
+	}
+
+	enum Expectation {
+
+		/**
+		 * Model should call listed tools (in any order) then produce a draft or summary.
+		 */
+		MUST_USE_TOOLS,
+		/** Model should ask a clarifying question before draft tools. */
+		MUST_CLARIFY,
+		/** Catalog search expected; draft tools optional when ingredient is missing. */
+		MUST_SEARCH_CATALOG
+
+	}
+
+	record Scenario(String id, String prompt, Category category, Expectation expectation, List<String> expectedTools,
+			List<String> expectedWarningFragments, String notes, boolean usesPatientContext) {
+	}
+
+	private AiNutritionGoldenPrompt() {
+	}
+
+	static Stream<Scenario> scenarios() {
+		return ALL.stream();
+	}
+
+	static Stream<Scenario> mustUseToolsScenarios() {
+		return ALL.stream().filter(scenario -> scenario.expectation() == Expectation.MUST_USE_TOOLS);
+	}
+
+	static Stream<Scenario> mustClarifyScenarios() {
+		return ALL.stream().filter(scenario -> scenario.expectation() == Expectation.MUST_CLARIFY);
+	}
+
+	static Stream<Scenario> mustSearchCatalogScenarios() {
+		return ALL.stream().filter(scenario -> scenario.expectation() == Expectation.MUST_SEARCH_CATALOG);
+	}
+
+	private static final List<Scenario> ALL = List.of(
+			new Scenario("high-protein-breakfast",
+					"Genera un desayuno alto en proteína usando alimentos de mi catálogo.", Category.DISH,
+					Expectation.MUST_USE_TOOLS,
+					List.of(SearchFoodCatalogToolService.TOOL_NAME, CalculateRecipeNutrientsToolService.TOOL_NAME,
+							CreateDishDraftToolService.TOOL_NAME),
+					List.of("Borrador IA", "revisión del nutriólogo"),
+					"Search catalog foods, calculate nutrients, save dish draft", false),
+			new Scenario("low-sodium-day-menu",
+					"Menú bajo en sodio de un día: desayuno, comida, cena y dos colaciones.", Category.MENU_DAILY,
+					Expectation.MUST_USE_TOOLS,
+					List.of(SearchFoodCatalogToolService.TOOL_NAME, SearchDishCatalogToolService.TOOL_NAME,
+							ValidatePlanConstraintsToolService.TOOL_NAME, CreateMenuDraftToolService.TOOL_NAME),
+					List.of("sodio", "Borrador IA"), "Daily menu with sodium constraint validation", false),
+			new Scenario("7-day-weight-loss-menu", "Menú semanal de 7 días para pérdida de peso, 1600 kcal.",
+					Category.MENU_WEEKLY, Expectation.MUST_USE_TOOLS,
+					List.of(SearchFoodCatalogToolService.TOOL_NAME, SearchDishCatalogToolService.TOOL_NAME,
+							ValidatePlanConstraintsToolService.TOOL_NAME, CreateDietPlanDraftToolService.TOOL_NAME),
+					List.of("1600", "Borrador IA"), "Seven-day plan draft within scope cap (#447)", false),
+			new Scenario("egg-allergy-plan", "Plan de 7 días sin huevo para el paciente vinculado.", Category.DIET_PLAN,
+					Expectation.MUST_USE_TOOLS,
+					List.of(SearchFoodCatalogToolService.TOOL_NAME, ValidatePlanConstraintsToolService.TOOL_NAME,
+							CreateDietPlanDraftToolService.TOOL_NAME),
+					List.of("huevo", "alergia", "Borrador IA"), "Uses linked patient allergy context (#362)", true),
+			new Scenario("diabetic-friendly-menu",
+					"Menú de un día amigable para diabetes, 1800 kcal, bajo índice glucémico.", Category.MENU_DAILY,
+					Expectation.MUST_USE_TOOLS,
+					List.of(SearchFoodCatalogToolService.TOOL_NAME, SearchDishCatalogToolService.TOOL_NAME,
+							ValidatePlanConstraintsToolService.TOOL_NAME, CreateMenuDraftToolService.TOOL_NAME),
+					List.of("revisión profesional", "Borrador IA"),
+					"No clinical diagnosis language; validation warnings only", false),
+			new Scenario("vegetarian-weekly-plan", "Plan semanal vegetariano de 7 días, lunes a viernes iguales.",
+					Category.MENU_WEEKLY, Expectation.MUST_USE_TOOLS,
+					List.of(SearchFoodCatalogToolService.TOOL_NAME, SearchDishCatalogToolService.TOOL_NAME,
+							CreateDietPlanDraftToolService.TOOL_NAME),
+					List.of("vegetariano", "supuesto", "Borrador IA"),
+					"Weekly vegetarian structure with repetition note in assumptions", false),
+			new Scenario("unsupported-ingredient", "Receta con pitahaya del catálogo.", Category.CATALOG_LOOKUP,
+					Expectation.MUST_SEARCH_CATALOG, List.of(SearchFoodCatalogToolService.TOOL_NAME),
+					List.of("catálogo", "no se encontró", "sustituto"),
+					"Must not invent foods missing from catalog (#361)", false),
+			new Scenario("menu-missing-calorie-target", "Arma un menú de un día con desayuno, comida y cena.",
+					Category.CLARIFY, Expectation.MUST_CLARIFY, List.of(), List.of("objetivo calórico", "kcal"),
+					"Ask for calorie target before extensive draft (#367)", false));
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiNutritionGoldenPromptTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiNutritionGoldenPromptTest.java
@@ -1,0 +1,276 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Golden prompt evaluation for supported nutrition workflows (#401). Uses mocked OpenAI
+ * only — no live API calls.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AiNutritionGoldenPromptTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	private static final long THREAD_ID = 10L;
+
+	@InjectMocks
+	private AiOrchestrationServiceImpl service;
+
+	@Mock
+	private AiProperties properties;
+
+	@Mock
+	private OpenAiClientService openAiClientService;
+
+	@Mock
+	private AiSystemPromptService systemPromptService;
+
+	@Mock
+	private AiChatThreadRepository threadRepository;
+
+	@Mock
+	private AiChatMessageRepository messageRepository;
+
+	@Mock
+	private AiOpenAiToolCatalog toolCatalog;
+
+	@Mock
+	private AiOrchestrationToolDispatcher toolDispatcher;
+
+	@Mock
+	private TransactionTemplate transactionTemplate;
+
+	@Mock
+	private AiUserMessageGuard userMessageGuard;
+
+	@Mock
+	private AiChatPersistence chatPersistence;
+
+	@Mock
+	private AiOrchestrationTools orchestrationTools;
+
+	@Mock
+	private AiRequestScopePipeline requestScopePipeline;
+
+	private AiRequestScopeGuard scopeGuard;
+
+	private AiOrchestrationGuardrails realGuardrails;
+
+	private AiUserMessageGuard realUserMessageGuard;
+
+	private AiChatThread thread;
+
+	@BeforeEach
+	void setUp() {
+		thread = new AiChatThread();
+		thread.setId(THREAD_ID);
+		thread.setNutritionistId(NUTRITIONIST_ID);
+		final AiProperties guardProperties = new AiProperties();
+		scopeGuard = new AiRequestScopeGuard(guardProperties);
+		realGuardrails = new AiOrchestrationGuardrails(new AiToolAllowlist(new AiOpenAiToolCatalog()),
+				new AiToolResultSanitizer(), new AiAssistantOutputValidator());
+		realUserMessageGuard = new AiUserMessageGuard(guardProperties);
+		when(userMessageGuard.validateAndSanitize(any(String.class)))
+			.thenAnswer(invocation -> realUserMessageGuard.validateAndSanitize(invocation.getArgument(0)));
+		when(userMessageGuard.wrapForModel(any(String.class)))
+			.thenAnswer(invocation -> realUserMessageGuard.wrapForModel(invocation.getArgument(0)));
+		when(chatPersistence.getThreadRepository()).thenReturn(threadRepository);
+		when(chatPersistence.getMessageRepository()).thenReturn(messageRepository);
+		when(chatPersistence.getTransactionTemplate()).thenReturn(transactionTemplate);
+		when(orchestrationTools.getToolCatalog()).thenReturn(toolCatalog);
+		when(orchestrationTools.getToolDispatcher()).thenReturn(toolDispatcher);
+		when(orchestrationTools.getGuardrails()).thenReturn(realGuardrails);
+		when(requestScopePipeline.evaluate(any(String.class))).thenReturn(Optional.empty());
+		when(transactionTemplate.execute(org.mockito.ArgumentMatchers.<TransactionCallback<Object>>any()))
+			.thenAnswer(invocation -> {
+				final TransactionCallback<?> callback = invocation.getArgument(0);
+				return callback.doInTransaction(null);
+			});
+		when(messageRepository.save(any(AiChatMessage.class))).thenAnswer(invocation -> {
+			final AiChatMessage saved = invocation.getArgument(0);
+			if (saved.getId() == null) {
+				saved.setId(100L);
+			}
+			return saved;
+		});
+	}
+
+	static Stream<AiNutritionGoldenPrompt.Scenario> allScenarios() {
+		return AiNutritionGoldenPrompt.scenarios();
+	}
+
+	static Stream<AiNutritionGoldenPrompt.Scenario> mustUseToolsScenarios() {
+		return AiNutritionGoldenPrompt.mustUseToolsScenarios();
+	}
+
+	static Stream<AiNutritionGoldenPrompt.Scenario> mustClarifyScenarios() {
+		return AiNutritionGoldenPrompt.mustClarifyScenarios();
+	}
+
+	static Stream<AiNutritionGoldenPrompt.Scenario> mustSearchCatalogScenarios() {
+		return AiNutritionGoldenPrompt.mustSearchCatalogScenarios();
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("allScenarios")
+	void scenarioPassesScopeGuard(final AiNutritionGoldenPrompt.Scenario scenario) {
+		assertThat(scopeGuard.evaluate(scenario.prompt())).as("scenario %s", scenario.id()).isEmpty();
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("allScenarios")
+	void expectedToolsAreRegistered(final AiNutritionGoldenPrompt.Scenario scenario) {
+		final AiToolAllowlist allowlist = new AiToolAllowlist(new AiOpenAiToolCatalog());
+		for (final String toolName : scenario.expectedTools()) {
+			assertThat(allowlist.isAllowed(toolName)).as("scenario %s tool %s", scenario.id(), toolName).isTrue();
+		}
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("mustUseToolsScenarios")
+	void simulatedToolLoopInvokesExpectedTools(final AiNutritionGoldenPrompt.Scenario scenario) {
+		stubOperational();
+		stubThreadAndHistory(scenario.prompt(), scenario.usesPatientContext());
+		stubToolDispatchSuccess();
+		final String assistantReply = buildAssistantReply(scenario.expectedWarningFragments());
+		when(openAiClientService.chatCompletion(any())).thenReturn(toolCallsResponse(scenario.expectedTools()))
+			.thenReturn(assistantOnlyResponse(assistantReply));
+
+		final AiOrchestrationResult result = service.processUserMessage(orchestrationContext(scenario),
+				scenario.prompt());
+
+		for (final String toolName : scenario.expectedTools()) {
+			verify(toolDispatcher).dispatch(any(), eq(toolName), any());
+		}
+		assertThat(result.toolCallsExecuted()).isEqualTo(scenario.expectedTools().size());
+		assertWarningFragments(result.assistantMessage().getContent(), scenario);
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("mustClarifyScenarios")
+	void clarifyScenarioDoesNotInvokeTools(final AiNutritionGoldenPrompt.Scenario scenario) {
+		stubOperational();
+		stubThreadAndHistory(scenario.prompt(), false);
+		final String clarifyReply = "¿Cuál es tu objetivo calórico (kcal) para este menú de un día?";
+		when(openAiClientService.chatCompletion(any())).thenReturn(assistantOnlyResponse(clarifyReply));
+
+		final AiOrchestrationResult result = service.processUserMessage(orchestrationContext(scenario),
+				scenario.prompt());
+
+		verify(toolDispatcher, never()).dispatch(any(), any(), any());
+		assertThat(result.toolCallsExecuted()).isZero();
+		assertWarningFragments(clarifyReply, scenario);
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("mustSearchCatalogScenarios")
+	void unsupportedIngredientUsesSearchWithoutInventing(final AiNutritionGoldenPrompt.Scenario scenario) {
+		stubOperational();
+		stubThreadAndHistory(scenario.prompt(), false);
+		when(toolDispatcher.dispatch(any(), eq(SearchFoodCatalogToolService.TOOL_NAME), any()))
+			.thenReturn("{\"success\":true,\"data\":{\"items\":[]}}");
+		final String assistantReply = "No se encontró pitahaya en el catálogo. "
+				+ "Puedes agregarla manualmente o elegir un sustituto del catálogo.";
+		when(openAiClientService.chatCompletion(any()))
+			.thenReturn(toolCallsResponse(List.of(SearchFoodCatalogToolService.TOOL_NAME)))
+			.thenReturn(assistantOnlyResponse(assistantReply));
+
+		final AiOrchestrationResult result = service.processUserMessage(orchestrationContext(scenario),
+				scenario.prompt());
+
+		verify(toolDispatcher).dispatch(any(), eq(SearchFoodCatalogToolService.TOOL_NAME), any());
+		verify(toolDispatcher, never()).dispatch(any(), eq(CreateDishDraftToolService.TOOL_NAME), any());
+		assertWarningFragments(result.assistantMessage().getContent(), scenario);
+	}
+
+	private void stubOperational() {
+		when(properties.isOperational()).thenReturn(true);
+		when(properties.getMaxToolCalls()).thenReturn(8);
+		when(openAiClientService.isAvailable()).thenReturn(true);
+		when(systemPromptService.buildSystemPrompt(any())).thenReturn("Eres un asistente nutricional.");
+		when(toolCatalog.definitions()).thenReturn(List.of());
+	}
+
+	private void stubThreadAndHistory(final String userPrompt, final boolean withPatient) {
+		when(threadRepository.findByIdAndNutritionistId(THREAD_ID, NUTRITIONIST_ID)).thenReturn(Optional.of(thread));
+		when(messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(THREAD_ID))
+			.thenReturn(List.of(userMessage(userPrompt)));
+		if (withPatient) {
+			when(systemPromptService.buildSystemPrompt(any())).thenReturn("Prompt con alergias: Huevo");
+		}
+	}
+
+	private void stubToolDispatchSuccess() {
+		when(toolDispatcher.dispatch(any(), any(), any())).thenReturn("{\"success\":true,\"data\":{}}");
+	}
+
+	private static OpenAiChatCompletionResponse toolCallsResponse(final List<String> toolNames) {
+		final List<OpenAiToolCall> calls = IntStream.range(0, toolNames.size())
+			.mapToObj(index -> new OpenAiToolCall("call_" + index, toolNames.get(index), "{}"))
+			.toList();
+		return new OpenAiChatCompletionResponse("id-tools", "assistant", null, calls, "tool_calls",
+				new OpenAiTokenUsage(10, 5, 15));
+	}
+
+	private static OpenAiChatCompletionResponse assistantOnlyResponse(final String content) {
+		return new OpenAiChatCompletionResponse("id-final", "assistant", content, List.of(), "stop",
+				new OpenAiTokenUsage(20, 10, 30));
+	}
+
+	private static String buildAssistantReply(final List<String> warningFragments) {
+		final StringBuilder reply = new StringBuilder("Borrador IA — revisión del nutriólogo requerida. ");
+		for (final String fragment : warningFragments) {
+			reply.append(fragment).append(". ");
+		}
+		return reply.toString().trim();
+	}
+
+	private static void assertWarningFragments(final String content, final AiNutritionGoldenPrompt.Scenario scenario) {
+		final String normalized = content.toLowerCase(Locale.ROOT);
+		for (final String fragment : scenario.expectedWarningFragments()) {
+			assertThat(normalized).as("scenario %s", scenario.id()).contains(fragment.toLowerCase(Locale.ROOT));
+		}
+	}
+
+	private static AiOrchestrationContext orchestrationContext(final AiNutritionGoldenPrompt.Scenario scenario) {
+		if (!scenario.usesPatientContext()) {
+			return new AiOrchestrationContext(NUTRITIONIST_ID, THREAD_ID, null, null, null);
+		}
+		final AiPatientPromptContext patient = new AiPatientPromptContext(42L, 1800.0, null, false, "F", false,
+				"NORMAL", 23.5, Map.of(), "Huevo", "MODERATE");
+		return new AiOrchestrationContext(NUTRITIONIST_ID, THREAD_ID, patient, null, null);
+	}
+
+	private static AiChatMessage userMessage(final String content) {
+		final AiChatMessage message = new AiChatMessage();
+		message.setRole(AiChatMessageRole.USER);
+		message.setContent(content);
+		return message;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds eight documented nutrition workflow golden prompts (high-protein breakfast, low-sodium menu, 7-day plan, allergies, diabetes, vegetarian, missing ingredient, missing kcal).
- Each scenario specifies expected tool usage and Spanish warning themes per `TOOL-CONTRACT.md` / `FUNCTIONAL-SCOPE.md`.
- `AiNutritionGoldenPromptTest` runs scope, allowlist, and mocked orchestration assertions in CI (no live OpenAI).

Closes #401.

## Test plan
- [x] `./lint.sh`
- [x] `mvn test -Dtest=AiNutritionGoldenPromptTest` (24 cases)


Made with [Cursor](https://cursor.com)