### PR TITLE
Add Micrometer AI usage metrics (#398)

### DIFF
--- a/docs/ai/DATA-ACCESS-RULES.md
+++ b/docs/ai/DATA-ACCESS-RULES.md
@@ -214,6 +214,21 @@ Align with [`PHI-LOGGING-AUDIT.md`](../mobile-api/PHI-LOGGING-AUDIT.md) and [`Lo
 
 Persist in `ai_chat_message` / `ai_generated_draft` (#369). Retention: follow general application backup policy; document in #405/#406.
 
+### Usage metrics (#398)
+
+Micrometer counters via `AiUsageMetrics` (Spring Boot Actuator). Exposed at `/actuator/metrics` when enabled. **No PHI in tags** — only low-cardinality labels (`mode`, `type`, `kind`, `source`, `tool`).
+
+| Metric | Tags | When incremented |
+|--------|------|------------------|
+| `ai.chat.messages` | `mode` | Chat request (send/stream/edit) |
+| `ai.drafts.created` | `type` | Draft tool creates borrador |
+| `ai.drafts.accepted` | — | Draft accepted |
+| `ai.drafts.discarded` | — | Draft discarded |
+| `ai.openai.errors` | `kind` | OpenAI client failure |
+| `ai.rate_limited` | `source=chat\|openai` | App or OpenAI rate limit |
+| `ai.openai.tokens` | `kind=prompt\|completion` | Orchestration token usage |
+| `ai.tool.calls` | `tool` | Tool invoked in orchestration |
+
 ---
 
 ## API key handling (confirmation)

--- a/src/main/java/com/nutriconsultas/ai/AiAuditLogger.java
+++ b/src/main/java/com/nutriconsultas/ai/AiAuditLogger.java
@@ -19,6 +19,12 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public final class AiAuditLogger {
 
+	private final AiUsageMetrics usageMetrics;
+
+	public AiAuditLogger(final AiUsageMetrics usageMetrics) {
+		this.usageMetrics = usageMetrics;
+	}
+
 	public void logThreadCreated(final long threadId, @Nullable final String nutritionistId,
 			final boolean patientLinked) {
 		if (log.isInfoEnabled()) {
@@ -30,6 +36,7 @@ public final class AiAuditLogger {
 	public void logChatRequest(final long threadId, @Nullable final String nutritionistId, final AiChatRequestMode mode,
 			final int messageLength, final boolean patientContext, final boolean dietaContext,
 			final boolean platilloContext) {
+		usageMetrics.recordChatMessage(mode);
 		if (log.isInfoEnabled()) {
 			log.info(
 					"AI audit event=chat_request threadId={} nutritionist={} mode={} messageLength={} patientContext={} dietaContext={} platilloContext={}",
@@ -40,6 +47,8 @@ public final class AiAuditLogger {
 
 	public void logOrchestrationComplete(final long threadId, @Nullable final String nutritionistId,
 			final int toolCallCount, final List<String> toolNames, @Nullable final OpenAiTokenUsage tokenUsage) {
+		usageMetrics.recordToolCalls(toolNames);
+		usageMetrics.recordTokenUsage(tokenUsage);
 		if (log.isInfoEnabled()) {
 			final String tools = formatToolNames(toolNames);
 			final Integer promptTokens = tokenUsage != null ? tokenUsage.promptTokens() : null;
@@ -79,12 +88,14 @@ public final class AiAuditLogger {
 	}
 
 	public void logDraftCreated(final long draftId, final long threadId, final AiDraftType draftType) {
+		usageMetrics.recordDraftCreated(draftType);
 		if (log.isInfoEnabled()) {
 			log.info("AI audit event=draft_created draftId={} threadId={} type={}", draftId, threadId, draftType);
 		}
 	}
 
 	public void logDraftAccepted(final long draftId, final long threadId, final AiDraftStatus status) {
+		usageMetrics.recordDraftAccepted();
 		if (log.isInfoEnabled()) {
 			log.info("AI audit event=draft_accepted draftId={} threadId={} status={}", draftId, threadId, status);
 		}
@@ -99,6 +110,7 @@ public final class AiAuditLogger {
 	}
 
 	public void logDraftDiscarded(final long draftId, final long threadId) {
+		usageMetrics.recordDraftDiscarded();
 		if (log.isInfoEnabled()) {
 			log.info("AI audit event=draft_discarded draftId={} threadId={}", draftId, threadId);
 		}
@@ -112,6 +124,10 @@ public final class AiAuditLogger {
 	}
 
 	public void logOpenAiError(@Nullable final Long threadId, final String errorKind, final int httpStatus) {
+		usageMetrics.recordOpenAiError(errorKind);
+		if (OpenAiClientException.ErrorKind.RATE_LIMIT.name().equals(errorKind)) {
+			usageMetrics.recordOpenAiRateLimited();
+		}
 		if (log.isWarnEnabled()) {
 			log.warn("AI audit event=openai_error threadId={} errorKind={} httpStatus={}", threadId, errorKind,
 					httpStatus);

--- a/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
@@ -31,9 +31,13 @@ public class AiChatRestController {
 
 	private final AiChatRateLimiter aiChatRateLimiter;
 
-	public AiChatRestController(final AiChatService chatService, final AiChatRateLimiter aiChatRateLimiter) {
+	private final AiUsageMetrics aiUsageMetrics;
+
+	public AiChatRestController(final AiChatService chatService, final AiChatRateLimiter aiChatRateLimiter,
+			final AiUsageMetrics aiUsageMetrics) {
 		this.chatService = chatService;
 		this.aiChatRateLimiter = aiChatRateLimiter;
+		this.aiUsageMetrics = aiUsageMetrics;
 	}
 
 	@PostMapping("/start")
@@ -94,9 +98,7 @@ public class AiChatRestController {
 			return mapOpenAiException(ex);
 		}
 		catch (final RequestNotPermitted ex) {
-			if (log.isDebugEnabled()) {
-				log.debug("AI chat message rate limit exceeded");
-			}
+			recordChatRateLimited("AI chat message rate limit exceeded");
 			return errorResponse(HttpStatus.TOO_MANY_REQUESTS, AiToolErrorCode.RATE_LIMIT,
 					AiChatRateLimiter.RATE_LIMIT_USER_MESSAGE);
 		}
@@ -123,9 +125,7 @@ public class AiChatRestController {
 			});
 		}
 		catch (final RequestNotPermitted ex) {
-			if (log.isDebugEnabled()) {
-				log.debug("AI chat stream rate limit exceeded");
-			}
+			recordChatRateLimited("AI chat stream rate limit exceeded");
 			completeStreamError(emitter, AiChatRateLimiter.RATE_LIMIT_USER_MESSAGE);
 		}
 		catch (final RuntimeException ex) {
@@ -166,9 +166,7 @@ public class AiChatRestController {
 			return mapOpenAiException(ex);
 		}
 		catch (final RequestNotPermitted ex) {
-			if (log.isDebugEnabled()) {
-				log.debug("AI chat edit rate limit exceeded");
-			}
+			recordChatRateLimited("AI chat edit rate limit exceeded");
 			return errorResponse(HttpStatus.TOO_MANY_REQUESTS, AiToolErrorCode.RATE_LIMIT,
 					AiChatRateLimiter.RATE_LIMIT_USER_MESSAGE);
 		}
@@ -195,9 +193,7 @@ public class AiChatRestController {
 			});
 		}
 		catch (final RequestNotPermitted ex) {
-			if (log.isDebugEnabled()) {
-				log.debug("AI chat edit stream rate limit exceeded");
-			}
+			recordChatRateLimited("AI chat edit stream rate limit exceeded");
 			completeStreamError(emitter, AiChatRateLimiter.RATE_LIMIT_USER_MESSAGE);
 		}
 		catch (final RuntimeException ex) {
@@ -260,6 +256,13 @@ public class AiChatRestController {
 		}
 		catch (final AiChatException ex) {
 			return errorResponse(ex);
+		}
+	}
+
+	private void recordChatRateLimited(final String debugMessage) {
+		aiUsageMetrics.recordChatRateLimited();
+		if (log.isDebugEnabled()) {
+			log.debug(debugMessage);
 		}
 	}
 

--- a/src/main/java/com/nutriconsultas/ai/AiUsageMetrics.java
+++ b/src/main/java/com/nutriconsultas/ai/AiUsageMetrics.java
@@ -1,0 +1,122 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Micrometer counters for AI assistant usage (#398). Tags are low-cardinality only —
+ * never nutritionist IDs, thread IDs, patient data, or message content.
+ */
+@Component
+public final class AiUsageMetrics {
+
+	static final String CHAT_MESSAGES = "ai.chat.messages";
+
+	static final String DRAFTS_CREATED = "ai.drafts.created";
+
+	static final String DRAFTS_ACCEPTED = "ai.drafts.accepted";
+
+	static final String DRAFTS_DISCARDED = "ai.drafts.discarded";
+
+	static final String OPENAI_ERRORS = "ai.openai.errors";
+
+	static final String RATE_LIMITED = "ai.rate_limited";
+
+	static final String OPENAI_TOKENS = "ai.openai.tokens";
+
+	static final String TOOL_CALLS = "ai.tool.calls";
+
+	private static final String TAG_MODE = "mode";
+
+	private static final String TAG_TYPE = "type";
+
+	private static final String TAG_KIND = "kind";
+
+	private static final String TAG_SOURCE = "source";
+
+	private static final String TAG_TOOL = "tool";
+
+	private static final String SOURCE_CHAT = "chat";
+
+	private static final String SOURCE_OPENAI = "openai";
+
+	private final MeterRegistry meterRegistry;
+
+	public AiUsageMetrics(final MeterRegistry meterRegistry) {
+		this.meterRegistry = meterRegistry;
+	}
+
+	public void recordChatMessage(final AiChatRequestMode mode) {
+		counter(CHAT_MESSAGES, TAG_MODE, safeEnum(mode)).increment();
+	}
+
+	public void recordDraftCreated(final AiDraftType draftType) {
+		counter(DRAFTS_CREATED, TAG_TYPE, safeEnum(draftType)).increment();
+	}
+
+	public void recordDraftAccepted() {
+		counter(DRAFTS_ACCEPTED).increment();
+	}
+
+	public void recordDraftDiscarded() {
+		counter(DRAFTS_DISCARDED).increment();
+	}
+
+	public void recordOpenAiError(final String errorKind) {
+		counter(OPENAI_ERRORS, TAG_KIND, safeTagValue(errorKind)).increment();
+	}
+
+	public void recordChatRateLimited() {
+		counter(RATE_LIMITED, TAG_SOURCE, SOURCE_CHAT).increment();
+	}
+
+	public void recordOpenAiRateLimited() {
+		counter(RATE_LIMITED, TAG_SOURCE, SOURCE_OPENAI).increment();
+	}
+
+	public void recordTokenUsage(@Nullable final OpenAiTokenUsage tokenUsage) {
+		if (tokenUsage == null) {
+			return;
+		}
+		if (tokenUsage.promptTokens() > 0) {
+			counter(OPENAI_TOKENS, TAG_KIND, "prompt").increment(tokenUsage.promptTokens());
+		}
+		if (tokenUsage.completionTokens() > 0) {
+			counter(OPENAI_TOKENS, TAG_KIND, "completion").increment(tokenUsage.completionTokens());
+		}
+	}
+
+	public void recordToolCalls(final java.util.List<String> toolNames) {
+		if (toolNames == null || toolNames.isEmpty()) {
+			return;
+		}
+		for (final String toolName : toolNames) {
+			if (StringUtils.hasText(toolName)) {
+				counter(TOOL_CALLS, TAG_TOOL, toolName.trim()).increment();
+			}
+		}
+	}
+
+	private Counter counter(final String name, final String... tags) {
+		return meterRegistry.counter(name, tags);
+	}
+
+	private static String safeEnum(@Nullable final Enum<?> value) {
+		if (value == null) {
+			return "unknown";
+		}
+		return value.name();
+	}
+
+	private static String safeTagValue(@Nullable final String value) {
+		if (!StringUtils.hasText(value)) {
+			return "unknown";
+		}
+		return value.trim();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiAuditLoggerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiAuditLoggerTest.java
@@ -27,7 +27,7 @@ class AiAuditLoggerTest {
 		logAppender.start();
 		logger.addAppender(logAppender);
 		logger.setLevel(Level.INFO);
-		auditLogger = new AiAuditLogger();
+		auditLogger = AiMetricsTestSupport.auditLogger();
 	}
 
 	@AfterEach

--- a/src/test/java/com/nutriconsultas/ai/AiBulkScopeGoldenPromptTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiBulkScopeGoldenPromptTest.java
@@ -182,7 +182,8 @@ class AiBulkScopeGoldenPromptTest {
 			service = new AiOrchestrationServiceImpl(properties, openAiClientService, systemPromptService,
 					new AiChatPersistence(threadRepository, messageRepository,
 							mock(org.springframework.transaction.support.TransactionTemplate.class)),
-					new AiOrchestrationTools(toolCatalog, toolDispatcher, guardrails, new AiAuditLogger()),
+					new AiOrchestrationTools(toolCatalog, toolDispatcher, guardrails,
+							AiMetricsTestSupport.auditLogger()),
 					userMessageGuard, requestScopePipeline);
 		}
 

--- a/src/test/java/com/nutriconsultas/ai/AiChatRestControllerEntitlementTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatRestControllerEntitlementTest.java
@@ -35,6 +35,9 @@ class AiChatRestControllerEntitlementTest {
 	@Mock
 	private AiChatRateLimiter aiChatRateLimiter;
 
+	@Mock
+	private AiUsageMetrics aiUsageMetrics;
+
 	@Test
 	void sendMessagePropagatesSubscriptionDenial() throws Exception {
 		when(aiChatRateLimiter.executeMessage(eq(NUTRITIONIST_ID), any())).thenAnswer(invocation -> {

--- a/src/test/java/com/nutriconsultas/ai/AiChatRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatRestControllerTest.java
@@ -42,6 +42,9 @@ class AiChatRestControllerTest {
 	@Mock
 	private AiChatRateLimiter aiChatRateLimiter;
 
+	@Mock
+	private AiUsageMetrics aiUsageMetrics;
+
 	@Test
 	void startChatReturnsCreatedThread() {
 		final AiChatThread thread = new AiChatThread();
@@ -147,6 +150,7 @@ class AiChatRestControllerTest {
 		assertThat(response.getBody()).containsEntry("success", false)
 			.containsEntry("errorCode", AiToolErrorCode.RATE_LIMIT.name())
 			.containsEntry("message", AiChatRateLimiter.RATE_LIMIT_USER_MESSAGE);
+		verify(aiUsageMetrics).recordChatRateLimited();
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/AiMetricsTestSupport.java
+++ b/src/test/java/com/nutriconsultas/ai/AiMetricsTestSupport.java
@@ -1,0 +1,21 @@
+package com.nutriconsultas.ai;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+/**
+ * Test helper for AI components that require {@link AiAuditLogger} (#397, #398).
+ */
+final class AiMetricsTestSupport {
+
+	private AiMetricsTestSupport() {
+	}
+
+	static AiAuditLogger auditLogger() {
+		return new AiAuditLogger(new AiUsageMetrics(new SimpleMeterRegistry()));
+	}
+
+	static AiUsageMetrics usageMetrics() {
+		return new AiUsageMetrics(new SimpleMeterRegistry());
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiNutritionGoldenPromptTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiNutritionGoldenPromptTest.java
@@ -105,7 +105,7 @@ class AiNutritionGoldenPromptTest {
 		when(orchestrationTools.getToolCatalog()).thenReturn(toolCatalog);
 		when(orchestrationTools.getToolDispatcher()).thenReturn(toolDispatcher);
 		when(orchestrationTools.getGuardrails()).thenReturn(realGuardrails);
-		when(orchestrationTools.getAuditLogger()).thenReturn(new AiAuditLogger());
+		when(orchestrationTools.getAuditLogger()).thenReturn(AiMetricsTestSupport.auditLogger());
 		when(requestScopePipeline.evaluate(any(String.class))).thenReturn(Optional.empty());
 		when(transactionTemplate.execute(org.mockito.ArgumentMatchers.<TransactionCallback<Object>>any()))
 			.thenAnswer(invocation -> {

--- a/src/test/java/com/nutriconsultas/ai/AiSecurityGoldenPromptTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiSecurityGoldenPromptTest.java
@@ -97,7 +97,7 @@ class AiSecurityGoldenPromptTest {
 		when(orchestrationTools.getToolCatalog()).thenReturn(toolCatalog);
 		when(orchestrationTools.getToolDispatcher()).thenReturn(toolDispatcher);
 		when(orchestrationTools.getGuardrails()).thenReturn(realGuardrails);
-		when(orchestrationTools.getAuditLogger()).thenReturn(new AiAuditLogger());
+		when(orchestrationTools.getAuditLogger()).thenReturn(AiMetricsTestSupport.auditLogger());
 		when(requestScopePipeline.evaluate(any(String.class))).thenReturn(Optional.empty());
 		when(transactionTemplate.execute(org.mockito.ArgumentMatchers.<TransactionCallback<Object>>any()))
 			.thenAnswer(invocation -> {

--- a/src/test/java/com/nutriconsultas/ai/AiUsageMetricsTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiUsageMetricsTest.java
@@ -1,0 +1,89 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class AiUsageMetricsTest {
+
+	private SimpleMeterRegistry registry;
+
+	private AiUsageMetrics metrics;
+
+	@BeforeEach
+	void setUp() {
+		registry = new SimpleMeterRegistry();
+		metrics = new AiUsageMetrics(registry);
+	}
+
+	@Test
+	void recordsChatMessagesByModeWithoutPhiTags() {
+		metrics.recordChatMessage(AiChatRequestMode.SEND);
+		metrics.recordChatMessage(AiChatRequestMode.STREAM);
+
+		assertThat(registry.get(AiUsageMetrics.CHAT_MESSAGES).tag("mode", "SEND").counter().count()).isEqualTo(1.0);
+		assertThat(registry.get(AiUsageMetrics.CHAT_MESSAGES).tag("mode", "STREAM").counter().count()).isEqualTo(1.0);
+		assertThat(registry.getMeters()).allSatisfy(meter -> {
+			assertThat(meter.getId().getTags()).noneMatch(tag -> tag.getKey().contains("nutritionist"));
+			assertThat(meter.getId().getTags()).noneMatch(tag -> tag.getKey().contains("thread"));
+			assertThat(meter.getId().getTags()).noneMatch(tag -> tag.getValue().contains("auth0|"));
+		});
+	}
+
+	@Test
+	void recordsDraftLifecycleCounters() {
+		metrics.recordDraftCreated(AiDraftType.DISH);
+		metrics.recordDraftAccepted();
+		metrics.recordDraftDiscarded();
+
+		assertThat(registry.get(AiUsageMetrics.DRAFTS_CREATED).tag("type", "DISH").counter().count()).isEqualTo(1.0);
+		assertThat(registry.get(AiUsageMetrics.DRAFTS_ACCEPTED).counter().count()).isEqualTo(1.0);
+		assertThat(registry.get(AiUsageMetrics.DRAFTS_DISCARDED).counter().count()).isEqualTo(1.0);
+	}
+
+	@Test
+	void recordsOpenAiErrorsAndRateLimits() {
+		metrics.recordOpenAiError(OpenAiClientException.ErrorKind.RATE_LIMIT.name());
+		metrics.recordOpenAiRateLimited();
+		metrics.recordChatRateLimited();
+
+		assertThat(registry.get(AiUsageMetrics.OPENAI_ERRORS).tag("kind", "RATE_LIMIT").counter().count())
+			.isEqualTo(1.0);
+		assertThat(registry.get(AiUsageMetrics.RATE_LIMITED).tag("source", "openai").counter().count()).isEqualTo(1.0);
+		assertThat(registry.get(AiUsageMetrics.RATE_LIMITED).tag("source", "chat").counter().count()).isEqualTo(1.0);
+	}
+
+	@Test
+	void recordsTokenUsageAndToolCalls() {
+		metrics.recordTokenUsage(new OpenAiTokenUsage(100, 40, 140));
+		metrics.recordToolCalls(List.of("search_food_catalog", "create_dish_draft"));
+
+		assertThat(registry.get(AiUsageMetrics.OPENAI_TOKENS).tag("kind", "prompt").counter().count()).isEqualTo(100.0);
+		assertThat(registry.get(AiUsageMetrics.OPENAI_TOKENS).tag("kind", "completion").counter().count())
+			.isEqualTo(40.0);
+		assertThat(registry.get(AiUsageMetrics.TOOL_CALLS).tag("tool", "search_food_catalog").counter().count())
+			.isEqualTo(1.0);
+	}
+
+	@Test
+	void ignoresNullTokenUsage() {
+		metrics.recordTokenUsage(null);
+
+		assertThat(registry.find(AiUsageMetrics.OPENAI_TOKENS).counters()).isEmpty();
+	}
+
+	@Test
+	void counterNamesUseAiPrefix() {
+		metrics.recordDraftAccepted();
+		final Counter counter = registry.find(AiUsageMetrics.DRAFTS_ACCEPTED).counter();
+		assertThat(counter).isNotNull();
+		assertThat(counter.getId().getName()).isEqualTo(AiUsageMetrics.DRAFTS_ACCEPTED);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/OpenAiClientServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/OpenAiClientServiceTest.java
@@ -37,7 +37,8 @@ class OpenAiClientServiceTest {
 		properties.getOpenai().setBaseUrl("https://api.openai.com");
 		final RestClient.Builder restClientBuilder = RestClient.builder().baseUrl(properties.getOpenai().getBaseUrl());
 		mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
-		service = new OpenAiClientServiceImpl(properties, restClientBuilder.build(), new AiAuditLogger());
+		service = new OpenAiClientServiceImpl(properties, restClientBuilder.build(),
+				AiMetricsTestSupport.auditLogger());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Adds `AiUsageMetrics` (Micrometer) for chat messages, draft lifecycle, OpenAI errors, rate limits, token usage, and tool calls.
- Wires metrics through `AiAuditLogger` and `AiChatRestController` rate-limit handlers.
- Tags are low-cardinality only — no nutritionist IDs, thread IDs, or PHI.
- Documents metric names in `DATA-ACCESS-RULES.md`.

## Test plan
- [x] `AiUsageMetricsTest` — counters, tags, no PHI
- [x] `AiChatRestControllerTest` — verifies `recordChatRateLimited()` on 429
- [x] Updated golden prompt / audit logger tests for new `AiAuditLogger` constructor
- [x] `mvn pmd:check`


Made with [Cursor](https://cursor.com)