### PR TITLE
Document production AI setup (#406)

### DIFF
--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -170,7 +170,8 @@ mvn test
 
 ## Local & production config
 
-Full local guide: [`docs/ai/LOCAL-AI-SETUP.md`](docs/ai/LOCAL-AI-SETUP.md) (#405). Production: #406.
+Full local guide: [`docs/ai/LOCAL-AI-SETUP.md`](docs/ai/LOCAL-AI-SETUP.md) (#405).  
+Production: [`docs/ai/PRODUCTION-AI-SETUP.md`](docs/ai/PRODUCTION-AI-SETUP.md) (#406) and `infrastructure/scripts/ssm-update-ai-openai.sh`.
 
 | Variable | Purpose |
 |----------|---------|

--- a/docs/ai/LOCAL-AI-SETUP.md
+++ b/docs/ai/LOCAL-AI-SETUP.md
@@ -1,7 +1,7 @@
 # Local AI setup (#405)
 
 **Issue:** [#405](https://github.com/diego-torres/nutriconsultas/issues/405) · Epic [#404](https://github.com/diego-torres/nutriconsultas/issues/404)  
-**Production counterpart:** [#406](https://github.com/diego-torres/nutriconsultas/issues/406) (EC2 `app.env`)
+**Production counterpart:** [`PRODUCTION-AI-SETUP.md`](PRODUCTION-AI-SETUP.md) (#406)
 
 How to enable or disable the **AI Nutrition Assistant** on a developer machine. OpenAI credentials stay **server-side only** — never in Git, the browser, or logs.
 
@@ -175,6 +175,6 @@ For evaluation scenarios without live API, see [`NUTRITION-GOLDEN-PROMPTS.md`](N
 | [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) | Architecture and milestones |
 | [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md) | PHI, logging, `OPENAI_STORE` |
 | [`FUNCTIONAL-SCOPE.md`](FUNCTIONAL-SCOPE.md) | Supported workflows |
-| [`../../AI-ASSISTANT-WORKFLOW.md`](../../AI-ASSISTANT-WORKFLOW.md) | Agent workflow and env summary |
+| [`PRODUCTION-AI-SETUP.md`](PRODUCTION-AI-SETUP.md) | Production EC2, SSM, spend controls (#406) |
 
 **Note:** Plan-tier gating (`Entitlement.AI_ASSISTANT`, #409) is not required for basic local enablement today; production rollout must follow #408 and #409.

--- a/docs/ai/PRODUCTION-AI-SETUP.md
+++ b/docs/ai/PRODUCTION-AI-SETUP.md
@@ -1,0 +1,192 @@
+# Production AI setup (#406)
+
+**Issue:** [#406](https://github.com/diego-torres/nutriconsultas/issues/406) · Epic [#404](https://github.com/diego-torres/nutriconsultas/issues/404)  
+**Local counterpart:** [`LOCAL-AI-SETUP.md`](LOCAL-AI-SETUP.md) (#405)
+
+How to configure the **AI Nutrition Assistant** on the production **app EC2** host. OpenAI credentials are **server-only** — loaded from `/opt/nutriconsultas/app.env` via systemd, never exposed to browsers or Git.
+
+**Before enabling in production:** complete release checklist **#408**, prompt security epic **#438**, and plan gating **#409** (see [Pre-production gates](#pre-production-gates)).
+
+---
+
+## Where secrets live
+
+| Location | Purpose |
+|----------|---------|
+| **`/opt/nutriconsultas/app.env`** | Runtime env file on the app EC2 instance (`root:nutri`, mode `640`). Spring reads `AI_*` / `OPENAI_*` via `EnvironmentFile` in `nutriconsultas.service`. |
+| **Terraform first boot** | [`infrastructure/templates/app.user_data.sh`](../../infrastructure/templates/app.user_data.sh) writes JDBC, Auth0, Stripe, etc. **OpenAI vars are not in Terraform today** — add them on brownfield hosts via SSM (below). |
+| **SSM Parameter Store** | Deploy metadata only: `/{project}/deploy/app_instance_id` (used by scripts to target the app instance). **Do not** store OpenAI API keys in SSM Parameter Store unless you adopt a dedicated secrets workflow; prefer `app.env` + rotation via script. |
+| **Git / CI** | **Never** commit `OPENAI_API_KEY`, `terraform.tfvars` secrets, or pipeline env with live keys. |
+
+Shell access: **SSM Session Manager only** (no public SSH). See [`infrastructure/README.md`](../../infrastructure/README.md#connect-to-the-ec2-instances-ssm-session-manager-only).
+
+---
+
+## Backend-only usage
+
+The OpenAI API key must **only** exist in server process memory loaded from `app.env`:
+
+| Layer | Behavior |
+|-------|----------|
+| **`OpenAiClientServiceImpl`** | Sends `Authorization: Bearer …` on server-side HTTP to OpenAI. |
+| **Thymeleaf / JS** | `AiEnabledModelAdvice` exposes **`aiEnabled` boolean only** — never the key or model config. |
+| **REST JSON** | Chat responses return assistant text and draft metadata — no OpenAI credentials. |
+| **Logs** | `AiConfig` logs model name and flags, **not** the API key (`AiConfigTest` enforces this). |
+| **Outbound redaction** | `AiAssistantOutputValidator` strips accidental `sk-…` patterns from model output. |
+
+See [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md) for PHI and `OPENAI_STORE=false` (default).
+
+---
+
+## Configure production (recommended)
+
+Use the SSM helper script (same pattern as Stripe / reCAPTCHA / patient broker):
+
+```bash
+export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+export AI_ENABLED=true
+export OPENAI_API_KEY='sk-proj-...'
+export OPENAI_MODEL='gpt-5-mini'
+# Optional:
+# export OPENAI_STORE=false
+# export AI_CHAT_MESSAGE_RATE_LIMIT=20
+# export AI_CHAT_MESSAGE_RATE_WINDOW=1h
+bash infrastructure/scripts/ssm-update-ai-openai.sh
+```
+
+The script:
+
+1. Resolves the app instance from `/{project}/deploy/app_instance_id`.
+2. Upserts vars in `/opt/nutriconsultas/app.env` (secrets base64-encoded in the SSM payload — not echoed in command history on the laptop beyond your shell).
+3. Restarts `nutriconsultas` and waits for `/actuator/health`.
+4. Prints an **audit line** (`OPENAI_API_KEY=SET(len=…)`, never the value).
+
+### Manual SSM (alternative)
+
+1. Start a session: `aws ssm start-session --target <app_instance_id>`
+2. Edit as root: `sudo vi /opt/nutriconsultas/app.env`
+3. Add or update:
+
+   ```bash
+   AI_ENABLED=true
+   OPENAI_API_KEY=sk-proj-...
+   OPENAI_MODEL=gpt-5-mini
+   OPENAI_STORE=false
+   ```
+
+4. `sudo systemctl restart nutriconsultas`
+5. `curl -sf http://127.0.0.1:3000/actuator/health`
+
+---
+
+## Environment variables (production)
+
+Same Spring mapping as local — see [`LOCAL-AI-SETUP.md`](LOCAL-AI-SETUP.md#environment-variables).
+
+| Variable | Production notes |
+|----------|------------------|
+| `AI_ENABLED` | **`false` by default** in `application.properties`. Must be `true` for `/admin/ai`. |
+| `OPENAI_API_KEY` | Production project key; rotate via OpenAI dashboard + SSM script. |
+| `OPENAI_MODEL` | Choose cost/latency-appropriate model; validate in staging first. |
+| `OPENAI_STORE` | Keep **`false`** unless legal approves provider retention. |
+| `AI_CHAT_MESSAGE_RATE_LIMIT` | App rate limit per nutritionist (default **20**). |
+| `AI_CHAT_MESSAGE_RATE_WINDOW` | Window for above (default **`1h`**). Resilience4j duration format. |
+| `AI_MAX_TOOL_CALLS` | Max tool round-trips per message (default **8**). |
+
+---
+
+## Rate limits and spend controls
+
+Defense is **layered** — use both OpenAI account controls and app limits.
+
+### OpenAI account (operator)
+
+| Control | Recommendation |
+|---------|----------------|
+| **Usage limits / budget alerts** | Set monthly budget and email alerts in [OpenAI billing](https://platform.openai.com/settings/organization/billing). |
+| **Project-scoped API keys** | Separate prod vs dev keys; revoke compromised keys immediately. |
+| **Model choice** | Prefer smaller/faster models for staging; promote model id to prod after smoke tests. |
+
+### Application (automatic)
+
+| Mechanism | Default | Config |
+|-----------|---------|--------|
+| **Per-nutritionist message limit** | 20 messages / hour | `AI_CHAT_MESSAGE_RATE_LIMIT`, `AI_CHAT_MESSAGE_RATE_WINDOW` |
+| **Tool calls per turn** | 8 max | `AI_MAX_TOOL_CALLS` |
+| **Bulk scope guard** | Refuses excessive batch requests | `AI_MAX_DAYS_PER_TURN`, `AI_MAX_DISHES_PER_TURN`, `AI_MAX_MENU_DAYS_PER_TURN` |
+| **Scope classifier** | Optional LLM pre-flight | `AI_SCOPE_CLASSIFIER_ENABLED` (default `true`) |
+| **User message length** | 4000 chars | `AI_MAX_USER_MESSAGE_LENGTH` |
+
+User-facing rate limit message (Spanish): *“Has alcanzado el límite de mensajes del asistente de IA…”* (`AiChatRateLimiter`).
+
+OpenAI 429 responses map to a separate Spanish saturation message from `OpenAiClientService`.
+
+---
+
+## Rollback and disable
+
+| Scenario | Action | User impact |
+|----------|--------|-------------|
+| **Emergency off** | `AI_ENABLED=false` via SSM script or manual `app.env` edit + `systemctl restart nutriconsultas` | `/admin/ai` → 404; sidebar link hidden; no OpenAI traffic |
+| **Misconfigured enable** | Leave `AI_ENABLED=true` but remove key/model | 503 Spanish message; startup WARN in journal |
+| **Key compromise** | Revoke key in OpenAI; deploy new key via SSM script; restart | Brief downtime during restart |
+| **Bad model deploy** | Set previous `OPENAI_MODEL` in `app.env`; restart | No JAR redeploy needed |
+| **Code rollback** | Redeploy previous JAR via CodePipeline / `deploy-jar-to-ec2-ssm.sh` | `app.env` unchanged — AI flag independent of JAR version |
+
+**Disable without removing secrets** (fast re-enable):
+
+```bash
+export AI_ENABLED=false
+# OPENAI_API_KEY and OPENAI_MODEL may remain in app.env
+bash infrastructure/scripts/ssm-update-ai-openai.sh
+```
+
+---
+
+## Verify production
+
+1. **Journal:** `sudo journalctl -u nutriconsultas -n 100 | grep -i 'AI assistant'`
+   - Success: `AI assistant enabled (model=…, openai.store=false, …)`
+   - Misconfigured: WARN about missing `OPENAI_API_KEY` or `OPENAI_MODEL`
+2. **Health:** `curl -sf https://minutriporcion.com/actuator/health` (or localhost from SSM).
+3. **UI:** Log in as nutritionist → **Asistente IA** → short Spanish prompt.
+4. **No key leakage:** Confirm browser devtools network responses and page source contain no `sk-` strings.
+
+---
+
+## Pre-production gates
+
+Do **not** set `AI_ENABLED=true` on production until:
+
+| Gate | Issue |
+|------|-------|
+| Release checklist | **#408** |
+| Prompt security hardening | Epic **#438** |
+| Plan entitlement (Plus + Consultorio) | **#409** |
+
+Staging may enable AI earlier for smoke tests; use a **separate OpenAI key** with lower budget.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `/admin/ai` 404 | `AI_ENABLED=false` | Enable via SSM script |
+| Chat 503 | Missing key/model | Set both; check journal WARN |
+| 429 to user | App or OpenAI limit | Lower usage; tune `AI_CHAT_MESSAGE_RATE_*`; check OpenAI dashboard |
+| No sidebar link | Feature flag off | Same as 404 |
+| Changes not applied | Forgot restart | `systemctl restart nutriconsultas` |
+| SSM script fails | Wrong profile/region/instance | `aws sts get-caller-identity`; verify `app_instance_id` parameter |
+
+---
+
+## Related documents
+
+| Doc | Topic |
+|-----|--------|
+| [`LOCAL-AI-SETUP.md`](LOCAL-AI-SETUP.md) | Developer `.env` setup |
+| [`infrastructure/README.md`](../../infrastructure/README.md) | EC2, SSM, CodePipeline |
+| [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md) | PHI, logging, retention |
+| [`PROMPT-SECURITY.md`](PROMPT-SECURITY.md) | Guardrails before prod enable |
+| [`../../AI-ASSISTANT-WORKFLOW.md`](../../AI-ASSISTANT-WORKFLOW.md) | Milestones and env summary |

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -15,6 +15,7 @@ Documentation for the **AI Nutrition Assistant** track.
 | [`DRAFT-SCHEMA-VALIDATION.md`](DRAFT-SCHEMA-VALIDATION.md) | JSON Schema validation for draft tool arguments (#402) |
 | [`E2E-DRAFT-FLOW-TEST.md`](E2E-DRAFT-FLOW-TEST.md) | End-to-end draft flow integration test (#403) |
 | [`LOCAL-AI-SETUP.md`](LOCAL-AI-SETUP.md) | Local dev: `.env`, `AI_ENABLED`, OpenAI keys (#405) |
+| [`PRODUCTION-AI-SETUP.md`](PRODUCTION-AI-SETUP.md) | Production EC2 `app.env`, SSM, rollback (#406) |
 | [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) | Architecture, security, tools, milestones, definition of done |
 | [`../../ISSUE-AI-ASSISTANT.md`](../../ISSUE-AI-ASSISTANT.md) | GitHub issue registry (#360–#408) |
 | [`../../AI-ASSISTANT-WORKFLOW.md`](../../AI-ASSISTANT-WORKFLOW.md) | Agent implementation workflow |

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -178,6 +178,24 @@ bash infrastructure/scripts/ssm-update-patient-broker.sh
 
 Verify: signup probe should **not** return HTTP 503 (400/403/409 is OK for a dummy email).
 
+**AI Nutrition Assistant (#406)** — OpenAI for nutritionist chat (`/admin/ai`). **Not** written by Terraform first boot; add on the running app host:
+
+| Variable | Purpose |
+|----------|---------|
+| `AI_ENABLED` | Feature flag (`false` until release checklist #408) |
+| `OPENAI_API_KEY` | Server-only OpenAI secret |
+| `OPENAI_MODEL` | Model id (e.g. `gpt-5-mini`) |
+| `OPENAI_STORE` | Keep `false` (no provider-side retention) |
+| `AI_CHAT_MESSAGE_RATE_LIMIT` / `AI_CHAT_MESSAGE_RATE_WINDOW` | Per-nutritionist app rate limit (default 20/hour) |
+
+```bash
+export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+export AI_ENABLED=true OPENAI_API_KEY='sk-proj-...' OPENAI_MODEL='gpt-5-mini'
+bash infrastructure/scripts/ssm-update-ai-openai.sh
+```
+
+Disable quickly: `export AI_ENABLED=false` and run the same script. Runbook: [`docs/ai/PRODUCTION-AI-SETUP.md`](../docs/ai/PRODUCTION-AI-SETUP.md).
+
 **Invitation email (#209)** — nutritionist invite delivery (SES prod / console local):
 
 | Variable | Purpose |

--- a/infrastructure/scripts/ssm-update-ai-openai.sh
+++ b/infrastructure/scripts/ssm-update-ai-openai.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Update AI assistant OpenAI env vars in /opt/nutriconsultas/app.env on the app EC2, then restart.
+#
+# Usage (enable):
+#   export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+#   export AI_ENABLED=true
+#   export OPENAI_API_KEY='sk-proj-...'
+#   export OPENAI_MODEL='gpt-5-mini'
+#   ./ssm-update-ai-openai.sh [project]
+#
+# Usage (disable — key/model may stay in app.env):
+#   export AI_ENABLED=false
+#   ./ssm-update-ai-openai.sh
+#
+# Optional: OPENAI_STORE, AI_CHAT_MESSAGE_RATE_LIMIT, AI_CHAT_MESSAGE_RATE_WINDOW, AI_MAX_TOOL_CALLS
+#
+# See docs/ai/PRODUCTION-AI-SETUP.md (#406).
+set -euo pipefail
+
+PROJECT="${1:-nutriconsultas}"
+P="/${PROJECT}/deploy"
+: "${AWS_REGION:-${AWS_DEFAULT_REGION:?Set AWS_DEFAULT_REGION (or use configure)}}"
+: "${AI_ENABLED:?Set AI_ENABLED (true or false)}"
+
+if [ "$AI_ENABLED" = "true" ]; then
+  : "${OPENAI_API_KEY:?Set OPENAI_API_KEY when AI_ENABLED=true}"
+  : "${OPENAI_MODEL:?Set OPENAI_MODEL when AI_ENABLED=true}"
+fi
+
+INSTANCE_ID="$(aws ssm get-parameter --name "$P/app_instance_id" --query "Parameter.Value" --output text)"
+
+b64() { printf '%s' "$1" | base64 | tr -d '\n'; }
+
+KEY_B64=""
+if [ -n "${OPENAI_API_KEY:-}" ]; then
+  KEY_B64="$(b64 "$OPENAI_API_KEY")"
+fi
+
+PARAMS="$(jq -n \
+  --arg enabled "$AI_ENABLED" \
+  --arg model "${OPENAI_MODEL:-}" \
+  --arg keyB64 "$KEY_B64" \
+  --arg store "${OPENAI_STORE:-}" \
+  --arg rateLimit "${AI_CHAT_MESSAGE_RATE_LIMIT:-}" \
+  --arg rateWindow "${AI_CHAT_MESSAGE_RATE_WINDOW:-}" \
+  --arg maxTools "${AI_MAX_TOOL_CALLS:-}" \
+  'def upsertPlain($key; $val):
+     [
+       ("grep -v \"^" + $key + "=\" \"$ENV_FILE\" > \"${ENV_FILE}.tmp\" || true"),
+       ("echo " + $key + "=" + $val + " >> \"${ENV_FILE}.tmp\""),
+       "mv \"${ENV_FILE}.tmp\" \"$ENV_FILE\""
+     ];
+   def upsertSecret($key; $valB64):
+     if ($valB64 | length) == 0 then [] else
+     [
+       ("grep -v \"^" + $key + "=\" \"$ENV_FILE\" > \"${ENV_FILE}.tmp\" || true"),
+       ("echo -n " + $key + "= >> \"${ENV_FILE}.tmp\""),
+       ("printf %s \"" + $valB64 + "\" | base64 -d >> \"${ENV_FILE}.tmp\""),
+       "echo >> \"${ENV_FILE}.tmp\"",
+       "mv \"${ENV_FILE}.tmp\" \"$ENV_FILE\""
+     ] end;
+   def upsertOptional($key; $val):
+     if ($val | length) == 0 then [] else upsertPlain($key; $val) end;
+   [
+     "set -euo pipefail",
+     "ENV_FILE=/opt/nutriconsultas/app.env",
+     "touch \"$ENV_FILE\""
+   ]
+   + upsertPlain("AI_ENABLED"; $enabled)
+   + upsertSecret("OPENAI_API_KEY"; $keyB64)
+   + upsertOptional("OPENAI_MODEL"; $model)
+   + upsertOptional("OPENAI_STORE"; $store)
+   + upsertOptional("AI_CHAT_MESSAGE_RATE_LIMIT"; $rateLimit)
+   + upsertOptional("AI_CHAT_MESSAGE_RATE_WINDOW"; $rateWindow)
+   + upsertOptional("AI_MAX_TOOL_CALLS"; $maxTools)
+   + [
+       "chmod 640 \"$ENV_FILE\"",
+       "chown root:nutri \"$ENV_FILE\"",
+       "systemctl restart nutriconsultas",
+       "for i in $(seq 1 60); do",
+       "  if curl -sf http://127.0.0.1:3000/actuator/health >/dev/null 2>&1; then break; fi",
+       "  sleep 2",
+       "done",
+       "curl -sf http://127.0.0.1:3000/actuator/health >/dev/null",
+       "systemctl is-active --quiet nutriconsultas",
+       "echo \"=== AI env audit ===\"",
+       "grep -E \"^AI_ENABLED=\" \"$ENV_FILE\" || echo \"AI_ENABLED=MISSING\"",
+       "v=$(grep -E \"^OPENAI_API_KEY=\" \"$ENV_FILE\" | cut -d= -f2- || true)",
+       "if [ -z \"$v\" ]; then echo \"OPENAI_API_KEY=EMPTY\"; else echo \"OPENAI_API_KEY=SET(len=${#v})\"; fi",
+       "grep -E \"^OPENAI_MODEL=\" \"$ENV_FILE\" || echo \"OPENAI_MODEL=MISSING\"",
+       "grep -E \"^OPENAI_STORE=\" \"$ENV_FILE\" || true",
+       "grep -E \"^AI_CHAT_MESSAGE_RATE_LIMIT=\" \"$ENV_FILE\" || true",
+       "grep -E \"^AI_CHAT_MESSAGE_RATE_WINDOW=\" \"$ENV_FILE\" || true",
+       "journalctl -u nutriconsultas -n 30 --no-pager | grep -i \"AI assistant\" || true"
+     ] | { commands: . }')"
+
+COMMAND_ID="$(aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunShellScript" \
+  --timeout-seconds 180 \
+  --parameters "$PARAMS" \
+  --query 'Command.CommandId' \
+  --output text)"
+
+echo "SSM command: $COMMAND_ID (instance $INSTANCE_ID)"
+aws ssm wait command-executed --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID"
+STATUS="$(aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" --query Status --output text)"
+STDOUT="$(aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" --query StandardOutputContent --output text)"
+if [ "$STATUS" != "Success" ]; then
+  aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+    --query '[Status,StandardErrorContent]' --output text >&2
+  exit 1
+fi
+echo "$STDOUT"
+echo "AI OpenAI env updated and nutriconsultas restarted."


### PR DESCRIPTION
## Summary
- Adds `docs/ai/PRODUCTION-AI-SETUP.md`: EC2 `app.env`, SSM workflow, backend-only usage, rate/spend controls, rollback/disable, and pre-production gates.
- Adds `infrastructure/scripts/ssm-update-ai-openai.sh` to upsert AI OpenAI vars and restart the app (mirrors Stripe/reCAPTCHA scripts).
- Links from `infrastructure/README.md`, `LOCAL-AI-SETUP.md`, and AI docs index.

## Test plan
- [x] Doc review against `application.properties`, `AiConfig`, and existing SSM scripts
- [ ] CI green

Closes #406


Made with [Cursor](https://cursor.com)