### PR TITLE
Fix mobile visits list 500 on PostgreSQL null filter params

### DIFF
--- a/src/main/java/com/nutriconsultas/calendar/CalendarEventPatientVisitSpecifications.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarEventPatientVisitSpecifications.java
@@ -1,0 +1,38 @@
+package com.nutriconsultas.calendar;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import jakarta.persistence.criteria.Predicate;
+
+/**
+ * Dynamic filters for mobile patient visit listing (#91). Avoids nullable-parameter JPQL
+ * that PostgreSQL cannot type-infer ({@code ? IS NULL OR column = ?}).
+ */
+public final class CalendarEventPatientVisitSpecifications {
+
+	private CalendarEventPatientVisitSpecifications() {
+	}
+
+	public static Specification<CalendarEvent> forPatient(final Long pacienteId, final EventStatus status,
+			final Date fromDate, final Date toDate) {
+		return (root, query, criteriaBuilder) -> {
+			final List<Predicate> predicates = new ArrayList<>();
+			predicates.add(criteriaBuilder.equal(root.get("paciente").get("id"), pacienteId));
+			if (status != null) {
+				predicates.add(criteriaBuilder.equal(root.get("status"), status));
+			}
+			if (fromDate != null) {
+				predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("eventDateTime"), fromDate));
+			}
+			if (toDate != null) {
+				predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("eventDateTime"), toDate));
+			}
+			return criteriaBuilder.and(predicates.toArray(Predicate[]::new));
+		};
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/calendar/CalendarEventRepository.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarEventRepository.java
@@ -4,7 +4,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;

