### PR TITLE
Add MCP tool descriptors catalog (#393)

### DIFF
--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#392 — Design MCP Server Endpoint](https://github.com/diego-torres/nutriconsultas/issues/392) (`in progress`, branch `issue-392-mcp-server-endpoint-design`). ~~#396~~ epic complete (~~#397~~ ~~#398~~ ~~#399~~).
+**Current next issue:** [#393 — Implement MCP Tool Descriptors](https://github.com/diego-torres/nutriconsultas/issues/393) (`in progress`, branch `issue-393-mcp-tool-descriptors`). ~~#392~~ merged (PR #486).
 
 **Registered backlog (2026-07-04):** Epic [#433](https://github.com/diego-torres/nutriconsultas/issues/433) chat UX (#434–#437). Epic [#438](https://github.com/diego-torres/nutriconsultas/issues/438) prompt security (#439–#441, **#447–#450** bulk scope guards). See registry for suggested order.
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-07-05 — ~~#399~~ merged (PR #485). Epic **#396** complete. Next: **#392** (MCP endpoint design).
+**Last updated:** 2026-07-05 — ~~#392~~ merged (PR #486). **#393** in progress (`issue-393-mcp-tool-descriptors`).
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -182,12 +182,12 @@ MCP-compatible exposure of nutrition tools.
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
 | **391** | Epic — MCP Tool Server for Nutriconsultas (Phase 7) | https://github.com/diego-torres/nutriconsultas/issues/391 | **open** | **372**, **378** | Milestone 4 |
-| **392** | Design MCP Server Endpoint | https://github.com/diego-torres/nutriconsultas/issues/392 | **in progress** | **391**, **363** | Branch `issue-392-mcp-server-endpoint-design` |
-| **393** | Implement MCP Tool Descriptors | https://github.com/diego-torres/nutriconsultas/issues/393 | **open** | **392** | Stable tool names |
+| **392** | Design MCP Server Endpoint | https://github.com/diego-torres/nutriconsultas/issues/392 | **done** | **391**, **363** | PR #486 — [`MCP-SERVER-ENDPOINT.md`](docs/ai/MCP-SERVER-ENDPOINT.md) |
+| **393** | Implement MCP Tool Descriptors | https://github.com/diego-torres/nutriconsultas/issues/393 | **in progress** | **392** | Branch `issue-393-mcp-tool-descriptors` |
 | **394** | Implement MCP Tool Dispatch | https://github.com/diego-torres/nutriconsultas/issues/394 | **open** | **393**, **372** | Map to Spring services |
 | **395** | Add MCP Security Review | https://github.com/diego-torres/nutriconsultas/issues/395 | **open** | **394** | Auth + scoping tests |
 
-**Suggested order:** #392 → #393 → #394 → #395.
+**Suggested order:** ~~#392~~ **done**. **#393** in progress → #394 → #395.
 
 ---
 
@@ -202,7 +202,7 @@ Audit logging, metrics, and error UX.
 | **398** | Add AI Usage Metrics | https://github.com/diego-torres/nutriconsultas/issues/398 | **done** | **396** | PR #484 — Micrometer metrics |
 | **399** | Add AI Error Handling UX | https://github.com/diego-torres/nutriconsultas/issues/399 | **done** | **389**, **385** | PR #485 — Spanish errors + `errorCode` |
 
-**Suggested order:** Epic **#396** complete. Next: **#392** → #393 → #394 → #395 (MCP). Prompt hardening epic **#438** complete.
+**Suggested order:** Epic **#396** complete. ~~#392~~ **done**. **#393** in progress → #394 → #395 (MCP). Prompt hardening epic **#438** complete.
 
 ---
 
@@ -221,7 +221,7 @@ Injection, jailbreak, and defense-in-depth guardrails for orchestration (#385).
 | **449** | System prompt volume limits and bulk refusal corpus | https://github.com/diego-torres/nutriconsultas/issues/449 | **done** | **438**, **367**, **447** | PR #458 — `VOLUMEN Y LÍMITES`, `FUNCTIONAL-SCOPE.md`, bulk corpus |
 | **450** | Golden prompts for excessive bulk AI requests | https://github.com/diego-torres/nutriconsultas/issues/450 | **done** | **400**, **401**, **447** | PR #462 — `AiBulkScopeGoldenPromptTest`, docs |
 
-**Suggested order:** ~~#401~~ ~~#402~~ ~~#403~~ **done**. Epic **#400** complete. Phase 10: ~~#405~~ ~~#406~~ ~~#407~~ ~~#408~~ ~~#409~~ **done**. Epic **#396** complete. **#392** in progress (MCP Phase 7).
+**Suggested order:** ~~#401~~ ~~#402~~ ~~#403~~ **done**. Epic **#400** complete. Phase 10: ~~#405~~ ~~#406~~ ~~#407~~ ~~#408~~ ~~#409~~ **done**. Epic **#396** complete. ~~#392~~ **done**. **#393** in progress (MCP Phase 7).
 
 ---
 
@@ -252,7 +252,7 @@ Setup docs, nutritionist guidance, release checklist.
 | **407** | Add Nutritionist User Guidance | https://github.com/diego-torres/nutriconsultas/issues/407 | **done** | **390** | PR #477 — in-app panel + [`NUTRITIONIST-USER-GUIDANCE.md`](docs/ai/NUTRITIONIST-USER-GUIDANCE.md) |
 | **408** | Create AI Assistant Release Checklist | https://github.com/diego-torres/nutriconsultas/issues/408 | **done** | **404** | PR #479 — [`RELEASE-CHECKLIST.md`](docs/ai/RELEASE-CHECKLIST.md) |
 
-**Suggested order:** ~~#397~~ ~~#398~~ ~~#399~~ **done**. Epic **#396** complete. **#392** in progress → #393 → #394 → #395.
+**Suggested order:** ~~#397~~ ~~#398~~ ~~#399~~ **done**. Epic **#396** complete. ~~#392~~ **done**. **#393** in progress → #394 → #395.
 
 ---
 
@@ -264,7 +264,7 @@ AI assistant is a **new entitlement** — do **not** replace `REPORTS_ADVANCED` 
 |---|-------|-----|-------|------------|-------|
 | **409** | Gate AI assistant by plan — Plus and Consultorio only | https://github.com/diego-torres/nutriconsultas/issues/409 | **done** | #181, **384**, **388** | PR #481 — `Entitlement.AI_ASSISTANT`, pricing row on `eterna/index.html` |
 
-**Suggested order:** ~~#409~~ **done** (PR #481). ~~#397~~ ~~#398~~ ~~#399~~ **done** (PR #483–#485). Epic **#396** complete. **#392** in progress (MCP Phase 7).
+**Suggested order:** ~~#409~~ **done** (PR #481). ~~#397~~ ~~#398~~ ~~#399~~ **done** (PR #483–#485). ~~#392~~ **done** (PR #486). **#393** in progress (MCP Phase 7).
 
 ---
 

--- a/docs/ai/MCP-SERVER-ENDPOINT.md
+++ b/docs/ai/MCP-SERVER-ENDPOINT.md
@@ -5,7 +5,7 @@
 
 Design for exposing the existing nutrition tool layer through an **MCP-compatible HTTP endpoint** so external AI agents can reuse the same Spring services as the in-app OpenAI orchestrator (#385).
 
-**Implementation follow-ups:** #393 (tool descriptors) · #394 (dispatch) · #395 (security review)
+**Implementation follow-ups:** `McpToolDescriptorCatalog` (#393) · #394 (dispatch) · #395 (security review)
 
 ---
 

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -18,7 +18,7 @@ Documentation for the **AI Nutrition Assistant** track.
 | [`PRODUCTION-AI-SETUP.md`](PRODUCTION-AI-SETUP.md) | Production EC2 `app.env`, SSM, rollback (#406) |
 | [`NUTRITIONIST-USER-GUIDANCE.md`](NUTRITIONIST-USER-GUIDANCE.md) | Nutritionist-facing guidance — drafts, prompts, limits (#407) |
 | [`RELEASE-CHECKLIST.md`](RELEASE-CHECKLIST.md) | Production rollout gate before `AI_ENABLED=true` (#408) |
-| [`MCP-SERVER-ENDPOINT.md`](MCP-SERVER-ENDPOINT.md) | MCP transport, auth, tool surface (#392) |
+| [`MCP-SERVER-ENDPOINT.md`](MCP-SERVER-ENDPOINT.md) | MCP transport, auth, tool surface (#392); descriptors via `McpToolDescriptorCatalog` (#393) |
 | [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) | Architecture, security, tools, milestones, definition of done |
 | [`../../ISSUE-AI-ASSISTANT.md`](../../ISSUE-AI-ASSISTANT.md) | GitHub issue registry (#360–#408) |
 | [`../../AI-ASSISTANT-WORKFLOW.md`](../../AI-ASSISTANT-WORKFLOW.md) | Agent implementation workflow |

--- a/src/main/java/com/nutriconsultas/ai/mcp/McpToolDescriptor.java
+++ b/src/main/java/com/nutriconsultas/ai/mcp/McpToolDescriptor.java
@@ -1,0 +1,45 @@
+package com.nutriconsultas.ai.mcp;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * MCP tool descriptor for {@code tools/list} (#393).
+ */
+public record McpToolDescriptor(String name, String title, String description, Map<String, Object> inputSchema,
+		boolean readOnly, boolean requiresNutritionistConfirmation) {
+
+	public McpToolDescriptor {
+		if (name == null || name.isBlank()) {
+			throw new IllegalArgumentException("name is required");
+		}
+		if (title == null || title.isBlank()) {
+			throw new IllegalArgumentException("title is required");
+		}
+		if (description == null || description.isBlank()) {
+			throw new IllegalArgumentException("description is required");
+		}
+		if (inputSchema == null || inputSchema.isEmpty()) {
+			throw new IllegalArgumentException("inputSchema is required");
+		}
+	}
+
+	/**
+	 * JSON-friendly map aligned with MCP {@code Tool} shape and project extensions.
+	 */
+	public Map<String, Object> toMap() {
+		final Map<String, Object> map = new LinkedHashMap<>();
+		map.put("name", name);
+		map.put("title", title);
+		map.put("description", description);
+		map.put("inputSchema", inputSchema);
+		if (readOnly) {
+			map.put("annotations", Map.of("readOnlyHint", true));
+		}
+		if (requiresNutritionistConfirmation) {
+			map.put("requiresNutritionistConfirmation", true);
+		}
+		return map;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/mcp/McpToolDescriptorCatalog.java
+++ b/src/main/java/com/nutriconsultas/ai/mcp/McpToolDescriptorCatalog.java
@@ -1,0 +1,60 @@
+package com.nutriconsultas.ai.mcp;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.nutriconsultas.ai.AiOpenAiToolCatalog;
+import com.nutriconsultas.ai.OpenAiToolDefinition;
+
+/**
+ * MCP tool descriptors derived from {@link AiOpenAiToolCatalog} (#393).
+ */
+@Component
+public final class McpToolDescriptorCatalog {
+
+	/**
+	 * Descriptor set version — bump when MCP names or schemas change incompatibly.
+	 */
+	public static final String DESCRIPTOR_VERSION = "1.0.0";
+
+	private final AiOpenAiToolCatalog openAiToolCatalog;
+
+	public McpToolDescriptorCatalog(final AiOpenAiToolCatalog openAiToolCatalog) {
+		this.openAiToolCatalog = openAiToolCatalog;
+	}
+
+	public String descriptorVersion() {
+		return DESCRIPTOR_VERSION;
+	}
+
+	public List<McpToolDescriptor> descriptors() {
+		final Map<String, OpenAiToolDefinition> byInternalName = openAiToolCatalog.definitions()
+			.stream()
+			.collect(Collectors.toUnmodifiableMap(OpenAiToolDefinition::name, Function.identity()));
+		final List<McpToolDescriptor> result = new ArrayList<>();
+		for (final McpToolRegistry entry : McpToolRegistry.orderedEntries()) {
+			final OpenAiToolDefinition definition = byInternalName.get(entry.internalToolName());
+			if (definition == null) {
+				throw new IllegalStateException(
+						"Missing OpenAI tool definition for MCP mapping: " + entry.internalToolName());
+			}
+			result.add(entry.toDescriptor(definition));
+		}
+		return List.copyOf(result);
+	}
+
+	public Optional<String> internalToolNameFor(final String mcpToolName) {
+		return McpToolRegistry.findByMcpName(mcpToolName).map(McpToolRegistry::internalToolName);
+	}
+
+	public Optional<String> mcpToolNameFor(final String internalToolName) {
+		return McpToolRegistry.findByInternalName(internalToolName).map(McpToolRegistry::mcpName);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/mcp/McpToolRegistry.java
+++ b/src/main/java/com/nutriconsultas/ai/mcp/McpToolRegistry.java
@@ -55,9 +55,9 @@ enum McpToolRegistry {
 	private static final Map<String, McpToolRegistry> BY_INTERNAL_NAME = Arrays.stream(values())
 		.collect(Collectors.toUnmodifiableMap(McpToolRegistry::internalToolName, Function.identity()));
 
-	private final String mcpName;
+	private final String registeredMcpName;
 
-	private final String internalToolName;
+	private final String registeredInternalToolName;
 
 	private final String title;
 
@@ -69,8 +69,8 @@ enum McpToolRegistry {
 
 	McpToolRegistry(final String mcpName, final String internalToolName, final String title,
 			final String summaryDescription, final boolean readOnly, final boolean requiresNutritionistConfirmation) {
-		this.mcpName = mcpName;
-		this.internalToolName = internalToolName;
+		this.registeredMcpName = mcpName;
+		this.registeredInternalToolName = internalToolName;
 		this.title = title;
 		this.summaryDescription = summaryDescription;
 		this.readOnly = readOnly;
@@ -78,11 +78,11 @@ enum McpToolRegistry {
 	}
 
 	String mcpName() {
-		return mcpName;
+		return registeredMcpName;
 	}
 
 	String internalToolName() {
-		return internalToolName;
+		return registeredInternalToolName;
 	}
 
 	static Optional<McpToolRegistry> findByMcpName(final String mcpName) {
@@ -99,7 +99,7 @@ enum McpToolRegistry {
 
 	McpToolDescriptor toDescriptor(final OpenAiToolDefinition openAiDefinition) {
 		final String description = buildDescription(openAiDefinition.description());
-		return new McpToolDescriptor(mcpName, title, description, openAiDefinition.parameters(), readOnly,
+		return new McpToolDescriptor(registeredMcpName, title, description, openAiDefinition.parameters(), readOnly,
 				requiresNutritionistConfirmation);
 	}
 

--- a/src/main/java/com/nutriconsultas/ai/mcp/McpToolRegistry.java
+++ b/src/main/java/com/nutriconsultas/ai/mcp/McpToolRegistry.java
@@ -1,0 +1,115 @@
+package com.nutriconsultas.ai.mcp;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.nutriconsultas.ai.CalculateRecipeNutrientsToolService;
+import com.nutriconsultas.ai.CreateDietPlanDraftToolService;
+import com.nutriconsultas.ai.CreateDishDraftToolService;
+import com.nutriconsultas.ai.CreateMenuDraftToolService;
+import com.nutriconsultas.ai.GetFoodNutrientsToolService;
+import com.nutriconsultas.ai.OpenAiToolDefinition;
+import com.nutriconsultas.ai.SearchDishCatalogToolService;
+import com.nutriconsultas.ai.SearchFoodCatalogToolService;
+import com.nutriconsultas.ai.ValidatePlanConstraintsToolService;
+
+/**
+ * Stable MCP tool names and metadata (#393). Versioned as a set — add new enum constants
+ * for v2 tools.
+ */
+enum McpToolRegistry {
+
+	SEARCH_FOODS("catalog.search_foods", SearchFoodCatalogToolService.TOOL_NAME, "Buscar alimentos",
+			"Busca alimentos en el catálogo autorizado.", true, false),
+
+	GET_FOOD_NUTRIENTS("catalog.get_food_nutrients", GetFoodNutrientsToolService.TOOL_NAME, "Nutrientes de alimento",
+			"Obtiene nutrientes de un alimento del catálogo para una cantidad dada.", true, false),
+
+	SEARCH_DISHES("catalog.search_dishes", SearchDishCatalogToolService.TOOL_NAME, "Buscar platillos",
+			"Busca platillos del catálogo del sistema y del nutriólogo autenticado.", true, false),
+
+	CALCULATE_RECIPE("nutrition.calculate_recipe", CalculateRecipeNutrientsToolService.TOOL_NAME,
+			"Calcular nutrientes de receta",
+			"Calcula nutrientes totales y por porción de una lista de ingredientes del catálogo.", true, false),
+
+	VALIDATE_PLAN("nutrition.validate_plan", ValidatePlanConstraintsToolService.TOOL_NAME, "Validar plan nutricional",
+			"Valida un borrador de menú o plan contra objetivos calóricos, macros y restricciones.", true, false),
+
+	CREATE_DISH("draft.create_dish", CreateDishDraftToolService.TOOL_NAME, "Crear borrador de platillo",
+			"Guarda un borrador de platillo para revisión del nutriólogo. No guarda en el catálogo final.", false,
+			true),
+
+	CREATE_MENU("draft.create_menu", CreateMenuDraftToolService.TOOL_NAME, "Crear borrador de menú",
+			"Guarda un borrador de menú de un día. No asigna al paciente.", false, true),
+
+	CREATE_DIET_PLAN("draft.create_diet_plan", CreateDietPlanDraftToolService.TOOL_NAME,
+			"Crear borrador de plan alimentario",
+			"Guarda un borrador de plan alimenticio multi-día. No asigna al paciente.", false, true);
+
+	private static final Map<String, McpToolRegistry> BY_MCP_NAME = Arrays.stream(values())
+		.collect(Collectors.toUnmodifiableMap(McpToolRegistry::mcpName, Function.identity()));
+
+	private static final Map<String, McpToolRegistry> BY_INTERNAL_NAME = Arrays.stream(values())
+		.collect(Collectors.toUnmodifiableMap(McpToolRegistry::internalToolName, Function.identity()));
+
+	private final String mcpName;
+
+	private final String internalToolName;
+
+	private final String title;
+
+	private final String summaryDescription;
+
+	private final boolean readOnly;
+
+	private final boolean requiresNutritionistConfirmation;
+
+	McpToolRegistry(final String mcpName, final String internalToolName, final String title,
+			final String summaryDescription, final boolean readOnly, final boolean requiresNutritionistConfirmation) {
+		this.mcpName = mcpName;
+		this.internalToolName = internalToolName;
+		this.title = title;
+		this.summaryDescription = summaryDescription;
+		this.readOnly = readOnly;
+		this.requiresNutritionistConfirmation = requiresNutritionistConfirmation;
+	}
+
+	String mcpName() {
+		return mcpName;
+	}
+
+	String internalToolName() {
+		return internalToolName;
+	}
+
+	static Optional<McpToolRegistry> findByMcpName(final String mcpName) {
+		return Optional.ofNullable(BY_MCP_NAME.get(mcpName));
+	}
+
+	static Optional<McpToolRegistry> findByInternalName(final String internalToolName) {
+		return Optional.ofNullable(BY_INTERNAL_NAME.get(internalToolName));
+	}
+
+	static McpToolRegistry[] orderedEntries() {
+		return values();
+	}
+
+	McpToolDescriptor toDescriptor(final OpenAiToolDefinition openAiDefinition) {
+		final String description = buildDescription(openAiDefinition.description());
+		return new McpToolDescriptor(mcpName, title, description, openAiDefinition.parameters(), readOnly,
+				requiresNutritionistConfirmation);
+	}
+
+	private String buildDescription(final String openAiDescription) {
+		if (requiresNutritionistConfirmation) {
+			return summaryDescription + " "
+					+ "Requiere revisión y aprobación del nutriólogo en Minutriporcion antes de guardar en el catálogo o asignar a un paciente. "
+					+ openAiDescription;
+		}
+		return summaryDescription + " " + openAiDescription;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/mcp/McpToolDescriptorCatalogTest.java
+++ b/src/test/java/com/nutriconsultas/ai/mcp/McpToolDescriptorCatalogTest.java
@@ -1,0 +1,121 @@
+package com.nutriconsultas.ai.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.ai.AiOpenAiToolCatalog;
+import com.nutriconsultas.ai.CalculateRecipeNutrientsToolService;
+import com.nutriconsultas.ai.CreateDietPlanDraftToolService;
+import com.nutriconsultas.ai.CreateDishDraftToolService;
+import com.nutriconsultas.ai.CreateMenuDraftToolService;
+import com.nutriconsultas.ai.GetFoodNutrientsToolService;
+import com.nutriconsultas.ai.OpenAiToolDefinition;
+import com.nutriconsultas.ai.SearchDishCatalogToolService;
+import com.nutriconsultas.ai.SearchFoodCatalogToolService;
+import com.nutriconsultas.ai.ValidatePlanConstraintsToolService;
+
+class McpToolDescriptorCatalogTest {
+
+	private static final Set<String> EXPECTED_MCP_NAMES = Set.of("catalog.search_foods", "catalog.get_food_nutrients",
+			"catalog.search_dishes", "nutrition.calculate_recipe", "nutrition.validate_plan", "draft.create_dish",
+			"draft.create_menu", "draft.create_diet_plan");
+
+	private final McpToolDescriptorCatalog catalog = new McpToolDescriptorCatalog(new AiOpenAiToolCatalog());
+
+	@Test
+	void descriptorsExposeEightStableMcpTools() {
+		final List<McpToolDescriptor> descriptors = catalog.descriptors();
+
+		assertThat(descriptors).hasSize(8);
+		assertThat(descriptors.stream().map(McpToolDescriptor::name).collect(Collectors.toSet()))
+			.isEqualTo(EXPECTED_MCP_NAMES);
+		assertThat(catalog.descriptorVersion()).isEqualTo(McpToolDescriptorCatalog.DESCRIPTOR_VERSION);
+	}
+
+	@Test
+	void eachDescriptorHasNameTitleDescriptionAndInputSchema() {
+		for (final McpToolDescriptor descriptor : catalog.descriptors()) {
+			assertThat(descriptor.name()).isNotBlank();
+			assertThat(descriptor.title()).isNotBlank();
+			assertThat(descriptor.description()).isNotBlank();
+			assertThat(descriptor.inputSchema()).containsKey("type").containsEntry("type", "object");
+			assertThat(descriptor.inputSchema()).containsKeys("properties", "required", "additionalProperties");
+
+			final Map<String, Object> exported = descriptor.toMap();
+			assertThat(exported).containsEntry("name", descriptor.name())
+				.containsEntry("title", descriptor.title())
+				.containsEntry("description", descriptor.description())
+				.containsEntry("inputSchema", descriptor.inputSchema());
+		}
+	}
+
+	@Test
+	void readOnlyToolsAreMarkedReadOnly() {
+		final Map<String, McpToolDescriptor> byName = catalog.descriptors()
+			.stream()
+			.collect(Collectors.toMap(McpToolDescriptor::name, descriptor -> descriptor));
+
+		assertThat(byName.get("catalog.search_foods").readOnly()).isTrue();
+		assertThat(byName.get("catalog.get_food_nutrients").readOnly()).isTrue();
+		assertThat(byName.get("catalog.search_dishes").readOnly()).isTrue();
+		assertThat(byName.get("nutrition.calculate_recipe").readOnly()).isTrue();
+		assertThat(byName.get("nutrition.validate_plan").readOnly()).isTrue();
+
+		for (final String readOnlyName : List.of("catalog.search_foods", "catalog.get_food_nutrients",
+				"catalog.search_dishes", "nutrition.calculate_recipe", "nutrition.validate_plan")) {
+			assertThat(byName.get(readOnlyName).toMap()).containsEntry("annotations", Map.of("readOnlyHint", true));
+			assertThat(byName.get(readOnlyName).requiresNutritionistConfirmation()).isFalse();
+		}
+	}
+
+	@Test
+	void draftToolsRequireNutritionistConfirmation() {
+		final Map<String, McpToolDescriptor> byName = catalog.descriptors()
+			.stream()
+			.collect(Collectors.toMap(McpToolDescriptor::name, descriptor -> descriptor));
+
+		for (final String draftName : List.of("draft.create_dish", "draft.create_menu", "draft.create_diet_plan")) {
+			final McpToolDescriptor descriptor = byName.get(draftName);
+			assertThat(descriptor.readOnly()).isFalse();
+			assertThat(descriptor.requiresNutritionistConfirmation()).isTrue();
+			assertThat(descriptor.toMap()).containsEntry("requiresNutritionistConfirmation", true);
+			assertThat(descriptor.description())
+				.contains("Requiere revisión y aprobación del nutriólogo en Minutriporcion");
+		}
+	}
+
+	@Test
+	void inputSchemasMatchOpenAiToolCatalog() {
+		final Map<String, OpenAiToolDefinition> openAiByName = new AiOpenAiToolCatalog().definitions()
+			.stream()
+			.collect(Collectors.toMap(OpenAiToolDefinition::name, definition -> definition));
+
+		for (final McpToolDescriptor descriptor : catalog.descriptors()) {
+			final String internalName = catalog.internalToolNameFor(descriptor.name()).orElseThrow();
+			assertThat(descriptor.inputSchema()).isEqualTo(openAiByName.get(internalName).parameters());
+		}
+	}
+
+	@Test
+	void mcpAndInternalNameMappingsAreBidirectional() {
+		assertThat(catalog.internalToolNameFor("catalog.search_foods"))
+			.contains(SearchFoodCatalogToolService.TOOL_NAME);
+		assertThat(catalog.internalToolNameFor("nutrition.validate_plan"))
+			.contains(ValidatePlanConstraintsToolService.TOOL_NAME);
+		assertThat(catalog.mcpToolNameFor(CreateMenuDraftToolService.TOOL_NAME)).contains("draft.create_menu");
+		assertThat(catalog.mcpToolNameFor(GetFoodNutrientsToolService.TOOL_NAME))
+			.contains("catalog.get_food_nutrients");
+		assertThat(catalog.mcpToolNameFor(CalculateRecipeNutrientsToolService.TOOL_NAME))
+			.contains("nutrition.calculate_recipe");
+		assertThat(catalog.mcpToolNameFor(CreateDietPlanDraftToolService.TOOL_NAME)).contains("draft.create_diet_plan");
+		assertThat(catalog.mcpToolNameFor(CreateDishDraftToolService.TOOL_NAME)).contains("draft.create_dish");
+		assertThat(catalog.mcpToolNameFor(SearchDishCatalogToolService.TOOL_NAME)).contains("catalog.search_dishes");
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `McpToolDescriptorCatalog` with stable dot-separated MCP names mapped 1:1 to existing OpenAI tool schemas.
- Read-only catalog/nutrition tools export `readOnlyHint`; draft tools set `requiresNutritionistConfirmation` with Spanish approval copy.
- Bidirectional MCP ↔ internal name lookup for #394 dispatch.

## Test plan
- [x] `mvn test -Dtest=McpToolDescriptorCatalogTest`
- [ ] #394 can call `internalToolNameFor("catalog.search_foods")` and `descriptors()` for `tools/list`

Closes #393


Made with [Cursor](https://cursor.com)