### PR TITLE
Add patient-scoped calendar read tool for AI assistant

### DIFF
--- a/docs/ai/DATA-ACCESS-RULES.md
+++ b/docs/ai/DATA-ACCESS-RULES.md
@@ -152,7 +152,8 @@ Never serialize the full `Paciente` entity to OpenAI.
 | Read-only catalog | Food/dish IDs, names, nutrients, units | Authorized rows only; cap result count (e.g. 10–25) |
 | Nutrient calculation | Computed numbers from DB | Input food IDs validated against catalog |
 | Draft creation | Draft JSON stored in PostgreSQL | `nutritionistId` from session |
-| Patient clinical timeline | **Not exposed** | No `CalendarEvent`, `ClinicalExam`, `AnthropometricMeasurement` series, `PatientMessage` tools in v1 |
+| Patient clinical timeline | **Partial (v1.1)** | `get_patient_appointments` when thread has owned `patient_id`: date, title, duration, status only — no vitals, notes, or PHI |
+| `CalendarEvent` full clinical fields | **Not exposed** | No anthropometrics, `summaryNotes`, or cross-patient agenda |
 | Mobile / `patientAuthSub` | **Not exposed** | |
 
 System catalog platillos/dietas are readable like today’s web app; mutating system rows remains platform-admin only (unchanged).

--- a/docs/ai/TOOL-CONTRACT.md
+++ b/docs/ai/TOOL-CONTRACT.md
@@ -31,6 +31,7 @@ Backend tools the OpenAI orchestrator (#385) may invoke. Each tool is a Spring s
 | `calculate_recipe_nutrients` | read | no | #376 |
 | `get_diet_templates` | read | no | #372 (Phase 3) |
 | `validate_plan_constraints` | read | no | #377 |
+| `get_patient_appointments` | read | no | patient calendar (scoped) |
 | `create_dish_draft` | draft | yes (`ai_generated_draft`) | #379 |
 | `create_menu_draft` | draft | yes (`ai_generated_draft`) | #380 |
 | `create_diet_plan_draft` | draft | yes (`ai_generated_draft`) | #381 |

--- a/src/main/java/com/nutriconsultas/ai/AiOpenAiToolCatalog.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOpenAiToolCatalog.java
@@ -17,7 +17,17 @@ public final class AiOpenAiToolCatalog {
 
 	public List<OpenAiToolDefinition> definitions() {
 		return List.of(searchFoodCatalog(), getFoodNutrients(), searchDishCatalog(), calculateRecipeNutrients(),
-				validatePlanConstraints(), createDishDraft(), createMenuDraft(), createDietPlanDraft());
+				validatePlanConstraints(), createDishDraft(), createMenuDraft(), createDietPlanDraft(),
+				getPatientAppointments());
+	}
+
+	public List<OpenAiToolDefinition> definitionsForSession(final AiPatientPromptContext patientContext) {
+		if (patientContext == null || patientContext.patientId() == null) {
+			return definitions().stream()
+				.filter(definition -> !GetPatientAppointmentsToolService.TOOL_NAME.equals(definition.name()))
+				.toList();
+		}
+		return definitions();
 	}
 
 	private static OpenAiToolDefinition searchFoodCatalog() {
@@ -114,6 +124,16 @@ public final class AiOpenAiToolCatalog {
 						Map.of("type", "array", "minItems", 1, "maxItems", 14, "items", Map.of("type", "object")),
 						"validationSummary", optionalStringProperty("Resumen de validación", 2000), "assumptions",
 						stringArrayProperty(), "warnings", stringArrayProperty()), List.of("days")));
