### PR TITLE
Add structured AI audit logging with redaction (#397)

### DIFF
--- a/docs/ai/DATA-ACCESS-RULES.md
+++ b/docs/ai/DATA-ACCESS-RULES.md
@@ -248,7 +248,7 @@ Rotate keys if exposed. Use separate test keys locally; never commit `.env`.
 |-----|-------|
 | [`FUNCTIONAL-SCOPE.md`](FUNCTIONAL-SCOPE.md) | Workflows and patient-linked UX |
 | System prompt (#367) | `AiSystemPromptService`, `ai/system-prompt-base.txt` |
-| Audit logging implementation | #397 |
+| Audit logging implementation | ~~#397~~ — `AiAuditLogger`, `AiAuditRedaction` |
 | Production setup | #406 |
 
 ---

--- a/docs/ai/RELEASE-CHECKLIST.md
+++ b/docs/ai/RELEASE-CHECKLIST.md
@@ -65,7 +65,7 @@ Staging may enable AI earlier for smoke tests using a **separate OpenAI key** wi
 - [ ] Draft accept/discard audited via draft lifecycle (status transitions in DB).
 - [ ] **Verify:** send one chat message in staging → rows in `ai_chat_message`; journal has no patient names/emails.
 
-**Note:** Enhanced structured audit (#397) may follow; baseline DB + redacted logs are required for v1.
+**Note:** Structured audit logging via `AiAuditLogger` (#397) supplements DB persistence; redacted INFO lines only.
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/AiAuditLogger.java
+++ b/src/main/java/com/nutriconsultas/ai/AiAuditLogger.java
@@ -1,0 +1,147 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Structured, redacted INFO/WARN audit lines for the AI nutrition assistant (#397).
+ * Aligns with {@code docs/ai/DATA-ACCESS-RULES.md#logging-and-audit-397}.
+ */
+@Component
+@Slf4j
+public final class AiAuditLogger {
+
+	public void logThreadCreated(final long threadId, @Nullable final String nutritionistId,
+			final boolean patientLinked) {
+		if (log.isInfoEnabled()) {
+			log.info("AI audit event=thread_created threadId={} nutritionist={} patientLinked={}", threadId,
+					LogRedaction.redactUserId(nutritionistId), patientLinked);
+		}
+	}
+
+	public void logChatRequest(final long threadId, @Nullable final String nutritionistId, final AiChatRequestMode mode,
+			final int messageLength, final boolean patientContext, final boolean dietaContext,
+			final boolean platilloContext) {
+		if (log.isInfoEnabled()) {
+			log.info(
+					"AI audit event=chat_request threadId={} nutritionist={} mode={} messageLength={} patientContext={} dietaContext={} platilloContext={}",
+					threadId, LogRedaction.redactUserId(nutritionistId), mode, messageLength, patientContext,
+					dietaContext, platilloContext);
+		}
+	}
+
+	public void logOrchestrationComplete(final long threadId, @Nullable final String nutritionistId,
+			final int toolCallCount, final List<String> toolNames, @Nullable final OpenAiTokenUsage tokenUsage) {
+		if (log.isInfoEnabled()) {
+			final String tools = formatToolNames(toolNames);
+			final Integer promptTokens = tokenUsage != null ? tokenUsage.promptTokens() : null;
+			final Integer completionTokens = tokenUsage != null ? tokenUsage.completionTokens() : null;
+			log.info(
+					"AI audit event=orchestration_complete threadId={} nutritionist={} toolCalls={} tools={} promptTokens={} completionTokens={}",
+					threadId, LogRedaction.redactUserId(nutritionistId), toolCallCount, tools, promptTokens,
+					completionTokens);
+		}
+	}
+
+	public void logOrchestrationShortCircuit(final long threadId, @Nullable final String nutritionistId,
+			final String sourceLabel, final String sourceDetail) {
+		if (log.isInfoEnabled()) {
+			log.info("AI audit event=orchestration_short_circuit threadId={} nutritionist={} source={} detail={}",
+					threadId, LogRedaction.redactUserId(nutritionistId), sourceLabel,
+					AiAuditRedaction.redactSecrets(sourceDetail));
+		}
+	}
+
+	public void logToolRejected(final long threadId, final String toolName) {
+		if (log.isWarnEnabled()) {
+			log.warn("AI audit event=tool_rejected threadId={} tool={}", threadId, toolName);
+		}
+	}
+
+	public void logToolDispatchFailed(final long threadId, final String toolName) {
+		if (log.isWarnEnabled()) {
+			log.warn("AI audit event=tool_dispatch_failed threadId={} tool={}", threadId, toolName);
+		}
+	}
+
+	public void logMaxToolCallsReached(final long threadId, final int maxToolCalls) {
+		if (log.isWarnEnabled()) {
+			log.warn("AI audit event=max_tool_calls threadId={} maxToolCalls={}", threadId, maxToolCalls);
+		}
+	}
+
+	public void logDraftCreated(final long draftId, final long threadId, final AiDraftType draftType) {
+		if (log.isInfoEnabled()) {
+			log.info("AI audit event=draft_created draftId={} threadId={} type={}", draftId, threadId, draftType);
+		}
+	}
+
+	public void logDraftAccepted(final long draftId, final long threadId, final AiDraftStatus status) {
+		if (log.isInfoEnabled()) {
+			log.info("AI audit event=draft_accepted draftId={} threadId={} status={}", draftId, threadId, status);
+		}
+	}
+
+	public void logDraftMaterialized(final long draftId, final long threadId, final AiDraftCreatedEntityType entityType,
+			final long entityId) {
+		if (log.isInfoEnabled()) {
+			log.info("AI audit event=draft_materialized draftId={} threadId={} entityType={} entityId={}", draftId,
+					threadId, entityType, entityId);
+		}
+	}
+
+	public void logDraftDiscarded(final long draftId, final long threadId) {
+		if (log.isInfoEnabled()) {
+			log.info("AI audit event=draft_discarded draftId={} threadId={}", draftId, threadId);
+		}
+	}
+
+	public void logAccessDenied(@Nullable final String nutritionistId, final String reason) {
+		if (log.isInfoEnabled()) {
+			log.info("AI audit event=access_denied nutritionist={} reason={}",
+					LogRedaction.redactUserId(nutritionistId), reason);
+		}
+	}
+
+	public void logOpenAiError(@Nullable final Long threadId, final String errorKind, final int httpStatus) {
+		if (log.isWarnEnabled()) {
+			log.warn("AI audit event=openai_error threadId={} errorKind={} httpStatus={}", threadId, errorKind,
+					httpStatus);
+		}
+	}
+
+	public void logInputBlocked(final String category, final int messageLength) {
+		if (log.isWarnEnabled()) {
+			log.warn("AI audit event=input_blocked category={} messageLength={}", category, messageLength);
+		}
+	}
+
+	public void logThreadTruncated(final long threadId, final long fromMessageId, final int removedMessages,
+			final int discardedDrafts) {
+		if (log.isInfoEnabled()) {
+			log.info(
+					"AI audit event=thread_truncated threadId={} fromMessageId={} removedMessages={} discardedDrafts={}",
+					threadId, fromMessageId, removedMessages, discardedDrafts);
+		}
+	}
+
+	private static String formatToolNames(final List<String> toolNames) {
+		if (toolNames == null || toolNames.isEmpty()) {
+			return "[]";
+		}
+		final List<String> sanitized = toolNames.stream()
+			.filter(StringUtils::hasText)
+			.map(AiAuditRedaction::redactSecrets)
+			.collect(Collectors.toList());
+		return sanitized.toString();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiAuditRedaction.java
+++ b/src/main/java/com/nutriconsultas/ai/AiAuditRedaction.java
@@ -1,0 +1,48 @@
+package com.nutriconsultas.ai;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Redacts secrets and PHI-bearing content from AI audit log lines (#397). Never log full
+ * message bodies or API keys at INFO.
+ */
+public final class AiAuditRedaction {
+
+	private static final Pattern OPENAI_API_KEY = Pattern.compile("sk-[A-Za-z0-9_-]{8,}");
+
+	private static final Pattern BEARER_TOKEN = Pattern.compile("Bearer\\s+\\S+", Pattern.CASE_INSENSITIVE);
+
+	private AiAuditRedaction() {
+	}
+
+	public static int safeMessageLength(final String message) {
+		if (message == null) {
+			return 0;
+		}
+		return message.length();
+	}
+
+	public static String redactSecrets(final String text) {
+		if (text == null || text.isEmpty()) {
+			return text;
+		}
+		String sanitized = BEARER_TOKEN.matcher(text).replaceAll("[REDACTED_AUTH]");
+		final Matcher keyMatcher = OPENAI_API_KEY.matcher(sanitized);
+		final StringBuffer buffer = new StringBuffer();
+		while (keyMatcher.find()) {
+			keyMatcher.appendReplacement(buffer, "sk-[REDACTED]");
+		}
+		keyMatcher.appendTail(buffer);
+		return buffer.toString();
+	}
+
+	public static boolean containsOpenAiApiKey(final String text) {
+		return text != null && OPENAI_API_KEY.matcher(text).find();
+	}
+
+	public static boolean containsBearerToken(final String text) {
+		return text != null && BEARER_TOKEN.matcher(text).find();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiChatRequestMode.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatRequestMode.java
@@ -1,0 +1,8 @@
+package com.nutriconsultas.ai;
+
+/** How a nutritionist submitted a chat turn (#397 audit metadata). */
+public enum AiChatRequestMode {
+
+	SEND, STREAM, EDIT, EDIT_STREAM
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
@@ -35,16 +35,19 @@ public class AiChatServiceImpl implements AiChatService {
 
 	private final AiChatRequestGuards chatRequestGuards;
 
+	private final AiAuditLogger auditLogger;
+
 	public AiChatServiceImpl(final AiChatPersistence chatPersistence, final AiGeneratedDraftRepository draftRepository,
 			final AiOrchestrationService orchestrationService,
 			final AiChatPromptContextResolvers promptContextResolvers, final PacienteRepository pacienteRepository,
-			final AiChatRequestGuards chatRequestGuards) {
+			final AiChatRequestGuards chatRequestGuards, final AiAuditLogger auditLogger) {
 		this.chatPersistence = chatPersistence;
 		this.draftRepository = draftRepository;
 		this.orchestrationService = orchestrationService;
 		this.promptContextResolvers = promptContextResolvers;
 		this.pacienteRepository = pacienteRepository;
 		this.chatRequestGuards = chatRequestGuards;
+		this.auditLogger = auditLogger;
 	}
 
 	@Override
@@ -61,9 +64,7 @@ public class AiChatServiceImpl implements AiChatService {
 		thread.setClinicId(clinicId);
 		thread.setPatient(patient);
 		final AiChatThread saved = chatPersistence.getThreadRepository().save(thread);
-		if (log.isInfoEnabled()) {
-			log.info("AI chat thread created id={} patientLinked={}", saved.getId(), patient != null);
-		}
+		auditLogger.logThreadCreated(saved.getId(), nutritionistId, patient != null);
 		return saved;
 	}
 
@@ -103,6 +104,7 @@ public class AiChatServiceImpl implements AiChatService {
 		final String sanitizedMessage = validateUserMessageContent(message);
 		final AiChatThread thread = loadOwnedThread(threadId, nutritionistId);
 		final AiChatPromptContext mergedContext = mergePromptContext(promptContext, patientId(thread));
+		auditChatRequest(nutritionistId, threadId, AiChatRequestMode.SEND, sanitizedMessage, mergedContext);
 		final AiOrchestrationContext context = buildOrchestrationContext(nutritionistId, threadId, mergedContext);
 		return orchestrationService.processUserMessage(context, sanitizedMessage);
 	}
@@ -128,6 +130,8 @@ public class AiChatServiceImpl implements AiChatService {
 				return patientId(ownedThread);
 			});
 			final AiChatPromptContext mergedContext = mergePromptContext(promptContext, threadPatientId);
+			auditChatRequest(nutritionistId, request.threadId(), AiChatRequestMode.STREAM, sanitizedMessage,
+					mergedContext);
 			final AiOrchestrationContext context = buildOrchestrationContext(nutritionistId, request.threadId(),
 					mergedContext);
 			orchestrationService.processUserMessageStreaming(context, sanitizedMessage,
@@ -167,6 +171,7 @@ public class AiChatServiceImpl implements AiChatService {
 				request.messageId());
 		final AiChatThread thread = loadOwnedThread(request.threadId(), nutritionistId);
 		final AiChatPromptContext mergedContext = mergePromptContext(promptContext, patientId(thread));
+		auditChatRequest(nutritionistId, request.threadId(), AiChatRequestMode.EDIT, sanitizedMessage, mergedContext);
 		final AiOrchestrationContext context = buildOrchestrationContext(nutritionistId, request.threadId(),
 				mergedContext);
 		final AiOrchestrationResult orchestration = orchestrationService.processUserMessage(context, sanitizedMessage);
@@ -202,15 +207,12 @@ public class AiChatServiceImpl implements AiChatService {
 				return patientId(ownedThread);
 			});
 			final AiChatPromptContext mergedContext = mergePromptContext(promptContext, threadPatientId);
+			auditChatRequest(nutritionistId, request.threadId(), AiChatRequestMode.EDIT_STREAM, sanitizedMessage,
+					mergedContext);
 			final AiOrchestrationContext context = buildOrchestrationContext(nutritionistId, request.threadId(),
 					mergedContext);
 			orchestrationService.processUserMessageStreaming(context, sanitizedMessage,
 					streamConsumerFor(emitter, cancellation));
-			if (log.isInfoEnabled()) {
-				log.info("AI chat edit-resubmit stream threadId={} truncatedMessages={} discardedDrafts={}",
-						request.threadId(), truncateOutcome.truncatedMessageCount(),
-						truncateOutcome.discardedDraftIds().size());
-			}
 			AiChatSseSupport.completeQuietly(emitter);
 		}
 		catch (final AiStreamCancelledException ex) {
@@ -281,6 +283,12 @@ public class AiChatServiceImpl implements AiChatService {
 			return;
 		}
 		AiChatSseSupport.completeQuietly(emitter);
+	}
+
+	private void auditChatRequest(final String nutritionistId, final long threadId, final AiChatRequestMode mode,
+			final String sanitizedMessage, final AiChatPromptContext context) {
+		auditLogger.logChatRequest(threadId, nutritionistId, mode, AiAuditRedaction.safeMessageLength(sanitizedMessage),
+				context.patientId() != null, context.dietaId() != null, context.platilloId() != null);
 	}
 
 	private AiOrchestrationContext buildOrchestrationContext(final String nutritionistId, final long threadId,
@@ -389,10 +397,7 @@ public class AiChatServiceImpl implements AiChatService {
 		}
 		final int truncatedMessageCount = chatPersistence.getMessageRepository()
 			.deleteByThreadIdAndIdGreaterThanEqual(threadId, anchor.getId());
-		if (log.isInfoEnabled()) {
-			log.info("AI chat truncated threadId={} fromMessageId={} removedMessages={} discardedDrafts={}", threadId,
-					messageId, truncatedMessageCount, discardedDraftIds.size());
-		}
+		auditLogger.logThreadTruncated(threadId, messageId, truncatedMessageCount, discardedDraftIds.size());
 		return new TruncateOutcome(truncatedMessageCount, List.copyOf(discardedDraftIds));
 	}
 

--- a/src/main/java/com/nutriconsultas/ai/AiDraftAcceptanceServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftAcceptanceServiceImpl.java
@@ -9,10 +9,7 @@ import org.springframework.util.StringUtils;
 import com.nutriconsultas.dieta.Dieta;
 import com.nutriconsultas.platillos.Platillo;
 
-import lombok.extern.slf4j.Slf4j;
-
 @Service
-@Slf4j
 public class AiDraftAcceptanceServiceImpl implements AiDraftAcceptanceService {
 
 	private final AiGeneratedDraftRepository draftRepository;
@@ -23,13 +20,17 @@ public class AiDraftAcceptanceServiceImpl implements AiDraftAcceptanceService {
 
 	private final AiEntitlementGuard aiEntitlementGuard;
 
+	private final AiAuditLogger auditLogger;
+
 	public AiDraftAcceptanceServiceImpl(final AiGeneratedDraftRepository draftRepository,
 			final AiDraftMaterializationService materializationService,
-			final AiDraftLifecycleService draftLifecycleService, final AiEntitlementGuard aiEntitlementGuard) {
+			final AiDraftLifecycleService draftLifecycleService, final AiEntitlementGuard aiEntitlementGuard,
+			final AiAuditLogger auditLogger) {
 		this.draftRepository = draftRepository;
 		this.materializationService = materializationService;
 		this.draftLifecycleService = draftLifecycleService;
 		this.aiEntitlementGuard = aiEntitlementGuard;
+		this.auditLogger = auditLogger;
 	}
 
 	@Override
@@ -44,10 +45,8 @@ public class AiDraftAcceptanceServiceImpl implements AiDraftAcceptanceService {
 		final MaterializedEntity entity = materialize(draft, nutritionistId, principal);
 		final AiGeneratedDraft accepted = draftLifecycleService.acceptDraft(draftId, nutritionistId);
 		final String summary = buildSummary(draft.getDraftType(), entity);
-		if (log.isInfoEnabled()) {
-			log.info("AI draft accepted id={} status={} createdEntityType={} createdEntityId={}", accepted.getId(),
-					accepted.getStatus(), entity.entityType(), entity.entityId());
-		}
+		auditLogger.logDraftMaterialized(accepted.getId(), accepted.getThread().getId(), entity.entityType(),
+				entity.entityId());
 		return new AiDraftAcceptanceResult(accepted.getId(), accepted.getDraftType(), accepted.getStatus(),
 				entity.entityType(), entity.entityId(), summary);
 	}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftLifecycleServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftLifecycleServiceImpl.java
@@ -7,10 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import lombok.extern.slf4j.Slf4j;
-
 @Service
-@Slf4j
 public class AiDraftLifecycleServiceImpl implements AiDraftLifecycleService {
 
 	private final AiChatThreadRepository threadRepository;
@@ -19,11 +16,15 @@ public class AiDraftLifecycleServiceImpl implements AiDraftLifecycleService {
 
 	private final AiEntitlementGuard aiEntitlementGuard;
 
+	private final AiAuditLogger auditLogger;
+
 	public AiDraftLifecycleServiceImpl(final AiChatThreadRepository threadRepository,
-			final AiGeneratedDraftRepository draftRepository, final AiEntitlementGuard aiEntitlementGuard) {
+			final AiGeneratedDraftRepository draftRepository, final AiEntitlementGuard aiEntitlementGuard,
+			final AiAuditLogger auditLogger) {
 		this.threadRepository = threadRepository;
 		this.draftRepository = draftRepository;
 		this.aiEntitlementGuard = aiEntitlementGuard;
+		this.auditLogger = auditLogger;
 	}
 
 	@Override
@@ -40,9 +41,7 @@ public class AiDraftLifecycleServiceImpl implements AiDraftLifecycleService {
 		draft.setJsonPayload(jsonPayload.trim());
 		draft.setStatus(AiDraftStatus.DRAFT);
 		final AiGeneratedDraft saved = draftRepository.save(draft);
-		if (log.isInfoEnabled()) {
-			log.info("AI draft created id={} threadId={} type={}", saved.getId(), threadId, draftType);
-		}
+		auditLogger.logDraftCreated(saved.getId(), threadId, draftType);
 		return saved;
 	}
 
@@ -54,9 +53,7 @@ public class AiDraftLifecycleServiceImpl implements AiDraftLifecycleService {
 		draft.setStatus(AiDraftStatus.ACCEPTED);
 		draft.setAcceptedAt(Instant.now());
 		final AiGeneratedDraft saved = draftRepository.save(draft);
-		if (log.isInfoEnabled()) {
-			log.info("AI draft accepted id={} threadId={}", saved.getId(), saved.getThread().getId());
-		}
+		auditLogger.logDraftAccepted(saved.getId(), saved.getThread().getId(), saved.getStatus());
 		return saved;
 	}
 
@@ -67,9 +64,7 @@ public class AiDraftLifecycleServiceImpl implements AiDraftLifecycleService {
 		final AiGeneratedDraft draft = loadMutableDraft(draftId, nutritionistId);
 		draft.setStatus(AiDraftStatus.DISCARDED);
 		final AiGeneratedDraft saved = draftRepository.save(draft);
-		if (log.isInfoEnabled()) {
-			log.info("AI draft discarded id={} threadId={}", saved.getId(), saved.getThread().getId());
-		}
+		auditLogger.logDraftDiscarded(saved.getId(), saved.getThread().getId());
 		return saved;
 	}
 

--- a/src/main/java/com/nutriconsultas/ai/AiEntitlementGuard.java
+++ b/src/main/java/com/nutriconsultas/ai/AiEntitlementGuard.java
@@ -16,11 +16,18 @@ public final class AiEntitlementGuard {
 
 	private final SubscriptionEntitlementService subscriptionEntitlementService;
 
-	public AiEntitlementGuard(final SubscriptionEntitlementService subscriptionEntitlementService) {
+	private final AiAuditLogger auditLogger;
+
+	public AiEntitlementGuard(final SubscriptionEntitlementService subscriptionEntitlementService,
+			final AiAuditLogger auditLogger) {
 		this.subscriptionEntitlementService = subscriptionEntitlementService;
+		this.auditLogger = auditLogger;
 	}
 
 	public void assertCanUseAiAssistant(@Nullable final String nutritionistId) {
+		if (!canUseAiAssistant(nutritionistId)) {
+			auditLogger.logAccessDenied(nutritionistId, "missing_entitlement");
+		}
 		if (!StringUtils.hasText(nutritionistId)) {
 			subscriptionEntitlementService.assertCanUseAiAssistant("");
 			return;

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationServiceImpl.java
@@ -9,10 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import lombok.extern.slf4j.Slf4j;
-
 @Service
-@Slf4j
 public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 
 	private static final int TOOL_AUDIT_MAX_CHARS = 2_000;
@@ -69,9 +66,9 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 		persistToolAuditMessages(thread, loopOutcome.toolAuditEntries());
 		touchThread(thread);
 
-		if (log.isInfoEnabled()) {
-			log.info("AI orchestration threadId={} toolCalls={}", thread.getId(), loopOutcome.toolCallsExecuted());
-		}
+		orchestrationTools.getAuditLogger()
+			.logOrchestrationComplete(thread.getId(), context.nutritionistId(), loopOutcome.toolCallsExecuted(),
+					toolNamesFrom(loopOutcome.toolAuditEntries()), loopOutcome.tokenUsage());
 		return new AiOrchestrationResult(thread.getId(), assistantMessage, loopOutcome.toolCallsExecuted(),
 				loopOutcome.tokenUsage());
 	}
@@ -115,10 +112,9 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 			final AiChatMessage assistantMessage = persistAssistantMessage(thread, loopOutcome.assistantContent());
 			persistToolAuditMessages(thread, loopOutcome.toolAuditEntries());
 			touchThread(thread);
-			if (log.isInfoEnabled()) {
-				log.info("AI streaming orchestration threadId={} toolCalls={}", thread.getId(),
-						loopOutcome.toolCallsExecuted());
-			}
+			orchestrationTools.getAuditLogger()
+				.logOrchestrationComplete(thread.getId(), context.nutritionistId(), loopOutcome.toolCallsExecuted(),
+						toolNamesFrom(loopOutcome.toolAuditEntries()), loopOutcome.tokenUsage());
 			return new AiOrchestrationResult(thread.getId(), assistantMessage, loopOutcome.toolCallsExecuted(),
 					loopOutcome.tokenUsage());
 		});
@@ -159,10 +155,9 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 			final AiRequestScopePipeline.ScopeShortCircuit shortCircuit) {
 		final AiChatMessage assistantMessage = persistAssistantMessage(thread, shortCircuit.assistantMessage());
 		touchThread(thread);
-		if (log.isInfoEnabled()) {
-			log.info("AI orchestration {} short-circuit threadId={} detail={}", shortCircuit.sourceLabel(),
-					thread.getId(), shortCircuit.sourceDetail());
-		}
+		orchestrationTools.getAuditLogger()
+			.logOrchestrationShortCircuit(thread.getId(), thread.getNutritionistId(), shortCircuit.sourceLabel(),
+					String.valueOf(shortCircuit.sourceDetail()));
 		return new AiOrchestrationResult(thread.getId(), assistantMessage, 0, null);
 	}
 
@@ -180,10 +175,9 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 		final AiOrchestrationResult result = chatPersistence.getTransactionTemplate().execute(status -> {
 			final AiChatMessage assistantMessage = persistAssistantMessage(thread, assistantContent);
 			touchThread(thread);
-			if (log.isInfoEnabled()) {
-				log.info("AI streaming {} short-circuit threadId={} detail={}", sourceLabel, thread.getId(),
-						sourceDetail);
-			}
+			orchestrationTools.getAuditLogger()
+				.logOrchestrationShortCircuit(thread.getId(), thread.getNutritionistId(), sourceLabel,
+						String.valueOf(sourceDetail));
 			return new AiOrchestrationResult(thread.getId(), assistantMessage, 0, null);
 		});
 		if (result == null) {
@@ -255,10 +249,8 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 			}
 			if (toolCallsExecuted >= properties.getMaxToolCalls()) {
 				assistantContent = TOOL_LIMIT_MESSAGE;
-				if (log.isWarnEnabled()) {
-					log.warn("AI orchestration threadId={} reached maxToolCalls={}", context.threadId(),
-							properties.getMaxToolCalls());
-				}
+				orchestrationTools.getAuditLogger()
+					.logMaxToolCallsReached(context.threadId(), properties.getMaxToolCalls());
 				break;
 			}
 
@@ -283,9 +275,7 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 
 	private String executeToolCall(final AiOrchestrationContext context, final OpenAiToolCall toolCall) {
 		if (!orchestrationTools.getGuardrails().isToolAllowed(toolCall.name())) {
-			if (log.isWarnEnabled()) {
-				log.warn("AI tool call rejected tool={} threadId={}", toolCall.name(), context.threadId());
-			}
+			orchestrationTools.getAuditLogger().logToolRejected(context.threadId(), toolCall.name());
 			return AiToolJsonSerializer
 				.toJson(AiToolResult.error(AiToolErrorCode.VALIDATION, AiToolAllowlist.REJECTION_MESSAGE));
 		}
@@ -295,9 +285,7 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 			return orchestrationTools.getGuardrails().sanitizeToolResult(toolCall.name(), rawResult);
 		}
 		catch (final AiOrchestrationException ex) {
-			if (log.isWarnEnabled()) {
-				log.warn("AI tool dispatch failed tool={} threadId={}", toolCall.name(), context.threadId());
-			}
+			orchestrationTools.getAuditLogger().logToolDispatchFailed(context.threadId(), toolCall.name());
 			return AiToolJsonSerializer.toJson(AiToolResult.error(AiToolErrorCode.VALIDATION, ex.getMessage()));
 		}
 	}
@@ -330,6 +318,10 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 			return json;
 		}
 		return json.substring(0, TOOL_AUDIT_MAX_CHARS) + "...";
+	}
+
+	private static List<String> toolNamesFrom(final List<ToolAuditEntry> entries) {
+		return entries.stream().map(ToolAuditEntry::toolName).toList();
 	}
 
 	private static OpenAiTokenUsage mergeUsage(final OpenAiTokenUsage accumulated, final OpenAiTokenUsage latest) {

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationTools.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationTools.java
@@ -14,11 +14,14 @@ public class AiOrchestrationTools {
 
 	private final AiOrchestrationGuardrails guardrails;
 
+	private final AiAuditLogger auditLogger;
+
 	public AiOrchestrationTools(final AiOpenAiToolCatalog catalog, final AiOrchestrationToolDispatcher dispatcher,
-			final AiOrchestrationGuardrails guardrails) {
+			final AiOrchestrationGuardrails guardrails, final AiAuditLogger auditLogger) {
 		this.catalog = catalog;
 		this.dispatcher = dispatcher;
 		this.guardrails = guardrails;
+		this.auditLogger = auditLogger;
 	}
 
 	public AiOpenAiToolCatalog getToolCatalog() {
@@ -31,6 +34,10 @@ public class AiOrchestrationTools {
 
 	public AiOrchestrationGuardrails getGuardrails() {
 		return guardrails;
+	}
+
+	public AiAuditLogger getAuditLogger() {
+		return auditLogger;
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/ai/OpenAiClientServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/OpenAiClientServiceImpl.java
@@ -17,10 +17,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import lombok.extern.slf4j.Slf4j;
-
 @Component
-@Slf4j
 public class OpenAiClientServiceImpl implements OpenAiClientService {
 
 	private static final String CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
@@ -29,10 +26,13 @@ public class OpenAiClientServiceImpl implements OpenAiClientService {
 
 	private final RestClient restClient;
 
+	private final AiAuditLogger auditLogger;
+
 	public OpenAiClientServiceImpl(final AiProperties properties,
-			@Qualifier("openAiRestClient") final RestClient openAiRestClient) {
+			@Qualifier("openAiRestClient") final RestClient openAiRestClient, final AiAuditLogger auditLogger) {
 		this.properties = properties;
 		this.restClient = openAiRestClient;
+		this.auditLogger = auditLogger;
 	}
 
 	@Override
@@ -55,15 +55,12 @@ public class OpenAiClientServiceImpl implements OpenAiClientService {
 			return toCompletionResponse(response);
 		}
 		catch (final RestClientResponseException ex) {
-			if (log.isWarnEnabled()) {
-				log.warn("OpenAI chat completion failed with status={}", ex.getStatusCode().value());
-			}
-			throw OpenAiClientErrorMapper.mapResponseException(ex);
+			final OpenAiClientException mapped = OpenAiClientErrorMapper.mapResponseException(ex);
+			auditLogger.logOpenAiError(null, mapped.getKind().name(), mapped.getHttpStatus().value());
+			throw mapped;
 		}
 		catch (final ResourceAccessException ex) {
-			if (log.isWarnEnabled()) {
-				log.warn("OpenAI chat completion timed out or connection failed");
-			}
+			auditLogger.logOpenAiError(null, OpenAiClientException.ErrorKind.TIMEOUT.name(), 0);
 			throw OpenAiClientErrorMapper.timeout(ex);
 		}
 	}
@@ -97,8 +94,8 @@ public class OpenAiClientServiceImpl implements OpenAiClientService {
 			tools.add(new OpenAiApiTool("function", function));
 		}
 		return new OpenAiApiRequest(properties.getOpenai().getModel(), messages, tools.isEmpty() ? null : tools,
-				properties.getOpenai().isStore(), request.parameters().temperature(),
-				request.parameters().maxTokens(), responseFormat(request.parameters().responseFormatType()));
+				properties.getOpenai().isStore(), request.parameters().temperature(), request.parameters().maxTokens(),
+				responseFormat(request.parameters().responseFormatType()));
 	}
 
 	private static Map<String, String> responseFormat(final String type) {

--- a/src/test/java/com/nutriconsultas/ai/AiAuditLoggerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiAuditLoggerTest.java
@@ -1,0 +1,92 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.slf4j.LoggerFactory;
+
+class AiAuditLoggerTest {
+
+	private ListAppender<ILoggingEvent> logAppender;
+
+	private AiAuditLogger auditLogger;
+
+	@BeforeEach
+	void setUp() {
+		final Logger logger = (Logger) LoggerFactory.getLogger(AiAuditLogger.class);
+		logAppender = new ListAppender<>();
+		logAppender.start();
+		logger.addAppender(logAppender);
+		logger.setLevel(Level.INFO);
+		auditLogger = new AiAuditLogger();
+	}
+
+	@AfterEach
+	void tearDown() {
+		final Logger logger = (Logger) LoggerFactory.getLogger(AiAuditLogger.class);
+		logger.detachAppender(logAppender);
+	}
+
+	@Test
+	void chatRequestLogsMetadataWithoutMessageBody() {
+		final String secretMessage = "Paciente Juan Pérez alergia mariscos sk-proj-leaked-key-abcdefghij";
+
+		auditLogger.logChatRequest(12L, "auth0|nutritionist-secret", AiChatRequestMode.SEND,
+				AiAuditRedaction.safeMessageLength(secretMessage), true, false, false);
+
+		assertThat(logAppender.list).hasSize(1);
+		final String formatted = logAppender.list.get(0).getFormattedMessage();
+		assertThat(formatted).contains("event=chat_request");
+		assertThat(formatted).contains("threadId=12");
+		assertThat(formatted).contains("messageLength=" + secretMessage.length());
+		assertThat(formatted).doesNotContain(secretMessage);
+		assertThat(formatted).doesNotContain("sk-proj-leaked-key-abcdefghij");
+		assertThat(formatted).doesNotContain("Juan Pérez");
+	}
+
+	@Test
+	void orchestrationCompleteLogsToolNamesWithoutSecrets() {
+		auditLogger.logOrchestrationComplete(7L, "auth0|abc123", 2, List.of("search_food_catalog", "create_dish_draft"),
+				new OpenAiTokenUsage(100, 50, 150));
+
+		assertThat(logAppender.list).hasSize(1);
+		final String formatted = logAppender.list.get(0).getFormattedMessage();
+		assertThat(formatted).contains("event=orchestration_complete");
+		assertThat(formatted).contains("tools=[search_food_catalog, create_dish_draft]");
+		assertThat(formatted).contains("promptTokens=100");
+		assertThat(formatted).contains("completionTokens=50");
+	}
+
+	@Test
+	void draftLifecycleEventsUseStructuredPrefix() {
+		auditLogger.logDraftCreated(3L, 9L, AiDraftType.DISH);
+		auditLogger.logDraftAccepted(3L, 9L, AiDraftStatus.ACCEPTED);
+		auditLogger.logDraftDiscarded(4L, 9L);
+
+		assertThat(logAppender.list).hasSize(3);
+		assertThat(logAppender.list.get(0).getFormattedMessage()).contains("event=draft_created");
+		assertThat(logAppender.list.get(1).getFormattedMessage()).contains("event=draft_accepted");
+		assertThat(logAppender.list.get(2).getFormattedMessage()).contains("event=draft_discarded");
+	}
+
+	@Test
+	void accessDeniedRedactsNutritionistId() {
+		auditLogger.logAccessDenied("auth0|full-nutritionist-id", "missing_entitlement");
+
+		assertThat(logAppender.list).hasSize(1);
+		final String formatted = logAppender.list.get(0).getFormattedMessage();
+		assertThat(formatted).contains("event=access_denied");
+		assertThat(formatted).contains("reason=missing_entitlement");
+		assertThat(formatted).doesNotContain("full-nutritionist-id");
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiAuditRedactionTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiAuditRedactionTest.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AiAuditRedactionTest {
+
+	@Test
+	void redactSecretsMasksOpenAiApiKey() {
+		final String input = "Authorization failed for sk-proj-abc123secretkey456789";
+
+		final String redacted = AiAuditRedaction.redactSecrets(input);
+
+		assertThat(redacted).doesNotContain("sk-proj-abc123secretkey456789");
+		assertThat(redacted).contains("sk-[REDACTED]");
+		assertThat(AiAuditRedaction.containsOpenAiApiKey(redacted)).isFalse();
+	}
+
+	@Test
+	void redactSecretsMasksBearerToken() {
+		final String input = "Header Authorization: Bearer sk-live-secret-token-value";
+
+		final String redacted = AiAuditRedaction.redactSecrets(input);
+
+		assertThat(redacted).doesNotContain("sk-live-secret-token-value");
+		assertThat(redacted).contains("[REDACTED_AUTH]");
+		assertThat(AiAuditRedaction.containsBearerToken(redacted)).isFalse();
+	}
+
+	@Test
+	void safeMessageLengthNeverExposesBody() {
+		assertThat(AiAuditRedaction.safeMessageLength(null)).isZero();
+		assertThat(AiAuditRedaction.safeMessageLength("Hola mundo")).isEqualTo(10);
+	}
+
+	@Test
+	void redactSecretsLeavesSafeMetadataUntouched() {
+		final String input = "threadId=5 tool=search_food_catalog resultCount=8";
+
+		assertThat(AiAuditRedaction.redactSecrets(input)).isEqualTo(input);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiBulkScopeGoldenPromptTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiBulkScopeGoldenPromptTest.java
@@ -182,8 +182,8 @@ class AiBulkScopeGoldenPromptTest {
 			service = new AiOrchestrationServiceImpl(properties, openAiClientService, systemPromptService,
 					new AiChatPersistence(threadRepository, messageRepository,
 							mock(org.springframework.transaction.support.TransactionTemplate.class)),
-					new AiOrchestrationTools(toolCatalog, toolDispatcher, guardrails), userMessageGuard,
-					requestScopePipeline);
+					new AiOrchestrationTools(toolCatalog, toolDispatcher, guardrails, new AiAuditLogger()),
+					userMessageGuard, requestScopePipeline);
 		}
 
 		private OpenAiClientService openAiClientService() {

--- a/src/test/java/com/nutriconsultas/ai/AiChatServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatServiceTest.java
@@ -62,6 +62,9 @@ class AiChatServiceTest {
 	@Mock
 	private AiChatRequestGuards chatRequestGuards;
 
+	@Mock
+	private AiAuditLogger auditLogger;
+
 	@BeforeEach
 	void stubGuardsAndPersistence() {
 		org.mockito.Mockito.lenient().when(chatPersistence.getThreadRepository()).thenReturn(threadRepository);

--- a/src/test/java/com/nutriconsultas/ai/AiDraftAcceptanceServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftAcceptanceServiceTest.java
@@ -43,6 +43,9 @@ class AiDraftAcceptanceServiceTest {
 	@Mock
 	private AiEntitlementGuard aiEntitlementGuard;
 
+	@Mock
+	private AiAuditLogger auditLogger;
+
 	@org.junit.jupiter.api.BeforeEach
 	void stubEntitlement() {
 		org.mockito.Mockito.lenient()
@@ -60,6 +63,7 @@ class AiDraftAcceptanceServiceTest {
 		when(materializationService.materializeDish(any(), eq(NUTRITIONIST_ID), any())).thenReturn(platillo);
 		final AiGeneratedDraft accepted = dishDraft();
 		accepted.setStatus(AiDraftStatus.ACCEPTED);
+		accepted.setThread(draft.getThread());
 		when(draftLifecycleService.acceptDraft(55L, NUTRITIONIST_ID)).thenReturn(accepted);
 
 		final AiDraftAcceptanceResult result = service.accept(55L, NUTRITIONIST_ID, principal());
@@ -89,6 +93,7 @@ class AiDraftAcceptanceServiceTest {
 		when(materializationService.materializeMenu(any(), eq(NUTRITIONIST_ID), any())).thenReturn(dieta);
 		final AiGeneratedDraft accepted = menuDraft();
 		accepted.setStatus(AiDraftStatus.ACCEPTED);
+		accepted.setThread(draft.getThread());
 		when(draftLifecycleService.acceptDraft(56L, NUTRITIONIST_ID)).thenReturn(accepted);
 
 		final AiDraftAcceptanceResult result = service.accept(56L, NUTRITIONIST_ID, principal());
@@ -98,8 +103,10 @@ class AiDraftAcceptanceServiceTest {
 	}
 
 	private static AiGeneratedDraft dishDraft() {
+		final AiChatThread thread = sampleThread();
 		final AiGeneratedDraft draft = new AiGeneratedDraft();
 		draft.setId(55L);
+		draft.setThread(thread);
 		draft.setDraftType(AiDraftType.DISH);
 		draft.setStatus(AiDraftStatus.DRAFT);
 		draft.setJsonPayload(
@@ -111,8 +118,10 @@ class AiDraftAcceptanceServiceTest {
 	}
 
 	private static AiGeneratedDraft menuDraft() {
+		final AiChatThread thread = sampleThread();
 		final AiGeneratedDraft draft = new AiGeneratedDraft();
 		draft.setId(56L);
+		draft.setThread(thread);
 		draft.setDraftType(AiDraftType.MENU);
 		draft.setStatus(AiDraftStatus.DRAFT);
 		draft.setJsonPayload("{\"ingestas\":[{\"nombre\":\"Desayuno\",\"orden\":1,"
@@ -128,6 +137,13 @@ class AiDraftAcceptanceServiceTest {
 		final OidcIdToken idToken = new OidcIdToken(jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(),
 				Map.of("sub", NUTRITIONIST_ID));
 		return new DefaultOidcUser(List.of(), idToken);
+	}
+
+	private static AiChatThread sampleThread() {
+		final AiChatThread thread = new AiChatThread();
+		thread.setId(10L);
+		thread.setNutritionistId(NUTRITIONIST_ID);
+		return thread;
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/ai/AiDraftLifecycleServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftLifecycleServiceTest.java
@@ -36,6 +36,9 @@ class AiDraftLifecycleServiceTest {
 	@Mock
 	private AiEntitlementGuard aiEntitlementGuard;
 
+	@Mock
+	private AiAuditLogger auditLogger;
+
 	@BeforeEach
 	void stubEntitlement() {
 		org.mockito.Mockito.lenient()
@@ -142,7 +145,13 @@ class AiDraftLifecycleServiceTest {
 	@Test
 	void createDraftTrimsJsonPayload() {
 		when(threadRepository.findByIdAndNutritionistId(10L, NUTRITIONIST_A)).thenReturn(Optional.of(thread));
-		when(draftRepository.save(any(AiGeneratedDraft.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		when(draftRepository.save(any(AiGeneratedDraft.class))).thenAnswer(invocation -> {
+			final AiGeneratedDraft draft = invocation.getArgument(0);
+			if (draft.getId() == null) {
+				draft.setId(99L);
+			}
+			return draft;
+		});
 
 		service.createDraft(10L, NUTRITIONIST_A, AiDraftType.DISH, "  {\"name\":\"Tacos\"}  ");
 

--- a/src/test/java/com/nutriconsultas/ai/AiEntitlementGuardTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiEntitlementGuardTest.java
@@ -27,6 +27,9 @@ class AiEntitlementGuardTest {
 	@Mock
 	private SubscriptionEntitlementService subscriptionEntitlementService;
 
+	@Mock
+	private AiAuditLogger auditLogger;
+
 	@Test
 	void canUseAiAssistantDelegatesToSubscriptionService() {
 		when(subscriptionEntitlementService.hasEntitlement(NUTRITIONIST_ID, Entitlement.AI_ASSISTANT)).thenReturn(true);
@@ -42,16 +45,22 @@ class AiEntitlementGuardTest {
 
 	@Test
 	void assertCanUseAiAssistantPropagatesSubscriptionDenial() {
+		when(subscriptionEntitlementService.hasEntitlement(NUTRITIONIST_ID, Entitlement.AI_ASSISTANT))
+			.thenReturn(false);
 		final SubscriptionLimitExceededException denied = new SubscriptionLimitExceededException(
 				SubscriptionErrorResponses.KEY_AI_ASSISTANT_DENIED);
-		org.mockito.Mockito.doThrow(denied).when(subscriptionEntitlementService).assertCanUseAiAssistant(NUTRITIONIST_ID);
+		org.mockito.Mockito.doThrow(denied)
+			.when(subscriptionEntitlementService)
+			.assertCanUseAiAssistant(NUTRITIONIST_ID);
 
 		assertThatThrownBy(() -> guard.assertCanUseAiAssistant(NUTRITIONIST_ID)).isSameAs(denied);
+		verify(auditLogger).logAccessDenied(NUTRITIONIST_ID, "missing_entitlement");
 	}
 
 	@Test
 	void assertCanUseAiAssistantChecksEmptyUserId() {
-		org.mockito.Mockito.doThrow(new SubscriptionLimitExceededException(SubscriptionErrorResponses.KEY_AI_ASSISTANT_DENIED))
+		org.mockito.Mockito
+			.doThrow(new SubscriptionLimitExceededException(SubscriptionErrorResponses.KEY_AI_ASSISTANT_DENIED))
 			.when(subscriptionEntitlementService)
 			.assertCanUseAiAssistant("");
 

--- a/src/test/java/com/nutriconsultas/ai/AiNutritionGoldenPromptTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiNutritionGoldenPromptTest.java
@@ -105,6 +105,7 @@ class AiNutritionGoldenPromptTest {
 		when(orchestrationTools.getToolCatalog()).thenReturn(toolCatalog);
 		when(orchestrationTools.getToolDispatcher()).thenReturn(toolDispatcher);
 		when(orchestrationTools.getGuardrails()).thenReturn(realGuardrails);
+		when(orchestrationTools.getAuditLogger()).thenReturn(new AiAuditLogger());
 		when(requestScopePipeline.evaluate(any(String.class))).thenReturn(Optional.empty());
 		when(transactionTemplate.execute(org.mockito.ArgumentMatchers.<TransactionCallback<Object>>any()))
 			.thenAnswer(invocation -> {

--- a/src/test/java/com/nutriconsultas/ai/AiOrchestrationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiOrchestrationServiceTest.java
@@ -72,6 +72,9 @@ class AiOrchestrationServiceTest {
 	@Mock
 	private AiOrchestrationGuardrails guardrails;
 
+	@Mock
+	private AiAuditLogger auditLogger;
+
 	private AiUserMessageGuard realUserMessageGuard;
 
 	private AiRequestScopeGuard realRequestScopeGuard;
@@ -96,6 +99,7 @@ class AiOrchestrationServiceTest {
 		lenient().when(orchestrationTools.getToolCatalog()).thenReturn(toolCatalog);
 		lenient().when(orchestrationTools.getToolDispatcher()).thenReturn(toolDispatcher);
 		lenient().when(orchestrationTools.getGuardrails()).thenReturn(guardrails);
+		lenient().when(orchestrationTools.getAuditLogger()).thenReturn(auditLogger);
 		lenient().when(guardrails.isToolAllowed(org.mockito.ArgumentMatchers.anyString())).thenReturn(true);
 		lenient()
 			.when(guardrails.sanitizeToolResult(org.mockito.ArgumentMatchers.anyString(),

--- a/src/test/java/com/nutriconsultas/ai/AiSecurityGoldenPromptTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiSecurityGoldenPromptTest.java
@@ -97,6 +97,7 @@ class AiSecurityGoldenPromptTest {
 		when(orchestrationTools.getToolCatalog()).thenReturn(toolCatalog);
 		when(orchestrationTools.getToolDispatcher()).thenReturn(toolDispatcher);
 		when(orchestrationTools.getGuardrails()).thenReturn(realGuardrails);
+		when(orchestrationTools.getAuditLogger()).thenReturn(new AiAuditLogger());
 		when(requestScopePipeline.evaluate(any(String.class))).thenReturn(Optional.empty());
 		when(transactionTemplate.execute(org.mockito.ArgumentMatchers.<TransactionCallback<Object>>any()))
 			.thenAnswer(invocation -> {

--- a/src/test/java/com/nutriconsultas/ai/OpenAiClientServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/OpenAiClientServiceTest.java
@@ -37,7 +37,7 @@ class OpenAiClientServiceTest {
 		properties.getOpenai().setBaseUrl("https://api.openai.com");
 		final RestClient.Builder restClientBuilder = RestClient.builder().baseUrl(properties.getOpenai().getBaseUrl());
 		mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
-		service = new OpenAiClientServiceImpl(properties, restClientBuilder.build());
+		service = new OpenAiClientServiceImpl(properties, restClientBuilder.build(), new AiAuditLogger());
 	}
 
 	@Test
@@ -213,26 +213,24 @@ class OpenAiClientServiceTest {
 
 	@Test
 	void chatCompletionSerializesOptionalParameters() {
-		mockServer.expect(requestTo("https://api.openai.com/v1/chat/completions"))
-			.andExpect(content().json("""
-					{
-					  "model": "gpt-test",
-					  "messages": [{"role":"user","content":"Clasifica"}],
-					  "store": false,
-					  "temperature": 0.0,
-					  "max_tokens": 200,
-					  "response_format": {"type":"json_object"}
-					}
-					""", false))
-			.andRespond(withSuccess("""
-					{
-					  "id": "chatcmpl-json",
-					  "choices": [{
-					    "message": {"role":"assistant","content":"{\\"decision\\":\\"ALLOW\\"}"},
-					    "finish_reason": "stop"
-					  }]
-					}
-					""", MediaType.APPLICATION_JSON));
+		mockServer.expect(requestTo("https://api.openai.com/v1/chat/completions")).andExpect(content().json("""
+				{
+				  "model": "gpt-test",
+				  "messages": [{"role":"user","content":"Clasifica"}],
+				  "store": false,
+				  "temperature": 0.0,
+				  "max_tokens": 200,
+				  "response_format": {"type":"json_object"}
+				}
+				""", false)).andRespond(withSuccess("""
+				{
+				  "id": "chatcmpl-json",
+				  "choices": [{
+				    "message": {"role":"assistant","content":"{\\"decision\\":\\"ALLOW\\"}"},
+				    "finish_reason": "stop"
+				  }]
+				}
+				""", MediaType.APPLICATION_JSON));
 
 		service.chatCompletion(new OpenAiChatCompletionRequest(List.of(OpenAiChatMessage.user("Clasifica")), List.of(),
 				OpenAiCompletionParameters.scopeClassifier(200)));


### PR DESCRIPTION
## Summary
- Adds `AiAuditLogger` and `AiAuditRedaction` for structured, redacted INFO/WARN audit lines aligned with `DATA-ACCESS-RULES.md`.
- Logs chat request metadata (mode, message length, context flags), orchestration tool names/counts, draft create/accept/discard/materialize, access denials, and OpenAI errors.
- Never logs message bodies, API keys, or full nutritionist IDs at INFO.

## Test plan
- [x] `AiAuditRedactionTest` — API key and Bearer token redaction
- [x] `AiAuditLoggerTest` — metadata logged without PHI/secrets
- [x] Updated AI service/guard tests for new dependencies
- [x] `AiDraftFlowIntegrationTest` — draft accept audit lines in integration flow
- [x] `mvn pmd:check`


Made with [Cursor](https://cursor.com)