### PR TITLE
Improve AI chat error handling UX (#399)

### DIFF
--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#397 — Add AI Audit Logging](https://github.com/diego-torres/nutriconsultas/issues/397) (`open`). ~~#409~~ merged (PR #481) — `Entitlement.AI_ASSISTANT` plan gating.
+**Current next issue:** [#399 — Add AI Error Handling UX](https://github.com/diego-torres/nutriconsultas/issues/399) (`in progress`, branch `issue-399-ai-error-handling-ux`). ~~#397~~ ~~#398~~ merged (PR #483, #484).
 
 **Registered backlog (2026-07-04):** Epic [#433](https://github.com/diego-torres/nutriconsultas/issues/433) chat UX (#434–#437). Epic [#438](https://github.com/diego-torres/nutriconsultas/issues/438) prompt security (#439–#441, **#447–#450** bulk scope guards). See registry for suggested order.
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-07-05 — ~~#409~~ merged (PR #481). Next: **#397** (AI audit logging).
+**Last updated:** 2026-07-05 — ~~#397~~ ~~#398~~ merged (PR #483, #484). **#399** in progress (`issue-399-ai-error-handling-ux`).
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -198,11 +198,11 @@ Audit logging, metrics, and error UX.
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
 | **396** | Epic — AI Safety and Observability (Phase 8) | https://github.com/diego-torres/nutriconsultas/issues/396 | **open** | **385** | Milestone 5 |
-| **397** | Add AI Audit Logging | https://github.com/diego-torres/nutriconsultas/issues/397 | **open** | **396** | Redacted logs |
-| **398** | Add AI Usage Metrics | https://github.com/diego-torres/nutriconsultas/issues/398 | **open** | **396** | No PHI in metrics |
-| **399** | Add AI Error Handling UX | https://github.com/diego-torres/nutriconsultas/issues/399 | **open** | **389**, **385** | Friendly errors |
+| **397** | Add AI Audit Logging | https://github.com/diego-torres/nutriconsultas/issues/397 | **done** | **396** | PR #483 — redacted audit logs |
+| **398** | Add AI Usage Metrics | https://github.com/diego-torres/nutriconsultas/issues/398 | **done** | **396** | PR #484 — Micrometer metrics |
+| **399** | Add AI Error Handling UX | https://github.com/diego-torres/nutriconsultas/issues/399 | **in progress** | **389**, **385** | Branch `issue-399-ai-error-handling-ux` |
 
-**Suggested order:** #397 + #398 parallel with #399 after #389. Prompt hardening epic **#438** before production (see below).
+**Suggested order:** ~~#397~~ ~~#398~~ **done**. **#399** in progress. Prompt hardening epic **#438** before production (see below).
 
 ---
 
@@ -221,7 +221,7 @@ Injection, jailbreak, and defense-in-depth guardrails for orchestration (#385).
 | **449** | System prompt volume limits and bulk refusal corpus | https://github.com/diego-torres/nutriconsultas/issues/449 | **done** | **438**, **367**, **447** | PR #458 — `VOLUMEN Y LÍMITES`, `FUNCTIONAL-SCOPE.md`, bulk corpus |
 | **450** | Golden prompts for excessive bulk AI requests | https://github.com/diego-torres/nutriconsultas/issues/450 | **done** | **400**, **401**, **447** | PR #462 — `AiBulkScopeGoldenPromptTest`, docs |
 
-**Suggested order:** ~~#401~~ ~~#402~~ ~~#403~~ **done**. Epic **#400** complete. Phase 10: ~~#405~~ ~~#406~~ ~~#407~~ ~~#408~~ ~~#409~~ **done**. Next: **#397–#399** before production enable.
+**Suggested order:** ~~#401~~ ~~#402~~ ~~#403~~ **done**. Epic **#400** complete. Phase 10: ~~#405~~ ~~#406~~ ~~#407~~ ~~#408~~ ~~#409~~ **done**. ~~#397~~ ~~#398~~ **done**. **#399** in progress before production enable.
 
 ---
 
@@ -252,7 +252,7 @@ Setup docs, nutritionist guidance, release checklist.
 | **407** | Add Nutritionist User Guidance | https://github.com/diego-torres/nutriconsultas/issues/407 | **done** | **390** | PR #477 — in-app panel + [`NUTRITIONIST-USER-GUIDANCE.md`](docs/ai/NUTRITIONIST-USER-GUIDANCE.md) |
 | **408** | Create AI Assistant Release Checklist | https://github.com/diego-torres/nutriconsultas/issues/408 | **done** | **404** | PR #479 — [`RELEASE-CHECKLIST.md`](docs/ai/RELEASE-CHECKLIST.md) |
 
-**Suggested order:** ~~#405~~ ~~#406~~ ~~#407~~ ~~#408~~ ~~#409~~ **done** (PR #472, #474, #477, #479, #481). Next: **#397–#399** before production `AI_ENABLED=true`.
+**Suggested order:** ~~#405~~ ~~#406~~ ~~#407~~ ~~#408~~ ~~#409~~ **done** (PR #472, #474, #477, #479, #481). ~~#397~~ ~~#398~~ **done** (PR #483, #484). **#399** in progress before production `AI_ENABLED=true`.
 
 ---
 
@@ -264,7 +264,7 @@ AI assistant is a **new entitlement** — do **not** replace `REPORTS_ADVANCED` 
 |---|-------|-----|-------|------------|-------|
 | **409** | Gate AI assistant by plan — Plus and Consultorio only | https://github.com/diego-torres/nutriconsultas/issues/409 | **done** | #181, **384**, **388** | PR #481 — `Entitlement.AI_ASSISTANT`, pricing row on `eterna/index.html` |
 
-**Suggested order:** ~~#409~~ **done** (PR #481). Next: **#397–#399** observability before production `AI_ENABLED=true`.
+**Suggested order:** ~~#409~~ **done** (PR #481). ~~#397~~ ~~#398~~ **done** (PR #483, #484). **#399** in progress — observability before production `AI_ENABLED=true`.
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/AiChatRateLimiter.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatRateLimiter.java
@@ -16,8 +16,7 @@ public final class AiChatRateLimiter {
 
 	public static final String AI_CHAT_MESSAGE = "aiChatMessage";
 
-	public static final String RATE_LIMIT_USER_MESSAGE = "Has alcanzado el límite de mensajes del asistente de IA. "
-			+ "Intenta de nuevo en unos minutos.";
+	public static final String RATE_LIMIT_USER_MESSAGE = AiErrorMessages.RATE_LIMIT;
 
 	private final RateLimiterRegistry rateLimiterRegistry;
 

--- a/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
@@ -77,7 +77,7 @@ public class AiChatRestController {
 			return unauthorized();
 		}
 		if (request == null) {
-			return errorResponse(HttpStatus.BAD_REQUEST, AiToolErrorCode.VALIDATION, "Solicitud no válida.");
+			return errorResponse(HttpStatus.BAD_REQUEST, AiToolErrorCode.VALIDATION, AiErrorMessages.INVALID_REQUEST);
 		}
 		try {
 			final AiChatPromptContext promptContext = new AiChatPromptContext(request.patientId(), request.dietaId(),
@@ -111,11 +111,11 @@ public class AiChatRestController {
 		emitter.onTimeout(emitter::complete);
 		final String nutritionistId = nutritionistId(principal);
 		if (nutritionistId == null) {
-			completeStreamError(emitter, "Sesión no válida.");
+			completeStreamError(emitter, AiToolErrorCode.VALIDATION, AiErrorMessages.INVALID_SESSION);
 			return emitter;
 		}
 		if (request == null) {
-			completeStreamError(emitter, "Solicitud no válida.");
+			completeStreamError(emitter, AiToolErrorCode.VALIDATION, AiErrorMessages.INVALID_REQUEST);
 			return emitter;
 		}
 		try {
@@ -126,13 +126,13 @@ public class AiChatRestController {
 		}
 		catch (final RequestNotPermitted ex) {
 			recordChatRateLimited("AI chat stream rate limit exceeded");
-			completeStreamError(emitter, AiChatRateLimiter.RATE_LIMIT_USER_MESSAGE);
+			completeStreamError(emitter, AiToolErrorCode.RATE_LIMIT, AiErrorMessages.RATE_LIMIT);
 		}
 		catch (final RuntimeException ex) {
 			if (log.isWarnEnabled()) {
 				log.warn("AI chat stream failed unexpectedly", ex);
 			}
-			completeStreamError(emitter, "No se pudo completar la solicitud.");
+			completeStreamError(emitter, AiToolErrorCode.INTERNAL, AiErrorMessages.GENERIC);
 		}
 		return emitter;
 	}
@@ -145,7 +145,7 @@ public class AiChatRestController {
 			return unauthorized();
 		}
 		if (request == null) {
-			return errorResponse(HttpStatus.BAD_REQUEST, AiToolErrorCode.VALIDATION, "Solicitud no válida.");
+			return errorResponse(HttpStatus.BAD_REQUEST, AiToolErrorCode.VALIDATION, AiErrorMessages.INVALID_REQUEST);
 		}
 		try {
 			final AiEditResubmitResult result = aiChatRateLimiter.executeMessage(nutritionistId,
@@ -179,11 +179,11 @@ public class AiChatRestController {
 		emitter.onTimeout(emitter::complete);
 		final String nutritionistId = nutritionistId(principal);
 		if (nutritionistId == null) {
-			completeStreamError(emitter, "Sesión no válida.");
+			completeStreamError(emitter, AiToolErrorCode.VALIDATION, AiErrorMessages.INVALID_SESSION);
 			return emitter;
 		}
 		if (request == null) {
-			completeStreamError(emitter, "Solicitud no válida.");
+			completeStreamError(emitter, AiToolErrorCode.VALIDATION, AiErrorMessages.INVALID_REQUEST);
 			return emitter;
 		}
 		try {
@@ -194,20 +194,21 @@ public class AiChatRestController {
 		}
 		catch (final RequestNotPermitted ex) {
 			recordChatRateLimited("AI chat edit stream rate limit exceeded");
-			completeStreamError(emitter, AiChatRateLimiter.RATE_LIMIT_USER_MESSAGE);
+			completeStreamError(emitter, AiToolErrorCode.RATE_LIMIT, AiErrorMessages.RATE_LIMIT);
 		}
 		catch (final RuntimeException ex) {
 			if (log.isWarnEnabled()) {
 				log.warn("AI chat edit stream failed unexpectedly", ex);
 			}
-			completeStreamError(emitter, "No se pudo completar la solicitud.");
+			completeStreamError(emitter, AiToolErrorCode.INTERNAL, AiErrorMessages.GENERIC);
 		}
 		return emitter;
 	}
 
-	private static void completeStreamError(final SseEmitter emitter, final String message) {
+	private static void completeStreamError(final SseEmitter emitter, final AiToolErrorCode errorCode,
+			final String message) {
 		try {
-			AiChatSseSupport.sendError(emitter, message);
+			AiChatSseSupport.sendError(emitter, errorCode, message);
 		}
 		catch (Exception ex) {
 			emitter.completeWithError(ex);
@@ -274,7 +275,7 @@ public class AiChatRestController {
 	}
 
 	private static ResponseEntity<Map<String, Object>> unauthorized() {
-		return errorResponse(HttpStatus.UNAUTHORIZED, AiToolErrorCode.VALIDATION, "Sesión no válida.");
+		return errorResponse(HttpStatus.UNAUTHORIZED, AiToolErrorCode.VALIDATION, AiErrorMessages.INVALID_SESSION);
 	}
 
 	private static Map<String, Object> successBody() {
@@ -303,7 +304,7 @@ public class AiChatRestController {
 			case TIMEOUT -> HttpStatus.GATEWAY_TIMEOUT;
 			default -> HttpStatus.BAD_GATEWAY;
 		};
-		return errorResponse(status, AiToolErrorCode.VALIDATION, ex.getUserMessage());
+		return errorResponse(status, AiErrorMessages.errorCodeForOpenAi(ex.getKind()), ex.getUserMessage());
 	}
 
 	private static Map<String, Object> tokenUsageMap(final OpenAiTokenUsage usage) {

--- a/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
@@ -114,7 +114,7 @@ public class AiChatServiceImpl implements AiChatService {
 			final SseEmitter emitter) {
 		assertNutritionistAccess(nutritionistId);
 		if (request == null || !StringUtils.hasText(request.message())) {
-			completeStreamWithError(emitter, "El mensaje no puede estar vacío.");
+			completeStreamWithError(emitter, AiToolErrorCode.VALIDATION, AiErrorMessages.EMPTY_MESSAGE);
 			return;
 		}
 		try {
@@ -138,8 +138,11 @@ public class AiChatServiceImpl implements AiChatService {
 					streamConsumerFor(emitter, cancellation));
 			AiChatSseSupport.completeQuietly(emitter);
 		}
-		catch (final AiChatException | AiOrchestrationException ex) {
-			completeStreamWithError(emitter, ex.getMessage());
+		catch (final AiChatException ex) {
+			completeStreamWithError(emitter, ex.getErrorCode(), ex.getMessage());
+		}
+		catch (final AiOrchestrationException ex) {
+			completeStreamWithError(emitter, AiToolErrorCode.VALIDATION, ex.getMessage());
 		}
 		catch (final AiStreamCancelledException ex) {
 			if (log.isDebugEnabled()) {
@@ -148,7 +151,7 @@ public class AiChatServiceImpl implements AiChatService {
 			AiChatSseSupport.completeQuietly(emitter);
 		}
 		catch (final OpenAiClientException ex) {
-			completeStreamWithError(emitter, ex.getUserMessage());
+			completeStreamWithError(emitter, AiErrorMessages.errorCodeForOpenAi(ex.getKind()), ex.getUserMessage());
 		}
 		catch (final AiStreamDeliveryException ex) {
 			if (log.isWarnEnabled()) {
@@ -184,7 +187,7 @@ public class AiChatServiceImpl implements AiChatService {
 			final SseEmitter emitter) {
 		assertNutritionistAccess(nutritionistId);
 		if (request == null) {
-			completeStreamWithError(emitter, "Solicitud no válida.");
+			completeStreamWithError(emitter, AiToolErrorCode.VALIDATION, AiErrorMessages.INVALID_REQUEST);
 			return;
 		}
 		try {
@@ -199,7 +202,7 @@ public class AiChatServiceImpl implements AiChatService {
 			final TruncateOutcome truncateOutcome = chatPersistence.getTransactionTemplate()
 				.execute(status -> truncateThreadFromMessage(nutritionistId, request.threadId(), request.messageId()));
 			if (truncateOutcome == null) {
-				completeStreamWithError(emitter, "No se pudo actualizar la conversación.");
+				completeStreamWithError(emitter, AiToolErrorCode.INTERNAL, AiErrorMessages.THREAD_UPDATE_FAILED);
 				return;
 			}
 			final Long threadPatientId = chatPersistence.getTransactionTemplate().execute(status -> {
@@ -221,11 +224,14 @@ public class AiChatServiceImpl implements AiChatService {
 			}
 			AiChatSseSupport.completeQuietly(emitter);
 		}
-		catch (final AiChatException | AiOrchestrationException ex) {
-			completeStreamWithError(emitter, ex.getMessage());
+		catch (final AiChatException ex) {
+			completeStreamWithError(emitter, ex.getErrorCode(), ex.getMessage());
+		}
+		catch (final AiOrchestrationException ex) {
+			completeStreamWithError(emitter, AiToolErrorCode.VALIDATION, ex.getMessage());
 		}
 		catch (final OpenAiClientException ex) {
-			completeStreamWithError(emitter, ex.getUserMessage());
+			completeStreamWithError(emitter, AiErrorMessages.errorCodeForOpenAi(ex.getKind()), ex.getUserMessage());
 		}
 		catch (final AiStreamDeliveryException ex) {
 			if (log.isWarnEnabled()) {
@@ -274,9 +280,10 @@ public class AiChatServiceImpl implements AiChatService {
 		};
 	}
 
-	private static void completeStreamWithError(final SseEmitter emitter, final String message) {
+	private static void completeStreamWithError(final SseEmitter emitter, final AiToolErrorCode errorCode,
+			final String message) {
 		try {
-			AiChatSseSupport.sendError(emitter, message);
+			AiChatSseSupport.sendError(emitter, errorCode, message);
 		}
 		catch (Exception ex) {
 			emitter.completeWithError(ex);

--- a/src/main/java/com/nutriconsultas/ai/AiChatSseSupport.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatSseSupport.java
@@ -43,8 +43,14 @@ public final class AiChatSseSupport {
 	}
 
 	public static void sendError(final SseEmitter emitter, final String message) throws IOException {
+		sendError(emitter, AiToolErrorCode.INTERNAL, message);
+	}
+
+	public static void sendError(final SseEmitter emitter, final AiToolErrorCode errorCode, final String message)
+			throws IOException {
 		final Map<String, Object> payload = new LinkedHashMap<>();
 		payload.put("success", false);
+		payload.put("errorCode", errorCode.name());
 		payload.put("message", message);
 		emitter.send(SseEmitter.event().name("error").data(AiToolJsonSerializer.toJson(payload)));
 	}

--- a/src/main/java/com/nutriconsultas/ai/AiErrorMessages.java
+++ b/src/main/java/com/nutriconsultas/ai/AiErrorMessages.java
@@ -1,0 +1,54 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Centralized Spanish user-facing messages for AI chat errors (#399).
+ */
+public final class AiErrorMessages {
+
+	public static final String GENERIC = "No se pudo completar la solicitud.";
+
+	public static final String MISCONFIGURATION = "El asistente de IA no está disponible en este momento. "
+			+ "Contacta al administrador del sistema.";
+
+	public static final String NOT_CONFIGURED = "El asistente de IA no está disponible en este momento.";
+
+	public static final String OPENAI_AUTH = "No se pudo autenticar con el servicio de IA. Contacta al administrador.";
+
+	public static final String OPENAI_RATE_LIMIT = "El servicio de IA está saturado. Intenta de nuevo en unos minutos.";
+
+	public static final String OPENAI_MODEL_NOT_FOUND = "El modelo de IA configurado no está disponible. "
+			+ "Contacta al administrador.";
+
+	public static final String OPENAI_INVALID_REQUEST = "No se pudo procesar la solicitud de IA. "
+			+ "Intenta reformular tu mensaje.";
+
+	public static final String OPENAI_UNAVAILABLE = "El servicio de IA no está disponible temporalmente. "
+			+ "Intenta más tarde.";
+
+	public static final String OPENAI_UNKNOWN = "Ocurrió un error al comunicarse con el servicio de IA.";
+
+	public static final String OPENAI_TIMEOUT = "El servicio de IA tardó demasiado en responder. Intenta de nuevo.";
+
+	public static final String RATE_LIMIT = "Has alcanzado el límite de mensajes del asistente de IA. "
+			+ "Intenta de nuevo en unos minutos.";
+
+	public static final String EMPTY_MESSAGE = "El mensaje no puede estar vacío.";
+
+	public static final String INVALID_REQUEST = "Solicitud no válida.";
+
+	public static final String INVALID_SESSION = "Sesión no válida.";
+
+	public static final String THREAD_UPDATE_FAILED = "No se pudo actualizar la conversación.";
+
+	private AiErrorMessages() {
+	}
+
+	public static AiToolErrorCode errorCodeForOpenAi(final OpenAiClientException.ErrorKind kind) {
+		return switch (kind) {
+			case RATE_LIMIT -> AiToolErrorCode.RATE_LIMIT;
+			case NOT_CONFIGURED, UNAVAILABLE, TIMEOUT, AUTH, MODEL_NOT_FOUND -> AiToolErrorCode.INTERNAL;
+			default -> AiToolErrorCode.VALIDATION;
+		};
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiProperties.java
+++ b/src/main/java/com/nutriconsultas/ai/AiProperties.java
@@ -145,7 +145,7 @@ public class AiProperties {
 	 * Spanish message for 503 responses when AI is enabled but not configured (#365).
 	 */
 	public String getMisconfigurationUserMessage() {
-		return "El asistente de IA no está disponible en este momento. " + "Contacta al administrador del sistema.";
+		return AiErrorMessages.MISCONFIGURATION;
 	}
 
 	public static class OpenAi {

--- a/src/main/java/com/nutriconsultas/ai/OpenAiClientErrorMapper.java
+++ b/src/main/java/com/nutriconsultas/ai/OpenAiClientErrorMapper.java
@@ -18,42 +18,37 @@ final class OpenAiClientErrorMapper {
 		final String providerMessage = extractProviderMessage(ex.getResponseBodyAsString());
 		if (status == HttpStatus.UNAUTHORIZED.value() || status == HttpStatus.FORBIDDEN.value()) {
 			return new OpenAiClientException(OpenAiClientException.ErrorKind.AUTH, HttpStatus.BAD_GATEWAY,
-					"No se pudo autenticar con el servicio de IA. Contacta al administrador.",
-					"OpenAI auth failure status=" + status, ex);
+					AiErrorMessages.OPENAI_AUTH, "OpenAI auth failure status=" + status, ex);
 		}
 		if (status == HttpStatus.TOO_MANY_REQUESTS.value()) {
 			return new OpenAiClientException(OpenAiClientException.ErrorKind.RATE_LIMIT, HttpStatus.TOO_MANY_REQUESTS,
-					"El servicio de IA está saturado. Intenta de nuevo en unos minutos.",
-					"OpenAI rate limit status=429", ex);
+					AiErrorMessages.OPENAI_RATE_LIMIT, "OpenAI rate limit status=429", ex);
 		}
 		if (status == HttpStatus.NOT_FOUND.value() && isModelError(providerMessage)) {
 			return new OpenAiClientException(OpenAiClientException.ErrorKind.MODEL_NOT_FOUND, HttpStatus.BAD_GATEWAY,
-					"El modelo de IA configurado no está disponible. Contacta al administrador.",
-					"OpenAI model not found status=404", ex);
+					AiErrorMessages.OPENAI_MODEL_NOT_FOUND, "OpenAI model not found status=404", ex);
 		}
 		if (status == HttpStatus.BAD_REQUEST.value()) {
 			return new OpenAiClientException(OpenAiClientException.ErrorKind.INVALID_REQUEST, HttpStatus.BAD_GATEWAY,
-					"No se pudo procesar la solicitud de IA. Intenta reformular tu mensaje.",
-					"OpenAI invalid request status=400", ex);
+					AiErrorMessages.OPENAI_INVALID_REQUEST, "OpenAI invalid request status=400", ex);
 		}
 		if (status == HttpStatus.BAD_GATEWAY.value() || status == HttpStatus.SERVICE_UNAVAILABLE.value()
 				|| status == HttpStatus.GATEWAY_TIMEOUT.value()) {
 			return new OpenAiClientException(OpenAiClientException.ErrorKind.UNAVAILABLE, HttpStatus.BAD_GATEWAY,
-					"El servicio de IA no está disponible temporalmente. Intenta más tarde.",
-					"OpenAI unavailable status=" + status, ex);
+					AiErrorMessages.OPENAI_UNAVAILABLE, "OpenAI unavailable status=" + status, ex);
 		}
 		return new OpenAiClientException(OpenAiClientException.ErrorKind.UNKNOWN, HttpStatus.BAD_GATEWAY,
-				"Ocurrió un error al comunicarse con el servicio de IA.", "OpenAI error status=" + status, ex);
+				AiErrorMessages.OPENAI_UNKNOWN, "OpenAI error status=" + status, ex);
 	}
 
 	static OpenAiClientException timeout(final Exception ex) {
 		return new OpenAiClientException(OpenAiClientException.ErrorKind.TIMEOUT, HttpStatus.GATEWAY_TIMEOUT,
-				"El servicio de IA tardó demasiado en responder. Intenta de nuevo.", "OpenAI request timed out", ex);
+				AiErrorMessages.OPENAI_TIMEOUT, "OpenAI request timed out", ex);
 	}
 
 	static OpenAiClientException notConfigured() {
 		return new OpenAiClientException(OpenAiClientException.ErrorKind.NOT_CONFIGURED, HttpStatus.SERVICE_UNAVAILABLE,
-				"El asistente de IA no está disponible en este momento.", "OpenAI client not configured", null);
+				AiErrorMessages.NOT_CONFIGURED, "OpenAI client not configured", null);
 	}
 
 	private static boolean isModelError(final String message) {

--- a/src/main/java/com/nutriconsultas/subscription/SubscriptionExceptionHandler.java
+++ b/src/main/java/com/nutriconsultas/subscription/SubscriptionExceptionHandler.java
@@ -1,11 +1,14 @@
 package com.nutriconsultas.subscription;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.nutriconsultas.ai.AiToolErrorCode;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,8 +31,13 @@ public class SubscriptionExceptionHandler {
 			log.debug("Subscription limit exceeded: messageKey={}", ex.getMessageKey());
 		}
 		final String message = errorResponses.resolve(ex);
-		return ResponseEntity.status(HttpStatus.FORBIDDEN)
-			.body(Map.of("success", false, "error", message, "code", ex.getMessageKey()));
+		final Map<String, Object> body = new LinkedHashMap<>();
+		body.put("success", false);
+		body.put("error", message);
+		body.put("message", message);
+		body.put("code", ex.getMessageKey());
+		body.put("errorCode", AiToolErrorCode.FORBIDDEN.name());
+		return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
 	}
 
 }

--- a/src/main/resources/static/sbadmin/js/ai-assistant-widget.js
+++ b/src/main/resources/static/sbadmin/js/ai-assistant-widget.js
@@ -139,7 +139,10 @@
     return fetch(url, options || {}).then(function (response) {
       return response.json().then(function (data) {
         if (!response.ok || data.success === false) {
-          var error = new Error(data.message || 'No se pudo completar la solicitud.');
+          if (window.NutriAiChatErrors && window.NutriAiChatErrors.createApiError) {
+            throw window.NutriAiChatErrors.createApiError(data, response.status);
+          }
+          var error = new Error(data.message || data.error || 'No se pudo completar la solicitud.');
           error.status = response.status;
           throw error;
         }
@@ -148,10 +151,10 @@
     });
   }
 
-  function showError(message) {
+  function showError(message, title) {
     if (typeof swal === 'function') {
       swal({
-        title: 'Error',
+        title: title || 'Error',
         text: message,
         type: 'error',
         timer: 5000
@@ -330,7 +333,7 @@
           renderMessages();
           return;
         }
-        showError(error.message);
+        showError(error.message, error.title);
       })
       .finally(function () {
         state.loadingThread = false;
@@ -468,8 +471,8 @@
             onAbort: function () {
               handleStreamAbort(assistantIndex);
             },
-            onError: function (message) {
-              throw new Error(message);
+            onError: function (error) {
+              throw error;
             }
           });
           state.activeStreamRequest = streamRequest;
@@ -491,7 +494,7 @@
         state.showLoading = false;
         state.messages.pop();
         renderMessages();
-        showError(error.message);
+        showError(error.message, error.title);
       })
       .finally(function () {
         state.showLoading = false;

--- a/src/main/resources/static/sbadmin/js/ai-chat-errors.js
+++ b/src/main/resources/static/sbadmin/js/ai-chat-errors.js
@@ -1,0 +1,54 @@
+/* AI chat error parsing and dialog titles (#399) */
+
+(function (global) {
+  'use strict';
+
+  var GENERIC = 'No se pudo completar la solicitud.';
+
+  function extractApiError(data, fallback) {
+    if (!data || typeof data !== 'object') {
+      return fallback || GENERIC;
+    }
+    if (data.message && String(data.message).trim()) {
+      return String(data.message);
+    }
+    if (data.error && String(data.error).trim()) {
+      return String(data.error);
+    }
+    return fallback || GENERIC;
+  }
+
+  function errorTitle(errorCode, status) {
+    if (errorCode === 'RATE_LIMIT' || status === 429) {
+      return 'Límite alcanzado';
+    }
+    if (errorCode === 'FORBIDDEN' || status === 403) {
+      return 'Acceso restringido';
+    }
+    if (errorCode === 'NOT_FOUND' || status === 404) {
+      return 'No encontrado';
+    }
+    if (errorCode === 'INTERNAL' || status === 503 || status === 502 || status === 504) {
+      return 'Servicio no disponible';
+    }
+    return 'Error';
+  }
+
+  function createApiError(data, status) {
+    var message = extractApiError(data);
+    var error = new Error(message);
+    error.status = status;
+    if (data && data.errorCode) {
+      error.errorCode = data.errorCode;
+    }
+    error.title = errorTitle(error.errorCode, status);
+    return error;
+  }
+
+  global.NutriAiChatErrors = {
+    GENERIC: GENERIC,
+    extractApiError: extractApiError,
+    errorTitle: errorTitle,
+    createApiError: createApiError
+  };
+})(typeof window !== 'undefined' ? window : this);

--- a/src/main/resources/static/sbadmin/js/ai-chat-stream.js
+++ b/src/main/resources/static/sbadmin/js/ai-chat-stream.js
@@ -3,6 +3,8 @@
 (function (global) {
   'use strict';
 
+  var GENERIC = 'No se pudo completar la solicitud.';
+
   function parseEventBlock(block) {
     var lines = block.split('\n');
     var eventName = 'message';
@@ -25,6 +27,14 @@
     }
   }
 
+  function buildStreamError(data) {
+    if (global.NutriAiChatErrors && global.NutriAiChatErrors.createApiError) {
+      return global.NutriAiChatErrors.createApiError(data || {});
+    }
+    var message = data && data.message ? data.message : GENERIC;
+    return new Error(message);
+  }
+
   function dispatchEvent(parsed, handlers) {
     if (!parsed) {
       return;
@@ -42,8 +52,7 @@
       return;
     }
     if (parsed.event === 'error' && handlers.onError) {
-      var message = parsed.data && parsed.data.message ? parsed.data.message : 'No se pudo completar la solicitud.';
-      handlers.onError(message);
+      handlers.onError(buildStreamError(parsed.data));
     }
   }
 
@@ -67,10 +76,10 @@
       if (!response.ok) {
         if (contentType.indexOf('application/json') >= 0) {
           return response.json().then(function (data) {
-            throw new Error(data.message || 'No se pudo completar la solicitud.');
+            throw buildStreamError(data);
           });
         }
-        throw new Error('No se pudo completar la solicitud.');
+        throw new Error(GENERIC);
       }
       if (!response.body || !response.body.getReader) {
         throw new Error('Streaming no disponible en este navegador.');

--- a/src/main/resources/static/sbadmin/js/ai-chat.js
+++ b/src/main/resources/static/sbadmin/js/ai-chat.js
@@ -140,7 +140,10 @@
     return fetch(url, options || {}).then(function (response) {
       return response.json().then(function (data) {
         if (!response.ok || data.success === false) {
-          var error = new Error(data.message || 'No se pudo completar la solicitud.');
+          if (window.NutriAiChatErrors && window.NutriAiChatErrors.createApiError) {
+            throw window.NutriAiChatErrors.createApiError(data, response.status);
+          }
+          var error = new Error(data.message || data.error || 'No se pudo completar la solicitud.');
           error.status = response.status;
           error.errorCode = data.errorCode;
           throw error;
@@ -150,10 +153,10 @@
     });
   }
 
-  function showError(message) {
+  function showError(message, title) {
     if (typeof swal === 'function') {
       swal({
-        title: 'Error',
+        title: title || 'Error',
         text: message,
         type: 'error',
         timer: 5000
@@ -352,7 +355,7 @@
         return null;
       })
       .catch(function (error) {
-        showError(error.message);
+        showError(error.message, error.title);
       });
   }
 
@@ -365,7 +368,7 @@
         renderDraftPreview(preview);
       })
       .catch(function (error) {
-        showError(error.message);
+        showError(error.message, error.title);
       });
   }
 
@@ -421,7 +424,7 @@
           return loadDrafts(state.threadId);
         })
         .catch(function (error) {
-          showError(error.message);
+          showError(error.message, error.title);
         })
         .finally(function () {
           setBusy(false);
@@ -453,7 +456,7 @@
           return loadDrafts(state.threadId);
         })
         .catch(function (error) {
-          showError(error.message);
+          showError(error.message, error.title);
         })
         .finally(function () {
           setBusy(false);
@@ -606,7 +609,7 @@
           renderMessages(false);
           return;
         }
-        showError(error.message);
+        showError(error.message, error.title);
       })
       .finally(function () {
         setBusy(false);
@@ -698,8 +701,8 @@
             onAbort: function () {
               handleStreamAbort(assistantIndex);
             },
-            onError: function (message) {
-              throw new Error(message);
+            onError: function (error) {
+              throw error;
             }
           });
           state.activeStreamRequest = streamRequest;
@@ -721,7 +724,7 @@
         state.showLoading = false;
         state.messages.pop();
         renderMessages(false);
-        showError(error.message);
+        showError(error.message, error.title);
       })
       .finally(function () {
         state.showLoading = false;

--- a/src/main/resources/templates/sbadmin/ai/chat.html
+++ b/src/main/resources/templates/sbadmin/ai/chat.html
@@ -180,6 +180,7 @@
   <script th:src="@{/sbadmin/vendor/marked/marked.min.js}"></script>
   <script th:src="@{/sbadmin/vendor/dompurify/purify.min.js}"></script>
   <script th:src="@{/sbadmin/js/ai-markdown.js}"></script>
+  <script th:src="@{/sbadmin/js/ai-chat-errors.js}"></script>
   <script th:src="@{/sbadmin/js/ai-chat-stream.js}"></script>
   <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
   <script th:src="@{/sbadmin/js/ai-chat.js}"></script>

--- a/src/main/resources/templates/sbadmin/fragments/ai-assistant-widget.html
+++ b/src/main/resources/templates/sbadmin/fragments/ai-assistant-widget.html
@@ -51,6 +51,7 @@
   <script th:src="@{/sbadmin/vendor/marked/marked.min.js}"></script>
   <script th:src="@{/sbadmin/vendor/dompurify/purify.min.js}"></script>
   <script th:src="@{/sbadmin/js/ai-markdown.js}"></script>
+  <script th:src="@{/sbadmin/js/ai-chat-errors.js}"></script>
   <script th:src="@{/sbadmin/js/ai-chat-stream.js}"></script>
   <script th:src="@{/sbadmin/js/ai-assistant-widget.js}" defer></script>
 </div>

--- a/src/test/java/com/nutriconsultas/ai/AiChatRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatRestControllerTest.java
@@ -134,8 +134,45 @@ class AiChatRestControllerTest {
 			.sendMessage(new AiSendMessageRequest(5L, "Hola"), principal(NUTRITIONIST_ID));
 
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
-		assertThat(response.getBody()).containsEntry("message",
-				"El servicio de IA está saturado. Intenta de nuevo en unos minutos.");
+		assertThat(response.getBody())
+			.containsEntry("message", "El servicio de IA está saturado. Intenta de nuevo en unos minutos.")
+			.containsEntry("errorCode", AiToolErrorCode.RATE_LIMIT.name());
+	}
+
+	@Test
+	void sendMessageMapsOpenAiNotConfigured() throws Exception {
+		when(chatService.sendMessage(any(), eq(5L), any(), any()))
+			.thenThrow(new OpenAiClientException(OpenAiClientException.ErrorKind.NOT_CONFIGURED,
+					HttpStatus.SERVICE_UNAVAILABLE, AiErrorMessages.NOT_CONFIGURED, "not configured", null));
+		when(aiChatRateLimiter.executeMessage(eq(NUTRITIONIST_ID), any())).thenAnswer(invocation -> {
+			final Callable<?> callable = invocation.getArgument(1);
+			return callable.call();
+		});
+
+		final ResponseEntity<Map<String, Object>> response = controller
+			.sendMessage(new AiSendMessageRequest(5L, "Hola"), principal(NUTRITIONIST_ID));
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+		assertThat(response.getBody()).containsEntry("message", AiErrorMessages.NOT_CONFIGURED)
+			.containsEntry("errorCode", AiToolErrorCode.INTERNAL.name());
+	}
+
+	@Test
+	void sendMessageMapsOpenAiTimeout() throws Exception {
+		when(chatService.sendMessage(any(), eq(5L), any(), any()))
+			.thenThrow(new OpenAiClientException(OpenAiClientException.ErrorKind.TIMEOUT, HttpStatus.GATEWAY_TIMEOUT,
+					AiErrorMessages.OPENAI_TIMEOUT, "timeout", null));
+		when(aiChatRateLimiter.executeMessage(eq(NUTRITIONIST_ID), any())).thenAnswer(invocation -> {
+			final Callable<?> callable = invocation.getArgument(1);
+			return callable.call();
+		});
+
+		final ResponseEntity<Map<String, Object>> response = controller
+			.sendMessage(new AiSendMessageRequest(5L, "Hola"), principal(NUTRITIONIST_ID));
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.GATEWAY_TIMEOUT);
+		assertThat(response.getBody()).containsEntry("message", AiErrorMessages.OPENAI_TIMEOUT)
+			.containsEntry("errorCode", AiToolErrorCode.INTERNAL.name());
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/AiChatSseSupportTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatSseSupportTest.java
@@ -1,0 +1,26 @@
+package com.nutriconsultas.ai;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class AiChatSseSupportTest {
+
+	@Test
+	void sendErrorWithCodeInvokesEmitterSend() throws Exception {
+		final SseEmitter emitter = mock(SseEmitter.class);
+		AiChatSseSupport.sendError(emitter, AiToolErrorCode.RATE_LIMIT, AiErrorMessages.RATE_LIMIT);
+		verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
+	}
+
+	@Test
+	void sendErrorStringOverloadDefaultsToInternal() throws Exception {
+		final SseEmitter emitter = mock(SseEmitter.class);
+		AiChatSseSupport.sendError(emitter, AiErrorMessages.GENERIC);
+		verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiErrorMessagesTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiErrorMessagesTest.java
@@ -1,0 +1,31 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AiErrorMessagesTest {
+
+	@Test
+	void errorCodeForOpenAiRateLimit() {
+		assertThat(AiErrorMessages.errorCodeForOpenAi(OpenAiClientException.ErrorKind.RATE_LIMIT))
+			.isEqualTo(AiToolErrorCode.RATE_LIMIT);
+	}
+
+	@Test
+	void errorCodeForOpenAiServiceFailures() {
+		assertThat(AiErrorMessages.errorCodeForOpenAi(OpenAiClientException.ErrorKind.NOT_CONFIGURED))
+			.isEqualTo(AiToolErrorCode.INTERNAL);
+		assertThat(AiErrorMessages.errorCodeForOpenAi(OpenAiClientException.ErrorKind.TIMEOUT))
+			.isEqualTo(AiToolErrorCode.INTERNAL);
+		assertThat(AiErrorMessages.errorCodeForOpenAi(OpenAiClientException.ErrorKind.UNAVAILABLE))
+			.isEqualTo(AiToolErrorCode.INTERNAL);
+	}
+
+	@Test
+	void errorCodeForOpenAiValidationFailures() {
+		assertThat(AiErrorMessages.errorCodeForOpenAi(OpenAiClientException.ErrorKind.INVALID_REQUEST))
+			.isEqualTo(AiToolErrorCode.VALIDATION);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiMarkdownStaticAssetsTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiMarkdownStaticAssetsTest.java
@@ -16,6 +16,7 @@ class AiMarkdownStaticAssetsTest {
 		assertThat(new ClassPathResource("static/sbadmin/vendor/dompurify/purify.min.js").exists()).isTrue();
 		assertThat(new ClassPathResource("static/sbadmin/js/ai-markdown.js").exists()).isTrue();
 		assertThat(new ClassPathResource("static/sbadmin/js/ai-chat-stream.js").exists()).isTrue();
+		assertThat(new ClassPathResource("static/sbadmin/js/ai-chat-errors.js").exists()).isTrue();
 		assertThat(new ClassPathResource("static/sbadmin/css/ai-markdown.css").exists()).isTrue();
 	}
 

--- a/src/test/java/com/nutriconsultas/subscription/SubscriptionExceptionHandlerTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/SubscriptionExceptionHandlerTest.java
@@ -34,6 +34,8 @@ class SubscriptionExceptionHandlerTest {
 		assertThat(response.getBody()).containsEntry("success", false);
 		assertThat(response.getBody()).containsEntry("code", SubscriptionErrorResponses.KEY_PATIENT_LIMIT);
 		assertThat(response.getBody()).containsEntry("error", "Plan cap reached");
+		assertThat(response.getBody()).containsEntry("message", "Plan cap reached");
+		assertThat(response.getBody()).containsEntry("errorCode", "FORBIDDEN");
 	}
 
 }


### PR DESCRIPTION
## Summary
- Centralize Spanish user-facing AI error messages in `AiErrorMessages` and map OpenAI failures to appropriate `errorCode` values (e.g. `RATE_LIMIT`, `INTERNAL`).
- Extend SSE error events and subscription 403 responses with `errorCode` + `message` so REST and streaming clients share a consistent shape.
- Add `ai-chat-errors.js` and wire chat/widget/stream clients to show contextual SweetAlert titles (rate limit, forbidden, unavailable) without stack traces.

## Test plan
- [x] `mvn test` — `AiErrorMessagesTest`, `AiChatSseSupportTest`, `AiChatRestControllerTest`, `SubscriptionExceptionHandlerTest`
- [ ] Send a chat message with AI disabled/misconfigured → 503 with Spanish message and "Servicio no disponible" title
- [ ] Trigger app rate limit → 429 with "Límite alcanzado" title
- [ ] Stream a message and simulate OpenAI timeout → SSE error event with `errorCode` and friendly message
- [ ] Access AI on a plan without entitlement → 403 shows subscription message (not generic fallback)

Closes #399


Made with [Cursor](https://cursor.com)