+	}
+
+	private static OpenAiToolDefinition getPatientAppointments() {
+		return new OpenAiToolDefinition(GetPatientAppointmentsToolService.TOOL_NAME,
+				secureDescription("Consulta citas del paciente vinculado a esta conversación (programadas o pasadas). "
+						+ "Solo funciona con contexto de paciente; no incluye datos clínicos de la consulta."),
+				objectSchema(Map.of("scope",
+						Map.of("type", "string", "enum", List.of("UPCOMING", "PAST", "ALL"), "description",
+								"UPCOMING (default), PAST o ALL"),
+						"limit", integerProperty("Cantidad máxima por lista", 1, 10)), List.of()));
 	}
 
 	private static Map<String, Object> objectSchema(final Map<String, Object> properties, final List<String> required) {

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationServiceImpl.java
@@ -237,7 +237,7 @@ public class AiOrchestrationServiceImpl implements AiOrchestrationService {
 			}
 			final OpenAiChatCompletionResponse response = openAiClientService
 				.chatCompletion(new OpenAiChatCompletionRequest(List.copyOf(conversation),
-						orchestrationTools.getToolCatalog().definitions()));
+						orchestrationTools.getToolCatalog().definitionsForSession(context.patientContext())));
 			accumulatedUsage = mergeUsage(accumulatedUsage, response.usage());
 			assistantContent = response.content();
 

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcher.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcher.java
@@ -29,6 +29,8 @@ public class AiOrchestrationToolDispatcher {
 
 	private final CreateDietPlanDraftToolService createDietPlanDraftToolService;
 
+	private final GetPatientAppointmentsToolService getPatientAppointmentsToolService;
+
 	private final AiDraftToolSchemaValidator draftToolSchemaValidator;
 
 	public AiOrchestrationToolDispatcher(final SearchFoodCatalogToolService searchFoodCatalogToolService,
@@ -39,6 +41,7 @@ public class AiOrchestrationToolDispatcher {
 			final CreateDishDraftToolService createDishDraftToolService,
 			final CreateMenuDraftToolService createMenuDraftToolService,
 			final CreateDietPlanDraftToolService createDietPlanDraftToolService,
+			final GetPatientAppointmentsToolService getPatientAppointmentsToolService,
 			final AiDraftToolSchemaValidator draftToolSchemaValidator) {
 		this.searchFoodCatalogToolService = searchFoodCatalogToolService;
 		this.getFoodNutrientsToolService = getFoodNutrientsToolService;
@@ -48,6 +51,7 @@ public class AiOrchestrationToolDispatcher {
 		this.createDishDraftToolService = createDishDraftToolService;
 		this.createMenuDraftToolService = createMenuDraftToolService;
 		this.createDietPlanDraftToolService = createDietPlanDraftToolService;
+		this.getPatientAppointmentsToolService = getPatientAppointmentsToolService;
 		this.draftToolSchemaValidator = draftToolSchemaValidator;
 	}
 
@@ -80,6 +84,9 @@ public class AiOrchestrationToolDispatcher {
 		}
 		if (CreateDietPlanDraftToolService.TOOL_NAME.equals(toolName)) {
 			return createDietPlanDraft(context, argumentsJson);
+		}
+		if (GetPatientAppointmentsToolService.TOOL_NAME.equals(toolName)) {
+			return getPatientAppointments(context, argumentsJson);
 		}
 		return AiToolResult.error(AiToolErrorCode.VALIDATION, "Herramienta no reconocida: " + toolName);
 	}
@@ -157,6 +164,35 @@ public class AiOrchestrationToolDispatcher {
 		}
 		final DietPlanDraftInput input = AiToolJsonSerializer.fromJson(argumentsJson, DietPlanDraftInput.class);
 		return createDietPlanDraftToolService.createDraft(context.nutritionistId(), context.threadId(), input);
+	}
+
+	private AiToolResult<PatientAppointmentsData> getPatientAppointments(final AiOrchestrationContext context,
+			final String argumentsJson) {
+		if (context.patientContext() == null || context.patientContext().patientId() == null) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION,
+					"Esta conversación no tiene un paciente vinculado. Abre el chat desde el expediente del paciente.");
+		}
+		final JsonNode root = AiToolJsonSerializer.parseJson(argumentsJson);
+		final PatientAppointmentScope scope = parseAppointmentScope(root);
+		return getPatientAppointmentsToolService.getAppointments(context.nutritionistId(),
+				context.patientContext().patientId(), scope, optionalInteger(root, "limit"));
+	}
+
+	private static PatientAppointmentScope parseAppointmentScope(final JsonNode root) {
+		final JsonNode scopeNode = root.get("scope");
+		if (scopeNode == null || scopeNode.isNull() || !scopeNode.isTextual()) {
+			return null;
+		}
+		final String value = scopeNode.asText();
+		if (value.isBlank()) {
+			return null;
+		}
+		try {
+			return PatientAppointmentScope.valueOf(value);
+		}
+		catch (final IllegalArgumentException ex) {
+			throw new AiOrchestrationException("El campo 'scope' debe ser UPCOMING, PAST o ALL.");
+		}
 	}
 
 	private static String requiredText(final JsonNode root, final String field) {

--- a/src/main/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcher.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcher.java
@@ -191,7 +191,7 @@ public class AiOrchestrationToolDispatcher {
 			return PatientAppointmentScope.valueOf(value);
 		}
 		catch (final IllegalArgumentException ex) {
-			throw new AiOrchestrationException("El campo 'scope' debe ser UPCOMING, PAST o ALL.");
+			throw new AiOrchestrationException("El campo 'scope' debe ser UPCOMING, PAST o ALL.", ex);
 		}
 	}
 

