### PR TITLE
Apple Sign-In webhook foundation (#498–#503)

### DIFF
--- a/ISSUE-APPLE-SIGNIN.md
+++ b/ISSUE-APPLE-SIGNIN.md
@@ -6,7 +6,7 @@ Living index of GitHub issues that implement **Sign in with Apple** through Auth
 **Roadmap:** [`docs/auth/apple-signin-backend-roadmap.md`](docs/auth/apple-signin-backend-roadmap.md)  
 **Setup (maintainer runbook):** [`docs/auth/apple-signin-setup.md`](docs/auth/apple-signin-setup.md)  
 **Epic comment:** [#497](https://github.com/diego-torres/nutriconsultas/issues/497#issuecomment-4904658287)  
-**Last updated:** 2026-07-07 — track registered (#497–#511).
+**Last updated:** 2026-07-07 — #498–#503 in progress on `apple-signin/498-503-webhook-foundation`.
 
 > **Scope.** Auth0 Apple social connection, backend webhook (`POST /rest/webhooks/apple/sign-in`), signed payload verification, notification persistence, identity mapping, and safe lifecycle handling. **Does not** replace Auth0 with custom Apple OAuth. Patient mobile API: [`ISSUE.md`](ISSUE.md). Auth0 patient gate: [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md).
 
@@ -40,13 +40,13 @@ Suggested order matches [`docs/auth/apple-signin-backend-roadmap.md`](docs/auth/
 
 | Step | # | Title | URL | State | Depends on | Notes |
 |------|---|-------|-----|-------|------------|-------|
-| 1 | **497** | Configure Auth0 Apple connection | https://github.com/diego-torres/nutriconsultas/issues/497 | **open** | — | Auth0 tenant + Apple Developer Portal; **NEXT** |
-| 2 | 498 | Add webhook configuration properties | https://github.com/diego-torres/nutriconsultas/issues/498 | open | — | `@ConfigurationProperties`; disabled by default |
-| 3 | 499 | Add webhook controller | https://github.com/diego-torres/nutriconsultas/issues/499 | open | 498 | `POST /rest/webhooks/apple/sign-in` |
-| 4 | 500 | Permit webhook path through Spring Security | https://github.com/diego-torres/nutriconsultas/issues/500 | open | 499 | Public route; verify payload in handler |
-| 5 | 501 | Implement signed payload verification | https://github.com/diego-torres/nutriconsultas/issues/501 | open | 498, 499 | JWKS + JWS; consider Nimbus JOSE JWT |
-| 6 | 502 | Persist notification events (Liquibase + JPA) | https://github.com/diego-torres/nutriconsultas/issues/502 | open | 498 | `apple_signin_notification`; idempotent |
-| 7 | 503 | Create notification processing service | https://github.com/diego-torres/nutriconsultas/issues/503 | open | 501, 502 | Observe-only first; no destructive auto |
+| 1 | **497** | Configure Auth0 Apple connection | https://github.com/diego-torres/nutriconsultas/issues/497 | **open** | — | Auth0 tenant + Apple Developer Portal; manual setup **NEXT** |
+| 2 | 498 | Add webhook configuration properties | https://github.com/diego-torres/nutriconsultas/issues/498 | **in-progress** | — | Branch `apple-signin/498-503-webhook-foundation` |
+| 3 | 499 | Add webhook controller | https://github.com/diego-torres/nutriconsultas/issues/499 | **in-progress** | 498 | `POST /rest/webhooks/apple/sign-in` |
+| 4 | 500 | Permit webhook path through Spring Security | https://github.com/diego-torres/nutriconsultas/issues/500 | **in-progress** | 499 | Public route; verify payload in handler |
+| 5 | 501 | Implement signed payload verification | https://github.com/diego-torres/nutriconsultas/issues/501 | **in-progress** | 498, 499 | Nimbus JOSE JWT + JWKS cache |
+| 6 | 502 | Persist notification events (Liquibase + JPA) | https://github.com/diego-torres/nutriconsultas/issues/502 | **in-progress** | 498 | `apple_signin_notification`; idempotent |
+| 7 | 503 | Create notification processing service | https://github.com/diego-torres/nutriconsultas/issues/503 | **in-progress** | 501, 502 | Observe-only first; no destructive auto |
 | 8 | 504 | Map Apple/Auth0 identity to local users | https://github.com/diego-torres/nutriconsultas/issues/504 | open | 497, 503 | Stable subject over email |
 | 9 | 505 | Add Auth0 Management API client methods | https://github.com/diego-torres/nutriconsultas/issues/505 | open | 497 | Narrow scopes; delete disabled by default |
 | 10 | 506 | Add safe account deletion workflow | https://github.com/diego-torres/nutriconsultas/issues/506 | open | 503, 504, 505 | Staged; no silent hard-delete |

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
       <version>0.9.1</version>
     </dependency>
     <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <version>9.37.3</version>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>

--- a/src/main/java/com/nutriconsultas/SecurityConfig.java
+++ b/src/main/java/com/nutriconsultas/SecurityConfig.java
@@ -49,6 +49,8 @@ public class SecurityConfig {
 			.headers(headers -> headers.frameOptions(options -> options.sameOrigin()))
 			.authorizeHttpRequests(ar -> ar.requestMatchers("/rest/subscription/payment/webhook")
 				.permitAll()
+				.requestMatchers(HttpMethod.POST, "/rest/webhooks/apple/sign-in")
+				.permitAll()
 				.requestMatchers("/rest/public/booking/**")
 				.permitAll()
 				.requestMatchers(HttpMethod.GET, "/invitation/nutritionist/redeem")

--- a/src/main/java/com/nutriconsultas/ai/AiDraftToolSchemaValidator.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftToolSchemaValidator.java
@@ -47,8 +47,8 @@ public final class AiDraftToolSchemaValidator {
 	public AiDraftToolSchemaValidator() {
 		final String schemaContent = loadSchemaContent();
 		final JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012,
-				builder -> builder.schemaLoaders(
-						schemaLoaders -> schemaLoaders.schemas(Map.of(SCHEMA_DOCUMENT_ID, schemaContent))));
+				builder -> builder
+					.schemaLoaders(schemaLoaders -> schemaLoaders.schemas(Map.of(SCHEMA_DOCUMENT_ID, schemaContent))));
 		dishDraftSchema = factory.getSchema(SchemaLocation.of(SCHEMA_DOCUMENT_ID + "#/definitions/DishDraftInput"));
 		menuDraftSchema = factory.getSchema(SchemaLocation.of(SCHEMA_DOCUMENT_ID + "#/definitions/MenuDraftInput"));
 		dietPlanDraftSchema = factory

--- a/src/main/java/com/nutriconsultas/ai/AiPromptThreatDetector.java
+++ b/src/main/java/com/nutriconsultas/ai/AiPromptThreatDetector.java
@@ -38,7 +38,8 @@ public final class AiPromptThreatDetector {
 					Pattern.CASE_INSENSITIVE),
 			Pattern.compile("you\\s+are\\s+(the|a|an)?\\s*(admin|administrator|platform\\s+admin|root|superuser)",
 					Pattern.CASE_INSENSITIVE),
-			Pattern.compile("role-?play\\s+as\\s+(an?\\s+)?((platform|system)\\s+)?(admin|administrator|developer|unrestricted\\s+ai)",
+			Pattern.compile(
+					"role-?play\\s+as\\s+(an?\\s+)?((platform|system)\\s+)?(admin|administrator|developer|unrestricted\\s+ai)",
 					Pattern.CASE_INSENSITIVE),
 			Pattern.compile("simulate\\s+(unrestricted|unfiltered|developer)\\s+mode", Pattern.CASE_INSENSITIVE),
 			Pattern.compile("bypass\\s+(safety|restrictions|guardrails|content\\s+filters?)", Pattern.CASE_INSENSITIVE),

--- a/src/main/java/com/nutriconsultas/ai/AiRequestScopeClassifier.java
+++ b/src/main/java/com/nutriconsultas/ai/AiRequestScopeClassifier.java
@@ -3,14 +3,15 @@ package com.nutriconsultas.ai;
 import java.util.Optional;
 
 /**
- * Optional LLM pre-flight scope evaluation before the main orchestration tool loop (#448).
+ * Optional LLM pre-flight scope evaluation before the main orchestration tool loop
+ * (#448).
  */
 @FunctionalInterface
 public interface AiRequestScopeClassifier {
 
 	/**
-	 * @return empty when {@link AiRequestScopeDecision#ALLOW}, disabled, or classifier fails
-	 *         open; present with assistant message for REFUSE/CLARIFY
+	 * @return empty when {@link AiRequestScopeDecision#ALLOW}, disabled, or classifier
+	 * fails open; present with assistant message for REFUSE/CLARIFY
 	 */
 	Optional<AiRequestScopeClassifierOutcome> evaluate(String sanitizedUserMessage);
 

--- a/src/main/java/com/nutriconsultas/ai/AiRequestScopeClassifierImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiRequestScopeClassifierImpl.java
@@ -53,11 +53,12 @@ public class AiRequestScopeClassifierImpl implements AiRequestScopeClassifier {
 			return Optional.empty();
 		}
 		try {
-			final OpenAiChatCompletionResponse response = openAiClientService.chatCompletion(
-					new OpenAiChatCompletionRequest(
-							List.of(OpenAiChatMessage.system(classifierPrompt),
-									OpenAiChatMessage.user(sanitizedUserMessage)),
-							List.of(), OpenAiCompletionParameters.scopeClassifier(properties.getScopeClassifierMaxTokens())));
+			final OpenAiChatCompletionResponse response = openAiClientService
+				.chatCompletion(new OpenAiChatCompletionRequest(
+						List.of(OpenAiChatMessage.system(classifierPrompt),
+								OpenAiChatMessage.user(sanitizedUserMessage)),
+						List.of(),
+						OpenAiCompletionParameters.scopeClassifier(properties.getScopeClassifierMaxTokens())));
 			final ParsedClassification parsed = parseClassification(response.content());
 			if (parsed.decision() == AiRequestScopeDecision.ALLOW) {
 				if (log.isInfoEnabled()) {
@@ -67,12 +68,12 @@ public class AiRequestScopeClassifierImpl implements AiRequestScopeClassifier {
 			}
 			final String assistantMessage = buildAssistantMessage(parsed);
 			if (log.isInfoEnabled()) {
-				log.info("AI scope classifier decision={} days={} dishes={} plans={} patients={}",
-						parsed.decision(), parsed.requestedUnits().days(), parsed.requestedUnits().dishes(),
+				log.info("AI scope classifier decision={} days={} dishes={} plans={} patients={}", parsed.decision(),
+						parsed.requestedUnits().days(), parsed.requestedUnits().dishes(),
 						parsed.requestedUnits().plans(), parsed.requestedUnits().patients());
 			}
-			return Optional.of(new AiRequestScopeClassifierOutcome(parsed.decision(), assistantMessage,
-					parsed.requestedUnits()));
+			return Optional
+				.of(new AiRequestScopeClassifierOutcome(parsed.decision(), assistantMessage, parsed.requestedUnits()));
 		}
 		catch (final RuntimeException ex) {
 			if (log.isWarnEnabled()) {
@@ -92,8 +93,7 @@ public class AiRequestScopeClassifierImpl implements AiRequestScopeClassifier {
 			}
 			return DEFAULT_CLARIFY_MESSAGE;
 		}
-		final Optional<String> refusalFromUnits = requestScopeGuard
-			.refusalMessageForUnits(parsed.requestedUnits());
+		final Optional<String> refusalFromUnits = requestScopeGuard.refusalMessageForUnits(parsed.requestedUnits());
 		if (refusalFromUnits.isPresent()) {
 			return refusalFromUnits.get();
 		}

--- a/src/main/java/com/nutriconsultas/ai/AiRequestScopeGuard.java
+++ b/src/main/java/com/nutriconsultas/ai/AiRequestScopeGuard.java
@@ -11,7 +11,8 @@ import org.springframework.util.StringUtils;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Deterministic pre-orchestration guard against excessive bulk generation requests (#447).
+ * Deterministic pre-orchestration guard against excessive bulk generation requests
+ * (#447).
  */
 @Component
 @Slf4j
@@ -21,22 +22,23 @@ public class AiRequestScopeGuard {
 
 	private static final Pattern WEEK_COUNT_PATTERN = Pattern.compile("(\\d{1,3})\\s*semanas?", Pattern.UNICODE_CASE);
 
-	private static final Pattern DISH_COUNT_PATTERN = Pattern
-		.compile("(\\d{1,4})\\s*(platillos?|recetas?|platos?)", Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
+	private static final Pattern DISH_COUNT_PATTERN = Pattern.compile("(\\d{1,4})\\s*(platillos?|recetas?|platos?)",
+			Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
 
-	private static final Pattern PLAN_COUNT_PATTERN = Pattern.compile("(\\d{1,4})\\s*(planes?(?:\\s+nutricionales?|"
-			+ "\\s+alimenticios?)?)", Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
+	private static final Pattern PLAN_COUNT_PATTERN = Pattern.compile(
+			"(\\d{1,4})\\s*(planes?(?:\\s+nutricionales?|" + "\\s+alimenticios?)?)",
+			Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
 
 	private static final Pattern MENU_COUNT_PATTERN = Pattern.compile("(\\d{1,4})\\s*men[uú]s?",
 			Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
 
-	private static final Pattern LARGE_BULK_PATTERN = Pattern.compile("(\\d{2,})\\s*(planes?|platillos?|recetas?"
-			+ "|men[uú]s?|pacientes?)", Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
-
-	private static final Pattern MULTI_PATIENT_PATTERN = Pattern.compile(
-			"todos\\s+(mis\\s+)?pacientes|cada\\s+paciente|para\\s+todos\\s+(mis\\s+)?pacientes|"
-					+ "todos\\s+los\\s+pacientes",
+	private static final Pattern LARGE_BULK_PATTERN = Pattern.compile(
+			"(\\d{2,})\\s*(planes?|platillos?|recetas?" + "|men[uú]s?|pacientes?)",
 			Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
+
+	private static final Pattern MULTI_PATIENT_PATTERN = Pattern
+		.compile("todos\\s+(mis\\s+)?pacientes|cada\\s+paciente|para\\s+todos\\s+(mis\\s+)?pacientes|"
+				+ "todos\\s+los\\s+pacientes", Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
 
 	private static final Pattern YEAR_SCOPE_PATTERN = Pattern.compile(
 			"cada\\s+d[ií]a\\s+del\\s+a[nñ]o|todo\\s+el\\s+a[nñ]o|365\\s*d[ií]as",
@@ -124,8 +126,8 @@ public class AiRequestScopeGuard {
 			return Optional.of(violation(AiRequestScopeKind.BULK_COUNT, 100,
 					refusalFor(AiRequestScopeKind.DISH_COUNT, 100, "platillos")));
 		}
-		return Optional.of(violation(AiRequestScopeKind.BULK_COUNT, 100,
-				refusalFor(AiRequestScopeKind.MENU_DAYS, 100, "menús")));
+		return Optional
+			.of(violation(AiRequestScopeKind.BULK_COUNT, 100, refusalFor(AiRequestScopeKind.MENU_DAYS, 100, "menús")));
 	}
 
 	private Optional<AiRequestScopeViolation> evaluateDishCount(final String normalized) {

--- a/src/main/java/com/nutriconsultas/ai/AiRequestScopePipeline.java
+++ b/src/main/java/com/nutriconsultas/ai/AiRequestScopePipeline.java
@@ -30,14 +30,13 @@ public class AiRequestScopePipeline {
 		final Optional<AiRequestScopeViolation> violation = deterministicGuard.evaluate(sanitizedUserMessage);
 		if (violation.isPresent()) {
 			final AiRequestScopeViolation scopeViolation = violation.get();
-			return Optional.of(new ScopeShortCircuit(scopeViolation.refusalMessage(), "scope refusal",
-					scopeViolation.kind()));
+			return Optional
+				.of(new ScopeShortCircuit(scopeViolation.refusalMessage(), "scope refusal", scopeViolation.kind()));
 		}
 		final Optional<AiRequestScopeClassifierOutcome> classifierOutcome = classifier.evaluate(sanitizedUserMessage);
 		if (classifierOutcome.isPresent()) {
 			final AiRequestScopeClassifierOutcome outcome = classifierOutcome.get();
-			return Optional.of(
-					new ScopeShortCircuit(outcome.assistantMessage(), "classifier", outcome.decision()));
+			return Optional.of(new ScopeShortCircuit(outcome.assistantMessage(), "classifier", outcome.decision()));
 		}
 		return Optional.empty();
 	}

--- a/src/main/java/com/nutriconsultas/ai/OpenAiChatCompletionRequest.java
+++ b/src/main/java/com/nutriconsultas/ai/OpenAiChatCompletionRequest.java
@@ -8,8 +8,7 @@ import java.util.List;
 public record OpenAiChatCompletionRequest(List<OpenAiChatMessage> messages, List<OpenAiToolDefinition> tools,
 		OpenAiCompletionParameters parameters) {
 
-	public OpenAiChatCompletionRequest(final List<OpenAiChatMessage> messages,
-			final List<OpenAiToolDefinition> tools) {
+	public OpenAiChatCompletionRequest(final List<OpenAiChatMessage> messages, final List<OpenAiToolDefinition> tools) {
 		this(messages, tools, OpenAiCompletionParameters.none());
 	}
 

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInConfig.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInConfig.java
@@ -1,0 +1,38 @@
+package com.nutriconsultas.auth.apple;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@EnableConfigurationProperties(AppleSignInProperties.class)
+@Slf4j
+public class AppleSignInConfig {
+
+	private final AppleSignInProperties properties;
+
+	public AppleSignInConfig(final AppleSignInProperties properties) {
+		this.properties = properties;
+	}
+
+	@PostConstruct
+	public void validateConfiguration() {
+		if (!properties.isWebhookEnabled()) {
+			if (log.isDebugEnabled()) {
+				log.debug("Apple Sign-In webhook disabled (APPLE_SIGNIN_WEBHOOK_ENABLED=false)");
+			}
+			return;
+		}
+		if (!properties.isWebhookConfigured()) {
+			throw new IllegalStateException(
+					"Apple Sign-In webhook is enabled but APPLE_SIGNIN_EXPECTED_AUDIENCE is not configured");
+		}
+		if (log.isInfoEnabled()) {
+			log.info("Apple Sign-In webhook enabled (issuer={}, destructiveAuto={})", properties.getExpectedIssuer(),
+					properties.isAutoProcessDestructiveEvents());
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInEventType.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInEventType.java
@@ -1,0 +1,29 @@
+package com.nutriconsultas.auth.apple;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Normalized Apple Sign-In server notification event types (#503).
+ */
+public enum AppleSignInEventType {
+
+	EMAIL_DISABLED, EMAIL_ENABLED, CONSENT_REVOKED, ACCOUNT_DELETE, UNKNOWN;
+
+	public static AppleSignInEventType fromAppleType(final String rawType) {
+		if (!StringUtils.hasText(rawType)) {
+			return UNKNOWN;
+		}
+		return switch (rawType.trim().toLowerCase()) {
+			case "email-disabled" -> EMAIL_DISABLED;
+			case "email-enabled" -> EMAIL_ENABLED;
+			case "consent-revoked" -> CONSENT_REVOKED;
+			case "account-delete" -> ACCOUNT_DELETE;
+			default -> UNKNOWN;
+		};
+	}
+
+	public boolean isDestructive() {
+		return this == CONSENT_REVOKED || this == ACCOUNT_DELETE;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInJwksKeySource.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInJwksKeySource.java
@@ -1,0 +1,13 @@
+package com.nutriconsultas.auth.apple;
+
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+
+/**
+ * Supplies Apple JWKS keys for notification signature verification (#501).
+ */
+public interface AppleSignInJwksKeySource {
+
+	JWKSource<SecurityContext> getKeySource();
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInJwksKeySource.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInJwksKeySource.java
@@ -6,6 +6,7 @@ import com.nimbusds.jose.proc.SecurityContext;
 /**
  * Supplies Apple JWKS keys for notification signature verification (#501).
  */
+@FunctionalInterface
 public interface AppleSignInJwksKeySource {
 
 	JWKSource<SecurityContext> getKeySource();

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotification.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotification.java
@@ -1,0 +1,98 @@
+package com.nutriconsultas.auth.apple;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Audit and idempotency store for Apple Sign-In server notifications (#502). Never store
+ * signed tokens or refresh tokens.
+ */
+@Entity
+@Table(name = "apple_signin_notification")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppleSignInNotification {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "apple_event_id", nullable = false, length = 255, unique = true)
+	private String appleEventId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "event_type", nullable = false, length = 40)
+	private AppleSignInEventType eventType;
+
+	@Column(name = "apple_subject", length = 255)
+	private String appleSubject;
+
+	@Column(name = "auth0_user_id", length = 255)
+	private String auth0UserId;
+
+	@Column(length = 320)
+	private String email;
+
+	@Column(name = "email_verified")
+	private Boolean emailVerified;
+
+	@Column(name = "is_private_email")
+	private Boolean isPrivateEmail;
+
+	@Column(name = "raw_claims_json", columnDefinition = "TEXT")
+	private String rawClaimsJson;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "processing_status", nullable = false, length = 20)
+	private AppleSignInNotificationProcessingStatus processingStatus;
+
+	@Column(name = "processing_error", length = 500)
+	private String processingError;
+
+	@Column(name = "received_at", nullable = false)
+	private Instant receivedAt;
+
+	@Column(name = "processed_at")
+	private Instant processedAt;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private Instant createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private Instant updatedAt;
+
+	@PrePersist
+	void onCreate() {
+		final Instant now = Instant.now();
+		if (createdAt == null) {
+			createdAt = now;
+		}
+		if (updatedAt == null) {
+			updatedAt = now;
+		}
+		if (receivedAt == null) {
+			receivedAt = now;
+		}
+	}
+
+	@PreUpdate
+	void onUpdate() {
+		updatedAt = Instant.now();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationClaims.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationClaims.java
@@ -1,0 +1,9 @@
+package com.nutriconsultas.auth.apple;
+
+/**
+ * Verified Apple server-to-server notification claims (#501).
+ */
+public record AppleSignInNotificationClaims(String eventId, String issuer, String audience, String appleSubject,
+		AppleSignInEventType eventType, String email, Boolean emailVerified, Boolean isPrivateEmail,
+		String rawClaimsJson) {
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationProcessingStatus.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationProcessingStatus.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.auth.apple;
+
+/**
+ * Processing lifecycle for persisted Apple Sign-In notifications (#502).
+ */
+public enum AppleSignInNotificationProcessingStatus {
+
+	RECEIVED, VERIFIED, IGNORED, PROCESSED, FAILED
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationRepository.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationRepository.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.auth.apple;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AppleSignInNotificationRepository extends JpaRepository<AppleSignInNotification, Long> {
+
+	Optional<AppleSignInNotification> findByAppleEventId(String appleEventId);
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationService.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationService.java
@@ -1,0 +1,82 @@
+package com.nutriconsultas.auth.apple;
+
+import java.time.Instant;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class AppleSignInNotificationService {
+
+	private final AppleSignInProperties properties;
+
+	private final AppleSignInNotificationVerifier notificationVerifier;
+
+	private final AppleSignInNotificationRepository notificationRepository;
+
+	public AppleSignInNotificationService(final AppleSignInProperties properties,
+			final AppleSignInNotificationVerifier notificationVerifier,
+			final AppleSignInNotificationRepository notificationRepository) {
+		this.properties = properties;
+		this.notificationVerifier = notificationVerifier;
+		this.notificationRepository = notificationRepository;
+	}
+
+	@Transactional
+	public AppleSignInWebhookOutcome handleNotification(final String signedPayload) {
+		final AppleSignInNotificationClaims claims = notificationVerifier.verifyAndParse(signedPayload);
+		if (notificationRepository.findByAppleEventId(claims.eventId()).isPresent()) {
+			if (log.isDebugEnabled()) {
+				log.debug("Duplicate Apple sign-in notification eventId={} type={}", claims.eventId(),
+						claims.eventType());
+			}
+			return AppleSignInWebhookOutcome.DUPLICATE;
+		}
+		final AppleSignInNotification notification = new AppleSignInNotification();
+		notification.setAppleEventId(claims.eventId());
+		notification.setEventType(claims.eventType());
+		notification.setAppleSubject(claims.appleSubject());
+		notification.setEmail(claims.email());
+		notification.setEmailVerified(claims.emailVerified());
+		notification.setIsPrivateEmail(claims.isPrivateEmail());
+		notification.setRawClaimsJson(claims.rawClaimsJson());
+		notification.setProcessingStatus(AppleSignInNotificationProcessingStatus.VERIFIED);
+		notification.setReceivedAt(Instant.now());
+		processNotification(notification, claims);
+		notificationRepository.save(notification);
+		if (log.isInfoEnabled()) {
+			log.info("Processed Apple sign-in notification eventId={} type={} status={}", claims.eventId(),
+					claims.eventType(), notification.getProcessingStatus());
+		}
+		return AppleSignInWebhookOutcome.PROCESSED;
+	}
+
+	private void processNotification(final AppleSignInNotification notification,
+			final AppleSignInNotificationClaims claims) {
+		if (claims.eventType() == AppleSignInEventType.UNKNOWN) {
+			notification.setProcessingStatus(AppleSignInNotificationProcessingStatus.IGNORED);
+			notification.setProcessedAt(Instant.now());
+			return;
+		}
+		if (claims.eventType().isDestructive() && !properties.isAutoProcessDestructiveEvents()) {
+			notification.setProcessingStatus(AppleSignInNotificationProcessingStatus.PROCESSED);
+			notification.setProcessedAt(Instant.now());
+			if (log.isInfoEnabled()) {
+				log.info("Recorded destructive Apple sign-in event without auto-processing eventId={} type={}",
+						claims.eventId(), claims.eventType());
+			}
+			return;
+		}
+		notification.setProcessingStatus(AppleSignInNotificationProcessingStatus.PROCESSED);
+		notification.setProcessedAt(Instant.now());
+		if (StringUtils.hasText(claims.appleSubject()) && log.isDebugEnabled()) {
+			log.debug("Apple sign-in observe-only processing complete for subject hash={}",
+					claims.appleSubject().hashCode());
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationVerifier.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationVerifier.java
@@ -3,6 +3,7 @@ package com.nutriconsultas.auth.apple;
 /**
  * Verifies Apple server-to-server notification signed payloads (#501).
  */
+@FunctionalInterface
 public interface AppleSignInNotificationVerifier {
 
 	AppleSignInNotificationClaims verifyAndParse(String signedPayload);

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationVerifier.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationVerifier.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.auth.apple;
+
+/**
+ * Verifies Apple server-to-server notification signed payloads (#501).
+ */
+public interface AppleSignInNotificationVerifier {
+
+	AppleSignInNotificationClaims verifyAndParse(String signedPayload);
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationVerifierImpl.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationVerifierImpl.java
@@ -1,0 +1,171 @@
+package com.nutriconsultas.auth.apple;
+
+import java.text.ParseException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class AppleSignInNotificationVerifierImpl implements AppleSignInNotificationVerifier {
+
+	private final AppleSignInProperties properties;
+
+	private final AppleSignInJwksKeySource jwksKeySource;
+
+	private final ObjectMapper objectMapper;
+
+	public AppleSignInNotificationVerifierImpl(final AppleSignInProperties properties,
+			final AppleSignInJwksKeySource jwksKeySource, final ObjectMapper objectMapper) {
+		this.properties = properties;
+		this.jwksKeySource = jwksKeySource;
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public AppleSignInNotificationClaims verifyAndParse(final String signedPayload) {
+		if (!StringUtils.hasText(signedPayload)) {
+			throw new InvalidAppleSignInNotificationException("Apple notification payload is required");
+		}
+		try {
+			final JWTClaimsSet claimsSet = verifySignature(signedPayload.trim());
+			validateStandardClaims(claimsSet);
+			return mapClaims(claimsSet);
+		}
+		catch (InvalidAppleSignInNotificationException ex) {
+			throw ex;
+		}
+		catch (BadJOSEException ex) {
+			throw new InvalidAppleSignInNotificationException("Invalid Apple notification signature", ex);
+		}
+		catch (ParseException | JOSEException ex) {
+			throw new InvalidAppleSignInNotificationException("Unable to parse Apple notification payload", ex);
+		}
+	}
+
+	private JWTClaimsSet verifySignature(final String signedPayload)
+			throws BadJOSEException, ParseException, JOSEException {
+		final ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+		jwtProcessor
+			.setJWSKeySelector(new JWSVerificationKeySelector<>(JWSAlgorithm.RS256, jwksKeySource.getKeySource()));
+		return jwtProcessor.process(signedPayload, null);
+	}
+
+	private void validateStandardClaims(final JWTClaimsSet claimsSet) {
+		final String issuer = claimsSet.getIssuer();
+		if (!properties.getExpectedIssuer().equals(issuer)) {
+			throw new InvalidAppleSignInNotificationException("Invalid Apple notification issuer");
+		}
+		final String audience = resolveAudience(claimsSet);
+		if (!properties.getExpectedAudience().equals(audience)) {
+			throw new InvalidAppleSignInNotificationException("Invalid Apple notification audience");
+		}
+		if (!StringUtils.hasText(claimsSet.getJWTID())) {
+			throw new InvalidAppleSignInNotificationException("Apple notification event id (jti) is required");
+		}
+	}
+
+	private static String resolveAudience(final JWTClaimsSet claimsSet) {
+		final List<String> audiences = claimsSet.getAudience();
+		if (audiences == null || audiences.isEmpty()) {
+			return null;
+		}
+		return audiences.get(0);
+	}
+
+	private AppleSignInNotificationClaims mapClaims(final JWTClaimsSet claimsSet) throws ParseException {
+		final Map<String, Object> events = readEventsClaim(claimsSet);
+		final Map.Entry<String, Object> firstEvent = events.entrySet().iterator().next();
+		final String rawEventType = firstEvent.getKey();
+		final Map<String, Object> eventPayload = asStringObjectMap(firstEvent.getValue());
+		final AppleSignInEventType eventType = AppleSignInEventType.fromAppleType(rawEventType);
+		final String appleSubject = stringValue(eventPayload.get("sub"));
+		final String email = stringValue(eventPayload.get("email"));
+		final Boolean emailVerified = booleanValue(eventPayload.get("email_verified"));
+		final Boolean isPrivateEmail = booleanValue(eventPayload.get("is_private_email"));
+		final String rawClaimsJson = serializeSafeClaims(claimsSet, events);
+		return new AppleSignInNotificationClaims(claimsSet.getJWTID(), claimsSet.getIssuer(),
+				resolveAudience(claimsSet), appleSubject, eventType, email, emailVerified, isPrivateEmail,
+				rawClaimsJson);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> readEventsClaim(final JWTClaimsSet claimsSet) throws ParseException {
+		final Object eventsClaim = claimsSet.getClaim("events");
+		if (!(eventsClaim instanceof Map<?, ?> eventsMap) || eventsMap.isEmpty()) {
+			throw new InvalidAppleSignInNotificationException("Apple notification events claim is required");
+		}
+		final Map<String, Object> events = new LinkedHashMap<>();
+		for (Map.Entry<?, ?> entry : eventsMap.entrySet()) {
+			if (entry.getKey() instanceof String key) {
+				events.put(key, entry.getValue());
+			}
+		}
+		if (events.isEmpty()) {
+			throw new InvalidAppleSignInNotificationException("Apple notification events claim is required");
+		}
+		return events;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> asStringObjectMap(final Object value) {
+		if (value instanceof Map<?, ?> map) {
+			final Map<String, Object> normalized = new LinkedHashMap<>();
+			for (Map.Entry<?, ?> entry : map.entrySet()) {
+				if (entry.getKey() instanceof String key) {
+					normalized.put(key, entry.getValue());
+				}
+			}
+			return normalized;
+		}
+		return Map.of();
+	}
+
+	private String serializeSafeClaims(final JWTClaimsSet claimsSet, final Map<String, Object> events) {
+		final Map<String, Object> safeClaims = new LinkedHashMap<>();
+		safeClaims.put("iss", claimsSet.getIssuer());
+		safeClaims.put("aud", resolveAudience(claimsSet));
+		safeClaims.put("jti", claimsSet.getJWTID());
+		safeClaims.put("events", events);
+		try {
+			return objectMapper.writeValueAsString(safeClaims);
+		}
+		catch (JsonProcessingException ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("Unable to serialize Apple notification claims for audit storage");
+			}
+			return null;
+		}
+	}
+
+	private static String stringValue(final Object value) {
+		if (value instanceof String text && StringUtils.hasText(text)) {
+			return text.trim();
+		}
+		return null;
+	}
+
+	private static Boolean booleanValue(final Object value) {
+		if (value instanceof Boolean bool) {
+			return bool;
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationVerifierImpl.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationVerifierImpl.java
@@ -48,9 +48,6 @@ public class AppleSignInNotificationVerifierImpl implements AppleSignInNotificat
 			validateStandardClaims(claimsSet);
 			return mapClaims(claimsSet);
 		}
-		catch (InvalidAppleSignInNotificationException ex) {
-			throw ex;
-		}
 		catch (BadJOSEException ex) {
 			throw new InvalidAppleSignInNotificationException("Invalid Apple notification signature", ex);
 		}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInProperties.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInProperties.java
@@ -1,0 +1,115 @@
+package com.nutriconsultas.auth.apple;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.util.StringUtils;
+
+/**
+ * Apple Sign-In server-to-server notification configuration (#498).
+ */
+@ConfigurationProperties(prefix = "nutriconsultas.apple.signin")
+public class AppleSignInProperties {
+
+	private static final String DEFAULT_ISSUER = "https://appleid.apple.com";
+
+	private static final String DEFAULT_JWKS_URL = "https://appleid.apple.com/auth/keys";
+
+	@NestedConfigurationProperty
+	private final Webhook webhook = new Webhook();
+
+	private String expectedIssuer = DEFAULT_ISSUER;
+
+	private String expectedAudience = "";
+
+	private String jwksUrl = DEFAULT_JWKS_URL;
+
+	private boolean autoProcessDestructiveEvents;
+
+	private Duration jwksCacheTtl = Duration.ofHours(6);
+
+	public Webhook getWebhook() {
+		return webhook;
+	}
+
+	public boolean isWebhookEnabled() {
+		return webhook.isEnabled();
+	}
+
+	public String getExpectedIssuer() {
+		return expectedIssuer;
+	}
+
+	public void setExpectedIssuer(final String expectedIssuer) {
+		if (StringUtils.hasText(expectedIssuer)) {
+			this.expectedIssuer = expectedIssuer.trim();
+		}
+		else {
+			this.expectedIssuer = DEFAULT_ISSUER;
+		}
+	}
+
+	public String getExpectedAudience() {
+		return expectedAudience;
+	}
+
+	public void setExpectedAudience(final String expectedAudience) {
+		if (StringUtils.hasText(expectedAudience)) {
+			this.expectedAudience = expectedAudience.trim();
+		}
+		else {
+			this.expectedAudience = "";
+		}
+	}
+
+	public String getJwksUrl() {
+		return jwksUrl;
+	}
+
+	public void setJwksUrl(final String jwksUrl) {
+		if (StringUtils.hasText(jwksUrl)) {
+			this.jwksUrl = jwksUrl.trim();
+		}
+		else {
+			this.jwksUrl = DEFAULT_JWKS_URL;
+		}
+	}
+
+	public boolean isAutoProcessDestructiveEvents() {
+		return autoProcessDestructiveEvents;
+	}
+
+	public void setAutoProcessDestructiveEvents(final boolean autoProcessDestructiveEvents) {
+		this.autoProcessDestructiveEvents = autoProcessDestructiveEvents;
+	}
+
+	public Duration getJwksCacheTtl() {
+		return jwksCacheTtl;
+	}
+
+	public void setJwksCacheTtl(final Duration jwksCacheTtl) {
+		if (jwksCacheTtl != null && !jwksCacheTtl.isNegative() && !jwksCacheTtl.isZero()) {
+			this.jwksCacheTtl = jwksCacheTtl;
+		}
+	}
+
+	public boolean isWebhookConfigured() {
+		return StringUtils.hasText(expectedAudience);
+	}
+
+	public static class Webhook {
+
+		private boolean enabled;
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(final boolean enabled) {
+			this.enabled = enabled;
+		}
+
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInRemoteJwksKeySource.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInRemoteJwksKeySource.java
@@ -1,0 +1,51 @@
+package com.nutriconsultas.auth.apple;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.springframework.stereotype.Component;
+
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
+import com.nimbusds.jose.proc.SecurityContext;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class AppleSignInRemoteJwksKeySource implements AppleSignInJwksKeySource {
+
+	private final AppleSignInProperties properties;
+
+	private volatile JWKSource<SecurityContext> cachedKeySource;
+
+	public AppleSignInRemoteJwksKeySource(final AppleSignInProperties properties) {
+		this.properties = properties;
+	}
+
+	@Override
+	public JWKSource<SecurityContext> getKeySource() {
+		JWKSource<SecurityContext> keySource = cachedKeySource;
+		if (keySource == null) {
+			synchronized (this) {
+				keySource = cachedKeySource;
+				if (keySource == null) {
+					keySource = buildKeySource();
+					cachedKeySource = keySource;
+				}
+			}
+		}
+		return keySource;
+	}
+
+	private JWKSource<SecurityContext> buildKeySource() {
+		try {
+			final URL jwksUrl = new URL(properties.getJwksUrl());
+			return JWKSourceBuilder.create(jwksUrl).cache(properties.getJwksCacheTtl().toMillis(), 60_000L).build();
+		}
+		catch (MalformedURLException ex) {
+			throw new IllegalStateException("Invalid Apple JWKS URL: " + properties.getJwksUrl(), ex);
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookController.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookController.java
@@ -1,0 +1,43 @@
+package com.nutriconsultas.auth.apple;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/webhooks/apple")
+@Slf4j
+public class AppleSignInWebhookController {
+
+	private final AppleSignInProperties properties;
+
+	private final AppleSignInNotificationService notificationService;
+
+	public AppleSignInWebhookController(final AppleSignInProperties properties,
+			final AppleSignInNotificationService notificationService) {
+		this.properties = properties;
+		this.notificationService = notificationService;
+	}
+
+	@PostMapping("/sign-in")
+	public ResponseEntity<Void> handleSignInNotification(@RequestBody final AppleSignInWebhookRequest request) {
+		if (!properties.isWebhookEnabled()) {
+			return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+		}
+		if (request == null || !StringUtils.hasText(request.payload())) {
+			return ResponseEntity.badRequest().build();
+		}
+		final AppleSignInWebhookOutcome outcome = notificationService.handleNotification(request.payload().trim());
+		if (outcome == AppleSignInWebhookOutcome.DUPLICATE) {
+			return ResponseEntity.ok().build();
+		}
+		return ResponseEntity.ok().build();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookExceptionHandler.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.nutriconsultas.auth.apple;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.nutriconsultas.auth.apple")
+public class AppleSignInWebhookExceptionHandler {
+
+	@ExceptionHandler(InvalidAppleSignInNotificationException.class)
+	public ResponseEntity<Void> handleInvalidNotification(final InvalidAppleSignInNotificationException ex) {
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookOutcome.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookOutcome.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.auth.apple;
+
+/**
+ * Outcome of Apple Sign-In webhook processing (#503).
+ */
+public enum AppleSignInWebhookOutcome {
+
+	PROCESSED, DUPLICATE
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookRequest.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookRequest.java
@@ -1,0 +1,7 @@
+package com.nutriconsultas.auth.apple;
+
+/**
+ * Apple server-to-server notification body ({@code payload} is a signed JWT string).
+ */
+public record AppleSignInWebhookRequest(String payload) {
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/InvalidAppleSignInNotificationException.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/InvalidAppleSignInNotificationException.java
@@ -1,0 +1,19 @@
+package com.nutriconsultas.auth.apple;
+
+/**
+ * Thrown when an Apple server-to-server notification fails verification or parsing
+ * (#501).
+ */
+public class InvalidAppleSignInNotificationException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public InvalidAppleSignInNotificationException(final String message) {
+		super(message);
+	}
+
+	public InvalidAppleSignInNotificationException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/subscription/lifecycle/SubscriptionAccessInterceptor.java
+++ b/src/main/java/com/nutriconsultas/subscription/lifecycle/SubscriptionAccessInterceptor.java
@@ -102,7 +102,8 @@ public class SubscriptionAccessInterceptor implements HandlerInterceptor {
 		if (uri.startsWith("/rest/mobile/")) {
 			return false;
 		}
-		return !uri.startsWith("/rest/subscription/payment/webhook") && !uri.startsWith("/rest/public/booking/");
+		return !uri.startsWith("/rest/subscription/payment/webhook") && !uri.startsWith("/rest/public/booking/")
+				&& !uri.startsWith("/rest/webhooks/apple/sign-in");
 	}
 
 	private static boolean isAllowedWithoutSubscription(final String uri) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -82,6 +82,13 @@ app.auth0.patient-broker.audience=${AUTH_AUDIENCE:}
 recaptcha.site-key=${RECAPTCHA_SITE_KEY:6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI}
 recaptcha.secret-key=${RECAPTCHA_SECRET_KEY:6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe}
 recaptcha.verification-enabled=${RECAPTCHA_VERIFICATION_ENABLED:true}
+# Apple Sign-In server-to-server notifications (#498)
+nutriconsultas.apple.signin.webhook.enabled=${APPLE_SIGNIN_WEBHOOK_ENABLED:false}
+nutriconsultas.apple.signin.expected-issuer=${APPLE_SIGNIN_EXPECTED_ISSUER:https://appleid.apple.com}
+nutriconsultas.apple.signin.expected-audience=${APPLE_SIGNIN_EXPECTED_AUDIENCE:}
+nutriconsultas.apple.signin.jwks-url=${APPLE_SIGNIN_JWKS_URL:https://appleid.apple.com/auth/keys}
+nutriconsultas.apple.signin.auto-process-destructive-events=${APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS:false}
+nutriconsultas.apple.signin.jwks-cache-ttl=${APPLE_SIGNIN_JWKS_CACHE_TTL:6h}
 # Platform administrators (Auth0 sub claims or OAuth login emails, comma-separated)
 nutriconsultas.platform.admin-user-ids=${PLATFORM_ADMIN_USER_IDS:}
 nutriconsultas.platform.admin-emails=${PLATFORM_ADMIN_EMAILS:}

--- a/src/main/resources/db/changelog/changes/025-apple-signin-notification.yaml
+++ b/src/main/resources/db/changelog/changes/025-apple-signin-notification.yaml
@@ -1,0 +1,84 @@
+databaseChangeLog:
+  - changeSet:
+      id: 025-apple-signin-notification
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            tableExists:
+              tableName: apple_signin_notification
+      changes:
+        - createTable:
+            tableName: apple_signin_notification
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: apple_event_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: event_type
+                  type: VARCHAR(40)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: apple_subject
+                  type: VARCHAR(255)
+              - column:
+                  name: auth0_user_id
+                  type: VARCHAR(255)
+              - column:
+                  name: email
+                  type: VARCHAR(320)
+              - column:
+                  name: email_verified
+                  type: BOOLEAN
+              - column:
+                  name: is_private_email
+                  type: BOOLEAN
+              - column:
+                  name: raw_claims_json
+                  type: TEXT
+              - column:
+                  name: processing_status
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: processing_error
+                  type: VARCHAR(500)
+              - column:
+                  name: received_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: processed_at
+                  type: TIMESTAMP
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: apple_signin_notification
+            columnNames: apple_event_id
+            constraintName: uk_apple_signin_notification_event_id
+        - createIndex:
+            indexName: idx_apple_signin_notification_status
+            tableName: apple_signin_notification
+            columns:
+              - column:
+                  name: processing_status

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -71,3 +71,6 @@ databaseChangeLog:
   - include:
       file: changes/024-ai-chat-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/025-apple-signin-notification.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -62,3 +62,6 @@ databaseChangeLog:
   - include:
       file: changes/024-ai-chat-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/025-apple-signin-notification.yaml
+      relativeToChangelogFile: true

--- a/src/test/java/com/nutriconsultas/ai/AiBulkScopeGoldenPrompt.java
+++ b/src/test/java/com/nutriconsultas/ai/AiBulkScopeGoldenPrompt.java
@@ -4,8 +4,8 @@ import java.util.List;
 import java.util.stream.Stream;
 
 /**
- * Golden prompt fixtures for bulk scope evaluation (#450). Mirrors scenarios documented in
- * {@code docs/ai/BULK-SCOPE-GOLDEN-PROMPTS.md}.
+ * Golden prompt fixtures for bulk scope evaluation (#450). Mirrors scenarios documented
+ * in {@code docs/ai/BULK-SCOPE-GOLDEN-PROMPTS.md}.
  */
 final class AiBulkScopeGoldenPrompt {
 

--- a/src/test/java/com/nutriconsultas/ai/AiChatControllerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatControllerTest.java
@@ -78,7 +78,8 @@ class AiChatControllerTest {
 		final SubscriptionLimitExceededException denied = new SubscriptionLimitExceededException(
 				SubscriptionErrorResponses.KEY_AI_ASSISTANT_DENIED);
 		org.mockito.Mockito.doThrow(denied).when(aiEntitlementGuard).assertCanUseAiAssistant(USER_ID);
-		when(subscriptionErrorResponses.resolve(denied)).thenReturn("El asistente de IA nutricional requiere el plan Plus o Consultorio.");
+		when(subscriptionErrorResponses.resolve(denied))
+			.thenReturn("El asistente de IA nutricional requiere el plan Plus o Consultorio.");
 
 		assertThatThrownBy(() -> controller.chatHome(null, new ExtendedModelMap(), principal()))
 			.isInstanceOf(ResponseStatusException.class)

--- a/src/test/java/com/nutriconsultas/ai/AiRequestScopeGuardTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiRequestScopeGuardTest.java
@@ -62,8 +62,7 @@ class AiRequestScopeGuardTest {
 		final AiProperties properties = new AiProperties();
 		final AiRequestScopeGuard scopeGuard = new AiRequestScopeGuard(properties);
 
-		assertThat(scopeGuard.refusalMessageForUnits(new AiRequestScopeRequestedUnits(null, 5, null, null)))
-			.get()
+		assertThat(scopeGuard.refusalMessageForUnits(new AiRequestScopeRequestedUnits(null, 5, null, null))).get()
 			.isEqualTo(AiRequestScopeGuard.refusalFor(AiRequestScopeKind.DISH_COUNT, 5, "platillos"));
 	}
 
@@ -76,9 +75,7 @@ class AiRequestScopeGuardTest {
 
 	@Test
 	void refusesYearLongScope() {
-		final AiRequestScopeViolation violation = guard
-			.evaluate("Genera comidas para cada día del año")
-			.orElseThrow();
+		final AiRequestScopeViolation violation = guard.evaluate("Genera comidas para cada día del año").orElseThrow();
 
 		assertThat(violation.kind()).isEqualTo(AiRequestScopeKind.DIET_PLAN_DAYS);
 		assertThat(violation.requestedAmount()).isEqualTo(365);

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationPersistenceTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationPersistenceTest.java
@@ -1,0 +1,45 @@
+package com.nutriconsultas.auth.apple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class AppleSignInNotificationPersistenceTest {
+
+	@Autowired
+	private AppleSignInNotificationRepository notificationRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	void notificationPersistsWithUniqueAppleEventId() {
+		final AppleSignInNotification notification = sampleNotification("apple-evt-1");
+		notificationRepository.saveAndFlush(notification);
+
+		entityManager.clear();
+
+		assertThat(notificationRepository.findByAppleEventId("apple-evt-1")).isPresent();
+	}
+
+	private static AppleSignInNotification sampleNotification(final String appleEventId) {
+		final AppleSignInNotification notification = new AppleSignInNotification();
+		notification.setAppleEventId(appleEventId);
+		notification.setEventType(AppleSignInEventType.EMAIL_DISABLED);
+		notification.setAppleSubject("001234.abc");
+		notification.setProcessingStatus(AppleSignInNotificationProcessingStatus.PROCESSED);
+		notification.setReceivedAt(Instant.now());
+		notification.setProcessedAt(Instant.now());
+		return notification;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationServiceTest.java
@@ -1,0 +1,84 @@
+package com.nutriconsultas.auth.apple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AppleSignInNotificationServiceTest {
+
+	@InjectMocks
+	private AppleSignInNotificationService service;
+
+	@Mock
+	private AppleSignInProperties properties;
+
+	@Mock
+	private AppleSignInNotificationVerifier notificationVerifier;
+
+	@Mock
+	private AppleSignInNotificationRepository notificationRepository;
+
+	@Test
+	void handleNotificationPersistsVerifiedEventInObserveOnlyMode() {
+		final AppleSignInNotificationClaims claims = sampleClaims(AppleSignInEventType.CONSENT_REVOKED);
+		when(notificationVerifier.verifyAndParse("signed-payload")).thenReturn(claims);
+		when(notificationRepository.findByAppleEventId("evt-1")).thenReturn(Optional.empty());
+		when(properties.isAutoProcessDestructiveEvents()).thenReturn(false);
+		when(notificationRepository.save(any(AppleSignInNotification.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		final AppleSignInWebhookOutcome outcome = service.handleNotification("signed-payload");
+
+		assertThat(outcome).isEqualTo(AppleSignInWebhookOutcome.PROCESSED);
+		final ArgumentCaptor<AppleSignInNotification> captor = ArgumentCaptor.forClass(AppleSignInNotification.class);
+		verify(notificationRepository).save(captor.capture());
+		assertThat(captor.getValue().getProcessingStatus())
+			.isEqualTo(AppleSignInNotificationProcessingStatus.PROCESSED);
+		assertThat(captor.getValue().getAppleSubject()).isEqualTo("001234.abc");
+	}
+
+	@Test
+	void handleNotificationReturnsDuplicateWithoutSavingAgain() {
+		final AppleSignInNotificationClaims claims = sampleClaims(AppleSignInEventType.EMAIL_ENABLED);
+		when(notificationVerifier.verifyAndParse("signed-payload")).thenReturn(claims);
+		when(notificationRepository.findByAppleEventId("evt-1")).thenReturn(Optional.of(new AppleSignInNotification()));
+
+		final AppleSignInWebhookOutcome outcome = service.handleNotification("signed-payload");
+
+		assertThat(outcome).isEqualTo(AppleSignInWebhookOutcome.DUPLICATE);
+		verify(notificationRepository, never()).save(any());
+	}
+
+	@Test
+	void handleNotificationMarksUnknownEventsIgnored() {
+		final AppleSignInNotificationClaims claims = sampleClaims(AppleSignInEventType.UNKNOWN);
+		when(notificationVerifier.verifyAndParse("signed-payload")).thenReturn(claims);
+		when(notificationRepository.findByAppleEventId("evt-1")).thenReturn(Optional.empty());
+		when(notificationRepository.save(any(AppleSignInNotification.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		service.handleNotification("signed-payload");
+
+		final ArgumentCaptor<AppleSignInNotification> captor = ArgumentCaptor.forClass(AppleSignInNotification.class);
+		verify(notificationRepository).save(captor.capture());
+		assertThat(captor.getValue().getProcessingStatus()).isEqualTo(AppleSignInNotificationProcessingStatus.IGNORED);
+	}
+
+	private static AppleSignInNotificationClaims sampleClaims(final AppleSignInEventType eventType) {
+		return new AppleSignInNotificationClaims("evt-1", "https://appleid.apple.com", "com.minutriporcion.app",
+				"001234.abc", eventType, "relay@privaterelay.appleid.com", true, true, "{\"jti\":\"evt-1\"}");
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationVerifierTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationVerifierTest.java
@@ -1,0 +1,111 @@
+package com.nutriconsultas.auth.apple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.RSAKey;
+
+@ExtendWith(MockitoExtension.class)
+class AppleSignInNotificationVerifierTest {
+
+	private static final String ISSUER = "https://appleid.apple.com";
+
+	private static final String AUDIENCE = "com.minutriporcion.app";
+
+	private RSAKey rsaKey;
+
+	private AppleSignInNotificationVerifier verifier;
+
+	@BeforeEach
+	void setUp() throws JOSEException {
+		rsaKey = AppleSignInTestJwtSupport.generateRsaKey();
+		final AppleSignInProperties properties = new AppleSignInProperties();
+		properties.setExpectedAudience(AUDIENCE);
+		verifier = new AppleSignInNotificationVerifierImpl(properties, AppleSignInTestJwtSupport.keySourceFrom(rsaKey),
+				new ObjectMapper());
+	}
+
+	@Test
+	void verifyAndParseAcceptsValidPayload() throws Exception {
+		final String signedPayload = signSampleNotification("evt-valid", "email-disabled");
+
+		final AppleSignInNotificationClaims claims = verifier.verifyAndParse(signedPayload);
+
+		assertThat(claims.eventId()).isEqualTo("evt-valid");
+		assertThat(claims.eventType()).isEqualTo(AppleSignInEventType.EMAIL_DISABLED);
+		assertThat(claims.appleSubject()).isEqualTo("001234.abc");
+		assertThat(claims.email()).isEqualTo("relay@privaterelay.appleid.com");
+		assertThat(claims.isPrivateEmail()).isTrue();
+	}
+
+	@Test
+	void verifyAndParseRejectsInvalidSignature() throws Exception {
+		final String signedPayload = signSampleNotification("evt-bad-signature", "email-disabled");
+		final String tamperedPayload = signedPayload.substring(0, signedPayload.length() - 4) + "xxxx";
+
+		assertThatThrownBy(() -> verifier.verifyAndParse(tamperedPayload))
+			.isInstanceOf(InvalidAppleSignInNotificationException.class);
+	}
+
+	@Test
+	void verifyAndParseRejectsWrongIssuer() throws Exception {
+		final AppleSignInProperties properties = new AppleSignInProperties();
+		properties.setExpectedIssuer("https://evil.example");
+		properties.setExpectedAudience(AUDIENCE);
+		final AppleSignInNotificationVerifier strictVerifier = new AppleSignInNotificationVerifierImpl(properties,
+				AppleSignInTestJwtSupport.keySourceFrom(rsaKey), new ObjectMapper());
+		final String signedPayload = signSampleNotification("evt-issuer", "email-disabled");
+
+		assertThatThrownBy(() -> strictVerifier.verifyAndParse(signedPayload))
+			.isInstanceOf(InvalidAppleSignInNotificationException.class)
+			.hasMessageContaining("issuer");
+	}
+
+	@Test
+	void verifyAndParseRejectsWrongAudience() throws Exception {
+		final AppleSignInProperties properties = new AppleSignInProperties();
+		properties.setExpectedAudience("com.other.app");
+		final AppleSignInNotificationVerifier strictVerifier = new AppleSignInNotificationVerifierImpl(properties,
+				AppleSignInTestJwtSupport.keySourceFrom(rsaKey), new ObjectMapper());
+		final String signedPayload = signSampleNotification("evt-audience", "email-disabled");
+
+		assertThatThrownBy(() -> strictVerifier.verifyAndParse(signedPayload))
+			.isInstanceOf(InvalidAppleSignInNotificationException.class)
+			.hasMessageContaining("audience");
+	}
+
+	@Test
+	void verifyAndParseRejectsExpiredPayload() throws Exception {
+		final Instant issuedAt = Instant.now().minus(2, ChronoUnit.HOURS);
+		final Instant expiresAt = Instant.now().minus(1, ChronoUnit.HOURS);
+		final String signedPayload = AppleSignInTestJwtSupport.signNotification(rsaKey, ISSUER, AUDIENCE, "evt-expired",
+				"email-disabled", sampleEventPayload(), issuedAt, expiresAt);
+
+		assertThatThrownBy(() -> verifier.verifyAndParse(signedPayload))
+			.isInstanceOf(InvalidAppleSignInNotificationException.class);
+	}
+
+	private String signSampleNotification(final String eventId, final String eventKey) throws JOSEException {
+		final Instant issuedAt = Instant.now();
+		final Instant expiresAt = issuedAt.plus(1, ChronoUnit.HOURS);
+		return AppleSignInTestJwtSupport.signNotification(rsaKey, ISSUER, AUDIENCE, eventId, eventKey,
+				sampleEventPayload(), issuedAt, expiresAt);
+	}
+
+	private static Map<String, Object> sampleEventPayload() {
+		return Map.of("type", "email-disabled", "sub", "001234.abc", "email", "relay@privaterelay.appleid.com",
+				"is_private_email", true);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationVerifierTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationVerifierTest.java
@@ -89,8 +89,9 @@ class AppleSignInNotificationVerifierTest {
 	void verifyAndParseRejectsExpiredPayload() throws Exception {
 		final Instant issuedAt = Instant.now().minus(2, ChronoUnit.HOURS);
 		final Instant expiresAt = Instant.now().minus(1, ChronoUnit.HOURS);
-		final String signedPayload = AppleSignInTestJwtSupport.signNotification(rsaKey, ISSUER, AUDIENCE, "evt-expired",
-				"email-disabled", sampleEventPayload(), issuedAt, expiresAt);
+		final String signedPayload = AppleSignInTestJwtSupport
+			.signNotification(new AppleSignInTestJwtSupport.SignNotificationRequest(rsaKey, ISSUER, AUDIENCE,
+					"evt-expired", "email-disabled", sampleEventPayload(), issuedAt, expiresAt));
 
 		assertThatThrownBy(() -> verifier.verifyAndParse(signedPayload))
 			.isInstanceOf(InvalidAppleSignInNotificationException.class);
@@ -99,8 +100,8 @@ class AppleSignInNotificationVerifierTest {
 	private String signSampleNotification(final String eventId, final String eventKey) throws JOSEException {
 		final Instant issuedAt = Instant.now();
 		final Instant expiresAt = issuedAt.plus(1, ChronoUnit.HOURS);
-		return AppleSignInTestJwtSupport.signNotification(rsaKey, ISSUER, AUDIENCE, eventId, eventKey,
-				sampleEventPayload(), issuedAt, expiresAt);
+		return AppleSignInTestJwtSupport.signNotification(new AppleSignInTestJwtSupport.SignNotificationRequest(rsaKey,
+				ISSUER, AUDIENCE, eventId, eventKey, sampleEventPayload(), issuedAt, expiresAt));
 	}
 
 	private static Map<String, Object> sampleEventPayload() {

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInPropertiesTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInPropertiesTest.java
@@ -1,0 +1,52 @@
+package com.nutriconsultas.auth.apple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AppleSignInPropertiesTest {
+
+	@Test
+	void webhookDisabledByDefault() {
+		final AppleSignInProperties properties = new AppleSignInProperties();
+
+		assertThat(properties.isWebhookEnabled()).isFalse();
+		assertThat(properties.isAutoProcessDestructiveEvents()).isFalse();
+		assertThat(properties.getExpectedIssuer()).isEqualTo("https://appleid.apple.com");
+		assertThat(properties.getJwksUrl()).isEqualTo("https://appleid.apple.com/auth/keys");
+		assertThat(properties.isWebhookConfigured()).isFalse();
+	}
+
+	@Test
+	void trimsExpectedAudienceWhenPresent() {
+		final AppleSignInProperties properties = new AppleSignInProperties();
+		properties.setExpectedAudience("  com.minutriporcion.app  ");
+
+		assertThat(properties.getExpectedAudience()).isEqualTo("com.minutriporcion.app");
+		assertThat(properties.isWebhookConfigured()).isTrue();
+	}
+
+	@Test
+	void ignoresBlankExpectedAudience() {
+		final AppleSignInProperties properties = new AppleSignInProperties();
+		properties.setExpectedAudience("   ");
+
+		assertThat(properties.getExpectedAudience()).isEmpty();
+		assertThat(properties.isWebhookConfigured()).isFalse();
+	}
+
+	@Test
+	void configValidationFailsWhenWebhookEnabledWithoutAudience() {
+		final AppleSignInProperties properties = new AppleSignInProperties();
+		properties.getWebhook().setEnabled(true);
+
+		assertThatThrownBy(() -> new AppleSignInConfig(properties).validateConfiguration())
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("APPLE_SIGNIN_EXPECTED_AUDIENCE");
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInTestJwtSupport.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInTestJwtSupport.java
@@ -1,0 +1,54 @@
+package com.nutriconsultas.auth.apple;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+public final class AppleSignInTestJwtSupport {
+
+	private AppleSignInTestJwtSupport() {
+	}
+
+	public static RSAKey generateRsaKey() throws JOSEException {
+		return new RSAKeyGenerator(2048).keyID("apple-signin-test-key").generate();
+	}
+
+	public static AppleSignInJwksKeySource keySourceFrom(final RSAKey rsaKey) {
+		final ImmutableJWKSet<SecurityContext> jwkSet = new ImmutableJWKSet<>(new JWKSet(rsaKey.toPublicJWK()));
+		return () -> jwkSet;
+	}
+
+	public static String signNotification(final RSAKey rsaKey, final String issuer, final String audience,
+			final String eventId, final String eventKey, final Map<String, Object> eventPayload, final Instant issuedAt,
+			final Instant expiresAt) throws JOSEException {
+		final Map<String, Object> events = new LinkedHashMap<>();
+		events.put(eventKey, eventPayload);
+		final JWTClaimsSet claims = new JWTClaimsSet.Builder().issuer(issuer)
+			.audience(List.of(audience))
+			.jwtID(eventId)
+			.issueTime(Date.from(issuedAt))
+			.expirationTime(Date.from(expiresAt))
+			.claim("events", events)
+			.build();
+		final SignedJWT signedJwt = new SignedJWT(
+				new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(rsaKey.getKeyID()).build(), claims);
+		signedJwt.sign(new RSASSASigner(rsaKey));
+		return signedJwt.serialize();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInTestJwtSupport.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInTestJwtSupport.java
@@ -14,7 +14,6 @@ import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
-import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
@@ -33,22 +32,24 @@ public final class AppleSignInTestJwtSupport {
 		return () -> jwkSet;
 	}
 
-	public static String signNotification(final RSAKey rsaKey, final String issuer, final String audience,
-			final String eventId, final String eventKey, final Map<String, Object> eventPayload, final Instant issuedAt,
-			final Instant expiresAt) throws JOSEException {
+	public static String signNotification(final SignNotificationRequest request) throws JOSEException {
 		final Map<String, Object> events = new LinkedHashMap<>();
-		events.put(eventKey, eventPayload);
-		final JWTClaimsSet claims = new JWTClaimsSet.Builder().issuer(issuer)
-			.audience(List.of(audience))
-			.jwtID(eventId)
-			.issueTime(Date.from(issuedAt))
-			.expirationTime(Date.from(expiresAt))
+		events.put(request.eventKey(), request.eventPayload());
+		final JWTClaimsSet claims = new JWTClaimsSet.Builder().issuer(request.issuer())
+			.audience(List.of(request.audience()))
+			.jwtID(request.eventId())
+			.issueTime(Date.from(request.issuedAt()))
+			.expirationTime(Date.from(request.expiresAt()))
 			.claim("events", events)
 			.build();
 		final SignedJWT signedJwt = new SignedJWT(
-				new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(rsaKey.getKeyID()).build(), claims);
-		signedJwt.sign(new RSASSASigner(rsaKey));
+				new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(request.rsaKey().getKeyID()).build(), claims);
+		signedJwt.sign(new RSASSASigner(request.rsaKey()));
 		return signedJwt.serialize();
+	}
+
+	public record SignNotificationRequest(RSAKey rsaKey, String issuer, String audience, String eventId,
+			String eventKey, Map<String, Object> eventPayload, Instant issuedAt, Instant expiresAt) {
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookControllerTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookControllerTest.java
@@ -1,0 +1,83 @@
+package com.nutriconsultas.auth.apple;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class AppleSignInWebhookControllerTest {
+
+	private static final String WEBHOOK_URL = "/rest/webhooks/apple/sign-in";
+
+	@Mock
+	private AppleSignInProperties properties;
+
+	@Mock
+	private AppleSignInNotificationService notificationService;
+
+	@InjectMocks
+	private AppleSignInWebhookController controller;
+
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp() {
+		mockMvc = MockMvcBuilders.standaloneSetup(controller)
+			.setControllerAdvice(new AppleSignInWebhookExceptionHandler())
+			.build();
+	}
+
+	@Test
+	void returnsServiceUnavailableWhenWebhookDisabled() throws Exception {
+		when(properties.isWebhookEnabled()).thenReturn(false);
+
+		mockMvc
+			.perform(post(WEBHOOK_URL).contentType(MediaType.APPLICATION_JSON)
+				.content("{\"payload\":\"eyJ.test.signature\"}"))
+			.andExpect(status().isServiceUnavailable());
+
+		verify(notificationService, never()).handleNotification(any());
+	}
+
+	@Test
+	void returnsBadRequestWhenPayloadMissing() throws Exception {
+		when(properties.isWebhookEnabled()).thenReturn(true);
+
+		mockMvc.perform(post(WEBHOOK_URL).contentType(MediaType.APPLICATION_JSON).content("{}"))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void returnsOkWhenNotificationProcessed() throws Exception {
+		when(properties.isWebhookEnabled()).thenReturn(true);
+		when(notificationService.handleNotification("signed-jwt")).thenReturn(AppleSignInWebhookOutcome.PROCESSED);
+
+		mockMvc
+			.perform(post(WEBHOOK_URL).contentType(MediaType.APPLICATION_JSON).content("{\"payload\":\"signed-jwt\"}"))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	void returnsBadRequestWhenVerificationFails() throws Exception {
+		when(properties.isWebhookEnabled()).thenReturn(true);
+		when(notificationService.handleNotification("bad-jwt"))
+			.thenThrow(new InvalidAppleSignInNotificationException("Invalid Apple notification signature"));
+
+		mockMvc.perform(post(WEBHOOK_URL).contentType(MediaType.APPLICATION_JSON).content("{\"payload\":\"bad-jwt\"}"))
+			.andExpect(status().isBadRequest());
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookSecurityTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookSecurityTest.java
@@ -1,0 +1,47 @@
+package com.nutriconsultas.auth.apple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = { "nutriconsultas.apple.signin.webhook.enabled=true",
+		"nutriconsultas.apple.signin.expected-audience=com.minutriporcion.app" })
+class AppleSignInWebhookSecurityTest {
+
+	private static final String WEBHOOK_URL = "/rest/webhooks/apple/sign-in";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private AppleSignInNotificationService notificationService;
+
+	@Test
+	void webhookIsReachableWithoutAuthentication() throws Exception {
+		when(notificationService.handleNotification(any())).thenReturn(AppleSignInWebhookOutcome.PROCESSED);
+
+		final int status = mockMvc
+			.perform(post(WEBHOOK_URL).contentType(MediaType.APPLICATION_JSON).content("{\"payload\":\"signed-jwt\"}"))
+			.andReturn()
+			.getResponse()
+			.getStatus();
+
+		assertThat(status).isEqualTo(200);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/subscription/PlanEntitlementsTest.java
+++ b/src/test/java/com/nutriconsultas/subscription/PlanEntitlementsTest.java
@@ -81,11 +81,11 @@ class PlanEntitlementsTest {
 					Entitlement.CALENDAR, Entitlement.REPORTS_BASIC, Entitlement.REPORTS_ADVANCED,
 					Entitlement.REPORTS_FULL, Entitlement.PDF_EXPORT, Entitlement.REPORTS_BRANDED,
 					Entitlement.PRIORITY_SUPPORT, Entitlement.AI_ASSISTANT);
-			case CONSULTORIO -> EnumSet.of(Entitlement.PATIENT_MANAGEMENT, Entitlement.CREATE_PATIENT,
-					Entitlement.DIET_PLANS, Entitlement.CALENDAR, Entitlement.REPORTS_BASIC,
-					Entitlement.REPORTS_ADVANCED, Entitlement.REPORTS_FULL, Entitlement.PDF_EXPORT,
-					Entitlement.REPORTS_BRANDED, Entitlement.PRIORITY_SUPPORT, Entitlement.USER_ADMINISTRATION,
-					Entitlement.AI_ASSISTANT);
+			case CONSULTORIO ->
+				EnumSet.of(Entitlement.PATIENT_MANAGEMENT, Entitlement.CREATE_PATIENT, Entitlement.DIET_PLANS,
+						Entitlement.CALENDAR, Entitlement.REPORTS_BASIC, Entitlement.REPORTS_ADVANCED,
+						Entitlement.REPORTS_FULL, Entitlement.PDF_EXPORT, Entitlement.REPORTS_BRANDED,
+						Entitlement.PRIORITY_SUPPORT, Entitlement.USER_ADMINISTRATION, Entitlement.AI_ASSISTANT);
 		};
 	}
 


### PR DESCRIPTION
## Summary
- Adds Apple Sign-In **server-to-server webhook** foundation at `POST /rest/webhooks/apple/sign-in` (#499).
- Introduces typed configuration with fail-fast when webhook is enabled without audience (#498).
- Verifies Apple signed JWT payloads via **Nimbus JOSE JWT** + cached JWKS (#501).
- Persists notifications in `apple_signin_notification` with idempotent `apple_event_id` (#502).
- Processes events in **observe-only** mode — destructive actions gated by config (#503).
- Permits public webhook route in Spring Security while verifying payloads in-handler (#500).

Closes #498, #499, #500, #501, #502, #503.

## Key behavior
- Webhook **disabled by default** (`APPLE_SIGNIN_WEBHOOK_ENABLED=false`).
- Returns `503` when disabled, `400` on invalid payload, `200` on verified + recorded events.
- Destructive Apple events (`consent-revoked`, `account-delete`) are recorded but **not** auto-applied unless `APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS=true`.

## Production enablement
```bash
APPLE_SIGNIN_WEBHOOK_ENABLED=true
APPLE_SIGNIN_EXPECTED_AUDIENCE=<bundle-id-or-services-id>
```

Apple notification URL: `https://minutriporcion.com/rest/webhooks/apple/sign-in`

## Test plan
- [x] `./lint.sh` (checkstyle, spotbugs, pmd, thymeleaf)
- [x] `mvn test -Dtest='com.nutriconsultas.auth.apple.**'` (18 tests)
- [ ] Enable webhook on staging with test audience; confirm Apple delivery + DB row
- [ ] Confirm other `/rest/**` routes remain authenticated

## Follow-ups (separate PRs)
- #497 Auth0 Apple connection (manual tenant setup)
- #504–#511 identity mapping, Auth0 Mgmt API, deletion workflow, observability metrics

Made with [Cursor](https://cursor.com)