### PR TITLE
Add JSON Schema validation for AI draft tool arguments (#402)

### DIFF
--- a/docs/ai/DRAFT-SCHEMA-VALIDATION.md
+++ b/docs/ai/DRAFT-SCHEMA-VALIDATION.md
@@ -1,0 +1,70 @@
+# Draft tool JSON schema validation (#402)
+
+**Issue:** [#402](https://github.com/diego-torres/nutriconsultas/issues/402) · Epic [#400](https://github.com/diego-torres/nutriconsultas/issues/400)  
+**Related:** [`TOOL-CONTRACT.md`](TOOL-CONTRACT.md) (#363) · [`NUTRITION-GOLDEN-PROMPTS.md`](NUTRITION-GOLDEN-PROMPTS.md) (#401)
+
+Structured output validation for OpenAI draft tool arguments **before** Jackson deserialization and domain validation in `Create*DraftToolServiceImpl`.
+
+---
+
+## Schema location
+
+| Resource | Purpose |
+|----------|---------|
+| `src/main/resources/ai/schemas/draft-tool-input-schemas.json` | Canonical JSON Schema definitions |
+| `AiDraftToolSchemaValidator` | Validates tool `arguments` JSON at dispatch time |
+
+Definitions (aligned with `TOOL-CONTRACT.md`):
+
+| Schema key | Tool |
+|------------|------|
+| `DishDraftInput` | `create_dish_draft` |
+| `MenuDraftInput` | `create_menu_draft` |
+| `DietPlanDraftInput` | `create_diet_plan_draft` |
+
+Shared types: `RecipeIngredientInput`, `IngestaSlot`, `IngestaSlotItem`, `NutrientSummary`, `DietPlanDayInput`.
+
+---
+
+## Validation pipeline
+
+```mermaid
+flowchart LR
+  A[OpenAI tool arguments JSON] --> B[AiDraftToolSchemaValidator]
+  B -->|invalid| C[AiToolResult VALIDATION Spanish error]
+  B -->|valid| D[Jackson → DishDraftInput / MenuDraftInput / DietPlanDraftInput]
+  D --> E[Create*DraftToolServiceImpl domain validation]
+  E --> F[Persist ai_generated_draft]
+```
+
+1. **Schema validation (#402)** — structure, required fields, `additionalProperties: false`, array bounds.
+2. **Domain validation (#379–#381)** — business rules (name length, duplicate days, catalog lookups).
+
+Schema failures return Spanish messages such as:
+
+- *Argumentos de herramienta no válidos: JSON mal formado.*
+- *Argumentos de herramienta no válidos: falta el campo obligatorio (ingredients).*
+- *Argumentos de herramienta no válidos: campo no permitido (unexpectedField).*
+
+The model receives these via the tool result envelope; the nutritionist sees the assistant explain the issue in Spanish (#399 follow-up).
+
+---
+
+## Tests
+
+| Class | Coverage |
+|-------|----------|
+| `AiDraftToolSchemaValidatorTest` | Valid/invalid JSON, missing required fields, extra properties |
+| `AiOrchestrationToolDispatcherTest` | Schema rejection before draft service invocation |
+
+Run:
+
+```bash
+mvn test -Dtest=AiDraftToolSchemaValidatorTest,AiOrchestrationToolDispatcherTest
+```
+
+---
+
+## Manual verification
+
+In `/admin/ai` with `AI_ENABLED=true`, tool audit rows for rejected drafts should show `"success": false` with `errorCode: "VALIDATION"` before any `ai_generated_draft` row is created.

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -12,6 +12,7 @@ Documentation for the **AI Nutrition Assistant** track.
 | [`BULK-SCOPE-GOLDEN-PROMPTS.md`](BULK-SCOPE-GOLDEN-PROMPTS.md) | Golden prompt evaluation for bulk scope (#450) |
 | [`SECURITY-GOLDEN-PROMPTS.md`](SECURITY-GOLDEN-PROMPTS.md) | Golden prompt evaluation for defense-in-depth (#441) |
 | [`NUTRITION-GOLDEN-PROMPTS.md`](NUTRITION-GOLDEN-PROMPTS.md) | Golden prompt evaluation for nutrition workflows (#401) |
+| [`DRAFT-SCHEMA-VALIDATION.md`](DRAFT-SCHEMA-VALIDATION.md) | JSON Schema validation for draft tool arguments (#402) |
 | [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) | Architecture, security, tools, milestones, definition of done |
 | [`../../ISSUE-AI-ASSISTANT.md`](../../ISSUE-AI-ASSISTANT.md) | GitHub issue registry (#360–#408) |
 | [`../../AI-ASSISTANT-WORKFLOW.md`](../../AI-ASSISTANT-WORKFLOW.md) | Agent implementation workflow |

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <spotbugs.version>4.9.8.2</spotbugs.version>
     <pmd.version>3.28.0</pmd.version>
     <spring-javaformat.version>0.0.47</spring-javaformat.version>
+    <json-schema-validator.version>1.5.6</json-schema-validator.version>
   </properties>
 
   <parent>
@@ -114,6 +115,11 @@
       <artifactId>lombok</artifactId>
       <version>1.18.38</version>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.networknt</groupId>
+      <artifactId>json-schema-validator</artifactId>
+      <version>${json-schema-validator.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>

--- a/src/main/java/com/nutriconsultas/ai/AiDraftToolSchemaValidator.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftToolSchemaValidator.java
@@ -115,7 +115,8 @@ public final class AiDraftToolSchemaValidator {
 	}
 
 	private static String loadSchemaContent() {
-		try (InputStream inputStream = AiDraftToolSchemaValidator.class.getClassLoader()
+		try (InputStream inputStream = Thread.currentThread()
+			.getContextClassLoader()
 			.getResourceAsStream(SCHEMA_RESOURCE)) {
 			if (inputStream == null) {
 				throw new IllegalStateException("Missing draft tool schema resource: " + SCHEMA_RESOURCE);

--- a/src/main/java/com/nutriconsultas/ai/AiDraftToolSchemaValidator.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftToolSchemaValidator.java
@@ -1,0 +1,130 @@
+package com.nutriconsultas.ai;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Validates OpenAI draft-tool arguments against JSON Schema before deserialization
+ * (#402). Schemas mirror {@code docs/ai/TOOL-CONTRACT.md} and
+ * {@code src/main/resources/ai/schemas/draft-tool-input-schemas.json}.
+ */
+@Component
+@Slf4j
+public final class AiDraftToolSchemaValidator {
+
+	static final String SCHEMA_RESOURCE = "ai/schemas/draft-tool-input-schemas.json";
+
+	static final String SCHEMA_DOCUMENT_ID = "https://minutriporcion.local/ai/schemas/draft-tool-input-schemas.json";
+
+	static final String INVALID_JSON_MESSAGE = "Argumentos de herramienta no válidos: JSON mal formado.";
+
+	static final String GENERIC_SCHEMA_MESSAGE = "Argumentos de herramienta no válidos: revisa los campos obligatorios e intenta de nuevo.";
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	private final JsonSchema dishDraftSchema;
+
+	private final JsonSchema menuDraftSchema;
+
+	private final JsonSchema dietPlanDraftSchema;
+
+	public AiDraftToolSchemaValidator() {
+		final String schemaContent = loadSchemaContent();
+		final JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012,
+				builder -> builder.schemaLoaders(
+						schemaLoaders -> schemaLoaders.schemas(Map.of(SCHEMA_DOCUMENT_ID, schemaContent))));
+		dishDraftSchema = factory.getSchema(SchemaLocation.of(SCHEMA_DOCUMENT_ID + "#/definitions/DishDraftInput"));
+		menuDraftSchema = factory.getSchema(SchemaLocation.of(SCHEMA_DOCUMENT_ID + "#/definitions/MenuDraftInput"));
+		dietPlanDraftSchema = factory
+			.getSchema(SchemaLocation.of(SCHEMA_DOCUMENT_ID + "#/definitions/DietPlanDraftInput"));
+	}
+
+	public Optional<String> validateDishDraftArguments(final String argumentsJson) {
+		return validate(dishDraftSchema, argumentsJson);
+	}
+
+	public Optional<String> validateMenuDraftArguments(final String argumentsJson) {
+		return validate(menuDraftSchema, argumentsJson);
+	}
+
+	public Optional<String> validateDietPlanDraftArguments(final String argumentsJson) {
+		return validate(dietPlanDraftSchema, argumentsJson);
+	}
+
+	private static Optional<String> validate(final JsonSchema schema, final String argumentsJson) {
+		final JsonNode payload;
+		try {
+			payload = OBJECT_MAPPER.readTree(argumentsJson);
+		}
+		catch (IOException ex) {
+			return Optional.of(INVALID_JSON_MESSAGE);
+		}
+		final Set<ValidationMessage> violations = schema.validate(payload);
+		if (violations.isEmpty()) {
+			return Optional.empty();
+		}
+		if (log.isWarnEnabled()) {
+			log.warn("AI draft tool schema validation failed violationCount={}", violations.size());
+		}
+		return Optional.of(toSpanishMessage(violations));
+	}
+
+	private static String toSpanishMessage(final Set<ValidationMessage> violations) {
+		final ValidationMessage first = violations.iterator().next();
+		final String keyword = first.getType();
+		final String path = formatPath(first.getInstanceLocation().toString());
+		if ("required".equals(keyword)) {
+			return "Argumentos de herramienta no válidos: falta el campo obligatorio" + path + ".";
+		}
+		if ("additionalProperties".equals(keyword)) {
+			return "Argumentos de herramienta no válidos: campo no permitido" + path + ".";
+		}
+		if ("minLength".equals(keyword) || "maxLength".equals(keyword)) {
+			return "Argumentos de herramienta no válidos: longitud no válida" + path + ".";
+		}
+		if ("minItems".equals(keyword) || "maxItems".equals(keyword)) {
+			return "Argumentos de herramienta no válidos: cantidad de elementos no válida" + path + ".";
+		}
+		if ("type".equals(keyword)) {
+			return "Argumentos de herramienta no válidos: formato incorrecto" + path + ".";
+		}
+		return GENERIC_SCHEMA_MESSAGE;
+	}
+
+	private static String formatPath(final String instanceLocation) {
+		if (instanceLocation == null || instanceLocation.isBlank() || "$".equals(instanceLocation)) {
+			return "";
+		}
+		return " (" + instanceLocation.replace("$.", "").replace('/', '.') + ")";
+	}
+
+	private static String loadSchemaContent() {
+		try (InputStream inputStream = AiDraftToolSchemaValidator.class.getClassLoader()
+			.getResourceAsStream(SCHEMA_RESOURCE)) {
+			if (inputStream == null) {
+				throw new IllegalStateException("Missing draft tool schema resource: " + SCHEMA_RESOURCE);
+			}
+			return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+		}
+		catch (IOException ex) {
+			throw new IllegalStateException("Could not load draft tool schemas: " + SCHEMA_RESOURCE, ex);
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcher.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcher.java
@@ -1,6 +1,7 @@
 package com.nutriconsultas.ai;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
@@ -28,6 +29,8 @@ public class AiOrchestrationToolDispatcher {
 
 	private final CreateDietPlanDraftToolService createDietPlanDraftToolService;
 
+	private final AiDraftToolSchemaValidator draftToolSchemaValidator;
+
 	public AiOrchestrationToolDispatcher(final SearchFoodCatalogToolService searchFoodCatalogToolService,
 			final GetFoodNutrientsToolService getFoodNutrientsToolService,
 			final SearchDishCatalogToolService searchDishCatalogToolService,
@@ -35,7 +38,8 @@ public class AiOrchestrationToolDispatcher {
 			final ValidatePlanConstraintsToolService validatePlanConstraintsToolService,
 			final CreateDishDraftToolService createDishDraftToolService,
 			final CreateMenuDraftToolService createMenuDraftToolService,
-			final CreateDietPlanDraftToolService createDietPlanDraftToolService) {
+			final CreateDietPlanDraftToolService createDietPlanDraftToolService,
+			final AiDraftToolSchemaValidator draftToolSchemaValidator) {
 		this.searchFoodCatalogToolService = searchFoodCatalogToolService;
 		this.getFoodNutrientsToolService = getFoodNutrientsToolService;
 		this.searchDishCatalogToolService = searchDishCatalogToolService;
@@ -44,6 +48,7 @@ public class AiOrchestrationToolDispatcher {
 		this.createDishDraftToolService = createDishDraftToolService;
 		this.createMenuDraftToolService = createMenuDraftToolService;
 		this.createDietPlanDraftToolService = createDietPlanDraftToolService;
+		this.draftToolSchemaValidator = draftToolSchemaValidator;
 	}
 
 	public String dispatch(final AiOrchestrationContext context, final String toolName, final String argumentsJson) {
@@ -126,18 +131,30 @@ public class AiOrchestrationToolDispatcher {
 
 	private AiToolResult<AiDraftCreationData> createDishDraft(final AiOrchestrationContext context,
 			final String argumentsJson) {
+		final Optional<String> schemaViolation = draftToolSchemaValidator.validateDishDraftArguments(argumentsJson);
+		if (schemaViolation.isPresent()) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, schemaViolation.get());
+		}
 		final DishDraftInput input = AiToolJsonSerializer.fromJson(argumentsJson, DishDraftInput.class);
 		return createDishDraftToolService.createDraft(context.nutritionistId(), context.threadId(), input);
 	}
 
 	private AiToolResult<AiDraftCreationData> createMenuDraft(final AiOrchestrationContext context,
 			final String argumentsJson) {
+		final Optional<String> schemaViolation = draftToolSchemaValidator.validateMenuDraftArguments(argumentsJson);
+		if (schemaViolation.isPresent()) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, schemaViolation.get());
+		}
 		final MenuDraftInput input = AiToolJsonSerializer.fromJson(argumentsJson, MenuDraftInput.class);
 		return createMenuDraftToolService.createDraft(context.nutritionistId(), context.threadId(), input);
 	}
 
 	private AiToolResult<AiDraftCreationData> createDietPlanDraft(final AiOrchestrationContext context,
 			final String argumentsJson) {
+		final Optional<String> schemaViolation = draftToolSchemaValidator.validateDietPlanDraftArguments(argumentsJson);
+		if (schemaViolation.isPresent()) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, schemaViolation.get());
+		}
 		final DietPlanDraftInput input = AiToolJsonSerializer.fromJson(argumentsJson, DietPlanDraftInput.class);
 		return createDietPlanDraftToolService.createDraft(context.nutritionistId(), context.threadId(), input);
 	}

--- a/src/main/resources/ai/schemas/draft-tool-input-schemas.json
+++ b/src/main/resources/ai/schemas/draft-tool-input-schemas.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://minutriporcion.local/ai/schemas/draft-tool-input-schemas.json",
+  "definitions": {
+    "NutrientSummary": {
+      "type": "object",
+      "properties": {
+        "energiaKcal": { "type": "number" },
+        "proteinaG": { "type": "number" },
+        "lipidosG": { "type": "number" },
+        "hidratosDeCarbonoG": { "type": "number" },
+        "fibraG": { "type": "number" },
+        "sodioMg": { "type": "number" },
+        "potasioMg": { "type": "number" }
+      },
+      "additionalProperties": false
+    },
+    "RecipeIngredientInput": {
+      "type": "object",
+      "properties": {
+        "alimentoId": { "type": "integer" },
+        "cantidad": { "type": "string", "minLength": 1 },
+        "pesoNetoG": { "type": "integer", "minimum": 1 },
+        "unidad": { "type": "string", "maxLength": 40 }
+      },
+      "required": ["alimentoId", "cantidad"],
+      "additionalProperties": false
+    },
+    "IngestaSlotItem": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["PLATILLO", "ALIMENTO", "RECIPE"] },
+        "platilloId": { "type": "integer" },
+        "alimentoId": { "type": "integer" },
+        "portions": { "type": "integer", "minimum": 1 },
+        "ingredients": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 40,
+          "items": { "$ref": "#/definitions/RecipeIngredientInput" }
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    "IngestaSlot": {
+      "type": "object",
+      "properties": {
+        "nombre": { "type": "string", "maxLength": 80 },
+        "orden": { "type": "integer" },
+        "items": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/IngestaSlotItem" }
+        }
+      },
+      "required": ["items"],
+      "additionalProperties": false
+    },
+    "DietPlanDayInput": {
+      "type": "object",
+      "properties": {
+        "dayIndex": { "type": "integer", "minimum": 1 },
+        "label": { "type": "string", "maxLength": 80 },
+        "ingestas": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 12,
+          "items": { "$ref": "#/definitions/IngestaSlot" }
+        }
+      },
+      "required": ["dayIndex", "ingestas"],
+      "additionalProperties": false
+    },
+    "DishDraftInput": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 2, "maxLength": 120 },
+        "description": { "type": "string", "maxLength": 2000 },
+        "preparationSteps": {
+          "type": "array",
+          "maxItems": 30,
+          "items": { "type": "string", "maxLength": 500 }
+        },
+        "ingestasSugeridas": { "type": "string", "maxLength": 80 },
+        "ingredients": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 40,
+          "items": { "$ref": "#/definitions/RecipeIngredientInput" }
+        },
+        "portions": { "type": "integer", "minimum": 1 },
+        "nutrientsPerPortion": { "$ref": "#/definitions/NutrientSummary" },
+        "assumptions": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 300 }
+        },
+        "warnings": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 300 }
+        }
+      },
+      "required": ["name", "ingredients"],
+      "additionalProperties": false
+    },
+    "MenuDraftInput": {
+      "type": "object",
+      "properties": {
+        "title": { "type": "string", "maxLength": 120 },
+        "targetKcal": { "type": "number" },
+        "ingestas": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 12,
+          "items": { "$ref": "#/definitions/IngestaSlot" }
+        },
+        "validationSummary": { "type": "string", "maxLength": 1000 },
+        "assumptions": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 300 }
+        },
+        "warnings": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 300 }
+        }
+      },
+      "required": ["ingestas"],
+      "additionalProperties": false
+    },
+    "DietPlanDraftInput": {
+      "type": "object",
+      "properties": {
+        "title": { "type": "string", "maxLength": 120 },
+        "dayCount": { "type": "integer", "minimum": 1, "maximum": 14 },
+        "targetKcalPerDay": { "type": "number" },
+        "days": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 14,
+          "items": { "$ref": "#/definitions/DietPlanDayInput" }
+        },
+        "validationSummary": { "type": "string", "maxLength": 2000 },
+        "assumptions": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 300 }
+        },
+        "warnings": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 300 }
+        }
+      },
+      "required": ["days"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/test/java/com/nutriconsultas/ai/AiDraftToolSchemaValidatorTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftToolSchemaValidatorTest.java
@@ -1,0 +1,149 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AiDraftToolSchemaValidatorTest {
+
+	private AiDraftToolSchemaValidator validator;
+
+	@BeforeEach
+	void setUp() {
+		validator = new AiDraftToolSchemaValidator();
+	}
+
+	@Test
+	void acceptsValidDishDraftArguments() {
+		final String json = """
+				{
+				  "name": "Tacos de pollo",
+				  "ingredients": [
+				    { "alimentoId": 1, "cantidad": "1" }
+				  ],
+				  "portions": 2
+				}
+				""";
+
+		assertThat(validator.validateDishDraftArguments(json)).isEmpty();
+	}
+
+	@Test
+	void rejectsDishDraftMissingRequiredName() {
+		final String json = """
+				{
+				  "ingredients": [
+				    { "alimentoId": 1, "cantidad": "1" }
+				  ]
+				}
+				""";
+
+		assertThat(validator.validateDishDraftArguments(json)).isPresent().get().asString().contains("obligatorio");
+	}
+
+	@Test
+	void rejectsDishDraftWithAdditionalProperties() {
+		final String json = """
+				{
+				  "name": "Ensalada",
+				  "ingredients": [
+				    { "alimentoId": 1, "cantidad": "1" }
+				  ],
+				  "unexpectedField": true
+				}
+				""";
+
+		assertThat(validator.validateDishDraftArguments(json)).isPresent().get().asString().contains("no permitido");
+	}
+
+	@Test
+	void rejectsMalformedJson() {
+		assertThat(validator.validateMenuDraftArguments("{name:")).isPresent()
+			.get()
+			.isEqualTo(AiDraftToolSchemaValidator.INVALID_JSON_MESSAGE);
+	}
+
+	@Test
+	void acceptsValidMenuDraftArguments() {
+		final String json = """
+				{
+				  "title": "Menú bajo en sodio",
+				  "targetKcal": 1800,
+				  "ingestas": [
+				    {
+				      "nombre": "Desayuno",
+				      "items": [
+				        { "type": "ALIMENTO", "alimentoId": 10, "portions": 1 }
+				      ]
+				    }
+				  ]
+				}
+				""";
+
+		assertThat(validator.validateMenuDraftArguments(json)).isEmpty();
+	}
+
+	@Test
+	void rejectsMenuDraftMissingIngestas() {
+		final String json = """
+				{
+				  "title": "Menú incompleto"
+				}
+				""";
+
+		assertThat(validator.validateMenuDraftArguments(json)).isPresent();
+	}
+
+	@Test
+	void acceptsValidDietPlanDraftArguments() {
+		final String json = """
+				{
+				  "title": "Plan 7 días",
+				  "dayCount": 1,
+				  "days": [
+				    {
+				      "dayIndex": 1,
+				      "ingestas": [
+				        {
+				          "nombre": "Comida",
+				          "items": [
+				            { "type": "PLATILLO", "platilloId": 5, "portions": 1 }
+				          ]
+				        }
+				      ]
+				    }
+				  ]
+				}
+				""";
+
+		assertThat(validator.validateDietPlanDraftArguments(json)).isEmpty();
+	}
+
+	@Test
+	void rejectsDietPlanDraftWithTooManyDays() {
+		final StringBuilder days = new StringBuilder("[");
+		for (int day = 1; day <= 15; day++) {
+			if (day > 1) {
+				days.append(',');
+			}
+			days.append("""
+					{
+					  "dayIndex": %d,
+					  "ingestas": [
+					    {
+					      "items": [
+					        { "type": "ALIMENTO", "alimentoId": 1, "portions": 1 }
+					      ]
+					    }
+					  ]
+					}
+					""".formatted(day));
+		}
+		days.append(']');
+		final String json = "{ \"days\": " + days + " }";
+
+		assertThat(validator.validateDietPlanDraftArguments(json)).isPresent();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcherTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcherTest.java
@@ -45,6 +45,9 @@ class AiOrchestrationToolDispatcherTest {
 	@Mock
 	private CreateDietPlanDraftToolService createDietPlanDraftToolService;
 
+	@Mock
+	private AiDraftToolSchemaValidator draftToolSchemaValidator;
+
 	@Test
 	void dispatchSearchFoodCatalog() {
 		final FoodCatalogSearchData data = new FoodCatalogSearchData(java.util.List.of(), 0, false);
@@ -64,6 +67,42 @@ class AiOrchestrationToolDispatcherTest {
 
 		assertThat(json).contains("\"success\":false");
 		assertThat(json).contains("Herramienta no reconocida");
+	}
+
+	@Test
+	void dispatchDishDraftRejectsSchemaViolationBeforeService() {
+		when(draftToolSchemaValidator.validateDishDraftArguments(org.mockito.ArgumentMatchers.anyString())).thenReturn(
+				java.util.Optional.of("Argumentos de herramienta no válidos: falta el campo obligatorio (name)."));
+
+		final String json = dispatcher.dispatch(context(), CreateDishDraftToolService.TOOL_NAME,
+				"{\"ingredients\":[{\"alimentoId\":1,\"cantidad\":\"1\"}]}");
+
+		assertThat(json).contains("\"success\":false");
+		assertThat(json).contains("obligatorio");
+		org.mockito.Mockito.verify(createDishDraftToolService, org.mockito.Mockito.never())
+			.createDraft(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyLong(),
+					org.mockito.ArgumentMatchers.any());
+	}
+
+	@Test
+	void dispatchDishDraftUsesRealSchemaValidatorWhenConfigured() {
+		final AiOrchestrationToolDispatcher realSchemaDispatcher = new AiOrchestrationToolDispatcher(
+				searchFoodCatalogToolService, getFoodNutrientsToolService, searchDishCatalogToolService,
+				calculateRecipeNutrientsToolService, validatePlanConstraintsToolService, createDishDraftToolService,
+				createMenuDraftToolService, createDietPlanDraftToolService, new AiDraftToolSchemaValidator());
+		when(createDishDraftToolService.createDraft(org.mockito.ArgumentMatchers.eq(NUTRITIONIST_ID),
+				org.mockito.ArgumentMatchers.eq(THREAD_ID), org.mockito.ArgumentMatchers.any()))
+			.thenReturn(AiToolResult
+				.success(new AiDraftCreationData(1L, AiDraftType.DISH, AiDraftStatus.DRAFT, "Borrador IA — Tacos")));
+
+		final String json = realSchemaDispatcher.dispatch(context(), CreateDishDraftToolService.TOOL_NAME, """
+				{
+				  "name": "Tacos",
+				  "ingredients": [{ "alimentoId": 1, "cantidad": "1" }]
+				}
+				""");
+
+		assertThat(json).contains("\"success\":true");
 	}
 
 	private static AiOrchestrationContext context() {


### PR DESCRIPTION
## Summary
- Adds `json-schema-validator` and canonical schemas for `create_dish_draft`, `create_menu_draft`, and `create_diet_plan_draft` tool arguments aligned with `TOOL-CONTRACT.md`.
- Introduces `AiDraftToolSchemaValidator` and wires it into `AiOrchestrationToolDispatcher` so malformed tool JSON returns `VALIDATION` errors in Spanish before domain validation.
- Documents the validation pipeline in `docs/ai/DRAFT-SCHEMA-VALIDATION.md` with unit and dispatcher tests.

## Test plan
- [x] `mvn test -Dtest=AiDraftToolSchemaValidatorTest,AiOrchestrationToolDispatcherTest`
- [x] `./lint.sh`
- [ ] CI green

Closes #402


Made with [Cursor](https://cursor.com)