### PR TITLE
Add nutritionist user guidance for AI assistant (#407)

### DIFF
--- a/docs/ai/NUTRITIONIST-USER-GUIDANCE.md
+++ b/docs/ai/NUTRITIONIST-USER-GUIDANCE.md
@@ -1,0 +1,91 @@
+# Guía para nutriólogos — Asistente de IA (#407)
+
+**Issue:** [#407](https://github.com/diego-torres/nutriconsultas/issues/407) · Epic [#404](https://github.com/diego-torres/nutriconsultas/issues/404)  
+**Related:** [`FUNCTIONAL-SCOPE.md`](FUNCTIONAL-SCOPE.md) (#361) · [`NUTRITION-GOLDEN-PROMPTS.md`](NUTRITION-GOLDEN-PROMPTS.md) (#401)
+
+Orientación en **español (es-MX)** para nutriólogos que usan el asistente en **`/admin/ai`**. La misma guía aparece de forma resumida en la pantalla de chat (panel «Cómo usar el asistente»).
+
+---
+
+## Borradores — siempre revisión profesional
+
+| Regla | Detalle |
+|-------|---------|
+| **Todo es borrador** | Platillos, menús y planes que genera la IA se guardan como **borrador IA**, no en tu catálogo ni en pacientes. |
+| **Etiqueta visible** | *«Borrador IA — revisión del nutriólogo requerida»* en borradores y respuestas. |
+| **Tu criterio manda** | Verifica porciones, alergias, objetivos clínicos y datos del catálogo antes de aceptar. |
+| **Sin asignación automática** | La IA **no** asigna dietas a pacientes; eso sigue en el flujo habitual de la plataforma. |
+
+---
+
+## Ejemplos de buenos prompts
+
+Escribe en español, con el mayor contexto posible (kcal, ingestas, restricciones).
+
+### Platillo / receta
+
+- *Genera un desayuno alto en proteína usando alimentos de mi catálogo.*
+- *Arma una receta con pechuga de pollo, arroz y verduras; calcula nutrientes por porción.*
+- *Necesito un platillo bajo en sodio para la cena, 2 porciones.*
+
+### Menú de un día
+
+- *Menú de hoy: 1800 kcal, desayuno, comida, cena y dos colaciones, bajo en sodio.*
+- *Menú de un día amigable para diabetes, 1800 kcal, bajo índice glucémico.*
+
+### Plan de varios días
+
+- *Plan semanal de 7 días, 1600 kcal, para pérdida de peso.*
+- *Plan de 7 días sin huevo* (con paciente vinculado en el chat si aplica).
+
+### Consultas puntuales
+
+- *¿Cuántas kcal tiene 150 g de pechuga de pollo del catálogo?*
+- *Busca avena en mi catálogo.*
+
+Si falta el objetivo calórico o las comidas del día, el asistente puede **pedir aclaración** antes de generar un borrador grande.
+
+---
+
+## Limitaciones
+
+| No hace la IA | Qué hacer en su lugar |
+|---------------|------------------------|
+| Diagnosticar o prescribir tratamiento | Usar tu juicio clínico; la IA solo apoya borradores nutricionales. |
+| Asignar plan a un paciente | Revisa el borrador → **Aceptar** → asigna la dieta en la UI de pacientes. |
+| Inventar nutrientes sin catálogo | Pide alimentos del catálogo; si no existen, agrégalos manualmente y vuelve a pedir. |
+| Generar decenas de platillos o planes en un mensaje | Pide **un borrador a la vez**; luego pide variaciones en mensajes nuevos. |
+| Tareas fuera de nutrición | Correos, marketing, etc. — fuera de alcance. |
+| Ver datos de otros nutriólogos | Solo tu catálogo y tus conversaciones. |
+
+Emergencias médicas: la IA debe redirigir a atención profesional presencial; **no** sustituye urgencias.
+
+---
+
+## Aceptar o descartar borradores
+
+1. Envía tu mensaje en el chat; el asistente puede crear uno o más borradores en el panel **Borradores IA** (derecha).
+2. Selecciona un borrador para ver el detalle (ingredientes, ingestas, nutrientes, advertencias).
+3. **Aceptar** — confirmación con SweetAlert → se crea un **platillo** o **dieta** en **tu** catálogo. Puedes editarlo después como cualquier otro registro.
+4. **Descartar** — el borrador queda descartado; no modifica el catálogo.
+
+Si editas un mensaje anterior en la conversación, los borradores ligados a respuestas posteriores pueden invalidarse (comportamiento documentado en la UI de chat).
+
+---
+
+## Consejos rápidos
+
+- Vincula **paciente** o **dieta** al iniciar la conversación cuando el contexto clínico importe (widget flotante en ficha de paciente, dieta o platillo).
+- Prefiere **un objetivo por mensaje** cuando estés probando (un menú, un platillo, un plan corto).
+- Revisa **advertencias** del borrador (sodio, alergias, datos faltantes en catálogo).
+- Si ves *límite de mensajes*, espera unos minutos (límite por hora por nutriólogo).
+
+---
+
+## Documentación técnica
+
+| Doc | Tema |
+|-----|------|
+| [`FUNCTIONAL-SCOPE.md`](FUNCTIONAL-SCOPE.md) | Alcance v1 y flujos soportados |
+| [`LOCAL-AI-SETUP.md`](LOCAL-AI-SETUP.md) | Configuración en desarrollo |
+| [`PRODUCTION-AI-SETUP.md`](PRODUCTION-AI-SETUP.md) | Producción y desactivación |

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -16,6 +16,7 @@ Documentation for the **AI Nutrition Assistant** track.
 | [`E2E-DRAFT-FLOW-TEST.md`](E2E-DRAFT-FLOW-TEST.md) | End-to-end draft flow integration test (#403) |
 | [`LOCAL-AI-SETUP.md`](LOCAL-AI-SETUP.md) | Local dev: `.env`, `AI_ENABLED`, OpenAI keys (#405) |
 | [`PRODUCTION-AI-SETUP.md`](PRODUCTION-AI-SETUP.md) | Production EC2 `app.env`, SSM, rollback (#406) |
+| [`NUTRITIONIST-USER-GUIDANCE.md`](NUTRITIONIST-USER-GUIDANCE.md) | Nutritionist-facing guidance — drafts, prompts, limits (#407) |
 | [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) | Architecture, security, tools, milestones, definition of done |
 | [`../../ISSUE-AI-ASSISTANT.md`](../../ISSUE-AI-ASSISTANT.md) | GitHub issue registry (#360–#408) |
 | [`../../AI-ASSISTANT-WORKFLOW.md`](../../AI-ASSISTANT-WORKFLOW.md) | Agent implementation workflow |

--- a/src/main/resources/static/sbadmin/css/ai-chat.css
+++ b/src/main/resources/static/sbadmin/css/ai-chat.css
@@ -232,6 +232,27 @@
   margin-right: 0.35rem;
 }
 
+.ai-chat-guidance-card .card-header {
+  background-color: #f8f9fc;
+}
+
+.ai-chat-guidance-toggle {
+  text-decoration: none;
+}
+
+.ai-chat-guidance-toggle:hover,
+.ai-chat-guidance-toggle:focus {
+  text-decoration: none;
+}
+
+.ai-chat-guidance-toggle[aria-expanded="true"] .ai-chat-guidance-chevron {
+  transform: rotate(180deg);
+}
+
+.ai-chat-guidance-chevron {
+  transition: transform 0.2s ease;
+}
+
 @media (min-width: 992px) {
   .ai-chat-drafts-column {
     margin-top: 0;

--- a/src/main/resources/templates/sbadmin/ai/chat.html
+++ b/src/main/resources/templates/sbadmin/ai/chat.html
@@ -42,6 +42,53 @@
             </h1>
           </div>
 
+          <div class="card shadow mb-3 ai-chat-guidance-card">
+            <div class="card-header py-2 px-3">
+              <button class="btn btn-link btn-block text-left p-0 font-weight-bold text-primary ai-chat-guidance-toggle"
+                type="button" data-toggle="collapse" data-target="#aiChatGuidance" aria-expanded="false"
+                aria-controls="aiChatGuidance" id="aiChatGuidanceToggle">
+                <i class="fas fa-info-circle mr-2" aria-hidden="true"></i>Cómo usar el asistente
+                <i class="fas fa-chevron-down float-right mt-1 ai-chat-guidance-chevron" aria-hidden="true"></i>
+              </button>
+            </div>
+            <div id="aiChatGuidance" class="collapse" aria-labelledby="aiChatGuidanceToggle">
+              <div class="card-body ai-chat-guidance pt-3">
+                <div class="alert alert-warning py-2 mb-3" role="alert">
+                  <strong>Borradores, no decisiones finales.</strong> Todo lo que genera la IA es un
+                  <strong>borrador</strong> etiquetado como <em>Borrador IA — revisión del nutriólogo requerida</em>.
+                  Debes revisar porciones, alergias y objetivos clínicos antes de usarlo con pacientes. La IA
+                  <strong>no asigna</strong> dietas a pacientes.
+                </div>
+
+                <h3 class="h6 font-weight-bold text-gray-800">Ejemplos de buenos prompts</h3>
+                <ul class="small text-gray-700 mb-3">
+                  <li>«Genera un desayuno alto en proteína usando alimentos de mi catálogo.»</li>
+                  <li>«Menú de hoy: 1800 kcal, desayuno, comida, cena y dos colaciones, bajo en sodio.»</li>
+                  <li>«Plan semanal de 7 días, 1600 kcal, sin huevo.»</li>
+                  <li>«¿Cuántas kcal tiene 150 g de pechuga de pollo del catálogo?»</li>
+                </ul>
+                <p class="small text-muted mb-3">
+                  Incluye kcal objetivo, número de comidas y restricciones cuando puedas.
+                </p>
+
+                <h3 class="h6 font-weight-bold text-gray-800">Limitaciones</h3>
+                <ul class="small text-gray-700 mb-3">
+                  <li>No diagnostica ni prescribe tratamiento médico.</li>
+                  <li>No inventa nutrientes: usa alimentos y platillos de <strong>tu catálogo</strong>.</li>
+                  <li>No genera decenas de platillos o planes en un solo mensaje — pide un borrador a la vez.</li>
+                  <li>No guarda en catálogo hasta que tú pulses <strong>Aceptar</strong>.</li>
+                </ul>
+
+                <h3 class="h6 font-weight-bold text-gray-800">Aceptar o descartar</h3>
+                <ol class="small text-gray-700 mb-0">
+                  <li>Revisa el borrador en el panel <strong>Borradores IA</strong> (derecha).</li>
+                  <li><strong>Aceptar</strong> — confirmación → crea un platillo o dieta en tu catálogo (editable después).</li>
+                  <li><strong>Descartar</strong> — descarta el borrador sin cambiar tu catálogo.</li>
+                </ol>
+              </div>
+            </div>
+          </div>
+
           <div class="card shadow mb-4">
             <div class="card-header py-3 d-flex align-items-center justify-content-between">
               <h2 class="h6 m-0 font-weight-bold text-primary">Chat nutricional</h2>

--- a/src/test/java/com/nutriconsultas/ai/AiChatGuidanceContentTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatGuidanceContentTest.java
@@ -1,0 +1,51 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * Ensures in-app nutritionist guidance is present on the AI chat page (#407).
+ */
+class AiChatGuidanceContentTest {
+
+	private static final String TEMPLATE = "templates/sbadmin/ai/chat.html";
+
+	@Test
+	void chatTemplateIncludesDraftReviewGuidance() throws IOException {
+		final String html = loadTemplate();
+
+		assertThat(html).contains("Cómo usar el asistente");
+		assertThat(html).contains("Borrador IA — revisión del nutriólogo requerida");
+		assertThat(html).contains("no asigna");
+	}
+
+	@Test
+	void chatTemplateIncludesPromptExamplesAndLimitations() throws IOException {
+		final String html = loadTemplate();
+
+		assertThat(html).contains("Ejemplos de buenos prompts");
+		assertThat(html).contains("Genera un desayuno alto en proteína");
+		assertThat(html).contains("Limitaciones");
+		assertThat(html).contains("No diagnostica");
+	}
+
+	@Test
+	void chatTemplateDocumentsAcceptAndDiscardFlow() throws IOException {
+		final String html = loadTemplate();
+
+		assertThat(html).contains("Aceptar o descartar");
+		assertThat(html).contains("id=\"aiChatDraftAcceptBtn\"");
+		assertThat(html).contains("id=\"aiChatDraftDiscardBtn\"");
+	}
+
+	private static String loadTemplate() throws IOException {
+		final ClassPathResource resource = new ClassPathResource(TEMPLATE);
+		return resource.getContentAsString(StandardCharsets.UTF_8);
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds collapsible **«Cómo usar el asistente»** panel on `/admin/ai` with draft-review warning, prompt examples, limitations, and accept/discard steps.
- Adds `docs/ai/NUTRITIONIST-USER-GUIDANCE.md` (Spanish) and links it from `docs/ai/README.md`.
- Adds `AiChatGuidanceContentTest` to assert key guidance strings remain in the chat template.

## Test plan
- [x] `mvn test -Dtest=AiChatGuidanceContentTest,AiChatControllerTest,ThymeleafTemplateValidationTest`
- [ ] Manual: open `/admin/ai`, expand guidance panel, verify Spanish copy and styling
- [ ] Confirm unrelated spring-javaformat noise in other files was not included in this PR

Closes #407


Made with [Cursor](https://cursor.com)