### PR TITLE
Resume widget AI chat in full /admin/ai page

### DIFF
--- a/src/main/resources/static/sbadmin/js/ai-assistant-widget.js
+++ b/src/main/resources/static/sbadmin/js/ai-assistant-widget.js
@@ -5,6 +5,7 @@
 
   var API_BASE = '/rest/nutritionist/ai/chat';
   var STORAGE_PREFIX = 'nutriconsultas.ai.widget.thread.';
+  var FULL_CHAT_THREAD_KEY = 'nutriconsultas.ai.threadId';
   var ASSISTANT_NAME = 'Mina';
   var WELCOME_MESSAGE = 'Hola, soy Mina';
 
@@ -180,6 +181,33 @@
     return STORAGE_PREFIX + scope;
   }
 
+  function fullChatBaseUrl() {
+    if (state.context && state.context.fullChatUrl) {
+      return state.context.fullChatUrl;
+    }
+    return '/admin/ai';
+  }
+
+  function updateOpenFullLink() {
+    var link = $('#aiAssistantOpenFull');
+    if (!link) {
+      return;
+    }
+    var base = fullChatBaseUrl();
+    if (state.threadId) {
+      var separator = base.indexOf('?') >= 0 ? '&' : '?';
+      link.href = base + separator + 'threadId=' + encodeURIComponent(String(state.threadId));
+    } else {
+      link.href = base;
+    }
+  }
+
+  function syncFullChatThreadStorage() {
+    if (state.threadId) {
+      sessionStorage.setItem(FULL_CHAT_THREAD_KEY, String(state.threadId));
+    }
+  }
+
   function persistThreadId(threadId) {
     state.threadId = threadId;
     if (threadId) {
@@ -187,6 +215,7 @@
     } else {
       sessionStorage.removeItem(storageKey());
     }
+    updateOpenFullLink();
   }
 
   function updateSendButton(busy) {
@@ -618,6 +647,10 @@
     if (newBtn) {
       newBtn.addEventListener('click', confirmNewConversation);
     }
+    var openFullLink = $('#aiAssistantOpenFull');
+    if (openFullLink) {
+      openFullLink.addEventListener('click', syncFullChatThreadStorage);
+    }
   }
 
   function init() {
@@ -629,7 +662,11 @@
     renderMessages();
     var stored = sessionStorage.getItem(storageKey());
     if (stored) {
+      state.threadId = Number(stored);
+      updateOpenFullLink();
       loadThread(Number(stored));
+    } else {
+      updateOpenFullLink();
     }
   }
 

--- a/src/main/resources/templates/sbadmin/fragments/ai-assistant-widget.html
+++ b/src/main/resources/templates/sbadmin/fragments/ai-assistant-widget.html
@@ -44,7 +44,8 @@
       patientId: /*[[${aiAssistantWidgetContext.patientId()}]]*/ null,
       dietaId: /*[[${aiAssistantWidgetContext.dietaId()}]]*/ null,
       platilloId: /*[[${aiAssistantWidgetContext.platilloId()}]]*/ null,
-      storageScopeKey: /*[[${aiAssistantWidgetContext.storageScopeKey()}]]*/ 'general'
+      storageScopeKey: /*[[${aiAssistantWidgetContext.storageScopeKey()}]]*/ 'general',
+      fullChatUrl: /*[[@{/admin/ai}]]*/ '/admin/ai'
     };
   </script>
   <script th:src="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.js}"></script>

--- a/src/test/java/com/nutriconsultas/ai/AiChatControllerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatControllerTest.java
@@ -48,6 +48,18 @@ class AiChatControllerTest {
 
 		assertThat(view).isEqualTo("sbadmin/ai/chat");
 		assertThat(model.getAttribute("activeMenu")).isEqualTo("ai");
+		assertThat(model.getAttribute("initialThreadId")).isNull();
+	}
+
+	@Test
+	void chatHomePassesInitialThreadIdWhenRequested() {
+		when(aiProperties.isEnabled()).thenReturn(true);
+		final ExtendedModelMap model = new ExtendedModelMap();
+
+		final String view = controller.chatHome(42L, model, principal());
+
+		assertThat(view).isEqualTo("sbadmin/ai/chat");
+		assertThat(model.getAttribute("initialThreadId")).isEqualTo(42L);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Update the widget "Abrir chat completo" link to include the active `threadId` query param when a conversation exists.
- Sync the full-chat sessionStorage key on click as a fallback for thread continuity.
- Expose `fullChatUrl` from the widget fragment so context paths resolve correctly.
- Add controller test coverage for `?threadId=` deep linking.

## Test plan
- [ ] Open AI widget on a patient or diet page and send a message.
- [ ] Click "Abrir chat completo" and confirm `/admin/ai?threadId=...` loads the same conversation and history.
- [ ] Start a new conversation in the widget and confirm the link returns to `/admin/ai` without a thread param.
- [ ] `mvn test -Dtest=AiChatControllerTest`


Made with [Cursor](https://cursor.com)