### PR TITLE
Close MCP Phase 7 epic and mark AI track complete (#391)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,7 +55,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
-**Current next issue (AI assistant):** [#390 — Build Draft Preview UI](https://github.com/diego-torres/nutriconsultas/issues/390) (`NEXT`). Backlog: epic [#433](https://github.com/diego-torres/nutriconsultas/issues/433) chat UX (#434–#437), epic [#438](https://github.com/diego-torres/nutriconsultas/issues/438) prompt security (#439–#441), [#442](https://github.com/diego-torres/nutriconsultas/issues/442) floating widget (PR #432). See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+**Current next issue (AI assistant):** None — registered implementation track **complete** (#360–#450). Production rollout: [`RELEASE-CHECKLIST.md`](docs/ai/RELEASE-CHECKLIST.md) (#408). See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
 ---
 

--- a/AI-ASSISTANT-WORKFLOW.md
+++ b/AI-ASSISTANT-WORKFLOW.md
@@ -11,7 +11,7 @@ How AI agents (and humans) ship the **`[AI Assistant]`** track on **`diego-torre
 | [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) | Nutritionist web (draft acceptance may touch platillos/dietas) |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#395 — Add MCP Security Review](https://github.com/diego-torres/nutriconsultas/issues/395) (`in progress`, branch `issue-395-mcp-security-review`). ~~#394~~ merged (PR #488).
+**Current next issue:** None — registered `[AI Assistant]` implementation track **complete** (epics #360–#450). ~~#391~~ MCP Phase 7 **done** (PR #486–#489). Triage new GitHub issues or production rollout via [`RELEASE-CHECKLIST.md`](docs/ai/RELEASE-CHECKLIST.md) (#408).
 
 **Registered backlog (2026-07-04):** Epic [#433](https://github.com/diego-torres/nutriconsultas/issues/433) chat UX (#434–#437). Epic [#438](https://github.com/diego-torres/nutriconsultas/issues/438) prompt security (#439–#441, **#447–#450** bulk scope guards). See registry for suggested order.
 
@@ -163,7 +163,7 @@ mvn test
 | M2 complete | Orchestration tool loop (#385) |
 | M3 complete | Nutritionist beta (`AI_ENABLED=true` staging); **#433** UX enhancements optional for beta |
 | M3b complete | Markdown + streaming + message controls (#434–#437) |
-| M4 complete | External MCP clients |
+| M4 complete | External MCP clients — `POST /mcp/nutriconsultas` (#391–#395) |
 | M5 + #408 + **#438** | Production `AI_ENABLED=true` — prompt security required |
 
 ---

--- a/ISSUE-AI-ASSISTANT.md
+++ b/ISSUE-AI-ASSISTANT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for the **AI Nutrition Assistant** — OpenAI-back
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md)  
 **Workflow:** [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md)  
-**Last updated:** 2026-07-05 — ~~#394~~ merged (PR #488). **#395** in progress (`issue-395-mcp-security-review`).
+**Last updated:** 2026-07-05 — Registered `[AI Assistant]` implementation track **complete** (#360–#450). ~~#395~~ merged (PR #489); epic **#391** (MCP Phase 7) closed.
 
 > **Scope.** AI assistant for **nutritionist web** (`/admin/**`, `/nutritionist/ai/**`). Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Do not mix AI orchestration into mobile or subscription PRs unless explicitly coupled.
 
@@ -56,7 +56,7 @@ Document architecture, security model, data flow, and first implementation scope
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **360** | Epic — Discovery and Architecture (Phase 0) | https://github.com/diego-torres/nutriconsultas/issues/360 | **open** | — | Milestone 1 |
+| **360** | Epic — Discovery and Architecture (Phase 0) | https://github.com/diego-torres/nutriconsultas/issues/360 | **done** | — | ~~#361–#363~~ |
 | **361** | Define AI Assistant Functional Scope | https://github.com/diego-torres/nutriconsultas/issues/361 | **done** | **360** | [`docs/ai/FUNCTIONAL-SCOPE.md`](docs/ai/FUNCTIONAL-SCOPE.md) |
 | **362** | Define AI Data Access Rules | https://github.com/diego-torres/nutriconsultas/issues/362 | **done** | **360** | [`docs/ai/DATA-ACCESS-RULES.md`](docs/ai/DATA-ACCESS-RULES.md) |
 | **363** | Design AI Tool Contract | https://github.com/diego-torres/nutriconsultas/issues/363 | **done** | **360**, **362** | [`docs/ai/TOOL-CONTRACT.md`](docs/ai/TOOL-CONTRACT.md) |
@@ -149,7 +149,7 @@ Thymeleaf chat window and draft preview.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **387** | Epic — Nutritionist AI Chat UI (Phase 6) | https://github.com/diego-torres/nutriconsultas/issues/387 | **open** | **384** | ~~#388–#389~~ |
+| **387** | Epic — Nutritionist AI Chat UI (Phase 6) | https://github.com/diego-torres/nutriconsultas/issues/387 | **done** | **384** | ~~#388–#390, #442, #433–#437~~ |
 | **388** | Add AI Chat Entry Point to Nutritionist UI | https://github.com/diego-torres/nutriconsultas/issues/388 | **done** | **387**, **365** | Sidebar + `/admin/ai`, gated by `AI_ENABLED` |
 | **389** | Build AI Chat Window | https://github.com/diego-torres/nutriconsultas/issues/389 | **done** | **388**, **384** | `ai-chat.js` + REST integration |
 | **390** | Build Draft Preview UI | https://github.com/diego-torres/nutriconsultas/issues/390 | **done** | **389**, **382** | PR #443 |
@@ -181,13 +181,13 @@ MCP-compatible exposure of nutrition tools.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **391** | Epic — MCP Tool Server for Nutriconsultas (Phase 7) | https://github.com/diego-torres/nutriconsultas/issues/391 | **open** | **372**, **378** | Milestone 4 |
+| **391** | Epic — MCP Tool Server for Nutriconsultas (Phase 7) | https://github.com/diego-torres/nutriconsultas/issues/391 | **done** | **372**, **378** | ~~#392–#395~~ PR #486–#489 |
 | **392** | Design MCP Server Endpoint | https://github.com/diego-torres/nutriconsultas/issues/392 | **done** | **391**, **363** | PR #486 — [`MCP-SERVER-ENDPOINT.md`](docs/ai/MCP-SERVER-ENDPOINT.md) |
 | **393** | Implement MCP Tool Descriptors | https://github.com/diego-torres/nutriconsultas/issues/393 | **done** | **392** | PR #487 |
 | **394** | Implement MCP Tool Dispatch | https://github.com/diego-torres/nutriconsultas/issues/394 | **done** | **393**, **372** | PR #488 |
-| **395** | Add MCP Security Review | https://github.com/diego-torres/nutriconsultas/issues/395 | **in progress** | **394** | Branch `issue-395-mcp-security-review` |
+| **395** | Add MCP Security Review | https://github.com/diego-torres/nutriconsultas/issues/395 | **done** | **394** | PR #489 |
 
-**Suggested order:** ~~#392~~ ~~#393~~ ~~#394~~ **done**. **#395** in progress.
+**Suggested order:** Epic **#391** complete. Registered MCP track **done**.
 
 ---
 
@@ -202,7 +202,7 @@ Audit logging, metrics, and error UX.
 | **398** | Add AI Usage Metrics | https://github.com/diego-torres/nutriconsultas/issues/398 | **done** | **396** | PR #484 — Micrometer metrics |
 | **399** | Add AI Error Handling UX | https://github.com/diego-torres/nutriconsultas/issues/399 | **done** | **389**, **385** | PR #485 — Spanish errors + `errorCode` |
 
-**Suggested order:** Epic **#396** complete. ~~#392~~ ~~#393~~ ~~#394~~ **done**. **#395** in progress (MCP). Prompt hardening epic **#438** complete.
+**Suggested order:** Epic **#396** complete. Epic **#391** (MCP) complete. Prompt hardening epic **#438** complete.
 
 ---
 
@@ -212,7 +212,7 @@ Injection, jailbreak, and defense-in-depth guardrails for orchestration (#385).
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **438** | Epic — Prompt Security Hardening (Phase 8b) | https://github.com/diego-torres/nutriconsultas/issues/438 | **open** | **396**, **385**, **362** | Required before prod `AI_ENABLED=true` |
+| **438** | Epic — Prompt Security Hardening (Phase 8b) | https://github.com/diego-torres/nutriconsultas/issues/438 | **done** | **396**, **385**, **362** | ~~#439–#441, #447–#450~~ |
 | **439** | Prompt injection input guardrails | https://github.com/diego-torres/nutriconsultas/issues/439 | **done** | **438**, **385** | PR #452 — `AiUserMessageGuard`, `docs/ai/PROMPT-SECURITY.md` |
 | **440** | Jailbreak and role-override defenses | https://github.com/diego-torres/nutriconsultas/issues/440 | **done** | **438**, **439**, **367** | PR #454 — `AiPromptThreatDetector`, tool hardening |
 | **441** | Defense-in-depth prompt engineering guardrails | https://github.com/diego-torres/nutriconsultas/issues/441 | **done** | **438**, **439**, **440**, **372** | PR #464 — delimiters, tool allowlist, output validation |
@@ -221,7 +221,7 @@ Injection, jailbreak, and defense-in-depth guardrails for orchestration (#385).
 | **449** | System prompt volume limits and bulk refusal corpus | https://github.com/diego-torres/nutriconsultas/issues/449 | **done** | **438**, **367**, **447** | PR #458 — `VOLUMEN Y LÍMITES`, `FUNCTIONAL-SCOPE.md`, bulk corpus |
 | **450** | Golden prompts for excessive bulk AI requests | https://github.com/diego-torres/nutriconsultas/issues/450 | **done** | **400**, **401**, **447** | PR #462 — `AiBulkScopeGoldenPromptTest`, docs |
 
-**Suggested order:** ~~#401~~ ~~#402~~ ~~#403~~ **done**. Epic **#400** complete. Phase 10: ~~#405~~ ~~#406~~ ~~#407~~ ~~#408~~ ~~#409~~ **done**. Epic **#396** complete. ~~#392~~ ~~#393~~ ~~#394~~ **done**. **#395** in progress (MCP Phase 7).
+**Suggested order:** ~~#401~~ ~~#402~~ ~~#403~~ **done**. Epic **#400** complete. Phase 10: ~~#405~~ ~~#406~~ ~~#407~~ ~~#408~~ ~~#409~~ **done**. Epic **#391** (MCP) complete.
 
 ---
 
@@ -246,13 +246,13 @@ Setup docs, nutritionist guidance, release checklist.
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **404** | Epic — AI Assistant Documentation and Release (Phase 10) | https://github.com/diego-torres/nutriconsultas/issues/404 | **open** | **396**, **403** | Milestone 5 |
+| **404** | Epic — AI Assistant Documentation and Release (Phase 10) | https://github.com/diego-torres/nutriconsultas/issues/404 | **done** | **396**, **403** | ~~#405–#409~~ PR #472–#481 |
 | **405** | Document Local AI Setup | https://github.com/diego-torres/nutriconsultas/issues/405 | **done** | **365** | PR #472 — [`docs/ai/LOCAL-AI-SETUP.md`](docs/ai/LOCAL-AI-SETUP.md) |
 | **406** | Document Production AI Setup | https://github.com/diego-torres/nutriconsultas/issues/406 | **done** | **365** | PR #474 — [`docs/ai/PRODUCTION-AI-SETUP.md`](docs/ai/PRODUCTION-AI-SETUP.md), `ssm-update-ai-openai.sh` |
 | **407** | Add Nutritionist User Guidance | https://github.com/diego-torres/nutriconsultas/issues/407 | **done** | **390** | PR #477 — in-app panel + [`NUTRITIONIST-USER-GUIDANCE.md`](docs/ai/NUTRITIONIST-USER-GUIDANCE.md) |
 | **408** | Create AI Assistant Release Checklist | https://github.com/diego-torres/nutriconsultas/issues/408 | **done** | **404** | PR #479 — [`RELEASE-CHECKLIST.md`](docs/ai/RELEASE-CHECKLIST.md) |
 
-**Suggested order:** ~~#397~~ ~~#398~~ ~~#399~~ **done**. Epic **#396** complete. ~~#392~~ ~~#393~~ ~~#394~~ **done**. **#395** in progress.
+**Suggested order:** ~~#397~~ ~~#398~~ ~~#399~~ **done**. Epic **#396** complete. Epic **#391** (MCP) complete.
 
 ---
 
@@ -264,7 +264,7 @@ AI assistant is a **new entitlement** — do **not** replace `REPORTS_ADVANCED` 
 |---|-------|-----|-------|------------|-------|
 | **409** | Gate AI assistant by plan — Plus and Consultorio only | https://github.com/diego-torres/nutriconsultas/issues/409 | **done** | #181, **384**, **388** | PR #481 — `Entitlement.AI_ASSISTANT`, pricing row on `eterna/index.html` |
 
-**Suggested order:** ~~#409~~ **done** (PR #481). ~~#397~~ ~~#398~~ ~~#399~~ **done** (PR #483–#485). ~~#392~~ ~~#393~~ ~~#394~~ **done** (PR #486–#488). **#395** in progress (MCP Phase 7).
+**Suggested order:** ~~#409~~ **done** (PR #481). ~~#397~~ ~~#398~~ ~~#399~~ **done** (PR #483–#485). Epic **#391** (MCP) **done** (PR #486–#489).
 
 ---
 

--- a/docs/ai/AI-ASSISTANT-PLAN.md
+++ b/docs/ai/AI-ASSISTANT-PLAN.md
@@ -195,13 +195,14 @@ MCP (Phase 7): `POST /mcp/nutriconsultas` — see [`MCP-SERVER-ENDPOINT.md`](MCP
 
 ## Definition of done (whole project)
 
-- [ ] Nutritionists can open AI chat and request dish/menu/diet drafts
-- [ ] AI uses application tools for catalogs and nutrients
-- [ ] Clarifying questions when required
-- [ ] Drafts stored; accept/discard by owner nutritionist
-- [ ] No patient assignment without explicit approval
-- [ ] API key server-side only; endpoints authenticated and scoped
-- [ ] Liquibase migrations tested
-- [ ] Unit, integration, template, and security tests pass
-- [ ] Local, production, and nutritionist documentation complete
-- [ ] Feature disable via `AI_ENABLED=false`
+- [x] Nutritionists can open AI chat and request dish/menu/diet drafts
+- [x] AI uses application tools for catalogs and nutrients
+- [x] Clarifying questions when required
+- [x] Drafts stored; accept/discard by owner nutritionist
+- [x] No patient assignment without explicit approval
+- [x] API key server-side only; endpoints authenticated and scoped
+- [x] Liquibase migrations tested
+- [x] Unit, integration, template, and security tests pass
+- [x] Local, production, and nutritionist documentation complete
+- [x] Feature disable via `AI_ENABLED=false`
+- [x] MCP tool server for external agents (`POST /mcp/nutriconsultas`, #391–#395)

--- a/docs/ai/LOCAL-AI-SETUP.md
+++ b/docs/ai/LOCAL-AI-SETUP.md
@@ -168,6 +168,25 @@ For evaluation scenarios without live API, see [`NUTRITION-GOLDEN-PROMPTS.md`](N
 
 ---
 
+## MCP endpoint (optional)
+
+External agents can call the same nutrition tools via **`POST /mcp/nutriconsultas`** (JSON-RPC 2.0). Requires the same nutritionist OAuth2 session cookie as `/admin/ai` and Plus/Consultorio entitlement (#409).
+
+1. Log in at `http://localhost:3000` as an entitled nutritionist.
+2. Copy the session cookie from browser devtools.
+3. Example `tools/list` request:
+
+   ```bash
+   curl -s -X POST http://localhost:3000/mcp/nutriconsultas \
+     -H 'Content-Type: application/json' \
+     -H 'Cookie: SESSION=your-session-cookie' \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+   ```
+
+For draft tools, start a chat thread via REST first and pass `"_meta":{"threadId":<id>}` on `tools/call`. See [`MCP-SERVER-ENDPOINT.md`](MCP-SERVER-ENDPOINT.md).
+
+---
+
 ## Related documents
 
 | Doc | Topic |
@@ -176,5 +195,6 @@ For evaluation scenarios without live API, see [`NUTRITION-GOLDEN-PROMPTS.md`](N
 | [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md) | PHI, logging, `OPENAI_STORE` |
 | [`FUNCTIONAL-SCOPE.md`](FUNCTIONAL-SCOPE.md) | Supported workflows |
 | [`PRODUCTION-AI-SETUP.md`](PRODUCTION-AI-SETUP.md) | Production EC2, SSM, spend controls (#406) |
+| [`MCP-SERVER-ENDPOINT.md`](MCP-SERVER-ENDPOINT.md) | MCP JSON-RPC tool server (#391–#395) |
 
 **Note:** Plan-tier gating (`Entitlement.AI_ASSISTANT`, #409) is not required for basic local enablement today; production rollout must follow #408 and #409.

--- a/docs/ai/MCP-SERVER-ENDPOINT.md
+++ b/docs/ai/MCP-SERVER-ENDPOINT.md
@@ -5,7 +5,7 @@
 
 Design for exposing the existing nutrition tool layer through an **MCP-compatible HTTP endpoint** so external AI agents can reuse the same Spring services as the in-app OpenAI orchestrator (#385).
 
-**Implementation follow-ups:** `McpToolDescriptorCatalog` (#393) · #394 (dispatch) · #395 (security review)
+**Implementation status:** **Shipped** — #393 `McpToolDescriptorCatalog`, #394 `McpNutriconsultasController` + `McpToolDispatchService`, #395 security tests.
 
 ---
 
@@ -259,19 +259,19 @@ MCP tool descriptors (#393) expose JSON Schema for each tool’s **arguments**. 
 
 ## Security configuration (Spring)
 
-Proposed `SecurityConfig` additions for #394:
+Implemented in `SecurityConfig` (#394):
 
 ```java
 .requestMatchers("/mcp/**").authenticated()
 ```
 
-MCP controller (`McpNutriconsultasController` or similar) will:
+`McpNutriconsultasController` + `McpToolDispatchService`:
 
-1. Resolve `OidcUser` from the security context.
-2. Assert `AiProperties.isEnabled()` and subscription `AI_ASSISTANT`.
-3. Build `AiOrchestrationContext` from session + `threadId`.
+1. Resolve `OidcUser` from the security context (reject unauthenticated with OAuth redirect or JSON-RPC 401 when principal is null).
+2. Assert `AiProperties.isEnabled()` and subscription `AI_ASSISTANT` via `AiChatRequestGuards`.
+3. Build `AiOrchestrationContext` from session + optional `_meta.threadId` (required for draft tools).
 4. Map MCP name → internal name → `AiOrchestrationToolDispatcher`.
-5. Log via `AiAuditLogger` with redaction (#397) — tool name + thread ID only at INFO.
+5. Log via `AiAuditLogger.logMcpToolCall` — tool names + redacted nutritionist ID only at INFO (#395).
 
 No alternate code paths that bypass `AiToolAllowlist`, `AiDraftToolSchemaValidator`, or tenant checks (#441, #402).
 
@@ -281,10 +281,10 @@ No alternate code paths that bypass `AiToolAllowlist`, `AiDraftToolSchemaValidat
 
 | Control | Behavior |
 |---------|----------|
-| **App rate limit** | MCP `tools/call` counts toward the same per-nutritionist `aiChatMessage` limiter (#386) unless a separate MCP limiter is added in #394. Document in #394 if split. |
+| **App rate limit** | MCP `tools/call` does **not** use `AiChatRateLimiter` in v1 — only REST chat messages are rate-limited (#386). Add a dedicated MCP limiter in a follow-up issue if agent traffic needs caps. |
 | **Max tool calls** | Bulk scope guard `nutriconsultas.ai.max-tool-calls` applies per agent turn when MCP is used inside a hosted orchestration loop. |
-| **Metrics** | `AiUsageMetrics` records MCP tool calls with a distinct tag in #394 (`source=mcp`). |
-| **Audit** | `AiAuditLogger.logToolCall` — redacted args/result lengths, no PHI. |
+| **Metrics** | MCP tool calls audited via `AiAuditLogger.logMcpToolCall`; distinct Micrometer `source=mcp` tag deferred. |
+| **Audit** | `AiAuditLogger.logMcpToolCall` — MCP + internal tool names, redacted nutritionist ID, no argument JSON at INFO (#395). |
 
 ---
 
@@ -301,14 +301,14 @@ No alternate code paths that bypass `AiToolAllowlist`, `AiDraftToolSchemaValidat
 
 ## Testing expectations (#395)
 
-| Area | Tests |
-|------|-------|
-| **Auth** | Unauthenticated → 401; wrong plan → 403; `AI_ENABLED=false` → 503 |
-| **Tenant** | User A cannot pass user B’s `threadId` |
-| **Descriptors** | Snapshot or schema tests for `tools/list` (#393) |
-| **Dispatch** | Each MCP name maps to correct service; unknown name → error |
-| **Draft** | Draft tools without `threadId` → `VALIDATION` |
-| **Redaction** | Logs contain no patient names or full argument JSON at INFO |
+| Area | Tests | Class |
+|------|-------|-------|
+| **Auth** | Unauthenticated denied; wrong plan → 403 JSON-RPC; `AI_ENABLED=false` → 503 | `McpNutriconsultasSecurityIntegrationTest`, `McpAiDisabledSecurityIntegrationTest` |
+| **Tenant** | User A cannot pass user B’s `threadId` | `McpNutriconsultasSecurityIntegrationTest`, `McpToolDispatchServiceTest` |
+| **Descriptors** | Eight tools, schemas, read-only vs draft | `McpToolDescriptorCatalogTest`, `McpSecurityReviewTest` |
+| **Dispatch** | Each MCP name maps to correct service; unknown name → error | `McpToolDispatchServiceTest` |
+| **Draft** | Draft tools without `threadId` → validation error | `McpToolDispatchServiceTest`, `McpSecurityReviewTest` |
+| **Redaction** | Logs contain no full user id or argument JSON at INFO | `AiAuditLoggerTest`, `McpSecurityReviewTest` |
 
 ---
 
@@ -330,4 +330,4 @@ No alternate code paths that bypass `AiToolAllowlist`, `AiDraftToolSchemaValidat
 | [`TOOL-CONTRACT.md`](TOOL-CONTRACT.md) | Tool schemas and MCP name table |
 | [`DATA-ACCESS-RULES.md`](DATA-ACCESS-RULES.md) | PHI and tenant rules |
 | [`PROMPT-SECURITY.md`](PROMPT-SECURITY.md) | Not applicable to MCP tool-only path, but agents should not bypass scope |
-| [`RELEASE-CHECKLIST.md`](RELEASE-CHECKLIST.md) | MCP can ship after #393–#395; not required for initial `AI_ENABLED=true` chat rollout |
+| [`RELEASE-CHECKLIST.md`](RELEASE-CHECKLIST.md) | MCP optional for initial chat rollout; required for external agent integrations |

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -18,7 +18,7 @@ Documentation for the **AI Nutrition Assistant** track.
 | [`PRODUCTION-AI-SETUP.md`](PRODUCTION-AI-SETUP.md) | Production EC2 `app.env`, SSM, rollback (#406) |
 | [`NUTRITIONIST-USER-GUIDANCE.md`](NUTRITIONIST-USER-GUIDANCE.md) | Nutritionist-facing guidance — drafts, prompts, limits (#407) |
 | [`RELEASE-CHECKLIST.md`](RELEASE-CHECKLIST.md) | Production rollout gate before `AI_ENABLED=true` (#408) |
-| [`MCP-SERVER-ENDPOINT.md`](MCP-SERVER-ENDPOINT.md) | MCP transport, auth, tool surface (#392); descriptors via `McpToolDescriptorCatalog` (#393) |
+| [`MCP-SERVER-ENDPOINT.md`](MCP-SERVER-ENDPOINT.md) | MCP transport, auth, tool surface (#392–#395); `POST /mcp/nutriconsultas` |
 | [`AI-ASSISTANT-PLAN.md`](AI-ASSISTANT-PLAN.md) | Architecture, security, tools, milestones, definition of done |
 | [`../../ISSUE-AI-ASSISTANT.md`](../../ISSUE-AI-ASSISTANT.md) | GitHub issue registry (#360–#408) |
 | [`../../AI-ASSISTANT-WORKFLOW.md`](../../AI-ASSISTANT-WORKFLOW.md) | Agent implementation workflow |

--- a/docs/ai/RELEASE-CHECKLIST.md
+++ b/docs/ai/RELEASE-CHECKLIST.md
@@ -88,12 +88,15 @@ Run from repo root:
 ```bash
 mvn test -Dtest=AiSecurityGoldenPromptTest,AiUserMessageGuardTest,AiPromptThreatDetectorTest,\
 AiToolAllowlistTest,AiAssistantOutputValidatorTest,AiToolResultSanitizerTest,\
-AiRequestScopeGuardTest,AiBulkScopeGoldenPromptTest,AiDraftFlowIntegrationTest
+AiRequestScopeGuardTest,AiBulkScopeGoldenPromptTest,AiDraftFlowIntegrationTest,\
+McpSecurityReviewTest,McpToolDispatchServiceTest,McpNutriconsultasSecurityIntegrationTest,\
+McpAiDisabledSecurityIntegrationTest
 ```
 
 - [ ] All tests above pass on the release commit.
 - [ ] Full CI green on `main` (lint, Thymeleaf validation, SpotBugs, PMD).
 - [ ] IDOR: user A cannot read user B threads/drafts (`AiDraftFlowIntegrationTest`, `AiChatRestControllerTest`).
+- [ ] MCP: cross-tenant `threadId` denied; draft tools require thread; no destructive tools exposed (`McpSecurityReviewTest`, `McpNutriconsultasSecurityIntegrationTest`).
 - [ ] Golden prompts: no tool execution on injection/jailbreak/bulk abuse scenarios.
 
 **Reference:** [`SECURITY-GOLDEN-PROMPTS.md`](SECURITY-GOLDEN-PROMPTS.md) · [`BULK-SCOPE-GOLDEN-PROMPTS.md`](BULK-SCOPE-GOLDEN-PROMPTS.md)


### PR DESCRIPTION
## Summary
- Mark epic **#391** (MCP Phase 7) and the registered `[AI Assistant]` implementation track (#360–#450) as complete in registries
- Update `MCP-SERVER-ENDPOINT.md` to reflect shipped implementation (#393–#395)
- Add MCP security tests to `RELEASE-CHECKLIST.md` and local MCP curl example in `LOCAL-AI-SETUP.md`

## Test plan
- [x] Documentation-only change — no code changes
- [x] Registry rows aligned with merged PRs #486–#489

Closes #391

Made with [Cursor](https://cursor.com)