### PR TITLE
Apple Sign-In identity mapping and Auth0 Management API (#504–#505)

### DIFF
--- a/ISSUE-APPLE-SIGNIN.md
+++ b/ISSUE-APPLE-SIGNIN.md
@@ -6,7 +6,7 @@ Living index of GitHub issues that implement **Sign in with Apple** through Auth
 **Roadmap:** [`docs/auth/apple-signin-backend-roadmap.md`](docs/auth/apple-signin-backend-roadmap.md)  
 **Setup (maintainer runbook):** [`docs/auth/apple-signin-setup.md`](docs/auth/apple-signin-setup.md)  
 **Epic comment:** [#497](https://github.com/diego-torres/nutriconsultas/issues/497#issuecomment-4904658287)  
-**Last updated:** 2026-07-07 — #498–#503 in progress on `apple-signin/498-503-webhook-foundation`.
+**Last updated:** 2026-07-07 — #504–#505 in progress on `apple-signin/504-505-identity-mapping`.
 
 > **Scope.** Auth0 Apple social connection, backend webhook (`POST /rest/webhooks/apple/sign-in`), signed payload verification, notification persistence, identity mapping, and safe lifecycle handling. **Does not** replace Auth0 with custom Apple OAuth. Patient mobile API: [`ISSUE.md`](ISSUE.md). Auth0 patient gate: [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md).
 
@@ -41,14 +41,14 @@ Suggested order matches [`docs/auth/apple-signin-backend-roadmap.md`](docs/auth/
 | Step | # | Title | URL | State | Depends on | Notes |
 |------|---|-------|-----|-------|------------|-------|
 | 1 | **497** | Configure Auth0 Apple connection | https://github.com/diego-torres/nutriconsultas/issues/497 | **open** | — | Auth0 tenant + Apple Developer Portal; manual setup **NEXT** |
-| 2 | 498 | Add webhook configuration properties | https://github.com/diego-torres/nutriconsultas/issues/498 | **in-progress** | — | Branch `apple-signin/498-503-webhook-foundation` |
-| 3 | 499 | Add webhook controller | https://github.com/diego-torres/nutriconsultas/issues/499 | **in-progress** | 498 | `POST /rest/webhooks/apple/sign-in` |
-| 4 | 500 | Permit webhook path through Spring Security | https://github.com/diego-torres/nutriconsultas/issues/500 | **in-progress** | 499 | Public route; verify payload in handler |
-| 5 | 501 | Implement signed payload verification | https://github.com/diego-torres/nutriconsultas/issues/501 | **in-progress** | 498, 499 | Nimbus JOSE JWT + JWKS cache |
-| 6 | 502 | Persist notification events (Liquibase + JPA) | https://github.com/diego-torres/nutriconsultas/issues/502 | **in-progress** | 498 | `apple_signin_notification`; idempotent |
-| 7 | 503 | Create notification processing service | https://github.com/diego-torres/nutriconsultas/issues/503 | **in-progress** | 501, 502 | Observe-only first; no destructive auto |
-| 8 | 504 | Map Apple/Auth0 identity to local users | https://github.com/diego-torres/nutriconsultas/issues/504 | open | 497, 503 | Stable subject over email |
-| 9 | 505 | Add Auth0 Management API client methods | https://github.com/diego-torres/nutriconsultas/issues/505 | open | 497 | Narrow scopes; delete disabled by default |
+| 2 | 498 | Add webhook configuration properties | https://github.com/diego-torres/nutriconsultas/issues/498 | **done** | — | PR #513 |
+| 3 | 499 | Add webhook controller | https://github.com/diego-torres/nutriconsultas/issues/499 | **done** | 498 | PR #513 |
+| 4 | 500 | Permit webhook path through Spring Security | https://github.com/diego-torres/nutriconsultas/issues/500 | **done** | 499 | PR #513 |
+| 5 | 501 | Implement signed payload verification | https://github.com/diego-torres/nutriconsultas/issues/501 | **done** | 498, 499 | PR #513 |
+| 6 | 502 | Persist notification events (Liquibase + JPA) | https://github.com/diego-torres/nutriconsultas/issues/502 | **done** | 498 | PR #513 |
+| 7 | 503 | Create notification processing service | https://github.com/diego-torres/nutriconsultas/issues/503 | **done** | 501, 502 | PR #513 |
+| 8 | 504 | Map Apple/Auth0 identity to local users | https://github.com/diego-torres/nutriconsultas/issues/504 | **in-progress** | 497, 503 | Branch `apple-signin/504-505-identity-mapping` |
+| 9 | 505 | Add Auth0 Management API client methods | https://github.com/diego-torres/nutriconsultas/issues/505 | **in-progress** | 497 | Same branch as #504 |
 | 10 | 506 | Add safe account deletion workflow | https://github.com/diego-torres/nutriconsultas/issues/506 | open | 503, 504, 505 | Staged; no silent hard-delete |
 | 11 | 507 | Handle private relay email changes | https://github.com/diego-torres/nutriconsultas/issues/507 | open | 503, 504 | Relay metadata; no email-as-primary-key |
 | 12 | 508 | Add observability and operational alerts | https://github.com/diego-torres/nutriconsultas/issues/508 | open | 499, 503 | Metrics + structured logs |

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleIdentityMappingResult.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleIdentityMappingResult.java
@@ -1,0 +1,37 @@
+package com.nutriconsultas.auth.apple;
+
+/**
+ * Mapping outcome for Apple Sign-In notifications (#504).
+ */
+public record AppleIdentityMappingResult(AppleIdentityMappingStatus status, String auth0UserId, Long pacienteId,
+		String detail) {
+
+	public static AppleIdentityMappingResult notAttempted() {
+		return new AppleIdentityMappingResult(AppleIdentityMappingStatus.NOT_ATTEMPTED, null, null, null);
+	}
+
+	public static AppleIdentityMappingResult noAppleSubject() {
+		return new AppleIdentityMappingResult(AppleIdentityMappingStatus.NO_APPLE_SUBJECT, null, null, null);
+	}
+
+	public static AppleIdentityMappingResult mapped(final String auth0UserId, final Long pacienteId) {
+		return new AppleIdentityMappingResult(AppleIdentityMappingStatus.MAPPED, auth0UserId, pacienteId, null);
+	}
+
+	public static AppleIdentityMappingResult noAuth0User() {
+		return new AppleIdentityMappingResult(AppleIdentityMappingStatus.NO_AUTH0_USER, null, null, null);
+	}
+
+	public static AppleIdentityMappingResult noLocalUser(final String auth0UserId) {
+		return new AppleIdentityMappingResult(AppleIdentityMappingStatus.NO_LOCAL_USER, auth0UserId, null, null);
+	}
+
+	public static AppleIdentityMappingResult ambiguous(final String detail) {
+		return new AppleIdentityMappingResult(AppleIdentityMappingStatus.AMBIGUOUS, null, null, detail);
+	}
+
+	public static AppleIdentityMappingResult auth0LookupFailed(final String detail) {
+		return new AppleIdentityMappingResult(AppleIdentityMappingStatus.AUTH0_LOOKUP_FAILED, null, null, detail);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleIdentityMappingService.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleIdentityMappingService.java
@@ -1,0 +1,12 @@
+package com.nutriconsultas.auth.apple;
+
+/**
+ * Maps Apple Sign-In notification subjects to Auth0 users and local patient accounts
+ * (#504).
+ */
+@FunctionalInterface
+public interface AppleIdentityMappingService {
+
+	AppleIdentityMappingResult mapNotification(String appleSubject, String email);
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleIdentityMappingServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleIdentityMappingServiceImpl.java
@@ -1,0 +1,135 @@
+package com.nutriconsultas.auth.apple;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.auth0.Auth0AppleIdentitySupport;
+import com.nutriconsultas.auth0.Auth0ManagementApiException;
+import com.nutriconsultas.auth0.Auth0ManagementUser;
+import com.nutriconsultas.auth0.Auth0ManagementUserService;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class AppleIdentityMappingServiceImpl implements AppleIdentityMappingService {
+
+	private final Auth0ManagementUserService auth0ManagementUserService;
+
+	private final PacienteRepository pacienteRepository;
+
+	public AppleIdentityMappingServiceImpl(final Auth0ManagementUserService auth0ManagementUserService,
+			final PacienteRepository pacienteRepository) {
+		this.auth0ManagementUserService = auth0ManagementUserService;
+		this.pacienteRepository = pacienteRepository;
+	}
+
+	@Override
+	@Transactional
+	public AppleIdentityMappingResult mapNotification(final String appleSubject, final String email) {
+		if (!StringUtils.hasText(appleSubject)) {
+			return AppleIdentityMappingResult.noAppleSubject();
+		}
+		final String normalizedSubject = appleSubject.trim();
+		final Optional<Paciente> pacienteByAppleSubject = pacienteRepository.findByAppleSubject(normalizedSubject);
+		if (pacienteByAppleSubject.isPresent()) {
+			final Paciente paciente = pacienteByAppleSubject.get();
+			return AppleIdentityMappingResult.mapped(paciente.getPatientAuthSub(), paciente.getId());
+		}
+		try {
+			final Auth0Resolution auth0Resolution = resolveAuth0UserId(normalizedSubject, email);
+			if (auth0Resolution.failureStatus() != null) {
+				return new AppleIdentityMappingResult(auth0Resolution.failureStatus(), null, null,
+						auth0Resolution.detail());
+			}
+			if (auth0Resolution.userId().isEmpty()) {
+				return AppleIdentityMappingResult.noAuth0User();
+			}
+			final String resolvedAuth0UserId = auth0Resolution.userId().get();
+			final Optional<Paciente> pacienteByAuthSub = pacienteRepository.findByPatientAuthSub(resolvedAuth0UserId);
+			if (pacienteByAuthSub.isPresent()) {
+				final Paciente paciente = pacienteByAuthSub.get();
+				backfillAppleSubjectIfMissing(paciente, normalizedSubject);
+				return AppleIdentityMappingResult.mapped(resolvedAuth0UserId, paciente.getId());
+			}
+			return AppleIdentityMappingResult.noLocalUser(resolvedAuth0UserId);
+		}
+		catch (Auth0ManagementApiException ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("Auth0 lookup failed for Apple subject hash={}", normalizedSubject.hashCode());
+			}
+			return AppleIdentityMappingResult.auth0LookupFailed(ex.getMessage());
+		}
+	}
+
+	private Auth0Resolution resolveAuth0UserId(final String appleSubject, final String email) {
+		if (auth0ManagementUserService.isConfigured()) {
+			final Optional<Auth0ManagementUser> auth0User = auth0ManagementUserService
+				.findUserByAppleSubject(appleSubject);
+			if (auth0User.isPresent()) {
+				return Auth0Resolution.found(auth0User.get().userId());
+			}
+			final Auth0Resolution emailResolution = resolveAuth0UserIdByEmail(email);
+			if (emailResolution != null) {
+				return emailResolution;
+			}
+		}
+		final String canonicalAuth0UserId = Auth0AppleIdentitySupport.toAuth0UserId(appleSubject);
+		final Optional<Paciente> localByCanonical = pacienteRepository.findByPatientAuthSub(canonicalAuth0UserId);
+		if (localByCanonical.isPresent()) {
+			return Auth0Resolution.found(canonicalAuth0UserId);
+		}
+		return Auth0Resolution.notFound();
+	}
+
+	private Auth0Resolution resolveAuth0UserIdByEmail(final String email) {
+		if (!StringUtils.hasText(email)) {
+			return null;
+		}
+		final List<Auth0ManagementUser> emailMatches = auth0ManagementUserService.searchUsersByEmail(email.trim());
+		final List<Auth0ManagementUser> appleEmailMatches = emailMatches.stream()
+			.filter(user -> Auth0AppleIdentitySupport.isAppleAuth0UserId(user.userId()))
+			.toList();
+		if (appleEmailMatches.size() == 1) {
+			return Auth0Resolution.found(appleEmailMatches.get(0).userId());
+		}
+		if (appleEmailMatches.size() > 1) {
+			return Auth0Resolution.failed(AppleIdentityMappingStatus.AMBIGUOUS,
+					"Multiple Auth0 Apple users matched relay email");
+		}
+		return null;
+	}
+
+	private void backfillAppleSubjectIfMissing(final Paciente paciente, final String appleSubject) {
+		if (!StringUtils.hasText(paciente.getAppleSubject())) {
+			paciente.setAppleSubject(appleSubject);
+			pacienteRepository.save(paciente);
+			if (log.isDebugEnabled()) {
+				log.debug("Backfilled Apple subject for pacienteId={}", paciente.getId());
+			}
+		}
+	}
+
+	private record Auth0Resolution(Optional<String> userId, AppleIdentityMappingStatus failureStatus, String detail) {
+
+		private static Auth0Resolution found(final String userId) {
+			return new Auth0Resolution(Optional.of(userId), null, null);
+		}
+
+		private static Auth0Resolution notFound() {
+			return new Auth0Resolution(Optional.empty(), null, null);
+		}
+
+		private static Auth0Resolution failed(final AppleIdentityMappingStatus status, final String detail) {
+			return new Auth0Resolution(Optional.empty(), status, detail);
+		}
+
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleIdentityMappingStatus.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleIdentityMappingStatus.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.auth.apple;
+
+/**
+ * Result of mapping an Apple notification subject to Auth0 and local accounts (#504).
+ */
+public enum AppleIdentityMappingStatus {
+
+	NOT_ATTEMPTED, MAPPED, NO_APPLE_SUBJECT, NO_AUTH0_USER, NO_LOCAL_USER, AMBIGUOUS, AUTH0_LOOKUP_FAILED
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotification.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotification.java
@@ -45,6 +45,13 @@ public class AppleSignInNotification {
 	@Column(name = "auth0_user_id", length = 255)
 	private String auth0UserId;
 
+	@Column(name = "paciente_id")
+	private Long pacienteId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "identity_mapping_status", length = 30)
+	private AppleIdentityMappingStatus identityMappingStatus;
+
 	@Column(length = 320)
 	private String email;
 

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationService.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationService.java
@@ -18,12 +18,16 @@ public class AppleSignInNotificationService {
 
 	private final AppleSignInNotificationRepository notificationRepository;
 
+	private final AppleIdentityMappingService identityMappingService;
+
 	public AppleSignInNotificationService(final AppleSignInProperties properties,
 			final AppleSignInNotificationVerifier notificationVerifier,
-			final AppleSignInNotificationRepository notificationRepository) {
+			final AppleSignInNotificationRepository notificationRepository,
+			final AppleIdentityMappingService identityMappingService) {
 		this.properties = properties;
 		this.notificationVerifier = notificationVerifier;
 		this.notificationRepository = notificationRepository;
+		this.identityMappingService = identityMappingService;
 	}
 
 	@Transactional
@@ -46,6 +50,7 @@ public class AppleSignInNotificationService {
 		notification.setRawClaimsJson(claims.rawClaimsJson());
 		notification.setProcessingStatus(AppleSignInNotificationProcessingStatus.VERIFIED);
 		notification.setReceivedAt(Instant.now());
+		applyIdentityMapping(notification, claims);
 		processNotification(notification, claims);
 		notificationRepository.save(notification);
 		if (log.isInfoEnabled()) {
@@ -53,6 +58,22 @@ public class AppleSignInNotificationService {
 					claims.eventType(), notification.getProcessingStatus());
 		}
 		return AppleSignInWebhookOutcome.PROCESSED;
+	}
+
+	private void applyIdentityMapping(final AppleSignInNotification notification,
+			final AppleSignInNotificationClaims claims) {
+		final AppleIdentityMappingResult mappingResult = identityMappingService.mapNotification(claims.appleSubject(),
+				claims.email());
+		notification.setIdentityMappingStatus(mappingResult.status());
+		notification.setAuth0UserId(mappingResult.auth0UserId());
+		notification.setPacienteId(mappingResult.pacienteId());
+		if (StringUtils.hasText(mappingResult.detail())) {
+			notification.setProcessingError(truncateDetail(mappingResult.detail()));
+		}
+		if (log.isDebugEnabled()) {
+			log.debug("Apple identity mapping status={} pacienteId={}", mappingResult.status(),
+					mappingResult.pacienteId());
+		}
 	}
 
 	private void processNotification(final AppleSignInNotification notification,
@@ -77,6 +98,13 @@ public class AppleSignInNotificationService {
 			log.debug("Apple sign-in observe-only processing complete for subject hash={}",
 					claims.appleSubject().hashCode());
 		}
+	}
+
+	private static String truncateDetail(final String detail) {
+		if (detail == null || detail.length() <= 500) {
+			return detail;
+		}
+		return detail.substring(0, 497) + "...";
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/auth0/Auth0AppleIdentitySupport.java
+++ b/src/main/java/com/nutriconsultas/auth0/Auth0AppleIdentitySupport.java
@@ -1,0 +1,26 @@
+package com.nutriconsultas.auth0;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Auth0 user_id conventions for Sign in with Apple (#504).
+ */
+public final class Auth0AppleIdentitySupport {
+
+	private static final String APPLE_PROVIDER = "apple";
+
+	private Auth0AppleIdentitySupport() {
+	}
+
+	public static String toAuth0UserId(final String appleSubject) {
+		if (!StringUtils.hasText(appleSubject)) {
+			return null;
+		}
+		return APPLE_PROVIDER + "|" + appleSubject.trim();
+	}
+
+	public static boolean isAppleAuth0UserId(final String auth0UserId) {
+		return StringUtils.hasText(auth0UserId) && auth0UserId.startsWith(APPLE_PROVIDER + "|");
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth0/Auth0ManagementApiException.java
+++ b/src/main/java/com/nutriconsultas/auth0/Auth0ManagementApiException.java
@@ -1,0 +1,18 @@
+package com.nutriconsultas.auth0;
+
+/**
+ * Auth0 Management API call failed after retries (#505).
+ */
+public class Auth0ManagementApiException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public Auth0ManagementApiException(final String message) {
+		super(message);
+	}
+
+	public Auth0ManagementApiException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth0/Auth0ManagementUser.java
+++ b/src/main/java/com/nutriconsultas/auth0/Auth0ManagementUser.java
@@ -1,0 +1,28 @@
+package com.nutriconsultas.auth0;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Minimal Auth0 Management API user view for Apple Sign-In identity mapping (#505).
+ */
+public record Auth0ManagementUser(String userId, String email, Map<String, Object> appMetadata,
+		List<Map<String, Object>> identities) {
+
+	public static Auth0ManagementUser fromApiMap(final Map<String, Object> user) {
+		if (user == null) {
+			return null;
+		}
+		final Object userId = user.get("user_id");
+		final Object email = user.get("email");
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> appMetadata = user.get("app_metadata") instanceof Map<?, ?> metadata
+				? (Map<String, Object>) metadata : Map.of();
+		@SuppressWarnings("unchecked")
+		final List<Map<String, Object>> identities = user.get("identities") instanceof List<?> identityList
+				? (List<Map<String, Object>>) identityList : List.of();
+		return new Auth0ManagementUser(userId == null ? null : userId.toString(),
+				email == null ? null : email.toString(), appMetadata, identities);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth0/Auth0ManagementUserService.java
+++ b/src/main/java/com/nutriconsultas/auth0/Auth0ManagementUserService.java
@@ -1,0 +1,24 @@
+package com.nutriconsultas.auth0;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Narrow Auth0 Management API operations for Apple Sign-In lifecycle handling (#505).
+ */
+public interface Auth0ManagementUserService {
+
+	boolean isConfigured();
+
+	Optional<Auth0ManagementUser> findUserByAppleSubject(String appleSubject);
+
+	List<Auth0ManagementUser> searchUsersByEmail(String email);
+
+	void updateAppMetadata(String auth0UserId, Map<String, Object> appMetadataPatch);
+
+	void blockUserInAppMetadata(String auth0UserId);
+
+	void deleteUser(String auth0UserId);
+
+}

--- a/src/main/java/com/nutriconsultas/auth0/Auth0ManagementUserServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/auth0/Auth0ManagementUserServiceImpl.java
@@ -1,0 +1,235 @@
+package com.nutriconsultas.auth0;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@ConditionalOnBean(Auth0ManagementTokenProvider.class)
+@Slf4j
+public class Auth0ManagementUserServiceImpl implements Auth0ManagementUserService {
+
+	private static final ParameterizedTypeReference<List<Map<String, Object>>> USER_LIST_TYPE = new ParameterizedTypeReference<>() {
+	};
+
+	private static final ParameterizedTypeReference<Map<String, Object>> USER_MAP_TYPE = new ParameterizedTypeReference<>() {
+	};
+
+	private final RestClient restClient;
+
+	private final Auth0ManagementTokenProvider tokenProvider;
+
+	private final boolean userDeleteEnabled;
+
+	private final int maxRetries;
+
+	public Auth0ManagementUserServiceImpl(final RestClient.Builder restClientBuilder,
+			final Auth0ManagementTokenProvider tokenProvider,
+			@Value("${app.auth0.management.user-delete-enabled:false}") final boolean userDeleteEnabled,
+			@Value("${app.auth0.management.max-retries:2}") final int maxRetries) {
+		this.restClient = restClientBuilder.build();
+		this.tokenProvider = tokenProvider;
+		this.userDeleteEnabled = userDeleteEnabled;
+		this.maxRetries = Math.max(0, maxRetries);
+	}
+
+	@Override
+	public boolean isConfigured() {
+		return tokenProvider.isConfigured();
+	}
+
+	@Override
+	public Optional<Auth0ManagementUser> findUserByAppleSubject(final String appleSubject) {
+		if (!StringUtils.hasText(appleSubject)) {
+			return Optional.empty();
+		}
+		final String normalizedSubject = appleSubject.trim();
+		final String auth0UserId = Auth0AppleIdentitySupport.toAuth0UserId(normalizedSubject);
+		final Optional<Auth0ManagementUser> direct = findUserById(auth0UserId);
+		if (direct.isPresent()) {
+			return direct;
+		}
+		final String luceneQuery = "identities.provider:\"apple\" AND identities.user_id:\""
+				+ escapeLuceneValue(normalizedSubject) + "\"";
+		final List<Auth0ManagementUser> matches = searchUsers(luceneQuery);
+		if (matches.isEmpty()) {
+			return Optional.empty();
+		}
+		if (matches.size() > 1 && log.isWarnEnabled()) {
+			log.warn("Ambiguous Auth0 Apple subject lookup: subjectHash={}, matchCount={}",
+					normalizedSubject.hashCode(), matches.size());
+		}
+		return Optional.of(matches.get(0));
+	}
+
+	@Override
+	public List<Auth0ManagementUser> searchUsersByEmail(final String email) {
+		if (!StringUtils.hasText(email)) {
+			return List.of();
+		}
+		final String luceneQuery = "email:\"" + escapeLuceneValue(email.trim().toLowerCase()) + "\"";
+		return searchUsers(luceneQuery);
+	}
+
+	@Override
+	public void updateAppMetadata(final String auth0UserId, final Map<String, Object> appMetadataPatch) {
+		requireConfiguredUserId(auth0UserId);
+		if (appMetadataPatch == null || appMetadataPatch.isEmpty()) {
+			throw new IllegalArgumentException("appMetadataPatch is required");
+		}
+		executeVoidWithRetry("update app_metadata", () -> {
+			final String token = tokenProvider.obtainToken();
+			restClient.patch()
+				.uri("https://{domain}/api/v2/users/{userId}", tokenProvider.getDomain(), auth0UserId)
+				.header("Authorization", "Bearer " + token)
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(Map.of("app_metadata", appMetadataPatch))
+				.retrieve()
+				.toBodilessEntity();
+		});
+	}
+
+	@Override
+	public void blockUserInAppMetadata(final String auth0UserId) {
+		updateAppMetadata(auth0UserId,
+				Map.of("apple_signin_blocked", true, "apple_signin_blocked_at", Instant.now().toString()));
+	}
+
+	@Override
+	public void deleteUser(final String auth0UserId) {
+		requireConfiguredUserId(auth0UserId);
+		if (!userDeleteEnabled) {
+			throw new IllegalStateException("Auth0 user deletion is disabled by configuration");
+		}
+		executeVoidWithRetry("delete user", () -> {
+			final String token = tokenProvider.obtainToken();
+			restClient.delete()
+				.uri("https://{domain}/api/v2/users/{userId}", tokenProvider.getDomain(), auth0UserId)
+				.header("Authorization", "Bearer " + token)
+				.retrieve()
+				.toBodilessEntity();
+		});
+	}
+
+	private void requireConfiguredUserId(final String auth0UserId) {
+		if (!isConfigured()) {
+			throw new IllegalStateException("Auth0 Management API is not configured");
+		}
+		if (!StringUtils.hasText(auth0UserId)) {
+			throw new IllegalArgumentException("auth0UserId is required");
+		}
+	}
+
+	private Optional<Auth0ManagementUser> findUserById(final String auth0UserId) {
+		if (!isConfigured() || !StringUtils.hasText(auth0UserId)) {
+			return Optional.empty();
+		}
+		try {
+			return Optional.ofNullable(executeWithRetry("get user", () -> {
+				final String token = tokenProvider.obtainToken();
+				final Map<String, Object> user = restClient.get()
+					.uri("https://{domain}/api/v2/users/{userId}", tokenProvider.getDomain(), auth0UserId)
+					.header("Authorization", "Bearer " + token)
+					.accept(MediaType.APPLICATION_JSON)
+					.retrieve()
+					.body(USER_MAP_TYPE);
+				return Auth0ManagementUser.fromApiMap(user);
+			}));
+		}
+		catch (Auth0ManagementApiException ex) {
+			if (log.isDebugEnabled()) {
+				log.debug("Auth0 user lookup by id missed for userIdHash={}", auth0UserId.hashCode());
+			}
+			return Optional.empty();
+		}
+	}
+
+	private List<Auth0ManagementUser> searchUsers(final String luceneQuery) {
+		if (!isConfigured()) {
+			return List.of();
+		}
+		final List<Map<String, Object>> users = executeWithRetry("search users", () -> {
+			final String token = tokenProvider.obtainToken();
+			return restClient.get()
+				.uri(uriBuilder -> uriBuilder.scheme("https")
+					.host(tokenProvider.getDomain())
+					.path("/api/v2/users")
+					.queryParam("q", luceneQuery)
+					.queryParam("search_engine", "v3")
+					.build())
+				.header("Authorization", "Bearer " + token)
+				.accept(MediaType.APPLICATION_JSON)
+				.retrieve()
+				.body(USER_LIST_TYPE);
+		});
+		if (users == null || users.isEmpty()) {
+			return List.of();
+		}
+		final List<Auth0ManagementUser> results = new ArrayList<>();
+		for (final Map<String, Object> user : users) {
+			final Auth0ManagementUser mapped = Auth0ManagementUser.fromApiMap(user);
+			if (mapped != null && StringUtils.hasText(mapped.userId())) {
+				results.add(mapped);
+			}
+		}
+		return results;
+	}
+
+	private void executeVoidWithRetry(final String operation, final Runnable operationRunnable) {
+		RuntimeException lastFailure = null;
+		for (int attempt = 0; attempt <= maxRetries; attempt++) {
+			try {
+				operationRunnable.run();
+				return;
+			}
+			catch (RestClientException ex) {
+				lastFailure = new Auth0ManagementApiException("Auth0 Management API " + operation + " failed", ex);
+				if (attempt < maxRetries && log.isWarnEnabled()) {
+					log.warn("Retrying Auth0 Management API {} attempt={}", operation, attempt + 1);
+				}
+			}
+		}
+		throw lastFailure;
+	}
+
+	private <T> T executeWithRetry(final String operation, final RetryableOperation<T> operationSupplier) {
+		RuntimeException lastFailure = null;
+		for (int attempt = 0; attempt <= maxRetries; attempt++) {
+			try {
+				return operationSupplier.execute();
+			}
+			catch (RestClientException ex) {
+				lastFailure = new Auth0ManagementApiException("Auth0 Management API " + operation + " failed", ex);
+				if (attempt < maxRetries && log.isWarnEnabled()) {
+					log.warn("Retrying Auth0 Management API {} attempt={}", operation, attempt + 1);
+				}
+			}
+		}
+		throw lastFailure;
+	}
+
+	private static String escapeLuceneValue(final String value) {
+		return value.replace("\\", "\\\\").replace("\"", "\\\"");
+	}
+
+	@FunctionalInterface
+	private interface RetryableOperation<T> {
+
+		T execute();
+
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth0/NoOpAuth0ManagementUserService.java
+++ b/src/main/java/com/nutriconsultas/auth0/NoOpAuth0ManagementUserService.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.auth0;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnMissingBean(Auth0ManagementUserServiceImpl.class)
+public class NoOpAuth0ManagementUserService implements Auth0ManagementUserService {
+
+	@Override
+	public boolean isConfigured() {
+		return false;
+	}
+
+	@Override
+	public Optional<Auth0ManagementUser> findUserByAppleSubject(final String appleSubject) {
+		return Optional.empty();
+	}
+
+	@Override
+	public List<Auth0ManagementUser> searchUsersByEmail(final String email) {
+		return List.of();
+	}
+
+	@Override
+	public void updateAppMetadata(final String auth0UserId, final Map<String, Object> appMetadataPatch) {
+		throw new IllegalStateException("Auth0 Management API is not configured");
+	}
+
+	@Override
+	public void blockUserInAppMetadata(final String auth0UserId) {
+		throw new IllegalStateException("Auth0 Management API is not configured");
+	}
+
+	@Override
+	public void deleteUser(final String auth0UserId) {
+		throw new IllegalStateException("Auth0 Management API is not configured");
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/Paciente.java
+++ b/src/main/java/com/nutriconsultas/paciente/Paciente.java
@@ -65,6 +65,13 @@ public class Paciente {
 	private String patientAuthSub;
 
 	/**
+	 * Apple Sign-In stable subject for mobile patient identity (#504). Distinct from
+	 * relay email; used for Apple server notification mapping.
+	 */
+	@Column(name = "apple_subject", unique = true, length = 255)
+	private String appleSubject;
+
+	/**
 	 * Invite-only onboarding lifecycle (#132). Existing patients default to
 	 * {@link PacienteStatus#ACTIVE}.
 	 */

--- a/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteRepository.java
@@ -36,6 +36,8 @@ public interface PacienteRepository extends JpaRepository<Paciente, Long> {
 
 	Optional<Paciente> findByPatientAuthSub(String patientAuthSub);
 
+	Optional<Paciente> findByAppleSubject(String appleSubject);
+
 	@Query(LIST_VIEW_SELECT + "FROM Paciente p WHERE p.userId = :userId")
 	Page<PacienteListView> findListViewsByUserId(@Param("userId") String userId, Pageable pageable);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -69,6 +69,9 @@ resilience4j.ratelimiter.instances.aiChatMessage.timeout-duration=0s
 app.auth0.management.client-id=${AUTH0_MGMT_CLIENT_ID:}
 app.auth0.management.client-secret=${AUTH0_MGMT_CLIENT_SECRET:}
 app.auth0.management.domain=${AUTH0_MGMT_DOMAIN:${AUTH_ISSUER}}
+# Apple Sign-In lifecycle — Auth0 user deletion stays disabled unless explicitly enabled (#505)
+app.auth0.management.user-delete-enabled=${AUTH0_MGMT_USER_DELETE_ENABLED:false}
+app.auth0.management.max-retries=${AUTH0_MGMT_MAX_RETRIES:2}
 # Patient mobile auth broker — confidential Auth0 app with Password grant (server-side only).
 app.auth0.patient-broker.domain=${AUTH0_PATIENT_BROKER_DOMAIN:${AUTH_ISSUER}}
 app.auth0.patient-broker.native-client-id=${AUTH0_MOBILE_NATIVE_CLIENT_ID:}

--- a/src/main/resources/db/changelog/changes/026-apple-identity-mapping.yaml
+++ b/src/main/resources/db/changelog/changes/026-apple-identity-mapping.yaml
@@ -1,0 +1,46 @@
+databaseChangeLog:
+  - changeSet:
+      id: 026-paciente-apple-subject
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            columnExists:
+              tableName: paciente
+              columnName: apple_subject
+      changes:
+        - addColumn:
+            tableName: paciente
+            columns:
+              - column:
+                  name: apple_subject
+                  type: VARCHAR(255)
+        - addUniqueConstraint:
+            tableName: paciente
+            columnNames: apple_subject
+            constraintName: uk_paciente_apple_subject
+  - changeSet:
+      id: 026-apple-signin-identity-mapping-columns
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            columnExists:
+              tableName: apple_signin_notification
+              columnName: identity_mapping_status
+      changes:
+        - addColumn:
+            tableName: apple_signin_notification
+            columns:
+              - column:
+                  name: identity_mapping_status
+                  type: VARCHAR(30)
+              - column:
+                  name: paciente_id
+                  type: BIGINT
+        - createIndex:
+            indexName: idx_apple_signin_notification_mapping_status
+            tableName: apple_signin_notification
+            columns:
+              - column:
+                  name: identity_mapping_status

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -74,3 +74,6 @@ databaseChangeLog:
   - include:
       file: changes/025-apple-signin-notification.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/026-apple-identity-mapping.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -65,3 +65,6 @@ databaseChangeLog:
   - include:
       file: changes/025-apple-signin-notification.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/026-apple-identity-mapping.yaml
+      relativeToChangelogFile: true

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleIdentityMappingServiceTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleIdentityMappingServiceTest.java
@@ -1,0 +1,125 @@
+package com.nutriconsultas.auth.apple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.auth0.Auth0ManagementUser;
+import com.nutriconsultas.auth0.Auth0ManagementUserService;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AppleIdentityMappingServiceTest {
+
+	@InjectMocks
+	private AppleIdentityMappingServiceImpl service;
+
+	@Mock
+	private Auth0ManagementUserService auth0ManagementUserService;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Test
+	void mapNotificationReturnsMappedWhenPacienteHasAppleSubject() {
+		final Paciente paciente = paciente(42L, "apple|001234.abc", "001234.abc");
+		when(pacienteRepository.findByAppleSubject("001234.abc")).thenReturn(Optional.of(paciente));
+
+		final AppleIdentityMappingResult result = service.mapNotification("001234.abc",
+				"relay@privaterelay.appleid.com");
+
+		assertThat(result.status()).isEqualTo(AppleIdentityMappingStatus.MAPPED);
+		assertThat(result.pacienteId()).isEqualTo(42L);
+		assertThat(result.auth0UserId()).isEqualTo("apple|001234.abc");
+		verify(auth0ManagementUserService, never()).findUserByAppleSubject(any());
+	}
+
+	@Test
+	void mapNotificationResolvesAuth0UserAndBackfillsAppleSubject() {
+		when(pacienteRepository.findByAppleSubject("001234.abc")).thenReturn(Optional.empty());
+		when(auth0ManagementUserService.isConfigured()).thenReturn(true);
+		when(auth0ManagementUserService.findUserByAppleSubject("001234.abc"))
+			.thenReturn(Optional.of(new Auth0ManagementUser("apple|001234.abc", "relay@privaterelay.appleid.com",
+					java.util.Map.of(), List.of())));
+		final Paciente paciente = paciente(7L, "apple|001234.abc", null);
+		when(pacienteRepository.findByPatientAuthSub("apple|001234.abc")).thenReturn(Optional.of(paciente));
+		when(pacienteRepository.save(paciente)).thenReturn(paciente);
+
+		final AppleIdentityMappingResult result = service.mapNotification("001234.abc",
+				"relay@privaterelay.appleid.com");
+
+		assertThat(result.status()).isEqualTo(AppleIdentityMappingStatus.MAPPED);
+		assertThat(result.pacienteId()).isEqualTo(7L);
+		verify(pacienteRepository).save(paciente);
+		assertThat(paciente.getAppleSubject()).isEqualTo("001234.abc");
+	}
+
+	@Test
+	void mapNotificationReturnsNoLocalUserWhenAuth0UserExistsWithoutPaciente() {
+		when(pacienteRepository.findByAppleSubject("001234.abc")).thenReturn(Optional.empty());
+		when(auth0ManagementUserService.isConfigured()).thenReturn(true);
+		when(auth0ManagementUserService.findUserByAppleSubject("001234.abc"))
+			.thenReturn(Optional.of(new Auth0ManagementUser("apple|001234.abc", null, java.util.Map.of(), List.of())));
+		when(pacienteRepository.findByPatientAuthSub("apple|001234.abc")).thenReturn(Optional.empty());
+
+		final AppleIdentityMappingResult result = service.mapNotification("001234.abc", null);
+
+		assertThat(result.status()).isEqualTo(AppleIdentityMappingStatus.NO_LOCAL_USER);
+		assertThat(result.auth0UserId()).isEqualTo("apple|001234.abc");
+	}
+
+	@Test
+	void mapNotificationReturnsAmbiguousWhenMultipleAppleUsersMatchEmail() {
+		when(pacienteRepository.findByAppleSubject("001234.abc")).thenReturn(Optional.empty());
+		when(auth0ManagementUserService.isConfigured()).thenReturn(true);
+		when(auth0ManagementUserService.findUserByAppleSubject("001234.abc")).thenReturn(Optional.empty());
+		when(auth0ManagementUserService.searchUsersByEmail("relay@privaterelay.appleid.com")).thenReturn(List.of(
+				new Auth0ManagementUser("apple|001234.abc", "relay@privaterelay.appleid.com", java.util.Map.of(),
+						List.of()),
+				new Auth0ManagementUser("apple|999999.xyz", "relay@privaterelay.appleid.com", java.util.Map.of(),
+						List.of())));
+
+		final AppleIdentityMappingResult result = service.mapNotification("001234.abc",
+				"relay@privaterelay.appleid.com");
+
+		assertThat(result.status()).isEqualTo(AppleIdentityMappingStatus.AMBIGUOUS);
+	}
+
+	@Test
+	void mapNotificationFallsBackToLocalPatientAuthSubWhenAuth0NotConfigured() {
+		when(pacienteRepository.findByAppleSubject("001234.abc")).thenReturn(Optional.empty());
+		when(auth0ManagementUserService.isConfigured()).thenReturn(false);
+		final Paciente paciente = paciente(3L, "apple|001234.abc", null);
+		when(pacienteRepository.findByPatientAuthSub("apple|001234.abc")).thenReturn(Optional.of(paciente));
+		when(pacienteRepository.save(paciente)).thenReturn(paciente);
+
+		final AppleIdentityMappingResult result = service.mapNotification("001234.abc", null);
+
+		assertThat(result.status()).isEqualTo(AppleIdentityMappingStatus.MAPPED);
+		verify(auth0ManagementUserService, never()).findUserByAppleSubject(eq("001234.abc"));
+	}
+
+	private static Paciente paciente(final Long id, final String patientAuthSub, final String appleSubject) {
+		final Paciente paciente = new Paciente();
+		paciente.setId(id);
+		paciente.setPatientAuthSub(patientAuthSub);
+		paciente.setAppleSubject(appleSubject);
+		paciente.setUserId("nutritionist-sub");
+		paciente.setName("Paciente Test");
+		return paciente;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationServiceTest.java
@@ -30,12 +30,17 @@ class AppleSignInNotificationServiceTest {
 	@Mock
 	private AppleSignInNotificationRepository notificationRepository;
 
+	@Mock
+	private AppleIdentityMappingService identityMappingService;
+
 	@Test
 	void handleNotificationPersistsVerifiedEventInObserveOnlyMode() {
 		final AppleSignInNotificationClaims claims = sampleClaims(AppleSignInEventType.CONSENT_REVOKED);
 		when(notificationVerifier.verifyAndParse("signed-payload")).thenReturn(claims);
 		when(notificationRepository.findByAppleEventId("evt-1")).thenReturn(Optional.empty());
 		when(properties.isAutoProcessDestructiveEvents()).thenReturn(false);
+		when(identityMappingService.mapNotification("001234.abc", "relay@privaterelay.appleid.com"))
+			.thenReturn(AppleIdentityMappingResult.mapped("apple|001234.abc", 42L));
 		when(notificationRepository.save(any(AppleSignInNotification.class)))
 			.thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -47,6 +52,9 @@ class AppleSignInNotificationServiceTest {
 		assertThat(captor.getValue().getProcessingStatus())
 			.isEqualTo(AppleSignInNotificationProcessingStatus.PROCESSED);
 		assertThat(captor.getValue().getAppleSubject()).isEqualTo("001234.abc");
+		assertThat(captor.getValue().getAuth0UserId()).isEqualTo("apple|001234.abc");
+		assertThat(captor.getValue().getPacienteId()).isEqualTo(42L);
+		assertThat(captor.getValue().getIdentityMappingStatus()).isEqualTo(AppleIdentityMappingStatus.MAPPED);
 	}
 
 	@Test
@@ -66,6 +74,8 @@ class AppleSignInNotificationServiceTest {
 		final AppleSignInNotificationClaims claims = sampleClaims(AppleSignInEventType.UNKNOWN);
 		when(notificationVerifier.verifyAndParse("signed-payload")).thenReturn(claims);
 		when(notificationRepository.findByAppleEventId("evt-1")).thenReturn(Optional.empty());
+		when(identityMappingService.mapNotification("001234.abc", "relay@privaterelay.appleid.com"))
+			.thenReturn(AppleIdentityMappingResult.noAuth0User());
 		when(notificationRepository.save(any(AppleSignInNotification.class)))
 			.thenAnswer(invocation -> invocation.getArgument(0));
 

--- a/src/test/java/com/nutriconsultas/auth0/Auth0AppleIdentitySupportTest.java
+++ b/src/test/java/com/nutriconsultas/auth0/Auth0AppleIdentitySupportTest.java
@@ -1,0 +1,27 @@
+package com.nutriconsultas.auth0;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class Auth0AppleIdentitySupportTest {
+
+	@Test
+	void toAuth0UserIdUsesApplePrefix() {
+		assertThat(Auth0AppleIdentitySupport.toAuth0UserId("001234.abc")).isEqualTo("apple|001234.abc");
+	}
+
+	@Test
+	void isAppleAuth0UserIdDetectsAppleProvider() {
+		assertThat(Auth0AppleIdentitySupport.isAppleAuth0UserId("apple|001234.abc")).isTrue();
+		assertThat(Auth0AppleIdentitySupport.isAppleAuth0UserId("google-oauth2|123")).isFalse();
+	}
+
+	@Test
+	void toAuth0UserIdReturnsNullForBlankSubject() {
+		assertThat(Auth0AppleIdentitySupport.toAuth0UserId("")).isNull();
+		assertThat(Auth0AppleIdentitySupport.toAuth0UserId(null)).isNull();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/auth0/Auth0ManagementUserServiceTest.java
+++ b/src/test/java/com/nutriconsultas/auth0/Auth0ManagementUserServiceTest.java
@@ -1,0 +1,89 @@
+package com.nutriconsultas.auth0;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class Auth0ManagementUserServiceTest {
+
+	private static final String DOMAIN = "tenant.example.com";
+
+	private Auth0ManagementTokenProvider tokenProvider;
+
+	private MockRestServiceServer mockServer;
+
+	private Auth0ManagementUserServiceImpl service;
+
+	@BeforeEach
+	void setUp() {
+		tokenProvider = mock(Auth0ManagementTokenProvider.class);
+		when(tokenProvider.isConfigured()).thenReturn(true);
+		when(tokenProvider.getDomain()).thenReturn(DOMAIN);
+		when(tokenProvider.obtainToken()).thenReturn("mgmt-token");
+		final RestClient.Builder restClientBuilder = RestClient.builder();
+		mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
+		service = new Auth0ManagementUserServiceImpl(restClientBuilder, tokenProvider, false, 0);
+	}
+
+	@Test
+	void findUserByAppleSubjectUsesDirectUserLookup() {
+		mockServer.expect(requestTo("https://" + DOMAIN + "/api/v2/users/apple%7C001234.abc"))
+			.andExpect(method(HttpMethod.GET))
+			.andRespond(withSuccess("""
+					{
+					  "user_id": "apple|001234.abc",
+					  "email": "relay@privaterelay.appleid.com",
+					  "app_metadata": {},
+					  "identities": [{"provider":"apple","user_id":"001234.abc"}]
+					}
+					""", MediaType.APPLICATION_JSON));
+
+		final Optional<Auth0ManagementUser> user = service.findUserByAppleSubject("001234.abc");
+
+		assertThat(user).isPresent();
+		assertThat(user.get().userId()).isEqualTo("apple|001234.abc");
+		mockServer.verify();
+	}
+
+	@Test
+	void updateAppMetadataPatchesUser() {
+		mockServer.expect(requestTo("https://" + DOMAIN + "/api/v2/users/apple%7C001234.abc"))
+			.andExpect(method(HttpMethod.PATCH))
+			.andRespond(withSuccess());
+
+		service.updateAppMetadata("apple|001234.abc", java.util.Map.of("apple_signin_seen", true));
+
+		mockServer.verify();
+	}
+
+	@Test
+	void deleteUserIsDisabledByDefault() {
+		assertThatThrownBy(() -> service.deleteUser("apple|001234.abc")).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("disabled");
+	}
+
+	@Test
+	void blockUserInAppMetadataSetsBlockedFlags() {
+		mockServer.expect(requestTo("https://" + DOMAIN + "/api/v2/users/apple%7C001234.abc"))
+			.andExpect(method(HttpMethod.PATCH))
+			.andRespond(withSuccess());
+
+		service.blockUserInAppMetadata("apple|001234.abc");
+
+		mockServer.verify();
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `AppleIdentityMappingService` to map Apple notification subjects → Auth0 users → local `Paciente` accounts, with ambiguous-match handling and Apple subject backfill.
- Add narrow `Auth0ManagementUserService` for Apple subject lookup, email search, app_metadata updates, and gated user deletion.
- Wire identity mapping into `AppleSignInNotificationService`; persist `identity_mapping_status`, `paciente_id`, and `auth0_user_id` on notifications.
- Liquibase `026`: `paciente.apple_subject` plus notification mapping columns.

## Test plan
- [x] `Auth0AppleIdentitySupportTest`, `Auth0ManagementUserServiceTest`
- [x] `AppleIdentityMappingServiceTest`, `AppleSignInNotificationServiceTest`, `AppleSignInNotificationPersistenceTest`
- [x] `mvn checkstyle:check pmd:check -Pci`
- [ ] CI Lint and Build green
- [ ] Manual: after #497 Auth0 Apple connection, verify webhook notification maps to Auth0/local patient


Made with [Cursor](https://cursor.com)