### PR TITLE
Implement MCP tool dispatch (#394)

### DIFF
--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#393 — Implement MCP Tool Descriptors](https://github.com/diego-torres/nutriconsultas/issues/393) (`in progress`, branch `issue-393-mcp-tool-descriptors`). ~~#392~~ merged (PR #486).
+**Current next issue:** [#394 — Implement MCP Tool Dispatch](https://github.com/diego-torres/nutriconsultas/issues/394) (`in progress`, branch `issue-394-mcp-tool-dispatch`). ~~#393~~ merged (PR #487).
 
 **Registered backlog (2026-07-04):** Epic [#433](https://github.com/diego-torres/nutriconsultas/issues/433) chat UX (#434–#437). Epic [#438](https://github.com/diego-torres/nutriconsultas/issues/438) prompt security (#439–#441, **#447–#450** bulk scope guards). See registry for suggested order.
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-07-05 — ~~#392~~ merged (PR #486). **#393** in progress (`issue-393-mcp-tool-descriptors`).
+**Last updated:** 2026-07-05 — ~~#393~~ merged (PR #487). **#394** in progress (`issue-394-mcp-tool-dispatch`).
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -183,11 +183,11 @@ MCP-compatible exposure of nutrition tools.
 |---|-------|-----|-------|------------|-------|
 | **391** | Epic — MCP Tool Server for Nutriconsultas (Phase 7) | https://github.com/diego-torres/nutriconsultas/issues/391 | **open** | **372**, **378** | Milestone 4 |
 | **392** | Design MCP Server Endpoint | https://github.com/diego-torres/nutriconsultas/issues/392 | **done** | **391**, **363** | PR #486 — [`MCP-SERVER-ENDPOINT.md`](docs/ai/MCP-SERVER-ENDPOINT.md) |
-| **393** | Implement MCP Tool Descriptors | https://github.com/diego-torres/nutriconsultas/issues/393 | **in progress** | **392** | Branch `issue-393-mcp-tool-descriptors` |
-| **394** | Implement MCP Tool Dispatch | https://github.com/diego-torres/nutriconsultas/issues/394 | **open** | **393**, **372** | Map to Spring services |
+| **393** | Implement MCP Tool Descriptors | https://github.com/diego-torres/nutriconsultas/issues/393 | **done** | **392** | PR #487 |
+| **394** | Implement MCP Tool Dispatch | https://github.com/diego-torres/nutriconsultas/issues/394 | **in progress** | **393**, **372** | Branch `issue-394-mcp-tool-dispatch` |
 | **395** | Add MCP Security Review | https://github.com/diego-torres/nutriconsultas/issues/395 | **open** | **394** | Auth + scoping tests |
 
-**Suggested order:** ~~#392~~ **done**. **#393** in progress → #394 → #395.
+**Suggested order:** ~~#392~~ ~~#393~~ **done**. **#394** in progress → #395.
 
 ---
 
@@ -202,7 +202,7 @@ Audit logging, metrics, and error UX.
 | **398** | Add AI Usage Metrics | https://github.com/diego-torres/nutriconsultas/issues/398 | **done** | **396** | PR #484 — Micrometer metrics |
 | **399** | Add AI Error Handling UX | https://github.com/diego-torres/nutriconsultas/issues/399 | **done** | **389**, **385** | PR #485 — Spanish errors + `errorCode` |
 
-**Suggested order:** Epic **#396** complete. ~~#392~~ **done**. **#393** in progress → #394 → #395 (MCP). Prompt hardening epic **#438** complete.
+**Suggested order:** Epic **#396** complete. ~~#392~~ ~~#393~~ **done**. **#394** in progress → #395 (MCP). Prompt hardening epic **#438** complete.
 
 ---
 
@@ -221,7 +221,7 @@ Injection, jailbreak, and defense-in-depth guardrails for orchestration (#385).
 | **449** | System prompt volume limits and bulk refusal corpus | https://github.com/diego-torres/nutriconsultas/issues/449 | **done** | **438**, **367**, **447** | PR #458 — `VOLUMEN Y LÍMITES`, `FUNCTIONAL-SCOPE.md`, bulk corpus |
 | **450** | Golden prompts for excessive bulk AI requests | https://github.com/diego-torres/nutriconsultas/issues/450 | **done** | **400**, **401**, **447** | PR #462 — `AiBulkScopeGoldenPromptTest`, docs |
 
-**Suggested order:** ~~#401~~ ~~#402~~ ~~#403~~ **done**. Epic **#400** complete. Phase 10: ~~#405~~ ~~#406~~ ~~#407~~ ~~#408~~ ~~#409~~ **done**. Epic **#396** complete. ~~#392~~ **done**. **#393** in progress (MCP Phase 7).
+**Suggested order:** ~~#401~~ ~~#402~~ ~~#403~~ **done**. Epic **#400** complete. Phase 10: ~~#405~~ ~~#406~~ ~~#407~~ ~~#408~~ ~~#409~~ **done**. Epic **#396** complete. ~~#392~~ ~~#393~~ **done**. **#394** in progress (MCP Phase 7).
 
 ---
 
@@ -252,7 +252,7 @@ Setup docs, nutritionist guidance, release checklist.
 | **407** | Add Nutritionist User Guidance | https://github.com/diego-torres/nutriconsultas/issues/407 | **done** | **390** | PR #477 — in-app panel + [`NUTRITIONIST-USER-GUIDANCE.md`](docs/ai/NUTRITIONIST-USER-GUIDANCE.md) |
 | **408** | Create AI Assistant Release Checklist | https://github.com/diego-torres/nutriconsultas/issues/408 | **done** | **404** | PR #479 — [`RELEASE-CHECKLIST.md`](docs/ai/RELEASE-CHECKLIST.md) |
 
-**Suggested order:** ~~#397~~ ~~#398~~ ~~#399~~ **done**. Epic **#396** complete. ~~#392~~ **done**. **#393** in progress → #394 → #395.
+**Suggested order:** ~~#397~~ ~~#398~~ ~~#399~~ **done**. Epic **#396** complete. ~~#392~~ ~~#393~~ **done**. **#394** in progress → #395.
 
 ---
 
@@ -264,7 +264,7 @@ AI assistant is a **new entitlement** — do **not** replace `REPORTS_ADVANCED` 
 |---|-------|-----|-------|------------|-------|
 | **409** | Gate AI assistant by plan — Plus and Consultorio only | https://github.com/diego-torres/nutriconsultas/issues/409 | **done** | #181, **384**, **388** | PR #481 — `Entitlement.AI_ASSISTANT`, pricing row on `eterna/index.html` |
 
-**Suggested order:** ~~#409~~ **done** (PR #481). ~~#397~~ ~~#398~~ ~~#399~~ **done** (PR #483–#485). ~~#392~~ **done** (PR #486). **#393** in progress (MCP Phase 7).
+**Suggested order:** ~~#409~~ **done** (PR #481). ~~#397~~ ~~#398~~ ~~#399~~ **done** (PR #483–#485). ~~#392~~ ~~#393~~ **done** (PR #486–#487). **#394** in progress (MCP Phase 7).
 
 ---
 

--- a/src/main/java/com/nutriconsultas/SecurityConfig.java
+++ b/src/main/java/com/nutriconsultas/SecurityConfig.java
@@ -63,6 +63,8 @@ public class SecurityConfig {
 				.permitAll()
 				.requestMatchers("/rest/**")
 				.authenticated()
+				.requestMatchers("/mcp/**")
+				.authenticated()
 				.requestMatchers("/admin/**")
 				.authenticated()
 				.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")

--- a/src/main/java/com/nutriconsultas/ai/AiAuditLogger.java
+++ b/src/main/java/com/nutriconsultas/ai/AiAuditLogger.java
@@ -81,6 +81,14 @@ public final class AiAuditLogger {
 		}
 	}
 
+	public void logMcpToolCall(final long threadId, final String nutritionistId, final String mcpToolName,
+			final String internalToolName, final boolean success) {
+		if (log.isInfoEnabled()) {
+			log.info("AI audit event=mcp_tool_call threadId={} nutritionist={} mcpTool={} internalTool={} success={}",
+					threadId, LogRedaction.redactUserId(nutritionistId), mcpToolName, internalToolName, success);
+		}
+	}
+
 	public void logMaxToolCallsReached(final long threadId, final int maxToolCalls) {
 		if (log.isWarnEnabled()) {
 			log.warn("AI audit event=max_tool_calls threadId={} maxToolCalls={}", threadId, maxToolCalls);

--- a/src/main/java/com/nutriconsultas/ai/mcp/McpAccessException.java
+++ b/src/main/java/com/nutriconsultas/ai/mcp/McpAccessException.java
@@ -1,0 +1,36 @@
+package com.nutriconsultas.ai.mcp;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Access failure for MCP requests (#394).
+ */
+public final class McpAccessException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final HttpStatus status;
+
+	private final String userMessage;
+
+	public McpAccessException(final HttpStatus status, final String userMessage) {
+		super(userMessage);
+		this.status = status;
+		this.userMessage = userMessage;
+	}
+
+	public McpAccessException(final HttpStatus status, final String userMessage, final Throwable cause) {
+		super(userMessage, cause);
+		this.status = status;
+		this.userMessage = userMessage;
+	}
+
+	public HttpStatus getStatus() {
+		return status;
+	}
+
+	public String getUserMessage() {
+		return userMessage;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/mcp/McpJsonRpcResponses.java
+++ b/src/main/java/com/nutriconsultas/ai/mcp/McpJsonRpcResponses.java
@@ -1,0 +1,59 @@
+package com.nutriconsultas.ai.mcp;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * JSON-RPC 2.0 response helpers for MCP (#394).
+ */
+public final class McpJsonRpcResponses {
+
+	public static final String PROTOCOL_VERSION = "2025-03-26";
+
+	public static final int ERROR_UNAUTHORIZED = -32_001;
+
+	public static final int ERROR_INVALID_REQUEST = -32_600;
+
+	public static final int ERROR_METHOD_NOT_FOUND = -32_601;
+
+	public static final int ERROR_FORBIDDEN = -32_003;
+
+	public static final int ERROR_NOT_FOUND = -32_004;
+
+	public static final int ERROR_UNAVAILABLE = -32_005;
+
+	public static final int ERROR_SERVER = -32_000;
+
+	private McpJsonRpcResponses() {
+	}
+
+	public static Map<String, Object> success(final Object id, final Map<String, Object> result) {
+		final Map<String, Object> body = new LinkedHashMap<>();
+		body.put("jsonrpc", "2.0");
+		body.put("id", id);
+		body.put("result", result);
+		return body;
+	}
+
+	public static Map<String, Object> error(final Object id, final int code, final String message) {
+		final Map<String, Object> body = new LinkedHashMap<>();
+		body.put("jsonrpc", "2.0");
+		body.put("id", id);
+		final Map<String, Object> error = new LinkedHashMap<>();
+		error.put("code", code);
+		error.put("message", message);
+		body.put("error", error);
+		return body;
+	}
+
+	public static Map<String, Object> toolCallResult(final Object id, final String toolResultJson,
+			final boolean isError) {
+		final Map<String, Object> content = Map.of("type", "text", "text", toolResultJson);
+		final Map<String, Object> result = new LinkedHashMap<>();
+		result.put("content", List.of(content));
+		result.put("isError", isError);
+		return success(id, result);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/mcp/McpNutriconsultasController.java
+++ b/src/main/java/com/nutriconsultas/ai/mcp/McpNutriconsultasController.java
@@ -1,0 +1,73 @@
+package com.nutriconsultas.ai.mcp;
+
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nutriconsultas.ai.AiErrorMessages;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * MCP-compatible HTTP endpoint for nutrition tool dispatch (#394).
+ */
+@RestController
+@RequestMapping("/mcp/nutriconsultas")
+@Slf4j
+public final class McpNutriconsultasController {
+
+	private final McpToolDispatchService dispatchService;
+
+	public McpNutriconsultasController(final McpToolDispatchService dispatchService) {
+		this.dispatchService = dispatchService;
+	}
+
+	@PostMapping
+	public ResponseEntity<Map<String, Object>> handle(@RequestBody(required = false) final Map<String, Object> body,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String nutritionistId = principal != null ? principal.getSubject() : null;
+		if (!StringUtils.hasText(nutritionistId)) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+				.body(McpJsonRpcResponses.error(null, McpJsonRpcResponses.ERROR_UNAUTHORIZED,
+						AiErrorMessages.INVALID_SESSION));
+		}
+		if (body == null || body.isEmpty()) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+				.body(McpJsonRpcResponses.error(null, McpJsonRpcResponses.ERROR_INVALID_REQUEST,
+						"Solicitud JSON-RPC no válida."));
+		}
+		try {
+			return ResponseEntity.ok(dispatchService.handle(nutritionistId, body));
+		}
+		catch (final McpAccessException ex) {
+			if (log.isDebugEnabled()) {
+				log.debug("MCP access denied status={}", ex.getStatus().value());
+			}
+			return ResponseEntity.status(ex.getStatus())
+				.body(McpJsonRpcResponses.error(body.get("id"), mapHttpStatusToJsonRpcCode(ex.getStatus()),
+						ex.getUserMessage()));
+		}
+	}
+
+	private static int mapHttpStatusToJsonRpcCode(final HttpStatus status) {
+		if (status == HttpStatus.FORBIDDEN) {
+			return McpJsonRpcResponses.ERROR_FORBIDDEN;
+		}
+		if (status == HttpStatus.NOT_FOUND) {
+			return McpJsonRpcResponses.ERROR_NOT_FOUND;
+		}
+		if (status == HttpStatus.SERVICE_UNAVAILABLE) {
+			return McpJsonRpcResponses.ERROR_UNAVAILABLE;
+		}
+		return McpJsonRpcResponses.ERROR_SERVER;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/mcp/McpToolDescriptorCatalog.java
+++ b/src/main/java/com/nutriconsultas/ai/mcp/McpToolDescriptorCatalog.java
@@ -57,4 +57,8 @@ public final class McpToolDescriptorCatalog {
 		return McpToolRegistry.findByInternalName(internalToolName).map(McpToolRegistry::mcpName);
 	}
 
+	public boolean requiresThreadId(final String mcpToolName) {
+		return McpToolRegistry.findByMcpName(mcpToolName).map(McpToolRegistry::requiresThreadId).orElse(false);
+	}
+
 }

--- a/src/main/java/com/nutriconsultas/ai/mcp/McpToolDispatchService.java
+++ b/src/main/java/com/nutriconsultas/ai/mcp/McpToolDispatchService.java
@@ -1,0 +1,219 @@
+package com.nutriconsultas.ai.mcp;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.nutriconsultas.ai.AiAuditLogger;
+import com.nutriconsultas.ai.AiChatException;
+import com.nutriconsultas.ai.AiChatPersistence;
+import com.nutriconsultas.ai.AiChatPromptContext;
+import com.nutriconsultas.ai.AiChatPromptContextResolvers;
+import com.nutriconsultas.ai.AiChatRequestGuards;
+import com.nutriconsultas.ai.AiChatThread;
+import com.nutriconsultas.ai.AiErrorMessages;
+import com.nutriconsultas.ai.AiOrchestrationContext;
+import com.nutriconsultas.ai.AiOrchestrationException;
+import com.nutriconsultas.ai.AiOrchestrationGuardrails;
+import com.nutriconsultas.ai.AiOrchestrationToolDispatcher;
+import com.nutriconsultas.ai.AiProperties;
+import com.nutriconsultas.ai.AiToolErrorCode;
+import com.nutriconsultas.ai.AiToolJsonSerializer;
+import com.nutriconsultas.ai.AiToolResult;
+
+/**
+ * MCP JSON-RPC dispatch to {@link AiOrchestrationToolDispatcher} (#394).
+ */
+@Service
+public final class McpToolDispatchService {
+
+	private static final String DRAFT_THREAD_REQUIRED = "Se requiere una conversación activa para crear borradores.";
+
+	private final AiProperties aiProperties;
+
+	private final AiChatRequestGuards chatRequestGuards;
+
+	private final McpToolDescriptorCatalog descriptorCatalog;
+
+	private final AiOrchestrationToolDispatcher toolDispatcher;
+
+	private final AiOrchestrationGuardrails guardrails;
+
+	private final AiChatPromptContextResolvers contextResolvers;
+
+	private final AiChatPersistence chatPersistence;
+
+	private final AiAuditLogger auditLogger;
+
+	public McpToolDispatchService(final AiProperties aiProperties, final AiChatRequestGuards chatRequestGuards,
+			final McpToolDescriptorCatalog descriptorCatalog, final AiOrchestrationToolDispatcher toolDispatcher,
+			final AiOrchestrationGuardrails guardrails, final AiChatPromptContextResolvers contextResolvers,
+			final AiChatPersistence chatPersistence, final AiAuditLogger auditLogger) {
+		this.aiProperties = aiProperties;
+		this.chatRequestGuards = chatRequestGuards;
+		this.descriptorCatalog = descriptorCatalog;
+		this.toolDispatcher = toolDispatcher;
+		this.guardrails = guardrails;
+		this.contextResolvers = contextResolvers;
+		this.chatPersistence = chatPersistence;
+		this.auditLogger = auditLogger;
+	}
+
+	public Map<String, Object> handle(final String nutritionistId, final Map<String, Object> requestBody) {
+		assertFeatureAccess(nutritionistId);
+		final JsonNode root = toJsonNode(requestBody);
+		final Object id = parseId(root);
+		if (!"2.0".equals(root.path("jsonrpc").asText())) {
+			return McpJsonRpcResponses.error(id, McpJsonRpcResponses.ERROR_INVALID_REQUEST,
+					"Solicitud JSON-RPC no válida.");
+		}
+		final String method = root.path("method").asText(null);
+		if (!StringUtils.hasText(method)) {
+			return McpJsonRpcResponses.error(id, McpJsonRpcResponses.ERROR_INVALID_REQUEST,
+					"Solicitud JSON-RPC no válida.");
+		}
+		return switch (method) {
+			case "initialize" -> handleInitialize(id, root.path("params"));
+			case "tools/list" -> handleToolsList(id);
+			case "tools/call" -> handleToolsCall(nutritionistId, id, root.path("params"));
+			case "ping" -> McpJsonRpcResponses.success(id, Map.of());
+			default ->
+				McpJsonRpcResponses.error(id, McpJsonRpcResponses.ERROR_METHOD_NOT_FOUND, "Método MCP no reconocido.");
+		};
+	}
+
+	private Map<String, Object> handleInitialize(final Object id, final JsonNode params) {
+		final Map<String, Object> result = new LinkedHashMap<>();
+		result.put("protocolVersion", McpJsonRpcResponses.PROTOCOL_VERSION);
+		result.put("capabilities", Map.of("tools", Map.of("listChanged", false)));
+		result.put("serverInfo",
+				Map.of("name", "nutriconsultas", "version", McpToolDescriptorCatalog.DESCRIPTOR_VERSION));
+		if (params != null && params.has("_meta")) {
+			result.put("_meta", params.get("_meta"));
+		}
+		return McpJsonRpcResponses.success(id, result);
+	}
+
+	private Map<String, Object> handleToolsList(final Object id) {
+		final List<Map<String, Object>> tools = new ArrayList<>();
+		for (final McpToolDescriptor descriptor : descriptorCatalog.descriptors()) {
+			tools.add(descriptor.toMap());
+		}
+		return McpJsonRpcResponses.success(id, Map.of("tools", tools));
+	}
+
+	private Map<String, Object> handleToolsCall(final String nutritionistId, final Object id, final JsonNode params) {
+		final String mcpToolName = params.path("name").asText(null);
+		if (!StringUtils.hasText(mcpToolName)) {
+			return toolErrorResponse(id,
+					AiToolResult.error(AiToolErrorCode.VALIDATION, "Nombre de herramienta requerido."));
+		}
+		final Optional<String> internalToolName = descriptorCatalog.internalToolNameFor(mcpToolName);
+		if (internalToolName.isEmpty()) {
+			return toolErrorResponse(id,
+					AiToolResult.error(AiToolErrorCode.VALIDATION, "Herramienta MCP no reconocida: " + mcpToolName));
+		}
+		final Long threadId = extractThreadId(params);
+		if (descriptorCatalog.requiresThreadId(mcpToolName) && threadId == null) {
+			return toolErrorResponse(id, AiToolResult.error(AiToolErrorCode.VALIDATION, DRAFT_THREAD_REQUIRED));
+		}
+		final AiOrchestrationContext context = buildContext(nutritionistId, threadId);
+		final String openAiToolName = internalToolName.get();
+		if (!guardrails.isToolAllowed(openAiToolName)) {
+			auditLogger.logToolRejected(context.threadId(), openAiToolName);
+			return toolErrorResponse(id, AiToolResult.error(AiToolErrorCode.VALIDATION, "Herramienta no permitida."));
+		}
+		final String argumentsJson = serializeArguments(params.path("arguments"));
+		try {
+			final String rawResult = toolDispatcher.dispatch(context, openAiToolName, argumentsJson);
+			final String sanitized = guardrails.sanitizeToolResult(openAiToolName, rawResult);
+			final boolean success = isSuccessfulToolResult(sanitized);
+			auditLogger.logMcpToolCall(context.threadId(), nutritionistId, mcpToolName, openAiToolName, success);
+			return McpJsonRpcResponses.toolCallResult(id, sanitized, !success);
+		}
+		catch (final AiOrchestrationException ex) {
+			auditLogger.logToolDispatchFailed(context.threadId(), openAiToolName);
+			return toolErrorResponse(id, AiToolResult.error(AiToolErrorCode.VALIDATION, ex.getMessage()));
+		}
+	}
+
+	private void assertFeatureAccess(final String nutritionistId) {
+		if (!aiProperties.isEnabled()) {
+			if (aiProperties.isEnabledButMisconfigured()) {
+				throw new McpAccessException(HttpStatus.SERVICE_UNAVAILABLE, AiErrorMessages.MISCONFIGURATION);
+			}
+			throw new McpAccessException(HttpStatus.SERVICE_UNAVAILABLE, "El asistente de IA no está habilitado.");
+		}
+		try {
+			chatRequestGuards.assertNutritionistAccess(nutritionistId);
+		}
+		catch (final AiChatException ex) {
+			throw new McpAccessException(ex.getHttpStatus(), ex.getMessage(), ex);
+		}
+	}
+
+	private AiOrchestrationContext buildContext(final String nutritionistId, @Nullable final Long threadId) {
+		if (threadId == null) {
+			return new AiOrchestrationContext(nutritionistId, 0L, null, null, null);
+		}
+		final AiChatThread thread = chatPersistence.getThreadRepository()
+			.findByIdAndNutritionistId(threadId, nutritionistId)
+			.orElseThrow(() -> new McpAccessException(HttpStatus.NOT_FOUND, "No se encontró la conversación."));
+		final Long patientId = thread.getPatient() != null ? thread.getPatient().getId() : null;
+		final AiChatPromptContext promptContext = new AiChatPromptContext(patientId, null, null);
+		return contextResolvers.buildOrchestrationContext(nutritionistId, threadId, promptContext);
+	}
+
+	private static Map<String, Object> toolErrorResponse(final Object id, final AiToolResult<?> toolResult) {
+		return McpJsonRpcResponses.toolCallResult(id, AiToolJsonSerializer.toJson(toolResult), true);
+	}
+
+	private static JsonNode toJsonNode(final Map<String, Object> requestBody) {
+		return AiToolJsonSerializer.parseJson(AiToolJsonSerializer.toJson(requestBody));
+	}
+
+	private static Object parseId(final JsonNode root) {
+		final JsonNode idNode = root.get("id");
+		if (idNode == null || idNode.isNull()) {
+			return null;
+		}
+		if (idNode.isNumber()) {
+			return idNode.numberValue();
+		}
+		return idNode.asText();
+	}
+
+	@Nullable
+	private static Long extractThreadId(final JsonNode params) {
+		final JsonNode meta = params.path("_meta");
+		if (meta.isMissingNode() || meta.isNull()) {
+			return null;
+		}
+		final JsonNode threadIdNode = meta.path("threadId");
+		if (threadIdNode.isMissingNode() || threadIdNode.isNull() || !threadIdNode.isNumber()) {
+			return null;
+		}
+		return threadIdNode.longValue();
+	}
+
+	private static String serializeArguments(final JsonNode argumentsNode) {
+		if (argumentsNode == null || argumentsNode.isMissingNode() || argumentsNode.isNull()) {
+			return "{}";
+		}
+		return AiToolJsonSerializer.toJson(argumentsNode);
+	}
+
+	private static boolean isSuccessfulToolResult(final String json) {
+		final JsonNode node = AiToolJsonSerializer.parseJson(json);
+		return !node.has("success") || node.get("success").asBoolean(true);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/mcp/McpToolRegistry.java
+++ b/src/main/java/com/nutriconsultas/ai/mcp/McpToolRegistry.java
@@ -85,6 +85,10 @@ enum McpToolRegistry {
 		return registeredInternalToolName;
 	}
 
+	boolean requiresThreadId() {
+		return requiresNutritionistConfirmation;
+	}
+
 	static Optional<McpToolRegistry> findByMcpName(final String mcpName) {
 		return Optional.ofNullable(BY_MCP_NAME.get(mcpName));
 	}

--- a/src/test/java/com/nutriconsultas/ai/mcp/McpNutriconsultasControllerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/mcp/McpNutriconsultasControllerTest.java
@@ -1,0 +1,79 @@
+package com.nutriconsultas.ai.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+
+import com.nutriconsultas.ai.AiErrorMessages;
+
+@ExtendWith(MockitoExtension.class)
+class McpNutriconsultasControllerTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	@InjectMocks
+	private McpNutriconsultasController controller;
+
+	@Mock
+	private McpToolDispatchService dispatchService;
+
+	@Test
+	void unauthenticatedRequestReturns401() {
+		final ResponseEntity<Map<String, Object>> response = controller
+			.handle(Map.of("jsonrpc", "2.0", "method", "tools/list", "id", 1), null);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> error = (Map<String, Object>) response.getBody().get("error");
+		assertThat(error).containsEntry("code", McpJsonRpcResponses.ERROR_UNAUTHORIZED)
+			.containsEntry("message", AiErrorMessages.INVALID_SESSION);
+	}
+
+	@Test
+	void authenticatedToolsListReturnsOk() {
+		when(dispatchService.handle(NUTRITIONIST_ID,
+				Map.of("jsonrpc", "2.0", "method", "tools/list", "id", 1, "params", Map.of())))
+			.thenReturn(Map.of("jsonrpc", "2.0", "id", 1, "result", Map.of("tools", List.of())));
+
+		final ResponseEntity<Map<String, Object>> response = controller.handle(
+				Map.of("jsonrpc", "2.0", "method", "tools/list", "id", 1, "params", Map.of()),
+				principal(NUTRITIONIST_ID));
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsKey("result");
+	}
+
+	@Test
+	void accessExceptionMapsToHttpStatus() {
+		when(dispatchService.handle(NUTRITIONIST_ID,
+				Map.of("jsonrpc", "2.0", "method", "tools/list", "id", 1, "params", Map.of())))
+			.thenThrow(new McpAccessException(HttpStatus.FORBIDDEN, "Sin acceso"));
+
+		final ResponseEntity<Map<String, Object>> response = controller.handle(
+				Map.of("jsonrpc", "2.0", "method", "tools/list", "id", 1, "params", Map.of()),
+				principal(NUTRITIONIST_ID));
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+	}
+
+	private static DefaultOidcUser principal(final String subject) {
+		final Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject(subject).build();
+		final OidcIdToken idToken = new OidcIdToken(jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(),
+				Map.of("sub", subject));
+		return new DefaultOidcUser(List.of(), idToken);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/mcp/McpToolDescriptorCatalogTest.java
+++ b/src/test/java/com/nutriconsultas/ai/mcp/McpToolDescriptorCatalogTest.java
@@ -118,4 +118,10 @@ class McpToolDescriptorCatalogTest {
 		assertThat(catalog.mcpToolNameFor(SearchDishCatalogToolService.TOOL_NAME)).contains("catalog.search_dishes");
 	}
 
+	@Test
+	void draftToolsRequireThreadId() {
+		assertThat(catalog.requiresThreadId("draft.create_dish")).isTrue();
+		assertThat(catalog.requiresThreadId("catalog.search_foods")).isFalse();
+	}
+
 }

--- a/src/test/java/com/nutriconsultas/ai/mcp/McpToolDispatchServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/mcp/McpToolDispatchServiceTest.java
@@ -1,0 +1,197 @@
+package com.nutriconsultas.ai.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.nutriconsultas.ai.AiAuditLogger;
+import com.nutriconsultas.ai.AiChatException;
+import com.nutriconsultas.ai.AiChatMessageRepository;
+import com.nutriconsultas.ai.AiChatPersistence;
+import com.nutriconsultas.ai.AiChatPromptContextResolvers;
+import com.nutriconsultas.ai.AiChatRequestGuards;
+import com.nutriconsultas.ai.AiChatThread;
+import com.nutriconsultas.ai.AiChatThreadRepository;
+import com.nutriconsultas.ai.AiOpenAiToolCatalog;
+import com.nutriconsultas.ai.AiOrchestrationContext;
+import com.nutriconsultas.ai.AiOrchestrationGuardrails;
+import com.nutriconsultas.ai.AiOrchestrationToolDispatcher;
+import com.nutriconsultas.ai.AiProperties;
+import com.nutriconsultas.ai.AiToolErrorCode;
+import com.nutriconsultas.ai.SearchFoodCatalogToolService;
+
+@ExtendWith(MockitoExtension.class)
+class McpToolDispatchServiceTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	@Mock
+	private AiProperties aiProperties;
+
+	@Mock
+	private AiChatRequestGuards chatRequestGuards;
+
+	@Mock
+	private AiOrchestrationToolDispatcher toolDispatcher;
+
+	@Mock
+	private AiOrchestrationGuardrails guardrails;
+
+	@Mock
+	private AiChatPromptContextResolvers contextResolvers;
+
+	@Mock
+	private AiChatMessageRepository messageRepository;
+
+	@Mock
+	private TransactionTemplate transactionTemplate;
+
+	@Mock
+	private AiAuditLogger auditLogger;
+
+	@Mock
+	private AiChatThreadRepository threadRepository;
+
+	private AiChatPersistence chatPersistence;
+
+	private McpToolDescriptorCatalog descriptorCatalog;
+
+	private McpToolDispatchService dispatchService;
+
+	@BeforeEach
+	void setUp() {
+		chatPersistence = new AiChatPersistence(threadRepository, messageRepository, transactionTemplate);
+		descriptorCatalog = new McpToolDescriptorCatalog(new AiOpenAiToolCatalog());
+		dispatchService = new McpToolDispatchService(aiProperties, chatRequestGuards, descriptorCatalog, toolDispatcher,
+				guardrails, contextResolvers, chatPersistence, auditLogger);
+		when(aiProperties.isEnabled()).thenReturn(true);
+	}
+
+	@Test
+	void toolsListReturnsEightDescriptors() {
+		final Map<String, Object> response = dispatchService.handle(NUTRITIONIST_ID, jsonRpc("tools/list", Map.of()));
+
+		assertThat(response).containsEntry("jsonrpc", "2.0");
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> result = (Map<String, Object>) response.get("result");
+		@SuppressWarnings("unchecked")
+		final List<Map<String, Object>> tools = (List<Map<String, Object>>) result.get("tools");
+		assertThat(tools).hasSize(8);
+		verify(chatRequestGuards).assertNutritionistAccess(NUTRITIONIST_ID);
+	}
+
+	@Test
+	void toolsCallDispatchesMappedInternalTool() {
+		when(guardrails.isToolAllowed(SearchFoodCatalogToolService.TOOL_NAME)).thenReturn(true);
+		when(toolDispatcher.dispatch(any(AiOrchestrationContext.class), eq(SearchFoodCatalogToolService.TOOL_NAME),
+				any()))
+			.thenReturn("{\"success\":true,\"data\":{\"items\":[],\"totalReturned\":0}}");
+		when(guardrails.sanitizeToolResult(eq(SearchFoodCatalogToolService.TOOL_NAME), any()))
+			.thenAnswer(invocation -> invocation.getArgument(1));
+
+		final Map<String, Object> params = new LinkedHashMap<>();
+		params.put("name", "catalog.search_foods");
+		params.put("arguments", Map.of("query", "avena"));
+		final Map<String, Object> response = dispatchService.handle(NUTRITIONIST_ID, jsonRpc("tools/call", params));
+
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> result = (Map<String, Object>) response.get("result");
+		assertThat(result.get("isError")).isEqualTo(false);
+		verify(toolDispatcher).dispatch(any(AiOrchestrationContext.class), eq(SearchFoodCatalogToolService.TOOL_NAME),
+				any());
+		verify(auditLogger).logMcpToolCall(eq(0L), eq(NUTRITIONIST_ID), eq("catalog.search_foods"),
+				eq(SearchFoodCatalogToolService.TOOL_NAME), eq(true));
+	}
+
+	@Test
+	void toolsCallRejectsUnknownMcpTool() {
+		final Map<String, Object> params = Map.of("name", "catalog.unknown", "arguments", Map.of());
+		final Map<String, Object> response = dispatchService.handle(NUTRITIONIST_ID, jsonRpc("tools/call", params));
+
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> result = (Map<String, Object>) response.get("result");
+		assertThat(result.get("isError")).isEqualTo(true);
+	}
+
+	@Test
+	void draftToolRequiresThreadId() {
+		final Map<String, Object> params = Map.of("name", "draft.create_dish", "arguments",
+				Map.of("name", "Ensalada", "ingredients", List.of(Map.of("alimentoId", 1, "cantidad", "1"))));
+		final Map<String, Object> response = dispatchService.handle(NUTRITIONIST_ID, jsonRpc("tools/call", params));
+
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> result = (Map<String, Object>) response.get("result");
+		assertThat(result.get("isError")).isEqualTo(true);
+	}
+
+	@Test
+	void rejectsWhenAiDisabled() {
+		when(aiProperties.isEnabled()).thenReturn(false);
+		when(aiProperties.isEnabledButMisconfigured()).thenReturn(false);
+
+		org.assertj.core.api.Assertions
+			.assertThatThrownBy(() -> dispatchService.handle(NUTRITIONIST_ID, jsonRpc("tools/list", Map.of())))
+			.isInstanceOf(McpAccessException.class)
+			.extracting(ex -> ((McpAccessException) ex).getStatus())
+			.isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+	}
+
+	@Test
+	void propagatesEntitlementFailure() {
+		org.mockito.Mockito.doThrow(new AiChatException(HttpStatus.FORBIDDEN, AiToolErrorCode.FORBIDDEN, "Sin acceso"))
+			.when(chatRequestGuards)
+			.assertNutritionistAccess(NUTRITIONIST_ID);
+
+		org.assertj.core.api.Assertions
+			.assertThatThrownBy(() -> dispatchService.handle(NUTRITIONIST_ID, jsonRpc("tools/list", Map.of())))
+			.isInstanceOf(McpAccessException.class)
+			.extracting(ex -> ((McpAccessException) ex).getStatus())
+			.isEqualTo(HttpStatus.FORBIDDEN);
+	}
+
+	@Test
+	void toolsCallUsesThreadContextWhenMetaProvided() {
+		final AiChatThread thread = new AiChatThread();
+		thread.setId(9L);
+		thread.setNutritionistId(NUTRITIONIST_ID);
+		when(threadRepository.findByIdAndNutritionistId(9L, NUTRITIONIST_ID)).thenReturn(Optional.of(thread));
+		when(contextResolvers.buildOrchestrationContext(eq(NUTRITIONIST_ID), eq(9L), any()))
+			.thenReturn(new AiOrchestrationContext(NUTRITIONIST_ID, 9L, null, null, null));
+		when(guardrails.isToolAllowed(SearchFoodCatalogToolService.TOOL_NAME)).thenReturn(true);
+		when(toolDispatcher.dispatch(any(), any(), any())).thenReturn("{\"success\":true,\"data\":{}}");
+		when(guardrails.sanitizeToolResult(any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
+
+		final Map<String, Object> params = new LinkedHashMap<>();
+		params.put("name", "catalog.search_foods");
+		params.put("arguments", Map.of("query", "avena"));
+		params.put("_meta", Map.of("threadId", 9));
+		dispatchService.handle(NUTRITIONIST_ID, jsonRpc("tools/call", params));
+
+		verify(contextResolvers).buildOrchestrationContext(eq(NUTRITIONIST_ID), eq(9L), any());
+	}
+
+	private static Map<String, Object> jsonRpc(final String method, final Map<String, Object> params) {
+		final Map<String, Object> body = new LinkedHashMap<>();
+		body.put("jsonrpc", "2.0");
+		body.put("id", 1);
+		body.put("method", method);
+		body.put("params", params);
+		return body;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `POST /mcp/nutriconsultas` JSON-RPC endpoint with `initialize`, `tools/list`, `tools/call`, and `ping` handlers
- Route MCP tool names through `McpToolDescriptorCatalog` into `AiOrchestrationToolDispatcher` with existing guardrails, entitlement checks, and audit logging
- Require `_meta.threadId` for draft tools; read-only catalog tools work without a thread context

## Test plan
- [x] `McpToolDispatchServiceTest` — list, dispatch, unknown tool, draft thread requirement, AI disabled, entitlement failure, thread context
- [x] `McpNutriconsultasControllerTest` — 401 unauthenticated, 200 authenticated, HTTP status mapping
- [x] `McpToolDescriptorCatalogTest` — `requiresThreadId` coverage
- [x] PMD clean on new MCP classes

Closes #394

Made with [Cursor](https://cursor.com)