### PR TITLE
Add Apple Sign-In webhook observability and alerts (#508)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -620,7 +620,7 @@ Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic ~~**#
 
 Issue registry: [`ISSUE-APPLE-SIGNIN.md`](ISSUE-APPLE-SIGNIN.md). Roadmap: [`docs/auth/apple-signin-backend-roadmap.md`](docs/auth/apple-signin-backend-roadmap.md). Setup: [`docs/auth/apple-signin-setup.md`](docs/auth/apple-signin-setup.md).
 
-**Epic #497–#511** (2026-07-07): Sign in with Apple via Auth0 + Apple server-to-server webhook (`POST /rest/webhooks/apple/sign-in`). ~~#497~~ **done** (Auth0 prod + Apple connection, 2026-07-07). ~~#498–#506~~ **done** (PRs [#513](https://github.com/diego-torres/nutriconsultas/pull/513), [#514](https://github.com/diego-torres/nutriconsultas/pull/514), [#515](https://github.com/diego-torres/nutriconsultas/pull/515)). **NEXT:** [#507](https://github.com/diego-torres/nutriconsultas/issues/507) relay email changes (`apple-signin/507-relay-email`). Auth0 callback: `https://minutriporcion-prod.us.auth0.com/login/callback` — **not** the Apple notification URL.
+**Epic #497–#511** (2026-07-07): Sign in with Apple via Auth0 + Apple server-to-server webhook (`POST /rest/webhooks/apple/sign-in`). ~~#497~~ **done** (Auth0 prod + Apple connection, 2026-07-07). ~~#498–#507~~ **done** (PRs [#513](https://github.com/diego-torres/nutriconsultas/pull/513), [#514](https://github.com/diego-torres/nutriconsultas/pull/514), [#515](https://github.com/diego-torres/nutriconsultas/pull/515), [#516](https://github.com/diego-torres/nutriconsultas/pull/516)). **NEXT:** [#508](https://github.com/diego-torres/nutriconsultas/issues/508) observability (`apple-signin/508-observability`). Auth0 callback: `https://minutriporcion-prod.us.auth0.com/login/callback` — **not** the Apple notification URL.
 
 ## Resources
 

--- a/ISSUE-APPLE-SIGNIN.md
+++ b/ISSUE-APPLE-SIGNIN.md
@@ -6,8 +6,9 @@ Living index of GitHub issues that implement **Sign in with Apple** through Auth
 **Roadmap:** [`docs/auth/apple-signin-backend-roadmap.md`](docs/auth/apple-signin-backend-roadmap.md)  
 **Setup (maintainer runbook):** [`docs/auth/apple-signin-setup.md`](docs/auth/apple-signin-setup.md)  
 **Deletion runbook:** [`docs/auth/apple-signin-deletion-runbook.md`](docs/auth/apple-signin-deletion-runbook.md)  
+**Observability:** [`docs/auth/apple-signin-observability.md`](docs/auth/apple-signin-observability.md)  
 **Epic comment:** [#497](https://github.com/diego-torres/nutriconsultas/issues/497#issuecomment-4904658287)  
-**Last updated:** 2026-07-07 — ~~#506~~ **done** (PR #515); #507 in progress on `apple-signin/507-relay-email`.
+**Last updated:** 2026-07-07 — ~~#507~~ **done** (PR #516); #508 in progress on `apple-signin/508-observability`.
 
 > **Scope.** Auth0 Apple social connection, backend webhook (`POST /rest/webhooks/apple/sign-in`), signed payload verification, notification persistence, identity mapping, and safe lifecycle handling. **Does not** replace Auth0 with custom Apple OAuth. Patient mobile API: [`ISSUE.md`](ISSUE.md). Auth0 patient gate: [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md).
 
@@ -51,8 +52,8 @@ Suggested order matches [`docs/auth/apple-signin-backend-roadmap.md`](docs/auth/
 | 8 | 504 | Map Apple/Auth0 identity to local users | https://github.com/diego-torres/nutriconsultas/issues/504 | **done** | 497, 503 | PR #514 |
 | 9 | 505 | Add Auth0 Management API client methods | https://github.com/diego-torres/nutriconsultas/issues/505 | **done** | 497 | PR #514 |
 | 10 | **506** | Add safe account deletion workflow | https://github.com/diego-torres/nutriconsultas/issues/506 | **done** | 503, 504, 505 | PR #515 |
-| 11 | **507** | Handle private relay email changes | https://github.com/diego-torres/nutriconsultas/issues/507 | **in-progress** | 503, 504 | Branch `apple-signin/507-relay-email` **NEXT** |
-| 12 | 508 | Add observability and operational alerts | https://github.com/diego-torres/nutriconsultas/issues/508 | open | 499, 503 | Metrics + structured logs |
+| 11 | **507** | Handle private relay email changes | https://github.com/diego-torres/nutriconsultas/issues/507 | **done** | 503, 504 | PR #516 |
+| 12 | **508** | Add observability and operational alerts | https://github.com/diego-torres/nutriconsultas/issues/508 | **in-progress** | 499, 503 | Branch `apple-signin/508-observability` **NEXT** |
 | 13 | 509 | Add integration tests | https://github.com/diego-torres/nutriconsultas/issues/509 | open | 499–503 | No live Apple/Auth0 in tests |
 | 14 | 510 | Document Apple Developer Portal setup | https://github.com/diego-torres/nutriconsultas/issues/510 | open | — | Expand [`apple-signin-setup.md`](docs/auth/apple-signin-setup.md) |
 | 15 | 511 | Add production rollout plan | https://github.com/diego-torres/nutriconsultas/issues/511 | open | 497–510 | Phased: observe → metadata → restrict → optional delete |

--- a/docs/auth/apple-signin-backend-roadmap.md
+++ b/docs/auth/apple-signin-backend-roadmap.md
@@ -580,8 +580,8 @@ Apple lifecycle handling is security-sensitive. It should be rolled out graduall
 8. ~~[#504](https://github.com/diego-torres/nutriconsultas/issues/504)~~ — Add Apple/Auth0/local identity mapping (**done**, PR #514).
 9. ~~[#505](https://github.com/diego-torres/nutriconsultas/issues/505)~~ — Add Auth0 Management API methods (**done**, PR #514).
 10. ~~[#506](https://github.com/diego-torres/nutriconsultas/issues/506)~~ — Add safe account deletion workflow (**done**, PR #515).
-11. [#507](https://github.com/diego-torres/nutriconsultas/issues/507) — Handle private relay email changes (**in progress**).
-12. [#508](https://github.com/diego-torres/nutriconsultas/issues/508) — Add observability.
+11. ~~[#507](https://github.com/diego-torres/nutriconsultas/issues/507)~~ — Handle private relay email changes (**done**, PR #516).
+12. [#508](https://github.com/diego-torres/nutriconsultas/issues/508) — Add observability (**in progress**).
 13. [#509](https://github.com/diego-torres/nutriconsultas/issues/509) — Add integration tests.
 14. [#510](https://github.com/diego-torres/nutriconsultas/issues/510) — Document Apple Developer Portal setup.
 15. [#511](https://github.com/diego-torres/nutriconsultas/issues/511) — Roll out in observe-only mode.

--- a/docs/auth/apple-signin-observability.md
+++ b/docs/auth/apple-signin-observability.md
@@ -1,0 +1,64 @@
+# Apple Sign-In webhook observability (#508)
+
+Operators can detect Apple server-to-server notification problems via structured logs, Micrometer counters, and alert log lines. No emails, Apple subjects, Auth0 user IDs, or signed payloads are logged.
+
+**Related:** [`apple-signin-setup.md`](apple-signin-setup.md), [`ISSUE-APPLE-SIGNIN.md`](../../ISSUE-APPLE-SIGNIN.md)
+
+---
+
+## Micrometer counters
+
+Exposed through Spring Boot Actuator (`/actuator/metrics`) when enabled:
+
+| Metric | When incremented | Tags |
+|--------|------------------|------|
+| `apple.signin.webhook.received` | Valid POST with non-empty payload | — |
+| `apple.signin.webhook.verified` | Payload signature and claims verified | `event_type` |
+| `apple.signin.webhook.failed` | Verification or parsing failed | `reason` |
+| `apple.signin.webhook.duplicate` | Duplicate `apple_event_id` | `event_type` |
+| `apple.signin.webhook.unmapped` | Destructive event without `MAPPED` patient | `event_type`, `mapping_status` |
+
+Tag values are low-cardinality enums only (`CONSENT_REVOKED`, `invalid_signature`, `NO_LOCAL_USER`, etc.).
+
+---
+
+## Structured log stages
+
+Search application logs for `apple_signin_webhook stage=`:
+
+| Stage | Level | Meaning |
+|-------|-------|---------|
+| `received` | DEBUG | Webhook accepted for processing |
+| `verified` | INFO | Signed payload verified (`eventId`, `eventType`) |
+| `verification_failed` | WARN | Invalid payload (`reason`, `consecutiveFailures`) |
+| `duplicate` | DEBUG | Idempotent duplicate event |
+| `processed` | INFO | Persisted notification summary (status, mapping, lifecycle, `pacienteId`) |
+| `auth0_update_failed` | WARN | Auth0 Management API metadata update failed |
+
+---
+
+## Operator alerts (log-based)
+
+Configure CloudWatch (or similar) alarms on these log substrings:
+
+| Alert token | Trigger | Suggested action |
+|-------------|---------|------------------|
+| `APPLE_SIGNIN_ALERT repeated_verification_failures` | `consecutiveFailures` ≥ threshold (default **5**) | Check `APPLE_SIGNIN_EXPECTED_AUDIENCE`, Apple JWKS reachability, clock skew, recent deploy |
+| `APPLE_SIGNIN_ALERT unmapped_destructive_event` | Destructive event (`consent-revoked`, `account-delete`) without mapped patient | Review `/admin/platform/apple-signin` and identity mapping (#504) |
+
+### Configuration
+
+```properties
+nutriconsultas.apple.signin.verification-failure-alert-threshold=5
+```
+
+Environment variable: `APPLE_SIGNIN_VERIFICATION_FAILURE_ALERT_THRESHOLD`
+
+---
+
+## Debugging checklist
+
+1. Confirm `APPLE_SIGNIN_WEBHOOK_ENABLED=true` and audience matches Apple Services ID.
+2. Check `apple.signin.webhook.failed` by `reason` tag in metrics.
+3. Query `apple_signin_notification` for `processing_status` and `identity_mapping_status`.
+4. Review platform admin UI: `/admin/platform/apple-signin`.

--- a/docs/auth/apple-signin-setup.md
+++ b/docs/auth/apple-signin-setup.md
@@ -136,4 +136,4 @@ Existing Auth0 variables (`AUTH_ISSUER`, `AUTH_CLIENT`, mobile broker keys, etc.
 - [ ] iOS Bundle ID and Apple Team ID values (reference only — store in secure ops vault, not in git)
 - [ ] Auth0 Apple `user_id` / `identities` shape for this tenant
 - [ ] SSM update script for Apple webhook env vars on EC2
-- [ ] Operator alert runbook for verification failures (#508)
+- [x] Operator alert runbook for verification failures (#508) — see [`apple-signin-observability.md`](apple-signin-observability.md)

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationService.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInNotificationService.java
@@ -24,24 +24,30 @@ public class AppleSignInNotificationService {
 
 	private final AppleSignInRelayEmailService relayEmailService;
 
+	private final AppleSignInWebhookObservability webhookObservability;
+
 	public AppleSignInNotificationService(final AppleSignInProperties properties,
 			final AppleSignInNotificationVerifier notificationVerifier,
 			final AppleSignInNotificationRepository notificationRepository,
 			final AppleIdentityMappingService identityMappingService,
 			final AppleSignInAccountLifecycleService accountLifecycleService,
-			final AppleSignInRelayEmailService relayEmailService) {
+			final AppleSignInRelayEmailService relayEmailService,
+			final AppleSignInWebhookObservability webhookObservability) {
 		this.properties = properties;
 		this.notificationVerifier = notificationVerifier;
 		this.notificationRepository = notificationRepository;
 		this.identityMappingService = identityMappingService;
 		this.accountLifecycleService = accountLifecycleService;
 		this.relayEmailService = relayEmailService;
+		this.webhookObservability = webhookObservability;
 	}
 
 	@Transactional
 	public AppleSignInWebhookOutcome handleNotification(final String signedPayload) {
 		final AppleSignInNotificationClaims claims = notificationVerifier.verifyAndParse(signedPayload);
+		webhookObservability.recordVerificationSuccess(claims);
 		if (notificationRepository.findByAppleEventId(claims.eventId()).isPresent()) {
+			webhookObservability.recordDuplicate(claims);
 			if (log.isDebugEnabled()) {
 				log.debug("Duplicate Apple sign-in notification eventId={} type={}", claims.eventId(),
 						claims.eventType());
@@ -61,6 +67,7 @@ public class AppleSignInNotificationService {
 		applyIdentityMapping(notification, claims);
 		processNotification(notification, claims);
 		notificationRepository.save(notification);
+		webhookObservability.recordProcessed(notification, claims);
 		if (log.isInfoEnabled()) {
 			log.info("Processed Apple sign-in notification eventId={} type={} status={}", claims.eventId(),
 					claims.eventType(), notification.getProcessingStatus());

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInProperties.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInProperties.java
@@ -29,6 +29,8 @@ public class AppleSignInProperties {
 
 	private Duration jwksCacheTtl = Duration.ofHours(6);
 
+	private int verificationFailureAlertThreshold = 5;
+
 	public Webhook getWebhook() {
 		return webhook;
 	}
@@ -91,6 +93,16 @@ public class AppleSignInProperties {
 	public void setJwksCacheTtl(final Duration jwksCacheTtl) {
 		if (jwksCacheTtl != null && !jwksCacheTtl.isNegative() && !jwksCacheTtl.isZero()) {
 			this.jwksCacheTtl = jwksCacheTtl;
+		}
+	}
+
+	public int getVerificationFailureAlertThreshold() {
+		return verificationFailureAlertThreshold;
+	}
+
+	public void setVerificationFailureAlertThreshold(final int verificationFailureAlertThreshold) {
+		if (verificationFailureAlertThreshold > 0) {
+			this.verificationFailureAlertThreshold = verificationFailureAlertThreshold;
 		}
 	}
 

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookController.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookController.java
@@ -19,10 +19,14 @@ public class AppleSignInWebhookController {
 
 	private final AppleSignInNotificationService notificationService;
 
+	private final AppleSignInWebhookObservability webhookObservability;
+
 	public AppleSignInWebhookController(final AppleSignInProperties properties,
-			final AppleSignInNotificationService notificationService) {
+			final AppleSignInNotificationService notificationService,
+			final AppleSignInWebhookObservability webhookObservability) {
 		this.properties = properties;
 		this.notificationService = notificationService;
+		this.webhookObservability = webhookObservability;
 	}
 
 	@PostMapping("/sign-in")
@@ -33,6 +37,7 @@ public class AppleSignInWebhookController {
 		if (request == null || !StringUtils.hasText(request.payload())) {
 			return ResponseEntity.badRequest().build();
 		}
+		webhookObservability.recordWebhookReceived();
 		final AppleSignInWebhookOutcome outcome = notificationService.handleNotification(request.payload().trim());
 		if (outcome == AppleSignInWebhookOutcome.DUPLICATE) {
 			return ResponseEntity.ok().build();

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookExceptionHandler.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookExceptionHandler.java
@@ -8,8 +8,15 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice(basePackages = "com.nutriconsultas.auth.apple")
 public class AppleSignInWebhookExceptionHandler {
 
+	private final AppleSignInWebhookObservability webhookObservability;
+
+	public AppleSignInWebhookExceptionHandler(final AppleSignInWebhookObservability webhookObservability) {
+		this.webhookObservability = webhookObservability;
+	}
+
 	@ExceptionHandler(InvalidAppleSignInNotificationException.class)
 	public ResponseEntity<Void> handleInvalidNotification(final InvalidAppleSignInNotificationException ex) {
+		webhookObservability.recordVerificationFailure(ex.getMessage());
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
 	}
 

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookMetrics.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookMetrics.java
@@ -1,0 +1,79 @@
+package com.nutriconsultas.auth.apple;
+
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Micrometer counters for Apple Sign-In webhook operations (#508). Tags are
+ * low-cardinality only — never emails, Apple subjects, Auth0 user IDs, or patient data.
+ */
+@Component
+public final class AppleSignInWebhookMetrics {
+
+	static final String WEBHOOK_RECEIVED = "apple.signin.webhook.received";
+
+	static final String WEBHOOK_VERIFIED = "apple.signin.webhook.verified";
+
+	static final String WEBHOOK_FAILED = "apple.signin.webhook.failed";
+
+	static final String WEBHOOK_DUPLICATE = "apple.signin.webhook.duplicate";
+
+	static final String WEBHOOK_UNMAPPED = "apple.signin.webhook.unmapped";
+
+	private static final String TAG_EVENT_TYPE = "event_type";
+
+	private static final String TAG_REASON = "reason";
+
+	private static final String TAG_MAPPING_STATUS = "mapping_status";
+
+	private final MeterRegistry meterRegistry;
+
+	public AppleSignInWebhookMetrics(final MeterRegistry meterRegistry) {
+		this.meterRegistry = meterRegistry;
+	}
+
+	public void recordReceived() {
+		counter(WEBHOOK_RECEIVED).increment();
+	}
+
+	public void recordVerified(@Nullable final AppleSignInEventType eventType) {
+		counter(WEBHOOK_VERIFIED, TAG_EVENT_TYPE, safeEnum(eventType)).increment();
+	}
+
+	public void recordFailed(final String reason) {
+		counter(WEBHOOK_FAILED, TAG_REASON, safeTagValue(reason)).increment();
+	}
+
+	public void recordDuplicate(@Nullable final AppleSignInEventType eventType) {
+		counter(WEBHOOK_DUPLICATE, TAG_EVENT_TYPE, safeEnum(eventType)).increment();
+	}
+
+	public void recordUnmapped(@Nullable final AppleSignInEventType eventType,
+			@Nullable final AppleIdentityMappingStatus mappingStatus) {
+		counter(WEBHOOK_UNMAPPED, TAG_EVENT_TYPE, safeEnum(eventType), TAG_MAPPING_STATUS, safeEnum(mappingStatus))
+			.increment();
+	}
+
+	private Counter counter(final String name, final String... tags) {
+		return meterRegistry.counter(name, tags);
+	}
+
+	private static String safeEnum(@Nullable final Enum<?> value) {
+		if (value == null) {
+			return "unknown";
+		}
+		return value.name();
+	}
+
+	private static String safeTagValue(@Nullable final String value) {
+		if (!StringUtils.hasText(value)) {
+			return "unknown";
+		}
+		return value.trim();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookObservability.java
+++ b/src/main/java/com/nutriconsultas/auth/apple/AppleSignInWebhookObservability.java
@@ -1,0 +1,131 @@
+package com.nutriconsultas.auth.apple;
+
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Structured logging, metrics, and operator alerts for Apple Sign-In webhooks (#508).
+ * Never logs emails, Apple subjects, Auth0 user IDs, or signed payloads.
+ */
+@Component
+@Slf4j
+public final class AppleSignInWebhookObservability {
+
+	private static final String ALERT_VERIFICATION_FAILURES = "APPLE_SIGNIN_ALERT repeated_verification_failures";
+
+	private static final String ALERT_UNMAPPED_DESTRUCTIVE = "APPLE_SIGNIN_ALERT unmapped_destructive_event";
+
+	private final AppleSignInWebhookMetrics metrics;
+
+	private final AppleSignInProperties properties;
+
+	private int consecutiveVerificationFailures;
+
+	public AppleSignInWebhookObservability(final AppleSignInWebhookMetrics metrics,
+			final AppleSignInProperties properties) {
+		this.metrics = metrics;
+		this.properties = properties;
+	}
+
+	public void recordWebhookReceived() {
+		metrics.recordReceived();
+		if (log.isDebugEnabled()) {
+			log.debug("apple_signin_webhook stage=received");
+		}
+	}
+
+	public void recordVerificationSuccess(final AppleSignInNotificationClaims claims) {
+		consecutiveVerificationFailures = 0;
+		metrics.recordVerified(claims.eventType());
+		if (log.isInfoEnabled()) {
+			log.info("apple_signin_webhook stage=verified eventId={} eventType={}", claims.eventId(),
+					claims.eventType());
+		}
+	}
+
+	public void recordVerificationFailure(@Nullable final String message) {
+		metrics.recordFailed(categorizeFailure(message));
+		consecutiveVerificationFailures++;
+		if (log.isWarnEnabled()) {
+			log.warn("apple_signin_webhook stage=verification_failed reason={} consecutiveFailures={}",
+					categorizeFailure(message), consecutiveVerificationFailures);
+		}
+		if (consecutiveVerificationFailures >= properties.getVerificationFailureAlertThreshold()
+				&& log.isErrorEnabled()) {
+			log.error("{} threshold={} consecutiveFailures={}", ALERT_VERIFICATION_FAILURES,
+					properties.getVerificationFailureAlertThreshold(), consecutiveVerificationFailures);
+		}
+	}
+
+	public void recordDuplicate(final AppleSignInNotificationClaims claims) {
+		metrics.recordDuplicate(claims.eventType());
+		if (log.isDebugEnabled()) {
+			log.debug("apple_signin_webhook stage=duplicate eventId={} eventType={}", claims.eventId(),
+					claims.eventType());
+		}
+	}
+
+	public void recordProcessed(final AppleSignInNotification notification,
+			final AppleSignInNotificationClaims claims) {
+		if (log.isInfoEnabled()) {
+			log.info(
+					"apple_signin_webhook stage=processed eventId={} eventType={} processingStatus={} mappingStatus={} lifecycleAction={} pacienteId={}",
+					claims.eventId(), claims.eventType(), notification.getProcessingStatus(),
+					notification.getIdentityMappingStatus(), notification.getLifecycleAction(),
+					notification.getPacienteId());
+		}
+		recordUnmappedDestructiveIfNeeded(notification, claims);
+		recordAuth0Outcome(notification);
+	}
+
+	private void recordUnmappedDestructiveIfNeeded(final AppleSignInNotification notification,
+			final AppleSignInNotificationClaims claims) {
+		if (!claims.eventType().isDestructive()) {
+			return;
+		}
+		if (notification.getIdentityMappingStatus() == AppleIdentityMappingStatus.MAPPED) {
+			return;
+		}
+		metrics.recordUnmapped(claims.eventType(), notification.getIdentityMappingStatus());
+		if (log.isWarnEnabled()) {
+			log.warn("{} eventId={} eventType={} mappingStatus={} processingStatus={}", ALERT_UNMAPPED_DESTRUCTIVE,
+					claims.eventId(), claims.eventType(), notification.getIdentityMappingStatus(),
+					notification.getProcessingStatus());
+		}
+	}
+
+	private void recordAuth0Outcome(final AppleSignInNotification notification) {
+		if (notification.getLifecycleAction() != AppleSignInLifecycleAction.AUTH0_UPDATE_FAILED) {
+			return;
+		}
+		if (log.isWarnEnabled()) {
+			log.warn("apple_signin_webhook stage=auth0_update_failed eventId={} eventType={} pacienteId={}",
+					notification.getAppleEventId(), notification.getEventType(), notification.getPacienteId());
+		}
+	}
+
+	static String categorizeFailure(@Nullable final String message) {
+		if (!StringUtils.hasText(message)) {
+			return "verification";
+		}
+		final String normalized = message.trim().toLowerCase();
+		if (normalized.contains("payload is required")) {
+			return "missing_payload";
+		}
+		if (normalized.contains("signature")) {
+			return "invalid_signature";
+		}
+		if (normalized.contains("unable to parse")) {
+			return "parse_error";
+		}
+		if (normalized.contains("issuer") || normalized.contains("audience") || normalized.contains("jti")
+				|| normalized.contains("events claim")) {
+			return "invalid_claims";
+		}
+		return "verification";
+	}
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -92,6 +92,7 @@ nutriconsultas.apple.signin.expected-audience=${APPLE_SIGNIN_EXPECTED_AUDIENCE:}
 nutriconsultas.apple.signin.jwks-url=${APPLE_SIGNIN_JWKS_URL:https://appleid.apple.com/auth/keys}
 nutriconsultas.apple.signin.auto-process-destructive-events=${APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS:false}
 nutriconsultas.apple.signin.jwks-cache-ttl=${APPLE_SIGNIN_JWKS_CACHE_TTL:6h}
+nutriconsultas.apple.signin.verification-failure-alert-threshold=${APPLE_SIGNIN_VERIFICATION_FAILURE_ALERT_THRESHOLD:5}
 # Platform administrators (Auth0 sub claims or OAuth login emails, comma-separated)
 nutriconsultas.platform.admin-user-ids=${PLATFORM_ADMIN_USER_IDS:}
 nutriconsultas.platform.admin-emails=${PLATFORM_ADMIN_EMAILS:}

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationServiceTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationServiceTest.java
@@ -40,6 +40,9 @@ class AppleSignInNotificationServiceTest {
 	@Mock
 	private AppleSignInRelayEmailService relayEmailService;
 
+	@Mock
+	private AppleSignInWebhookObservability webhookObservability;
+
 	@Test
 	void handleNotificationPersistsVerifiedEventInObserveOnlyMode() {
 		final AppleSignInNotificationClaims claims = sampleClaims(AppleSignInEventType.CONSENT_REVOKED);

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInPropertiesTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInPropertiesTest.java
@@ -16,6 +16,7 @@ class AppleSignInPropertiesTest {
 
 		assertThat(properties.isWebhookEnabled()).isFalse();
 		assertThat(properties.isAutoProcessDestructiveEvents()).isFalse();
+		assertThat(properties.getVerificationFailureAlertThreshold()).isEqualTo(5);
 		assertThat(properties.getExpectedIssuer()).isEqualTo("https://appleid.apple.com");
 		assertThat(properties.getJwksUrl()).isEqualTo("https://appleid.apple.com/auth/keys");
 		assertThat(properties.isWebhookConfigured()).isFalse();

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookControllerTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookControllerTest.java
@@ -3,6 +3,7 @@ package com.nutriconsultas.auth.apple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -28,6 +29,9 @@ class AppleSignInWebhookControllerTest {
 	@Mock
 	private AppleSignInNotificationService notificationService;
 
+	@Mock
+	private AppleSignInWebhookObservability webhookObservability;
+
 	@InjectMocks
 	private AppleSignInWebhookController controller;
 
@@ -36,7 +40,7 @@ class AppleSignInWebhookControllerTest {
 	@BeforeEach
 	void setUp() {
 		mockMvc = MockMvcBuilders.standaloneSetup(controller)
-			.setControllerAdvice(new AppleSignInWebhookExceptionHandler())
+			.setControllerAdvice(new AppleSignInWebhookExceptionHandler(webhookObservability))
 			.build();
 	}
 
@@ -68,6 +72,8 @@ class AppleSignInWebhookControllerTest {
 		mockMvc
 			.perform(post(WEBHOOK_URL).contentType(MediaType.APPLICATION_JSON).content("{\"payload\":\"signed-jwt\"}"))
 			.andExpect(status().isOk());
+
+		verify(webhookObservability).recordWebhookReceived();
 	}
 
 	@Test
@@ -78,6 +84,9 @@ class AppleSignInWebhookControllerTest {
 
 		mockMvc.perform(post(WEBHOOK_URL).contentType(MediaType.APPLICATION_JSON).content("{\"payload\":\"bad-jwt\"}"))
 			.andExpect(status().isBadRequest());
+
+		verify(webhookObservability).recordWebhookReceived();
+		verify(webhookObservability).recordVerificationFailure("Invalid Apple notification signature");
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookMetricsTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookMetricsTest.java
@@ -1,0 +1,54 @@
+package com.nutriconsultas.auth.apple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class AppleSignInWebhookMetricsTest {
+
+	private SimpleMeterRegistry registry;
+
+	private AppleSignInWebhookMetrics metrics;
+
+	@BeforeEach
+	void setUp() {
+		registry = new SimpleMeterRegistry();
+		metrics = new AppleSignInWebhookMetrics(registry);
+	}
+
+	@Test
+	void recordsWebhookLifecycleCountersWithLowCardinalityTags() {
+		metrics.recordReceived();
+		metrics.recordVerified(AppleSignInEventType.CONSENT_REVOKED);
+		metrics.recordFailed("invalid_signature");
+		metrics.recordDuplicate(AppleSignInEventType.EMAIL_ENABLED);
+		metrics.recordUnmapped(AppleSignInEventType.ACCOUNT_DELETE, AppleIdentityMappingStatus.NO_LOCAL_USER);
+
+		assertThat(registry.get(AppleSignInWebhookMetrics.WEBHOOK_RECEIVED).counter().count()).isEqualTo(1.0);
+		assertThat(registry.get(AppleSignInWebhookMetrics.WEBHOOK_VERIFIED)
+			.tag("event_type", "CONSENT_REVOKED")
+			.counter()
+			.count()).isEqualTo(1.0);
+		assertThat(registry.get(AppleSignInWebhookMetrics.WEBHOOK_FAILED)
+			.tag("reason", "invalid_signature")
+			.counter()
+			.count()).isEqualTo(1.0);
+		assertThat(registry.get(AppleSignInWebhookMetrics.WEBHOOK_DUPLICATE)
+			.tag("event_type", "EMAIL_ENABLED")
+			.counter()
+			.count()).isEqualTo(1.0);
+		assertThat(registry.get(AppleSignInWebhookMetrics.WEBHOOK_UNMAPPED)
+			.tag("event_type", "ACCOUNT_DELETE")
+			.tag("mapping_status", "NO_LOCAL_USER")
+			.counter()
+			.count()).isEqualTo(1.0);
+		assertThat(registry.getMeters()).allSatisfy(meter -> {
+			assertThat(meter.getId().getTags()).noneMatch(tag -> tag.getValue().contains("@"));
+			assertThat(meter.getId().getTags()).noneMatch(tag -> tag.getValue().contains("apple|"));
+		});
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookObservabilityTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookObservabilityTest.java
@@ -1,0 +1,103 @@
+package com.nutriconsultas.auth.apple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class AppleSignInWebhookObservabilityTest {
+
+	private AppleSignInProperties properties;
+
+	private AppleSignInWebhookObservability observability;
+
+	private SimpleMeterRegistry registry;
+
+	@BeforeEach
+	void setUp() {
+		properties = new AppleSignInProperties();
+		properties.setVerificationFailureAlertThreshold(3);
+		registry = new SimpleMeterRegistry();
+		observability = new AppleSignInWebhookObservability(new AppleSignInWebhookMetrics(registry), properties);
+	}
+
+	@Test
+	void categorizesVerificationFailureReasonsWithoutLoggingSecrets() {
+		assertThat(AppleSignInWebhookObservability.categorizeFailure("Invalid Apple notification signature"))
+			.isEqualTo("invalid_signature");
+		assertThat(AppleSignInWebhookObservability.categorizeFailure("Invalid Apple notification audience"))
+			.isEqualTo("invalid_claims");
+		assertThat(AppleSignInWebhookObservability.categorizeFailure(null)).isEqualTo("verification");
+	}
+
+	@Test
+	void recordsUnmappedDestructiveEvents() {
+		final AppleSignInNotification notification = new AppleSignInNotification();
+		notification.setIdentityMappingStatus(AppleIdentityMappingStatus.NO_LOCAL_USER);
+		notification.setProcessingStatus(AppleSignInNotificationProcessingStatus.PROCESSED);
+		notification.setLifecycleAction(AppleSignInLifecycleAction.SKIPPED_OBSERVE_ONLY);
+		final AppleSignInNotificationClaims claims = new AppleSignInNotificationClaims("evt-1",
+				"https://appleid.apple.com", "com.minutriporcion.app", "001234.abc",
+				AppleSignInEventType.ACCOUNT_DELETE, null, null, null, "{}");
+
+		observability.recordProcessed(notification, claims);
+
+		assertThat(registry.get(AppleSignInWebhookMetrics.WEBHOOK_UNMAPPED)
+			.tag("event_type", "ACCOUNT_DELETE")
+			.tag("mapping_status", "NO_LOCAL_USER")
+			.counter()
+			.count()).isEqualTo(1.0);
+	}
+
+	@Test
+	void skipsUnmappedMetricWhenDestructiveEventIsMapped() {
+		final AppleSignInNotification notification = new AppleSignInNotification();
+		notification.setIdentityMappingStatus(AppleIdentityMappingStatus.MAPPED);
+		notification.setPacienteId(42L);
+		notification.setProcessingStatus(AppleSignInNotificationProcessingStatus.PROCESSED);
+		final AppleSignInNotificationClaims claims = new AppleSignInNotificationClaims("evt-2",
+				"https://appleid.apple.com", "com.minutriporcion.app", "001234.abc",
+				AppleSignInEventType.CONSENT_REVOKED, null, null, null, "{}");
+
+		observability.recordProcessed(notification, claims);
+
+		assertThat(registry.find(AppleSignInWebhookMetrics.WEBHOOK_UNMAPPED).counters()).isEmpty();
+	}
+
+	@Test
+	void incrementsVerificationFailureCounter() {
+		observability.recordVerificationFailure("Invalid Apple notification signature");
+		observability.recordVerificationFailure("Invalid Apple notification audience");
+
+		assertThat(registry.get(AppleSignInWebhookMetrics.WEBHOOK_FAILED)
+			.tag("reason", "invalid_signature")
+			.counter()
+			.count()).isEqualTo(1.0);
+		assertThat(registry.get(AppleSignInWebhookMetrics.WEBHOOK_FAILED)
+			.tag("reason", "invalid_claims")
+			.counter()
+			.count()).isEqualTo(1.0);
+	}
+
+	@Test
+	void resetsVerificationFailureStreakAfterSuccess() {
+		observability.recordVerificationFailure("Invalid Apple notification signature");
+		observability.recordVerificationFailure("Invalid Apple notification signature");
+		observability.recordVerificationSuccess(sampleClaims());
+
+		observability.recordVerificationFailure("Invalid Apple notification signature");
+
+		assertThat(registry.get(AppleSignInWebhookMetrics.WEBHOOK_FAILED)
+			.tag("reason", "invalid_signature")
+			.counter()
+			.count()).isEqualTo(3.0);
+	}
+
+	private static AppleSignInNotificationClaims sampleClaims() {
+		return new AppleSignInNotificationClaims("evt-ok", "https://appleid.apple.com", "com.minutriporcion.app",
+				"001234.abc", AppleSignInEventType.EMAIL_ENABLED, null, null, null, "{}");
+	}
+
+}


### PR DESCRIPTION
## Summary
- Implements #508 observability for Apple Sign-In webhooks with Micrometer counters (`apple.signin.webhook.*`), structured log stages, and log-based operator alerts
- Adds `AppleSignInWebhookObservability` wired into the webhook controller, exception handler, and notification service
- Documents metrics, log search patterns, and CloudWatch alarm tokens in `docs/auth/apple-signin-observability.md`

## Test plan
- [x] `AppleSignInWebhookMetricsTest` — counter names and low-cardinality tags
- [x] `AppleSignInWebhookObservabilityTest` — failure categorization, unmapped destructive alerts, streak reset
- [x] `AppleSignInWebhookControllerTest` — received + verification failure observability hooks
- [x] `AppleSignInNotificationServiceTest`, `AppleSignInPropertiesTest`
- [x] `mvn pmd:check -Pci`


Made with [Cursor](https://cursor.com)