--- a/src/main/java/com/nutriconsultas/calendar/CalendarEventRepository.java
+++ b/src/main/java/com/nutriconsultas/calendar/CalendarEventRepository.java
@@ -7,21 +7,16 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Long> {
+public interface CalendarEventRepository
+		extends JpaRepository<CalendarEvent, Long>, JpaSpecificationExecutor<CalendarEvent> {
 
 	List<CalendarEvent> findByPacienteId(Long pacienteId);
-
-	@Query("SELECT e FROM CalendarEvent e WHERE e.paciente.id = :pacienteId "
-			+ "AND (:status IS NULL OR e.status = :status) "
-			+ "AND (:fromDate IS NULL OR e.eventDateTime >= :fromDate) "
-			+ "AND (:toDate IS NULL OR e.eventDateTime <= :toDate)")
-	Page<CalendarEvent> findPatientVisits(@Param("pacienteId") Long pacienteId, @Param("status") EventStatus status,
-			@Param("fromDate") Date fromDate, @Param("toDate") Date toDate, Pageable pageable);
 
 	Optional<CalendarEvent> findByIdAndPacienteId(Long id, Long pacienteId);
 

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientVisitService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.nutriconsultas.calendar.CalendarEvent;
+import com.nutriconsultas.calendar.CalendarEventPatientVisitSpecifications;
 import com.nutriconsultas.calendar.CalendarEventRepository;
 import com.nutriconsultas.calendar.EventStatus;
 import com.nutriconsultas.mobile.dto.PagedResponse;
@@ -42,8 +43,8 @@ public class MobilePatientVisitService {
 		final Pageable pageable = PageRequest.of(safePage, safeSize, Sort.by(Sort.Direction.DESC, "eventDateTime"));
 		final Date fromDate = from != null ? Date.from(from) : null;
 		final Date toDate = to != null ? Date.from(to) : null;
-		final Page<CalendarEvent> events = calendarEventRepository.findPatientVisits(pacienteId, status, fromDate,
-				toDate, pageable);
+		final Page<CalendarEvent> events = calendarEventRepository.findAll(
+				CalendarEventPatientVisitSpecifications.forPatient(pacienteId, status, fromDate, toDate), pageable);
 		final Page<VisitSummaryDto> summaries = events.map(VisitSummaryDto::fromEntity);
 		if (log.isDebugEnabled()) {
 			log.debug("Listed mobile visits page={} size={} count={} for patient {}", safePage, safeSize,

--- a/src/test/java/com/nutriconsultas/calendar/CalendarEventPatientVisitSpecificationsTest.java
+++ b/src/test/java/com/nutriconsultas/calendar/CalendarEventPatientVisitSpecificationsTest.java
@@ -1,0 +1,86 @@
+package com.nutriconsultas.calendar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class CalendarEventPatientVisitSpecificationsTest {
+
+	@Autowired
+	private CalendarEventRepository calendarEventRepository;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	private Paciente paciente;
+
+	@BeforeEach
+	void seedPaciente() {
+		paciente = pacienteRepository.saveAndFlush(samplePaciente());
+	}
+
+	@Test
+	void findAll_withNullOptionalFilters_returnsPatientVisits() {
+		calendarEventRepository.saveAndFlush(sampleEvent("Consulta A", EventStatus.SCHEDULED, 3));
+		calendarEventRepository.saveAndFlush(sampleEvent("Consulta B", EventStatus.COMPLETED, -1));
+
+		final Page<CalendarEvent> page = calendarEventRepository.findAll(
+				CalendarEventPatientVisitSpecifications.forPatient(paciente.getId(), null, null, null),
+				PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "eventDateTime")));
+
+		assertThat(page.getTotalElements()).isEqualTo(2);
+		assertThat(page.getContent().get(0).getTitle()).isEqualTo("Consulta A");
+	}
+
+	@Test
+	void findAll_withStatusFilter_returnsMatchingVisitsOnly() {
+		calendarEventRepository.saveAndFlush(sampleEvent("Programada", EventStatus.SCHEDULED, 2));
+		calendarEventRepository.saveAndFlush(sampleEvent("Completada", EventStatus.COMPLETED, -2));
+
+		final Page<CalendarEvent> page = calendarEventRepository.findAll(
+				CalendarEventPatientVisitSpecifications.forPatient(paciente.getId(), EventStatus.SCHEDULED, null, null),
+				PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "eventDateTime")));
+
+		assertThat(page.getTotalElements()).isEqualTo(1);
+		assertThat(page.getContent().get(0).getTitle()).isEqualTo("Programada");
+	}
+
+	private CalendarEvent sampleEvent(final String title, final EventStatus status, final int dayOffset) {
+		final CalendarEvent event = new CalendarEvent();
+		event.setPaciente(paciente);
+		event.setTitle(title);
+		event.setStatus(status);
+		event.setDurationMinutes(60);
+		event.setEventDateTime(
+				Date.from(LocalDate.now().plusDays(dayOffset).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		return event;
+	}
+
+	private static Paciente samplePaciente() {
+		final Paciente pacienteEntity = new Paciente();
+		pacienteEntity.setName("Spec Visit Patient");
+		pacienteEntity.setUserId("auth0|nutritionist-spec");
+		pacienteEntity.setPatientAuthSub("auth0|patient-spec");
+		final LocalDate dob = LocalDate.now().minusYears(30);
+		pacienteEntity.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		pacienteEntity.setGender("F");
+		return pacienteEntity;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/calendar/CalendarEventPatientVisitSpecificationsTest.java
+++ b/src/test/java/com/nutriconsultas/calendar/CalendarEventPatientVisitSpecificationsTest.java
@@ -36,7 +36,7 @@ class CalendarEventPatientVisitSpecificationsTest {
 	}
 
 	@Test
-	void findAll_withNullOptionalFilters_returnsPatientVisits() {
+	void findAllWithNullOptionalFiltersReturnsPatientVisits() {
 		calendarEventRepository.saveAndFlush(sampleEvent("Consulta A", EventStatus.SCHEDULED, 3));
 		calendarEventRepository.saveAndFlush(sampleEvent("Consulta B", EventStatus.COMPLETED, -1));
 
@@ -49,7 +49,7 @@ class CalendarEventPatientVisitSpecificationsTest {
 	}
 
 	@Test
-	void findAll_withStatusFilter_returnsMatchingVisitsOnly() {
+	void findAllWithStatusFilterReturnsMatchingVisitsOnly() {
 		calendarEventRepository.saveAndFlush(sampleEvent("Programada", EventStatus.SCHEDULED, 2));
 		calendarEventRepository.saveAndFlush(sampleEvent("Completada", EventStatus.COMPLETED, -2));
 

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientVisitServiceTest.java
@@ -3,7 +3,6 @@ package com.nutriconsultas.mobile;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -23,6 +22,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -48,8 +48,7 @@ class MobilePatientVisitServiceTest {
 	void listVisits_mapsEventsToSummaryDtos() {
 		final CalendarEvent event = sampleEvent(10L, "Consulta inicial", EventStatus.COMPLETED);
 		final Page<CalendarEvent> page = new PageImpl<>(List.of(event), PageRequest.of(0, 20), 1);
-		when(calendarEventRepository.findPatientVisits(eq(1L), eq(null), eq(null), eq(null), any(Pageable.class)))
-			.thenReturn(page);
+		when(calendarEventRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(page);
 
 		final PagedResponse<VisitSummaryDto> result = service.listVisits(1L, 0, 20, null, null, null);
 
@@ -62,14 +61,12 @@ class MobilePatientVisitServiceTest {
 
 	@Test
 	void listVisits_capsPageSizeAt100() {
-		when(calendarEventRepository.findPatientVisits(eq(1L), eq(null), eq(null), eq(null), any(Pageable.class)))
-			.thenReturn(Page.empty());
+		when(calendarEventRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(Page.empty());
 
 		service.listVisits(1L, 0, 500, null, null, null);
 
 		final ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-		verify(calendarEventRepository).findPatientVisits(eq(1L), eq(null), eq(null), eq(null),
-				pageableCaptor.capture());
+		verify(calendarEventRepository).findAll(any(Specification.class), pageableCaptor.capture());
 		assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(100);
 		assertThat(pageableCaptor.getValue().getSort()).isEqualTo(Sort.by(Sort.Direction.DESC, "eventDateTime"));
 	}
@@ -78,14 +75,11 @@ class MobilePatientVisitServiceTest {
 	void listVisits_passesStatusAndDateFilters() {
 		final Instant from = Instant.parse("2026-01-01T00:00:00Z");
 		final Instant to = Instant.parse("2026-06-01T00:00:00Z");
-		when(calendarEventRepository.findPatientVisits(eq(2L), eq(EventStatus.SCHEDULED), any(Date.class),
-				any(Date.class), any(Pageable.class)))
-			.thenReturn(Page.empty());
+		when(calendarEventRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(Page.empty());
 
 		service.listVisits(2L, 1, 10, EventStatus.SCHEDULED, from, to);
 
-		verify(calendarEventRepository).findPatientVisits(eq(2L), eq(EventStatus.SCHEDULED), any(Date.class),
-				any(Date.class), any(Pageable.class));
+		verify(calendarEventRepository).findAll(any(Specification.class), any(Pageable.class));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Fixes **500 Internal Server Error** on `GET /rest/mobile/patient/visits` in production (PostgreSQL).
- Root cause: nullable JPQL filters (`:status IS NULL OR …`) — PG cannot type-infer null enum/timestamp bind parameters when no query filters are sent.
- Replaces `findPatientVisits` JPQL with `CalendarEventPatientVisitSpecifications` + `JpaSpecificationExecutor` so only non-null filters are applied.

**Verified on prod (pre-fix):** Jane Doe (`pacienteId=10`) — `/patient/me` → 200, `/patient/visits` → 500 with `could not determine data type of parameter $4`.

## Test plan
- [x] `CalendarEventPatientVisitSpecificationsTest` — DataJpaTest with null filters + status filter
- [x] `MobilePatientVisitServiceTest` — service uses `findAll(Specification, Pageable)`
- [x] `MobilePatientVisitIntegrationTest` — end-to-end mobile visits list
- [x] `./lint.sh` + PHI audit scripts
- [x] `mvn -B package -Pci` (1880 tests) + `jacoco:check -Pci`
- [ ] Post-deploy: `GET https://minutriporcion.com/rest/mobile/patient/visits` with patient JWT → **200**


Made with [Cursor](https://cursor.com)