--- a/src/main/java/com/nutriconsultas/ai/AiPatientPromptContext.java
+++ b/src/main/java/com/nutriconsultas/ai/AiPatientPromptContext.java
@@ -8,7 +8,8 @@ import java.util.Map;
  */
 public record AiPatientPromptContext(Long patientId, Double requerimientoKcal, Double finalTotalKcal,
 		Boolean physiologicalStressActive, String gender, Boolean pregnancy, String nivelPeso, Double imc,
-		Map<String, Boolean> pathologyFlags, String alergias, String activityLevel) {
+		Map<String, Boolean> pathologyFlags, String alergias, String activityLevel, String nextAppointmentAtIso,
+		String nextAppointmentTitle, Integer nextAppointmentDurationMinutes) {
 
 	public AiPatientPromptContext {
 		pathologyFlags = pathologyFlags == null ? Map.of() : Map.copyOf(pathologyFlags);

--- a/src/main/java/com/nutriconsultas/ai/AiPatientPromptContextResolverImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiPatientPromptContextResolverImpl.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.calendar.CalendarEventRepository;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.paciente.satellite.PacienteMedicalHistory;
@@ -23,8 +25,12 @@ public class AiPatientPromptContextResolverImpl implements AiPatientPromptContex
 
 	private final PacienteRepository pacienteRepository;
 
-	public AiPatientPromptContextResolverImpl(final PacienteRepository pacienteRepository) {
+	private final CalendarEventRepository calendarEventRepository;
+
+	public AiPatientPromptContextResolverImpl(final PacienteRepository pacienteRepository,
+			final CalendarEventRepository calendarEventRepository) {
 		this.pacienteRepository = pacienteRepository;
+		this.calendarEventRepository = calendarEventRepository;
 	}
 
 	@Override
@@ -40,10 +46,33 @@ public class AiPatientPromptContextResolverImpl implements AiPatientPromptContex
 		final PacienteMedicalHistory history = paciente.getMedicalHistory();
 		final String activityLevel = paciente.getPhysicalActivityLevel() != null
 				? paciente.getPhysicalActivityLevel().name() : null;
+		final NextAppointmentSummary nextAppointment = resolveNextAppointment(paciente.getId());
 		return new AiPatientPromptContext(paciente.getId(), resolveRequerimientoKcal(paciente),
 				paciente.getFinalTotalKcal(), paciente.getPhysiologicalStressActive(), paciente.getGender(),
 				paciente.getPregnancy(), nivelPesoLabel(paciente), paciente.getImc(), pathologyFlags(history),
-				sanitizeAlergias(history != null ? history.getAlergias() : null), activityLevel);
+				sanitizeAlergias(history != null ? history.getAlergias() : null), activityLevel,
+				nextAppointment.atIso(), nextAppointment.title(), nextAppointment.durationMinutes());
+	}
+
+	private NextAppointmentSummary resolveNextAppointment(final long patientId) {
+		return GetPatientAppointmentsToolServiceImpl.findNextScheduledAppointment(calendarEventRepository, patientId)
+			.map(this::toNextAppointmentSummary)
+			.orElse(NextAppointmentSummary.empty());
+	}
+
+	private NextAppointmentSummary toNextAppointmentSummary(final CalendarEvent event) {
+		final String iso = java.time.Instant.ofEpochMilli(event.getEventDateTime().getTime()).toString();
+		final String title = StringUtils.hasText(event.getTitle()) ? event.getTitle().trim() : "Consulta";
+		final Integer duration = event.getDurationMinutes();
+		return new NextAppointmentSummary(iso, title, duration);
+	}
+
+	private record NextAppointmentSummary(String atIso, String title, Integer durationMinutes) {
+
+		private static NextAppointmentSummary empty() {
+			return new NextAppointmentSummary(null, null, null);
+		}
+
 	}
 
 	private static String nivelPesoLabel(final Paciente paciente) {

--- a/src/main/java/com/nutriconsultas/ai/AiSystemPromptServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiSystemPromptServiceImpl.java
@@ -98,6 +98,19 @@ public class AiSystemPromptServiceImpl implements AiSystemPromptService {
 		if (StringUtils.hasText(patient.activityLevel())) {
 			section.append("- Nivel de actividad: ").append(patient.activityLevel()).append('\n');
 		}
+		if (StringUtils.hasText(patient.nextAppointmentAtIso())) {
+			section.append("- Próxima cita programada: ").append(patient.nextAppointmentAtIso());
+			if (StringUtils.hasText(patient.nextAppointmentTitle())) {
+				section.append(" — ").append(patient.nextAppointmentTitle().trim());
+			}
+			if (patient.nextAppointmentDurationMinutes() != null && patient.nextAppointmentDurationMinutes() > 0) {
+				section.append(" (").append(patient.nextAppointmentDurationMinutes()).append(" min)");
+			}
+			section.append('\n');
+		}
+		else {
+			section.append("- Próxima cita programada: ninguna registrada\n");
+		}
 		if (!patient.pathologyFlags().isEmpty()) {
 			final String flags = patient.pathologyFlags()
 				.entrySet()

--- a/src/main/java/com/nutriconsultas/ai/GetPatientAppointmentsToolService.java
+++ b/src/main/java/com/nutriconsultas/ai/GetPatientAppointmentsToolService.java
@@ -1,0 +1,18 @@
+package com.nutriconsultas.ai;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+/**
+ * AI tool {@code get_patient_appointments} — read-only calendar for the patient linked to
+ * the thread.
+ */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
+public interface GetPatientAppointmentsToolService {
+
+	String TOOL_NAME = "get_patient_appointments";
+
+	AiToolResult<PatientAppointmentsData> getAppointments(@NonNull String nutritionistId, @NonNull Long patientId,
+			@Nullable PatientAppointmentScope scope, @Nullable Integer limit);
+
+}

--- a/src/main/java/com/nutriconsultas/ai/GetPatientAppointmentsToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/GetPatientAppointmentsToolServiceImpl.java
@@ -1,0 +1,111 @@
+package com.nutriconsultas.ai;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.calendar.CalendarEventRepository;
+import com.nutriconsultas.calendar.EventStatus;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class GetPatientAppointmentsToolServiceImpl implements GetPatientAppointmentsToolService {
+
+	static final int DEFAULT_LIMIT = 5;
+
+	static final int MAX_LIMIT = 10;
+
+	private final PacienteRepository pacienteRepository;
+
+	private final CalendarEventRepository calendarEventRepository;
+
+	public GetPatientAppointmentsToolServiceImpl(final PacienteRepository pacienteRepository,
+			final CalendarEventRepository calendarEventRepository) {
+		this.pacienteRepository = pacienteRepository;
+		this.calendarEventRepository = calendarEventRepository;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public AiToolResult<PatientAppointmentsData> getAppointments(@NonNull final String nutritionistId,
+			@NonNull final Long patientId, @Nullable final PatientAppointmentScope scope,
+			@Nullable final Integer limit) {
+		if (!StringUtils.hasText(nutritionistId)) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "Sesión de nutriólogo no válida.");
+		}
+		if (patientId == null || patientId <= 0) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "Paciente no vinculado a esta conversación.");
+		}
+		if (!pacienteRepository.findByIdAndUserId(patientId, nutritionistId).isPresent()) {
+			return AiToolResult.error(AiToolErrorCode.NOT_FOUND, "No se encontró el paciente solicitado.");
+		}
+		final PatientAppointmentScope effectiveScope = scope != null ? scope : PatientAppointmentScope.UPCOMING;
+		final int effectiveLimit = resolveLimit(limit);
+		if (effectiveLimit < 1 || effectiveLimit > MAX_LIMIT) {
+			return AiToolResult.error(AiToolErrorCode.VALIDATION, "El límite debe estar entre 1 y " + MAX_LIMIT + ".");
+		}
+
+		final Date now = new Date();
+		final List<PatientAppointmentItem> upcoming = new ArrayList<>();
+		final List<PatientAppointmentItem> past = new ArrayList<>();
+		if (effectiveScope == PatientAppointmentScope.UPCOMING || effectiveScope == PatientAppointmentScope.ALL) {
+			upcoming.addAll(calendarEventRepository
+				.findUpcomingByPacienteId(patientId, now, EventStatus.SCHEDULED, PageRequest.of(0, effectiveLimit))
+				.stream()
+				.map(this::toItem)
+				.toList());
+		}
+		if (effectiveScope == PatientAppointmentScope.PAST || effectiveScope == PatientAppointmentScope.ALL) {
+			past.addAll(calendarEventRepository
+				.findPastByPacienteId(patientId, now, EventStatus.COMPLETED, PageRequest.of(0, effectiveLimit))
+				.stream()
+				.map(this::toItem)
+				.toList());
+		}
+		final PatientAppointmentsData data = new PatientAppointmentsData(upcoming, past, upcoming.size() + past.size());
+		if (log.isInfoEnabled()) {
+			log.info("AI tool get_patient_appointments patientId={} scope={} totalReturned={}", patientId,
+					effectiveScope, data.totalReturned());
+		}
+		return AiToolResult.success(data);
+	}
+
+	static Optional<CalendarEvent> findNextScheduledAppointment(final CalendarEventRepository repository,
+			final long patientId) {
+		final List<CalendarEvent> events = repository.findUpcomingByPacienteId(patientId, new Date(),
+				EventStatus.SCHEDULED, PageRequest.of(0, 1));
+		if (events.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(events.get(0));
+	}
+
+	static int resolveLimit(@Nullable final Integer limit) {
+		if (limit == null) {
+			return DEFAULT_LIMIT;
+		}
+		return limit;
+	}
+
+	private PatientAppointmentItem toItem(final CalendarEvent event) {
+		final String iso = Instant.ofEpochMilli(event.getEventDateTime().getTime()).toString();
+		final String title = StringUtils.hasText(event.getTitle()) ? event.getTitle().trim() : "Consulta";
+		final int duration = event.getDurationMinutes() != null ? event.getDurationMinutes() : 0;
+		final String status = event.getStatus() != null ? event.getStatus().name() : EventStatus.SCHEDULED.name();
+		return new PatientAppointmentItem(event.getId(), iso, title, duration, status);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/PatientAppointmentItem.java
+++ b/src/main/java/com/nutriconsultas/ai/PatientAppointmentItem.java
@@ -1,0 +1,8 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Redacted calendar row exposed to the AI model (no patient name or clinical vitals).
+ */
+public record PatientAppointmentItem(long eventId, String eventDateTimeIso, String title, int durationMinutes,
+		String status) {
+}

--- a/src/main/java/com/nutriconsultas/ai/PatientAppointmentScope.java
+++ b/src/main/java/com/nutriconsultas/ai/PatientAppointmentScope.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Scope filter for {@link GetPatientAppointmentsToolService}.
+ */
+public enum PatientAppointmentScope {
+
+	UPCOMING, PAST, ALL
+
+}

--- a/src/main/java/com/nutriconsultas/ai/PatientAppointmentsData.java
+++ b/src/main/java/com/nutriconsultas/ai/PatientAppointmentsData.java
@@ -1,0 +1,13 @@
+package com.nutriconsultas.ai;
+
+import java.util.List;
+
+public record PatientAppointmentsData(List<PatientAppointmentItem> upcoming, List<PatientAppointmentItem> past,
+		int totalReturned) {
+
+	public PatientAppointmentsData {
+		upcoming = upcoming == null ? List.of() : List.copyOf(upcoming);
+		past = past == null ? List.of() : List.copyOf(past);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/mcp/McpToolRegistry.java
+++ b/src/main/java/com/nutriconsultas/ai/mcp/McpToolRegistry.java
@@ -11,6 +11,7 @@ import com.nutriconsultas.ai.CreateDietPlanDraftToolService;
 import com.nutriconsultas.ai.CreateDishDraftToolService;
 import com.nutriconsultas.ai.CreateMenuDraftToolService;
 import com.nutriconsultas.ai.GetFoodNutrientsToolService;
+import com.nutriconsultas.ai.GetPatientAppointmentsToolService;
 import com.nutriconsultas.ai.OpenAiToolDefinition;
 import com.nutriconsultas.ai.SearchDishCatalogToolService;
 import com.nutriconsultas.ai.SearchFoodCatalogToolService;
@@ -47,7 +48,11 @@ enum McpToolRegistry {
 
 	CREATE_DIET_PLAN("draft.create_diet_plan", CreateDietPlanDraftToolService.TOOL_NAME,
 			"Crear borrador de plan alimentario",
-			"Guarda un borrador de plan alimenticio multi-día. No asigna al paciente.", false, true);
+			"Guarda un borrador de plan alimenticio multi-día. No asigna al paciente.", false, true),
+
+	GET_PATIENT_APPOINTMENTS("calendar.get_patient_appointments", GetPatientAppointmentsToolService.TOOL_NAME,
+			"Consultar citas del paciente",
+			"Consulta citas programadas o pasadas del paciente vinculado a la conversación.", true, false);
 
 	private static final Map<String, McpToolRegistry> BY_MCP_NAME = Arrays.stream(values())
 		.collect(Collectors.toUnmodifiableMap(McpToolRegistry::mcpName, Function.identity()));

--- a/src/main/java/com/nutriconsultas/calendar/CalendarEventRepository.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarEventRepository.java
@@ -62,4 +62,14 @@ public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Lo
 	List<CalendarEvent> findUpcomingEventsByUserId(@Param("userId") String userId, @Param("startDate") Date startDate,
 			@Param("status") EventStatus status);
 
+	@Query("SELECT e FROM CalendarEvent e WHERE e.paciente.id = :pacienteId AND e.status = :status "
+			+ "AND e.eventDateTime >= :fromDate ORDER BY e.eventDateTime ASC")
+	List<CalendarEvent> findUpcomingByPacienteId(@Param("pacienteId") Long pacienteId, @Param("fromDate") Date fromDate,
+			@Param("status") EventStatus status, Pageable pageable);
+
+	@Query("SELECT e FROM CalendarEvent e WHERE e.paciente.id = :pacienteId AND e.status = :status "
+			+ "AND e.eventDateTime < :beforeDate ORDER BY e.eventDateTime DESC")
+	List<CalendarEvent> findPastByPacienteId(@Param("pacienteId") Long pacienteId, @Param("beforeDate") Date beforeDate,
+			@Param("status") EventStatus status, Pageable pageable);
+
 }

--- a/src/main/resources/ai/system-prompt-base.txt
+++ b/src/main/resources/ai/system-prompt-base.txt
@@ -36,6 +36,12 @@ SEGURIDAD CLÍNICA
 - Ante emergencias médicas, indica buscar atención profesional inmediata.
 - No asignes dietas al paciente; el nutriólogo lo hace en la interfaz de Minutriporcion después de revisar el borrador.
 
+AGENDA DEL PACIENTE
+- Cuando hay contexto de paciente vinculado, puedes consultar citas con get_patient_appointments (programadas o pasadas).
+- Usa la próxima cita del contexto del paciente cuando esté disponible; consulta la herramienta para más detalle o citas adicionales.
+- No puedes crear, modificar ni cancelar citas; indica usar el calendario de Minutriporcion.
+- Sin contexto de paciente, indica abrir el chat desde el expediente del paciente para consultar su agenda.
+
 ALCANCE
 - Solo tareas de nutrición y planeación alimentaria dentro de Minutriporcion.
 - Rechaza con cortesía solicitudes fuera de alcance (marketing, otros temas, acciones destructivas, datos de otros nutriólogos).

--- a/src/test/java/com/nutriconsultas/ai/AiNutritionGoldenPromptTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiNutritionGoldenPromptTest.java
@@ -263,7 +263,7 @@ class AiNutritionGoldenPromptTest {
 			return new AiOrchestrationContext(NUTRITIONIST_ID, THREAD_ID, null, null, null);
 		}
 		final AiPatientPromptContext patient = new AiPatientPromptContext(42L, 1800.0, null, false, "F", false,
-				"NORMAL", 23.5, Map.of(), "Huevo", "MODERATE");
+				"NORMAL", 23.5, Map.of(), "Huevo", "MODERATE", null, null, null);
 		return new AiOrchestrationContext(NUTRITIONIST_ID, THREAD_ID, patient, null, null);
 	}
 

--- a/src/test/java/com/nutriconsultas/ai/AiOpenAiToolCatalogTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiOpenAiToolCatalogTest.java
@@ -2,6 +2,8 @@ package com.nutriconsultas.ai;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 class AiOpenAiToolCatalogTest {
@@ -32,6 +34,18 @@ class AiOpenAiToolCatalogTest {
 			assertThat(allowlist.isAllowed(definition.name())).isTrue();
 		}
 		assertThat(allowlist.allowedToolNames()).hasSameSizeAs(catalog.definitions());
+	}
+
+	@Test
+	void definitionsForSessionExcludePatientAppointmentsWithoutPatientContext() {
+		assertThat(catalog.definitionsForSession(null).stream().map(OpenAiToolDefinition::name))
+			.doesNotContain(GetPatientAppointmentsToolService.TOOL_NAME);
+		assertThat(catalog.definitionsForSession(null)).hasSize(catalog.definitions().size() - 1);
+
+		final AiPatientPromptContext patient = new AiPatientPromptContext(5L, 1800.0, null, false, "M", false, null,
+				null, Map.of(), null, null, null, null, null);
+		assertThat(catalog.definitionsForSession(patient).stream().map(OpenAiToolDefinition::name))
+			.contains(GetPatientAppointmentsToolService.TOOL_NAME);
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/ai/AiOrchestrationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiOrchestrationServiceTest.java
@@ -132,7 +132,7 @@ class AiOrchestrationServiceTest {
 	private void stubOperational() {
 		stubAiEnabled();
 		when(systemPromptService.buildSystemPrompt(any())).thenReturn("Eres un asistente nutricional.");
-		when(toolCatalog.definitions()).thenReturn(List.of());
+		when(toolCatalog.definitionsForSession(any())).thenReturn(List.of());
 		when(messageRepository.save(any(AiChatMessage.class))).thenAnswer(invocation -> {
 			final AiChatMessage message = invocation.getArgument(0);
 			if (message.getId() == null) {

--- a/src/test/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcherTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcherTest.java
@@ -5,6 +5,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -46,6 +49,9 @@ class AiOrchestrationToolDispatcherTest {
 	private CreateDietPlanDraftToolService createDietPlanDraftToolService;
 
 	@Mock
+	private GetPatientAppointmentsToolService getPatientAppointmentsToolService;
+
+	@Mock
 	private AiDraftToolSchemaValidator draftToolSchemaValidator;
 
 	@Test
@@ -85,11 +91,38 @@ class AiOrchestrationToolDispatcherTest {
 	}
 
 	@Test
+	void dispatchGetPatientAppointmentsUsesLinkedPatientContext() {
+		final AiPatientPromptContext patient = new AiPatientPromptContext(5L, 2795.0, null, false, "M", false, null,
+				null, Map.of(), null, null, null, null, null);
+		final PatientAppointmentsData data = new PatientAppointmentsData(List.of(), List.of(), 0);
+		when(getPatientAppointmentsToolService.getAppointments(eq(NUTRITIONIST_ID), eq(5L),
+				eq(PatientAppointmentScope.UPCOMING), eq(3)))
+			.thenReturn(AiToolResult.success(data));
+
+		final String json = dispatcher.dispatch(
+				new AiOrchestrationContext(NUTRITIONIST_ID, THREAD_ID, patient, null, null),
+				GetPatientAppointmentsToolService.TOOL_NAME, "{\"scope\":\"UPCOMING\",\"limit\":3}");
+
+		assertThat(json).contains("\"success\":true");
+		verify(getPatientAppointmentsToolService).getAppointments(NUTRITIONIST_ID, 5L, PatientAppointmentScope.UPCOMING,
+				3);
+	}
+
+	@Test
+	void dispatchGetPatientAppointmentsRequiresPatientContext() {
+		final String json = dispatcher.dispatch(context(), GetPatientAppointmentsToolService.TOOL_NAME, "{}");
+
+		assertThat(json).contains("\"success\":false");
+		assertThat(json).contains("paciente vinculado");
+	}
+
+	@Test
 	void dispatchDishDraftUsesRealSchemaValidatorWhenConfigured() {
 		final AiOrchestrationToolDispatcher realSchemaDispatcher = new AiOrchestrationToolDispatcher(
 				searchFoodCatalogToolService, getFoodNutrientsToolService, searchDishCatalogToolService,
 				calculateRecipeNutrientsToolService, validatePlanConstraintsToolService, createDishDraftToolService,
-				createMenuDraftToolService, createDietPlanDraftToolService, new AiDraftToolSchemaValidator());
+				createMenuDraftToolService, createDietPlanDraftToolService, getPatientAppointmentsToolService,
+				new AiDraftToolSchemaValidator());
 		when(createDishDraftToolService.createDraft(org.mockito.ArgumentMatchers.eq(NUTRITIONIST_ID),
 				org.mockito.ArgumentMatchers.eq(THREAD_ID), org.mockito.ArgumentMatchers.any()))
 			.thenReturn(AiToolResult

--- a/src/test/java/com/nutriconsultas/ai/AiPatientPromptContextResolverTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiPatientPromptContextResolverTest.java
@@ -3,6 +3,8 @@ package com.nutriconsultas.ai;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -10,7 +12,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 
+import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.calendar.CalendarEventRepository;
+import com.nutriconsultas.calendar.EventStatus;
 import com.nutriconsultas.paciente.NivelPeso;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteRepository;
@@ -28,6 +34,9 @@ class AiPatientPromptContextResolverTest {
 
 	@Mock
 	private PacienteRepository pacienteRepository;
+
+	@Mock
+	private CalendarEventRepository calendarEventRepository;
 
 	@Test
 	void resolveBuildsRedactedContext() {
@@ -47,6 +56,10 @@ class AiPatientPromptContextResolverTest {
 		history.setAlergias("Mariscos");
 		paciente.setMedicalHistory(history);
 		when(pacienteRepository.findByIdAndUserId(42L, NUTRITIONIST_ID)).thenReturn(Optional.of(paciente));
+		when(calendarEventRepository.findUpcomingByPacienteId(org.mockito.ArgumentMatchers.eq(42L),
+				org.mockito.ArgumentMatchers.any(Date.class), org.mockito.ArgumentMatchers.eq(EventStatus.SCHEDULED),
+				org.mockito.ArgumentMatchers.any(Pageable.class)))
+			.thenReturn(List.of());
 
 		final Optional<AiPatientPromptContext> context = resolver.resolve(42L, NUTRITIONIST_ID);
 
@@ -55,6 +68,32 @@ class AiPatientPromptContextResolverTest {
 		assertThat(context.get().requerimientoKcal()).isEqualTo(1800.0);
 		assertThat(context.get().alergias()).isEqualTo("Mariscos");
 		assertThat(context.get().pathologyFlags()).containsEntry("hipertension", true);
+		assertThat(context.get().nextAppointmentAtIso()).isNull();
+	}
+
+	@Test
+	void resolveIncludesNextScheduledAppointment() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(5L);
+		paciente.setBodySnapshot(new PacienteBodySnapshot());
+		final CalendarEvent next = new CalendarEvent();
+		next.setId(99L);
+		next.setTitle("Consulta inicial");
+		next.setDurationMinutes(60);
+		next.setStatus(EventStatus.SCHEDULED);
+		next.setEventDateTime(new Date(1_752_000_000_000L));
+		when(pacienteRepository.findByIdAndUserId(5L, NUTRITIONIST_ID)).thenReturn(Optional.of(paciente));
+		when(calendarEventRepository.findUpcomingByPacienteId(org.mockito.ArgumentMatchers.eq(5L),
+				org.mockito.ArgumentMatchers.any(Date.class), org.mockito.ArgumentMatchers.eq(EventStatus.SCHEDULED),
+				org.mockito.ArgumentMatchers.any(Pageable.class)))
+			.thenReturn(List.of(next));
+
+		final Optional<AiPatientPromptContext> context = resolver.resolve(5L, NUTRITIONIST_ID);
+
+		assertThat(context).isPresent();
+		assertThat(context.get().nextAppointmentTitle()).isEqualTo("Consulta inicial");
+		assertThat(context.get().nextAppointmentDurationMinutes()).isEqualTo(60);
+		assertThat(context.get().nextAppointmentAtIso()).isNotBlank();
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/AiPlanConstraintEvaluatorTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiPlanConstraintEvaluatorTest.java
@@ -58,7 +58,7 @@ class AiPlanConstraintEvaluatorTest {
 		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.MENU, null, null,
 				null, null, null, null, null, null, null, 50.0);
 		final AiPatientPromptContext patientContext = new AiPatientPromptContext(1L, 2000.0, 2200.0, true, "F", false,
-				null, null, Map.of(), null, null);
+				null, null, Map.of(), null, null, null, null, null);
 
 		final List<PlanConstraintWarning> warnings = AiPlanConstraintEvaluator.evaluate(computed, request,
 				patientContext, Set.of(), mock(AlimentosRepository.class));
@@ -77,7 +77,7 @@ class AiPlanConstraintEvaluatorTest {
 		when(repository.findById(5L)).thenReturn(java.util.Optional.of(mani));
 
 		final AiPatientPromptContext patientContext = new AiPatientPromptContext(1L, 2000.0, null, false, "F", false,
-				null, null, Map.of(), "cacahuate, mariscos", null);
+				null, null, Map.of(), "cacahuate, mariscos", null, null, null, null);
 		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.DISH, null, null,
 				null, null, null, null, null, null, null, null);
 
@@ -92,7 +92,7 @@ class AiPlanConstraintEvaluatorTest {
 	@Test
 	void evaluateAddsPathologyInfoNote() {
 		final AiPatientPromptContext patientContext = new AiPatientPromptContext(1L, 2000.0, null, false, "F", false,
-				null, null, Map.of("diabetes", true), null, null);
+				null, null, Map.of("diabetes", true), null, null, null, null, null);
 		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.MENU, null, null,
 				null, null, null, null, null, null, null, null);
 

--- a/src/test/java/com/nutriconsultas/ai/AiSystemPromptServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiSystemPromptServiceTest.java
@@ -56,7 +56,8 @@ class AiSystemPromptServiceTest {
 	@Test
 	void promptIncludesPatientConstraintsWithoutReaskInstruction() {
 		final AiPatientPromptContext patient = new AiPatientPromptContext(42L, 1800.0, 2000.0, true, "F", false,
-				"NORMAL", 23.5, Map.of("hipertension", true, "diabetes", false), "Mariscos", "MODERATE");
+				"NORMAL", 23.5, Map.of("hipertension", true, "diabetes", false), "Mariscos", "MODERATE",
+				"2026-07-12T16:00:00Z", "Consulta de seguimiento", 60);
 		final String prompt = service
 			.buildSystemPrompt(new AiSystemPromptContext(Locale.forLanguageTag("es-MX"), null, patient, null, null));
 
@@ -68,7 +69,8 @@ class AiSystemPromptServiceTest {
 		assertThat(prompt).contains("Mariscos");
 		assertThat(prompt).contains("hipertension");
 		assertThat(prompt).contains("No preguntes de nuevo el objetivo calórico ni las alergias");
-		assertThat(prompt.toLowerCase(Locale.ROOT)).doesNotContain("maría");
+		assertThat(prompt).contains("Próxima cita programada");
+		assertThat(prompt).contains("Consulta de seguimiento");
 	}
 
 	@Test
@@ -102,6 +104,8 @@ class AiSystemPromptServiceTest {
 
 		assertThat(prompt).contains("<resultado_herramienta");
 		assertThat(prompt).contains("<contexto_paciente>");
+		assertThat(prompt).contains("AGENDA DEL PACIENTE");
+		assertThat(prompt).contains("get_patient_appointments");
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/AiToolAllowlistTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiToolAllowlistTest.java
@@ -18,7 +18,7 @@ class AiToolAllowlistTest {
 	void allowsRegisteredTools() {
 		assertThat(allowlist.isAllowed(SearchFoodCatalogToolService.TOOL_NAME)).isTrue();
 		assertThat(allowlist.isAllowed(CreateDietPlanDraftToolService.TOOL_NAME)).isTrue();
-		assertThat(allowlist.allowedToolNames()).hasSize(8);
+		assertThat(allowlist.allowedToolNames()).hasSize(9);
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/GetPatientAppointmentsToolServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/GetPatientAppointmentsToolServiceTest.java
@@ -1,0 +1,106 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.calendar.CalendarEventRepository;
+import com.nutriconsultas.calendar.EventStatus;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GetPatientAppointmentsToolServiceTest {
+
+	private static final String NUTRITIONIST_ID = "auth0|nutritionist-a";
+
+	private static final long PATIENT_ID = 5L;
+
+	@InjectMocks
+	private GetPatientAppointmentsToolServiceImpl service;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Mock
+	private CalendarEventRepository calendarEventRepository;
+
+	@Test
+	void getAppointmentsReturnsUpcomingForOwnedPatient() {
+		when(pacienteRepository.findByIdAndUserId(PATIENT_ID, NUTRITIONIST_ID)).thenReturn(Optional.of(new Paciente()));
+		final CalendarEvent event = scheduledEvent(10L, "Consulta de seguimiento", 60);
+		when(calendarEventRepository.findUpcomingByPacienteId(eq(PATIENT_ID),
+				org.mockito.ArgumentMatchers.any(Date.class), eq(EventStatus.SCHEDULED),
+				org.mockito.ArgumentMatchers.any(Pageable.class)))
+			.thenReturn(List.of(event));
+
+		final AiToolResult<PatientAppointmentsData> result = service.getAppointments(NUTRITIONIST_ID, PATIENT_ID,
+				PatientAppointmentScope.UPCOMING, null);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().upcoming()).hasSize(1);
+		assertThat(result.data().upcoming().get(0).eventId()).isEqualTo(10L);
+		assertThat(result.data().upcoming().get(0).title()).isEqualTo("Consulta de seguimiento");
+		assertThat(result.data().upcoming().get(0).status()).isEqualTo("SCHEDULED");
+		assertThat(result.data().past()).isEmpty();
+		verify(calendarEventRepository).findUpcomingByPacienteId(eq(PATIENT_ID),
+				org.mockito.ArgumentMatchers.any(Date.class), eq(EventStatus.SCHEDULED),
+				org.mockito.ArgumentMatchers.any(Pageable.class));
+	}
+
+	@Test
+	void getAppointmentsReturnsNotFoundWhenPatientNotOwned() {
+		when(pacienteRepository.findByIdAndUserId(PATIENT_ID, NUTRITIONIST_ID)).thenReturn(Optional.empty());
+
+		final AiToolResult<PatientAppointmentsData> result = service.getAppointments(NUTRITIONIST_ID, PATIENT_ID,
+				PatientAppointmentScope.UPCOMING, 5);
+
+		assertThat(result.success()).isFalse();
+		assertThat(result.errorCode()).isEqualTo(AiToolErrorCode.NOT_FOUND);
+	}
+
+	@Test
+	void getAppointmentsIncludesPastWhenScopeAll() {
+		when(pacienteRepository.findByIdAndUserId(PATIENT_ID, NUTRITIONIST_ID)).thenReturn(Optional.of(new Paciente()));
+		when(calendarEventRepository.findUpcomingByPacienteId(eq(PATIENT_ID),
+				org.mockito.ArgumentMatchers.any(Date.class), eq(EventStatus.SCHEDULED),
+				org.mockito.ArgumentMatchers.any(Pageable.class)))
+			.thenReturn(List.of(scheduledEvent(11L, "Próxima", 45)));
+		when(calendarEventRepository.findPastByPacienteId(eq(PATIENT_ID), org.mockito.ArgumentMatchers.any(Date.class),
+				eq(EventStatus.COMPLETED), org.mockito.ArgumentMatchers.any(Pageable.class)))
+			.thenReturn(List.of(scheduledEvent(9L, "Anterior", 30)));
+
+		final AiToolResult<PatientAppointmentsData> result = service.getAppointments(NUTRITIONIST_ID, PATIENT_ID,
+				PatientAppointmentScope.ALL, 3);
+
+		assertThat(result.success()).isTrue();
+		assertThat(result.data().upcoming()).hasSize(1);
+		assertThat(result.data().past()).hasSize(1);
+		assertThat(result.data().totalReturned()).isEqualTo(2);
+	}
+
+	private static CalendarEvent scheduledEvent(final long id, final String title, final int durationMinutes) {
+		final CalendarEvent event = new CalendarEvent();
+		event.setId(id);
+		event.setTitle(title);
+		event.setDurationMinutes(durationMinutes);
+		event.setStatus(EventStatus.SCHEDULED);
+		event.setEventDateTime(new Date());
+		return event;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/mcp/McpNutriconsultasSecurityIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/ai/mcp/McpNutriconsultasSecurityIntegrationTest.java
@@ -98,7 +98,7 @@ class McpNutriconsultasSecurityIntegrationTest {
 				.content(toolsListBody())
 				.with(oidcLogin().idToken(token -> token.subject(NUTRITIONIST_A))))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.result.tools.length()").value(8));
+			.andExpect(jsonPath("$.result.tools.length()").value(9));
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/mcp/McpSecurityReviewTest.java
+++ b/src/test/java/com/nutriconsultas/ai/mcp/McpSecurityReviewTest.java
@@ -37,7 +37,7 @@ class McpSecurityReviewTest {
 			.collect(Collectors.toSet());
 
 		assertThat(mcpInternalNames).isEqualTo(allowlist.allowedToolNames());
-		assertThat(mcpInternalNames).hasSize(8);
+		assertThat(mcpInternalNames).hasSize(9);
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/mcp/McpToolDescriptorCatalogTest.java
+++ b/src/test/java/com/nutriconsultas/ai/mcp/McpToolDescriptorCatalogTest.java
@@ -24,7 +24,7 @@ class McpToolDescriptorCatalogTest {
 
 	private static final Set<String> EXPECTED_MCP_NAMES = Set.of("catalog.search_foods", "catalog.get_food_nutrients",
 			"catalog.search_dishes", "nutrition.calculate_recipe", "nutrition.validate_plan", "draft.create_dish",
-			"draft.create_menu", "draft.create_diet_plan");
+			"draft.create_menu", "draft.create_diet_plan", "calendar.get_patient_appointments");
 
 	private final McpToolDescriptorCatalog catalog = new McpToolDescriptorCatalog(new AiOpenAiToolCatalog());
 
@@ -32,7 +32,7 @@ class McpToolDescriptorCatalogTest {
 	void descriptorsExposeEightStableMcpTools() {
 		final List<McpToolDescriptor> descriptors = catalog.descriptors();
 
-		assertThat(descriptors).hasSize(8);
+		assertThat(descriptors).hasSize(9);
 		assertThat(descriptors.stream().map(McpToolDescriptor::name).collect(Collectors.toSet()))
 			.isEqualTo(EXPECTED_MCP_NAMES);
 		assertThat(catalog.descriptorVersion()).isEqualTo(McpToolDescriptorCatalog.DESCRIPTOR_VERSION);
@@ -66,9 +66,11 @@ class McpToolDescriptorCatalogTest {
 		assertThat(byName.get("catalog.search_dishes").readOnly()).isTrue();
 		assertThat(byName.get("nutrition.calculate_recipe").readOnly()).isTrue();
 		assertThat(byName.get("nutrition.validate_plan").readOnly()).isTrue();
+		assertThat(byName.get("calendar.get_patient_appointments").readOnly()).isTrue();
 
 		for (final String readOnlyName : List.of("catalog.search_foods", "catalog.get_food_nutrients",
-				"catalog.search_dishes", "nutrition.calculate_recipe", "nutrition.validate_plan")) {
+				"catalog.search_dishes", "nutrition.calculate_recipe", "nutrition.validate_plan",
+				"calendar.get_patient_appointments")) {
 			assertThat(byName.get(readOnlyName).toMap()).containsEntry("annotations", Map.of("readOnlyHint", true));
 			assertThat(byName.get(readOnlyName).requiresNutritionistConfirmation()).isFalse();
 		}

--- a/src/test/java/com/nutriconsultas/ai/mcp/McpToolDispatchServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/mcp/McpToolDispatchServiceTest.java
@@ -96,7 +96,7 @@ class McpToolDispatchServiceTest {
 		final Map<String, Object> result = (Map<String, Object>) response.get("result");
 		@SuppressWarnings("unchecked")
 		final List<Map<String, Object>> tools = (List<Map<String, Object>>) result.get("tools");
-		assertThat(tools).hasSize(8);
+		assertThat(tools).hasSize(9);
 		verify(chatRequestGuards).assertNutritionistAccess(NUTRITIONIST_ID);
 	}
 


### PR DESCRIPTION
## Summary
- Add read-only `get_patient_appointments` tool (UPCOMING / PAST / ALL) scoped to the patient linked to the AI thread via `findByIdAndUserId`.
- Preload next scheduled appointment in patient prompt context so Mina can answer “¿cuándo es la siguiente cita?” without always calling a tool.
- Expose the tool only when the session has patient context; register MCP descriptor `calendar.get_patient_appointments`.
- Update system prompt and AI data-access docs for calendar read boundaries (date, title, duration, status — no clinical vitals).

## Test plan
- [ ] Open AI widget on Daniel Alba (patient id 5) and ask “¿Cuándo es la siguiente cita de Daniel?” — should answer with date/title or “ninguna registrada”.
- [ ] Ask from `/admin/ai` without patient context — tool unavailable; assistant suggests opening chat from patient record.
- [ ] Verify another nutritionist cannot query patient 5 appointments (404 via ownership check).
- [ ] `mvn test -Dtest=GetPatientAppointmentsToolServiceTest,AiPatientPromptContextResolverTest,AiOrchestrationToolDispatcherTest,AiOpenAiToolCatalogTest,McpToolDescriptorCatalogTest`


Made with [Cursor](https://cursor.com)