### PR TITLE
Add MCP security review (#395)

### DIFF
--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#394 — Implement MCP Tool Dispatch](https://github.com/diego-torres/nutriconsultas/issues/394) (`in progress`, branch `issue-394-mcp-tool-dispatch`). ~~#393~~ merged (PR #487).
+**Current next issue:** [#395 — Add MCP Security Review](https://github.com/diego-torres/nutriconsultas/issues/395) (`in progress`, branch `issue-395-mcp-security-review`). ~~#394~~ merged (PR #488).
 
 **Registered backlog (2026-07-04):** Epic [#433](https://github.com/diego-torres/nutriconsultas/issues/433) chat UX (#434–#437). Epic [#438](https://github.com/diego-torres/nutriconsultas/issues/438) prompt security (#439–#441, **#447–#450** bulk scope guards). See registry for suggested order.
 

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-07-05 — ~~#393~~ merged (PR #487). **#394** in progress (`issue-394-mcp-tool-dispatch`).
+**Last updated:** 2026-07-05 — ~~#394~~ merged (PR #488). **#395** in progress (`issue-395-mcp-security-review`).
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -184,10 +184,10 @@ MCP-compatible exposure of nutrition tools.
 | **391** | Epic — MCP Tool Server for Nutriconsultas (Phase 7) | https://github.com/diego-torres/nutriconsultas/issues/391 | **open** | **372**, **378** | Milestone 4 |
 | **392** | Design MCP Server Endpoint | https://github.com/diego-torres/nutriconsultas/issues/392 | **done** | **391**, **363** | PR #486 — [`MCP-SERVER-ENDPOINT.md`](docs/ai/MCP-SERVER-ENDPOINT.md) |
 | **393** | Implement MCP Tool Descriptors | https://github.com/diego-torres/nutriconsultas/issues/393 | **done** | **392** | PR #487 |
-| **394** | Implement MCP Tool Dispatch | https://github.com/diego-torres/nutriconsultas/issues/394 | **in progress** | **393**, **372** | Branch `issue-394-mcp-tool-dispatch` |
-| **395** | Add MCP Security Review | https://github.com/diego-torres/nutriconsultas/issues/395 | **open** | **394** | Auth + scoping tests |
+| **394** | Implement MCP Tool Dispatch | https://github.com/diego-torres/nutriconsultas/issues/394 | **done** | **393**, **372** | PR #488 |
+| **395** | Add MCP Security Review | https://github.com/diego-torres/nutriconsultas/issues/395 | **in progress** | **394** | Branch `issue-395-mcp-security-review` |
 
-**Suggested order:** ~~#392~~ ~~#393~~ **done**. **#394** in progress → #395.
+**Suggested order:** ~~#392~~ ~~#393~~ ~~#394~~ **done**. **#395** in progress.
 
 ---
 
@@ -202,7 +202,7 @@ Audit logging, metrics, and error UX.
 | **398** | Add AI Usage Metrics | https://github.com/diego-torres/nutriconsultas/issues/398 | **done** | **396** | PR #484 — Micrometer metrics |
 | **399** | Add AI Error Handling UX | https://github.com/diego-torres/nutriconsultas/issues/399 | **done** | **389**, **385** | PR #485 — Spanish errors + `errorCode` |
 
-**Suggested order:** Epic **#396** complete. ~~#392~~ ~~#393~~ **done**. **#394** in progress → #395 (MCP). Prompt hardening epic **#438** complete.
+**Suggested order:** Epic **#396** complete. ~~#392~~ ~~#393~~ ~~#394~~ **done**. **#395** in progress (MCP). Prompt hardening epic **#438** complete.
 
 ---
 
@@ -221,7 +221,7 @@ Injection, jailbreak, and defense-in-depth guardrails for orchestration (#385).
 | **449** | System prompt volume limits and bulk refusal corpus | https://github.com/diego-torres/nutriconsultas/issues/449 | **done** | **438**, **367**, **447** | PR #458 — `VOLUMEN Y LÍMITES`, `FUNCTIONAL-SCOPE.md`, bulk corpus |
 | **450** | Golden prompts for excessive bulk AI requests | https://github.com/diego-torres/nutriconsultas/issues/450 | **done** | **400**, **401**, **447** | PR #462 — `AiBulkScopeGoldenPromptTest`, docs |
 
-**Suggested order:** ~~#401~~ ~~#402~~ ~~#403~~ **done**. Epic **#400** complete. Phase 10: ~~#405~~ ~~#406~~ ~~#407~~ ~~#408~~ ~~#409~~ **done**. Epic **#396** complete. ~~#392~~ ~~#393~~ **done**. **#394** in progress (MCP Phase 7).
+**Suggested order:** ~~#401~~ ~~#402~~ ~~#403~~ **done**. Epic **#400** complete. Phase 10: ~~#405~~ ~~#406~~ ~~#407~~ ~~#408~~ ~~#409~~ **done**. Epic **#396** complete. ~~#392~~ ~~#393~~ ~~#394~~ **done**. **#395** in progress (MCP Phase 7).
 
 ---
 
@@ -252,7 +252,7 @@ Setup docs, nutritionist guidance, release checklist.
 | **407** | Add Nutritionist User Guidance | https://github.com/diego-torres/nutriconsultas/issues/407 | **done** | **390** | PR #477 — in-app panel + [`NUTRITIONIST-USER-GUIDANCE.md`](docs/ai/NUTRITIONIST-USER-GUIDANCE.md) |
 | **408** | Create AI Assistant Release Checklist | https://github.com/diego-torres/nutriconsultas/issues/408 | **done** | **404** | PR #479 — [`RELEASE-CHECKLIST.md`](docs/ai/RELEASE-CHECKLIST.md) |
 
-**Suggested order:** ~~#397~~ ~~#398~~ ~~#399~~ **done**. Epic **#396** complete. ~~#392~~ ~~#393~~ **done**. **#394** in progress → #395.
+**Suggested order:** ~~#397~~ ~~#398~~ ~~#399~~ **done**. Epic **#396** complete. ~~#392~~ ~~#393~~ ~~#394~~ **done**. **#395** in progress.
 
 ---
 
@@ -264,7 +264,7 @@ AI assistant is a **new entitlement** — do **not** replace `REPORTS_ADVANCED` 
 |---|-------|-----|-------|------------|-------|
 | **409** | Gate AI assistant by plan — Plus and Consultorio only | https://github.com/diego-torres/nutriconsultas/issues/409 | **done** | #181, **384**, **388** | PR #481 — `Entitlement.AI_ASSISTANT`, pricing row on `eterna/index.html` |
 
-**Suggested order:** ~~#409~~ **done** (PR #481). ~~#397~~ ~~#398~~ ~~#399~~ **done** (PR #483–#485). ~~#392~~ ~~#393~~ **done** (PR #486–#487). **#394** in progress (MCP Phase 7).
+**Suggested order:** ~~#409~~ **done** (PR #481). ~~#397~~ ~~#398~~ ~~#399~~ **done** (PR #483–#485). ~~#392~~ ~~#393~~ ~~#394~~ **done** (PR #486–#488). **#395** in progress (MCP Phase 7).
 
 ---
 

--- a/src/main/java/com/nutriconsultas/ai/mcp/McpToolDispatchService.java
+++ b/src/main/java/com/nutriconsultas/ai/mcp/McpToolDispatchService.java
@@ -28,6 +28,8 @@ import com.nutriconsultas.ai.AiProperties;
 import com.nutriconsultas.ai.AiToolErrorCode;
 import com.nutriconsultas.ai.AiToolJsonSerializer;
 import com.nutriconsultas.ai.AiToolResult;
+import com.nutriconsultas.subscription.SubscriptionErrorResponses;
+import com.nutriconsultas.subscription.SubscriptionLimitExceededException;
 
 /**
  * MCP JSON-RPC dispatch to {@link AiOrchestrationToolDispatcher} (#394).
@@ -53,10 +55,13 @@ public final class McpToolDispatchService {
 
 	private final AiAuditLogger auditLogger;
 
+	private final SubscriptionErrorResponses subscriptionErrorResponses;
+
 	public McpToolDispatchService(final AiProperties aiProperties, final AiChatRequestGuards chatRequestGuards,
 			final McpToolDescriptorCatalog descriptorCatalog, final AiOrchestrationToolDispatcher toolDispatcher,
 			final AiOrchestrationGuardrails guardrails, final AiChatPromptContextResolvers contextResolvers,
-			final AiChatPersistence chatPersistence, final AiAuditLogger auditLogger) {
+			final AiChatPersistence chatPersistence, final AiAuditLogger auditLogger,
+			final SubscriptionErrorResponses subscriptionErrorResponses) {
 		this.aiProperties = aiProperties;
 		this.chatRequestGuards = chatRequestGuards;
 		this.descriptorCatalog = descriptorCatalog;
@@ -65,6 +70,7 @@ public final class McpToolDispatchService {
 		this.contextResolvers = contextResolvers;
 		this.chatPersistence = chatPersistence;
 		this.auditLogger = auditLogger;
+		this.subscriptionErrorResponses = subscriptionErrorResponses;
 	}
 
 	public Map<String, Object> handle(final String nutritionistId, final Map<String, Object> requestBody) {
@@ -157,6 +163,9 @@ public final class McpToolDispatchService {
 		}
 		catch (final AiChatException ex) {
 			throw new McpAccessException(ex.getHttpStatus(), ex.getMessage(), ex);
+		}
+		catch (final SubscriptionLimitExceededException ex) {
+			throw new McpAccessException(HttpStatus.FORBIDDEN, subscriptionErrorResponses.resolve(ex), ex);
 		}
 	}
 

--- a/src/test/java/com/nutriconsultas/ai/AiAuditLoggerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiAuditLoggerTest.java
@@ -89,4 +89,19 @@ class AiAuditLoggerTest {
 		assertThat(formatted).doesNotContain("full-nutritionist-id");
 	}
 
+	@Test
+	void mcpToolCallLogsMetadataWithoutArgumentsOrFullUserId() {
+		auditLogger.logMcpToolCall(12L, "auth0|full-nutritionist-id", "catalog.search_foods", "search_food_catalog",
+				true);
+
+		assertThat(logAppender.list).hasSize(1);
+		final String formatted = logAppender.list.get(0).getFormattedMessage();
+		assertThat(formatted).contains("event=mcp_tool_call");
+		assertThat(formatted).contains("threadId=12");
+		assertThat(formatted).contains("mcpTool=catalog.search_foods");
+		assertThat(formatted).contains("internalTool=search_food_catalog");
+		assertThat(formatted).doesNotContain("full-nutritionist-id");
+		assertThat(formatted).doesNotContain("Juan Pérez");
+	}
+
 }

--- a/src/test/java/com/nutriconsultas/ai/mcp/McpAiDisabledSecurityIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/ai/mcp/McpAiDisabledSecurityIntegrationTest.java
@@ -1,0 +1,36 @@
+package com.nutriconsultas.ai.mcp;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * MCP access when {@code nutriconsultas.ai.enabled=false} (#395).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class McpAiDisabledSecurityIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void aiDisabledReturnsServiceUnavailableJsonRpc() throws Exception {
+		mockMvc.perform(post("/mcp/nutriconsultas").contentType(MediaType.APPLICATION_JSON).content("""
+				{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}
+				""").with(oidcLogin().idToken(token -> token.subject("auth0|any-user"))))
+			.andExpect(status().isServiceUnavailable())
+			.andExpect(jsonPath("$.error.code").value(McpJsonRpcResponses.ERROR_UNAVAILABLE));
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/mcp/McpNutriconsultasSecurityIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/ai/mcp/McpNutriconsultasSecurityIntegrationTest.java
@@ -1,0 +1,154 @@
+package com.nutriconsultas.ai.mcp;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nutriconsultas.ai.AiChatService;
+import com.nutriconsultas.ai.AiChatThread;
+import com.nutriconsultas.subscription.Clinic;
+import com.nutriconsultas.subscription.ClinicMember;
+import com.nutriconsultas.subscription.ClinicMemberRepository;
+import com.nutriconsultas.subscription.ClinicMemberRole;
+import com.nutriconsultas.subscription.ClinicRepository;
+import com.nutriconsultas.subscription.MembershipStatus;
+import com.nutriconsultas.subscription.PlanTier;
+import com.nutriconsultas.subscription.Subscription;
+import com.nutriconsultas.subscription.SubscriptionRepository;
+import com.nutriconsultas.subscription.SubscriptionStatus;
+
+/**
+ * MCP endpoint auth, entitlement, and tenant isolation (#395).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = { "nutriconsultas.ai.enabled=true", "nutriconsultas.ai.openai.api-key=test-key",
+		"nutriconsultas.ai.openai.model=gpt-test", "nutriconsultas.ai.scope-classifier-enabled=false" })
+class McpNutriconsultasSecurityIntegrationTest {
+
+	private static final String NUTRITIONIST_A = "auth0|mcp-security-a";
+
+	private static final String NUTRITIONIST_B = "auth0|mcp-security-b";
+
+	private static final String UNENTITLED_USER = "auth0|mcp-security-unentitled";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private AiChatService chatService;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private SubscriptionRepository subscriptionRepository;
+
+	@Autowired
+	private ClinicRepository clinicRepository;
+
+	@Autowired
+	private ClinicMemberRepository clinicMemberRepository;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@BeforeEach
+	void setUpEntitlements() {
+		resetPlusEntitlements(NUTRITIONIST_A);
+		resetPlusEntitlements(NUTRITIONIST_B);
+		jdbcTemplate.update("DELETE FROM clinic_member WHERE user_id = ?", UNENTITLED_USER);
+		jdbcTemplate.update("DELETE FROM clinic WHERE director_user_id = ?", UNENTITLED_USER);
+	}
+
+	@Test
+	void unauthenticatedMcpRequestIsDenied() throws Exception {
+		mockMvc.perform(post("/mcp/nutriconsultas").contentType(MediaType.APPLICATION_JSON).content(toolsListBody()))
+			.andExpect(status().is3xxRedirection());
+	}
+
+	@Test
+	void unentitledUserReceivesForbiddenJsonRpc() throws Exception {
+		mockMvc
+			.perform(post("/mcp/nutriconsultas").contentType(MediaType.APPLICATION_JSON)
+				.content(toolsListBody())
+				.with(oidcLogin().idToken(token -> token.subject(UNENTITLED_USER))))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.error.code").value(McpJsonRpcResponses.ERROR_FORBIDDEN));
+	}
+
+	@Test
+	void entitledUserCanListTools() throws Exception {
+		mockMvc
+			.perform(post("/mcp/nutriconsultas").contentType(MediaType.APPLICATION_JSON)
+				.content(toolsListBody())
+				.with(oidcLogin().idToken(token -> token.subject(NUTRITIONIST_A))))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.result.tools.length()").value(8));
+	}
+
+	@Test
+	void crossTenantThreadIdReturnsNotFoundJsonRpc() throws Exception {
+		final AiChatThread thread = chatService.startThread(NUTRITIONIST_A, "MCP tenant", null, null, null);
+
+		mockMvc
+			.perform(post("/mcp/nutriconsultas").contentType(MediaType.APPLICATION_JSON)
+				.content(toolsCallBody("catalog.search_foods", thread.getId()))
+				.with(oidcLogin().idToken(token -> token.subject(NUTRITIONIST_B))))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error.code").value(McpJsonRpcResponses.ERROR_NOT_FOUND));
+	}
+
+	private void resetPlusEntitlements(final String userId) {
+		jdbcTemplate.update("DELETE FROM clinic_member WHERE user_id = ?", userId);
+		jdbcTemplate.update("DELETE FROM clinic WHERE director_user_id = ?", userId);
+		provisionPlusSubscription(userId);
+	}
+
+	private void provisionPlusSubscription(final String userId) {
+		Subscription subscription = new Subscription();
+		subscription.setPlanTier(PlanTier.PLUS);
+		subscription.setStatus(SubscriptionStatus.ACTIVE);
+		subscription.setPaymentExempt(true);
+		subscription = subscriptionRepository.saveAndFlush(subscription);
+
+		final Clinic clinic = new Clinic();
+		clinic.setName("Clinic " + userId);
+		clinic.setDirectorUserId(userId);
+		clinic.setSubscription(subscription);
+		final Clinic savedClinic = clinicRepository.saveAndFlush(clinic);
+
+		final ClinicMember member = new ClinicMember();
+		member.setClinic(savedClinic);
+		member.setUserId(userId);
+		member.setRole(ClinicMemberRole.DIRECTOR);
+		member.setMembershipStatus(MembershipStatus.ACTIVE);
+		clinicMemberRepository.saveAndFlush(member);
+	}
+
+	private String toolsListBody() throws Exception {
+		return objectMapper.writeValueAsString(
+				java.util.Map.of("jsonrpc", "2.0", "id", 1, "method", "tools/list", "params", java.util.Map.of()));
+	}
+
+	private String toolsCallBody(final String toolName, final long threadId) throws Exception {
+		return objectMapper.writeValueAsString(java.util.Map.of("jsonrpc", "2.0", "id", 2, "method", "tools/call",
+				"params", java.util.Map.of("name", toolName, "arguments", java.util.Map.of("query", "avena"), "_meta",
+						java.util.Map.of("threadId", threadId))));
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/mcp/McpSecurityReviewTest.java
+++ b/src/test/java/com/nutriconsultas/ai/mcp/McpSecurityReviewTest.java
@@ -1,0 +1,93 @@
+package com.nutriconsultas.ai.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.ai.AiOpenAiToolCatalog;
+import com.nutriconsultas.ai.AiToolAllowlist;
+import com.nutriconsultas.ai.CreateDishDraftToolService;
+import com.nutriconsultas.ai.CreateDietPlanDraftToolService;
+import com.nutriconsultas.ai.CreateMenuDraftToolService;
+
+/**
+ * MCP tool surface security assertions (#395).
+ */
+class McpSecurityReviewTest {
+
+	private static final Set<String> FORBIDDEN_MCP_NAME_FRAGMENTS = Set.of("accept", "delete", "assign", "save",
+			"update", "remove", "discard", "materialize");
+
+	private static final Set<String> FORBIDDEN_INTERNAL_TOOL_FRAGMENTS = Set.of("accept", "delete", "assign",
+			"materialize", "discard");
+
+	private final McpToolDescriptorCatalog catalog = new McpToolDescriptorCatalog(new AiOpenAiToolCatalog());
+
+	private final AiToolAllowlist allowlist = new AiToolAllowlist(new AiOpenAiToolCatalog());
+
+	@Test
+	void mcpExposesOnlyAllowlistedInternalTools() {
+		final Set<String> mcpInternalNames = catalog.descriptors()
+			.stream()
+			.map(descriptor -> catalog.internalToolNameFor(descriptor.name()).orElseThrow())
+			.collect(Collectors.toSet());
+
+		assertThat(mcpInternalNames).isEqualTo(allowlist.allowedToolNames());
+		assertThat(mcpInternalNames).hasSize(8);
+	}
+
+	@Test
+	void mcpDoesNotExposeDestructiveToolNamePatterns() {
+		for (final McpToolDescriptor descriptor : catalog.descriptors()) {
+			final String lowerName = descriptor.name().toLowerCase();
+			assertThat(FORBIDDEN_MCP_NAME_FRAGMENTS).noneMatch(lowerName::contains);
+
+			final String internalName = catalog.internalToolNameFor(descriptor.name()).orElseThrow().toLowerCase();
+			assertThat(FORBIDDEN_INTERNAL_TOOL_FRAGMENTS).noneMatch(internalName::contains);
+		}
+	}
+
+	@Test
+	void writeActionsAreDraftToolsRequiringConfirmationAndThread() {
+		final List<McpToolDescriptor> writeTools = catalog.descriptors()
+			.stream()
+			.filter(descriptor -> !descriptor.readOnly())
+			.toList();
+
+		assertThat(writeTools).hasSize(3);
+		assertThat(writeTools.stream().map(McpToolDescriptor::name).collect(Collectors.toSet()))
+			.containsExactlyInAnyOrder("draft.create_dish", "draft.create_menu", "draft.create_diet_plan");
+
+		for (final McpToolDescriptor descriptor : writeTools) {
+			assertThat(descriptor.requiresNutritionistConfirmation()).isTrue();
+			final String description = descriptor.description();
+			assertThat(description.contains("No guarda en el catálogo final")
+					|| description.contains("No asigna al paciente"))
+				.isTrue();
+			assertThat(catalog.requiresThreadId(descriptor.name())).isTrue();
+		}
+	}
+
+	@Test
+	void readOnlyToolsDoNotRequireThreadOrConfirmation() {
+		for (final McpToolDescriptor descriptor : catalog.descriptors()) {
+			if (descriptor.readOnly()) {
+				assertThat(descriptor.requiresNutritionistConfirmation()).isFalse();
+				assertThat(catalog.requiresThreadId(descriptor.name())).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void draftInternalToolsMapToDraftServicesOnly() {
+		assertThat(catalog.internalToolNameFor("draft.create_dish")).contains(CreateDishDraftToolService.TOOL_NAME);
+		assertThat(catalog.internalToolNameFor("draft.create_menu")).contains(CreateMenuDraftToolService.TOOL_NAME);
+		assertThat(catalog.internalToolNameFor("draft.create_diet_plan"))
+			.contains(CreateDietPlanDraftToolService.TOOL_NAME);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/mcp/McpToolDispatchServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/mcp/McpToolDispatchServiceTest.java
@@ -34,6 +34,8 @@ import com.nutriconsultas.ai.AiOrchestrationToolDispatcher;
 import com.nutriconsultas.ai.AiProperties;
 import com.nutriconsultas.ai.AiToolErrorCode;
 import com.nutriconsultas.ai.SearchFoodCatalogToolService;
+import com.nutriconsultas.subscription.SubscriptionErrorResponses;
+import com.nutriconsultas.subscription.SubscriptionLimitExceededException;
 
 @ExtendWith(MockitoExtension.class)
 class McpToolDispatchServiceTest {
@@ -65,6 +67,9 @@ class McpToolDispatchServiceTest {
 	private AiAuditLogger auditLogger;
 
 	@Mock
+	private SubscriptionErrorResponses subscriptionErrorResponses;
+
+	@Mock
 	private AiChatThreadRepository threadRepository;
 
 	private AiChatPersistence chatPersistence;
@@ -78,7 +83,7 @@ class McpToolDispatchServiceTest {
 		chatPersistence = new AiChatPersistence(threadRepository, messageRepository, transactionTemplate);
 		descriptorCatalog = new McpToolDescriptorCatalog(new AiOpenAiToolCatalog());
 		dispatchService = new McpToolDispatchService(aiProperties, chatRequestGuards, descriptorCatalog, toolDispatcher,
-				guardrails, contextResolvers, chatPersistence, auditLogger);
+				guardrails, contextResolvers, chatPersistence, auditLogger, subscriptionErrorResponses);
 		when(aiProperties.isEnabled()).thenReturn(true);
 	}
 
@@ -162,6 +167,36 @@ class McpToolDispatchServiceTest {
 			.isInstanceOf(McpAccessException.class)
 			.extracting(ex -> ((McpAccessException) ex).getStatus())
 			.isEqualTo(HttpStatus.FORBIDDEN);
+	}
+
+	@Test
+	void propagatesSubscriptionEntitlementFailure() {
+		final SubscriptionLimitExceededException denied = new SubscriptionLimitExceededException(
+				SubscriptionErrorResponses.KEY_AI_ASSISTANT_DENIED);
+		org.mockito.Mockito.doThrow(denied).when(chatRequestGuards).assertNutritionistAccess(NUTRITIONIST_ID);
+		when(subscriptionErrorResponses.resolve(denied)).thenReturn("Plan Plus requerido.");
+
+		org.assertj.core.api.Assertions
+			.assertThatThrownBy(() -> dispatchService.handle(NUTRITIONIST_ID, jsonRpc("tools/list", Map.of())))
+			.isInstanceOf(McpAccessException.class)
+			.extracting(ex -> ((McpAccessException) ex).getStatus(), ex -> ((McpAccessException) ex).getUserMessage())
+			.containsExactly(HttpStatus.FORBIDDEN, "Plan Plus requerido.");
+	}
+
+	@Test
+	void crossTenantThreadIdReturnsNotFound() {
+		when(threadRepository.findByIdAndNutritionistId(42L, NUTRITIONIST_ID)).thenReturn(Optional.empty());
+
+		final Map<String, Object> params = new LinkedHashMap<>();
+		params.put("name", "catalog.search_foods");
+		params.put("arguments", Map.of("query", "avena"));
+		params.put("_meta", Map.of("threadId", 42));
+
+		org.assertj.core.api.Assertions
+			.assertThatThrownBy(() -> dispatchService.handle(NUTRITIONIST_ID, jsonRpc("tools/call", params)))
+			.isInstanceOf(McpAccessException.class)
+			.extracting(ex -> ((McpAccessException) ex).getStatus())
+			.isEqualTo(HttpStatus.NOT_FOUND);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Add security-focused tests for MCP auth, entitlements, tenant isolation, draft-only write surface, and audit log redaction
- Map `SubscriptionLimitExceededException` to JSON-RPC 403 in `McpToolDispatchService` so plan denials use the MCP error envelope

## Test plan
- [x] `McpSecurityReviewTest` — allowlist parity, no destructive tool names, draft-only writes
- [x] `McpNutriconsultasSecurityIntegrationTest` — unauthenticated denied, unentitled 403, entitled tools/list, cross-tenant thread 404
- [x] `McpAiDisabledSecurityIntegrationTest` — AI disabled 503 JSON-RPC
- [x] `McpToolDispatchServiceTest` — subscription 403, cross-tenant thread unit coverage
- [x] `AiAuditLoggerTest` — MCP tool call log redaction

Closes #395

Made with [Cursor](https://cursor.com)