### PR TITLE
Document local AI setup (#405)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,13 +58,15 @@ JDBC_DATABASE_PASSWORD=nutriconsultas
 # STRIPE_SUCCESS_URL=http://localhost:3000/admin
 # STRIPE_CANCEL_URL=http://localhost:3000/admin
 
-# OpenAI — AI Nutrition Assistant (#365); keep AI_ENABLED=false until OpenAI keys are set
+# OpenAI — AI Nutrition Assistant (#365); see docs/ai/LOCAL-AI-SETUP.md
 # AI_ENABLED=false
 # OPENAI_API_KEY=sk-proj-your_openai_api_key_here
 # OPEN_API_KEY=sk-proj-legacy_alias_same_as_openai_api_key
-# OPENAI_MODEL=gpt-5.5
+# OPENAI_MODEL=gpt-5-mini
 # OPENAI_STORE=false
 # OPENAI_BASE_URL=https://api.openai.com
 # OPENAI_CONNECT_TIMEOUT_MS=5000
 # OPENAI_READ_TIMEOUT_MS=120000
 # AI_MAX_TOOL_CALLS=8
+# AI_MAX_USER_MESSAGE_LENGTH=4000
+# AI_SCOPE_CLASSIFIER_ENABLED=true

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -170,11 +170,12 @@ mvn test
 
 ## Local & production config
 
+Full local guide: [`docs/ai/LOCAL-AI-SETUP.md`](docs/ai/LOCAL-AI-SETUP.md) (#405). Production: #406.
+
 | Variable | Purpose |
 |----------|---------|
 | `AI_ENABLED` | Feature flag |
 | `OPENAI_API_KEY` / `OPEN_API_KEY` | Server secret |
-| `OPENAI_MODEL` | e.g. `gpt-5.5` |
-| `AI_MAX_TOOL_CALLS` | Orchestration limit (default 8) |
+| `OPENAI_MODEL` | e.g. `gpt-5-mini` |
 
 EC2: `/opt/nutriconsultas/app.env` — update via SSM (see #406).

--- a/docs/ai/LOCAL-AI-SETUP.md
+++ b/docs/ai/LOCAL-AI-SETUP.md
@@ -1,0 +1,180 @@
+# Local AI setup (#405)
+
+**Issue:** [#405](https://github.com/diego-torres/nutriconsultas/issues/405) · Epic [#404](https://github.com/diego-torres/nutriconsultas/issues/404)  
+**Production counterpart:** [#406](https://github.com/diego-torres/nutriconsultas/issues/406) (EC2 `app.env`)
+
+How to enable or disable the **AI Nutrition Assistant** on a developer machine. OpenAI credentials stay **server-side only** — never in Git, the browser, or logs.
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|-------------|--------|
+| Java **21** | Same as the rest of the app |
+| PostgreSQL | `./dev-start.sh` starts Podman Postgres and runs the app |
+| Auth0 login | Nutritionist OAuth2 session (same as other `/admin/**` pages) |
+| OpenAI account | API key with access to your chosen chat model |
+
+---
+
+## Quick start (enable AI)
+
+1. Copy the env template if you do not have a local `.env` yet:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Edit **`.env`** (gitignored — see [Never commit keys](#never-commit-keys)) and set at minimum:
+
+   ```bash
+   AI_ENABLED=true
+   OPENAI_API_KEY=sk-proj-your_key_here
+   OPENAI_MODEL=gpt-5-mini
+   ```
+
+   `OPENAI_MODEL` must match a model your API key can call (e.g. `gpt-5-mini`, `gpt-4o`). The app does **not** default a model when the variable is empty.
+
+3. Start the stack:
+
+   ```bash
+   ./dev-start.sh
+   ```
+
+   The script loads `.env` and exports variables before `mvn spring-boot:run`.
+
+4. Confirm startup logs (no API key in output):
+
+   - **OK:** `AI assistant enabled (model=gpt-5-mini, openai.store=false, maxToolCalls=8)`
+   - **Misconfigured:** `AI assistant is enabled (AI_ENABLED=true) but OpenAI is not fully configured (OPENAI_API_KEY or OPENAI_MODEL missing)...`
+
+5. Open **`http://localhost:3000/admin/ai`** after logging in as a nutritionist.
+
+---
+
+## Environment variables
+
+Spring maps env vars in `application.properties` under `nutriconsultas.ai.*`.
+
+### Required to run AI locally
+
+| Variable | Spring property | Purpose |
+|----------|-----------------|---------|
+| `AI_ENABLED` | `nutriconsultas.ai.enabled` | Feature flag. Default **`false`**. Set `true` to expose `/admin/ai` and REST chat endpoints. |
+| `OPENAI_API_KEY` | `nutriconsultas.ai.openai.api-key` | Server secret for OpenAI HTTP calls. |
+| `OPENAI_MODEL` | `nutriconsultas.ai.openai.model` | Model id sent on every completion (e.g. `gpt-5-mini`). |
+
+**Legacy alias:** `OPEN_API_KEY` is accepted if `OPENAI_API_KEY` is unset (`OPENAI_API_KEY` takes precedence).
+
+### Recommended defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OPENAI_STORE` | `false` | Do not enable provider-side conversation retention without legal review ([`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md)). |
+| `OPENAI_BASE_URL` | `https://api.openai.com` | Override only for proxies or compatible APIs. |
+
+### Optional tuning
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OPENAI_CONNECT_TIMEOUT_MS` | `5000` | HTTP connect timeout |
+| `OPENAI_READ_TIMEOUT_MS` | `120000` | HTTP read timeout (long tool loops) |
+| `AI_MAX_TOOL_CALLS` | `8` | Max tool round-trips per user message |
+| `AI_MAX_USER_MESSAGE_LENGTH` | `4000` | User input cap (matches UI `maxlength`) |
+| `AI_MAX_DAYS_PER_TURN` | `14` | Diet-plan day cap per turn |
+| `AI_MAX_DISHES_PER_TURN` | `1` | Dish drafts per turn |
+| `AI_MAX_MENU_DAYS_PER_TURN` | `7` | Menu day cap per turn |
+| `AI_SCOPE_CLASSIFIER_ENABLED` | `true` | LLM pre-flight scope classifier (#448) |
+| `AI_SCOPE_CLASSIFIER_MAX_TOKENS` | `200` | Classifier completion budget |
+
+See also [`PROMPT-SECURITY.md`](PROMPT-SECURITY.md) for guardrail-related limits.
+
+---
+
+## Disable AI locally
+
+Use any of these — **`AI_ENABLED=false` is enough** for most developers:
+
+| Approach | Effect |
+|----------|--------|
+| `AI_ENABLED=false` (or omit / comment out) | Default. `/admin/ai` returns **404**; sidebar AI entry hidden; REST chat unavailable. |
+| Omit `OPENAI_API_KEY` / `OPENAI_MODEL` with `AI_ENABLED=true` | Feature “on” but **not operational** — REST returns **503** with Spanish misconfiguration message; startup **WARN** in logs. |
+| Tests | `application-test.properties` sets `nutriconsultas.ai.enabled=false` unless a test overrides it. |
+
+Restart the app after changing `.env`.
+
+---
+
+## Never commit keys
+
+| Rule | Detail |
+|------|--------|
+| **`.env` is gitignored** | Listed in `.gitignore` — keep secrets only there or in your shell profile. |
+| **Use `.env.example`** | Commit placeholder names and comments, never real `sk-…` values. |
+| **No keys in code or docs** | Do not paste live keys into issues, PRs, Slack, or Cursor chats. |
+| **Rotate if exposed** | Revoke the key in the OpenAI dashboard and issue a new one. |
+| **Separate test keys** | Prefer a project-scoped key with usage limits for local dev. |
+
+Startup logging intentionally **never** prints the API key (`AiConfigTest` guards this).
+
+---
+
+## Verify the integration
+
+### UI
+
+1. Log in as a nutritionist.
+2. Sidebar → **Asistente IA** (visible only when `AI_ENABLED=true`).
+3. Send a short prompt in Spanish, e.g. *“Busca avena en mi catálogo.”*
+4. Expect a streamed or JSON reply; draft tools show **Borrador IA** labels before accept.
+
+### REST (optional)
+
+With session cookie from browser login:
+
+```bash
+curl -s -X POST http://localhost:3000/rest/nutritionist/ai/chat/start \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"Prueba local"}' \
+  --cookie 'JSESSIONID=...'
+```
+
+### Automated tests (no live OpenAI)
+
+```bash
+mvn test -Dtest=AiDraftFlowIntegrationTest,AiNutritionGoldenPromptTest
+```
+
+Golden and E2E tests mock OpenAI; they do not require `OPENAI_API_KEY` in `.env`.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `/admin/ai` → 404 | `AI_ENABLED=false` | Set `AI_ENABLED=true` and restart. |
+| Chat → 503 “no está disponible” | Missing key or model | Set `OPENAI_API_KEY` and `OPENAI_MODEL`; check startup WARN. |
+| Startup WARN about misconfiguration | Same as above | Fill both variables; alias `OPEN_API_KEY` only if you omit `OPENAI_API_KEY`. |
+| OpenAI 401 / invalid API key | Wrong or revoked key | Regenerate key; update `.env`; restart. |
+| Model not found / 404 from OpenAI | Typo in `OPENAI_MODEL` | Use a model id valid for your account. |
+| Rate limit / 429 | OpenAI or app limiter | Wait and retry; app message: *“El servicio de IA está saturado…”* |
+| Empty sidebar link | Feature flag off | `AI_ENABLED=true` + restart. |
+| Changes ignored | Env not loaded | Use `./dev-start.sh` or `export $(grep -v '^#' .env \| xargs)` before `mvn spring-boot:run`. |
+| `.env` not found warning | No file in repo root | `cp .env.example .env` |
+
+For evaluation scenarios without live API, see [`NUTRITION-GOLDEN-PROMPTS.md`](NUTRITION-GOLDEN-PROMPTS.md).
+
+---
+
+## Related documents
+
+| Doc | Topic |
+|-----|--------|
+| [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) | Architecture and milestones |
+| [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md) | PHI, logging, `OPENAI_STORE` |
+| [`FUNCTIONAL-SCOPE.md`](FUNCTIONAL-SCOPE.md) | Supported workflows |
+| [`../../AI-ASSISTANT-WORKFLOW.md`](../../AI-ASSISTANT-WORKFLOW.md) | Agent workflow and env summary |
+
+**Note:** Plan-tier gating (`Entitlement.AI_ASSISTANT`, #409) is not required for basic local enablement today; production rollout must follow #408 and #409.

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -14,6 +14,7 @@ Documentation for the **AI Nutrition Assistant** track.
 | [`NUTRITION-GOLDEN-PROMPTS.md`](NUTRITION-GOLDEN-PROMPTS.md) | Golden prompt evaluation for nutrition workflows (#401) |
 | [`DRAFT-SCHEMA-VALIDATION.md`](DRAFT-SCHEMA-VALIDATION.md) | JSON Schema validation for draft tool arguments (#402) |
 | [`E2E-DRAFT-FLOW-TEST.md`](E2E-DRAFT-FLOW-TEST.md) | End-to-end draft flow integration test (#403) |
+| [`LOCAL-AI-SETUP.md`](LOCAL-AI-SETUP.md) | Local dev: `.env`, `AI_ENABLED`, OpenAI keys (#405) |
 | [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) | Architecture, security, tools, milestones, definition of done |
 | [`../../ISSUE-AI-ASSISTANT.md`](../../ISSUE-AI-ASSISTANT.md) | GitHub issue registry (#360–#408) |
 | [`../../AI-ASSISTANT-WORKFLOW.md`](../../AI-ASSISTANT-WORKFLOW.md) | Agent implementation workflow |


### PR DESCRIPTION
## Summary
- Adds `docs/ai/LOCAL-AI-SETUP.md`: `AI_ENABLED`, `OPENAI_API_KEY`, `OPENAI_MODEL`, disable paths, key safety, verification, and troubleshooting.
- Links from `docs/ai/README.md` and `AI-ASSISTANT-WORKFLOW.md`.
- Expands `.env.example` OpenAI section with optional tuning vars and doc pointer.

## Test plan
- [x] Doc review against `application.properties` and `AiConfig` startup behavior
- [ ] CI green (docs-only)

Closes #405


Made with [Cursor](https://cursor.com)