### PR TITLE
Add Apple Sign-In webhook integration tests (#509)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -620,7 +620,7 @@ Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic ~~**#
 
 Issue registry: [`ISSUE-APPLE-SIGNIN.md`](ISSUE-APPLE-SIGNIN.md). Roadmap: [`docs/auth/apple-signin-backend-roadmap.md`](docs/auth/apple-signin-backend-roadmap.md). Setup: [`docs/auth/apple-signin-setup.md`](docs/auth/apple-signin-setup.md).
 
-**Epic #497–#511** (2026-07-07): Sign in with Apple via Auth0 + Apple server-to-server webhook (`POST /rest/webhooks/apple/sign-in`). ~~#497~~ **done** (Auth0 prod + Apple connection, 2026-07-07). ~~#498–#507~~ **done** (PRs [#513](https://github.com/diego-torres/nutriconsultas/pull/513), [#514](https://github.com/diego-torres/nutriconsultas/pull/514), [#515](https://github.com/diego-torres/nutriconsultas/pull/515), [#516](https://github.com/diego-torres/nutriconsultas/pull/516)). **NEXT:** [#508](https://github.com/diego-torres/nutriconsultas/issues/508) observability (`apple-signin/508-observability`). Auth0 callback: `https://minutriporcion-prod.us.auth0.com/login/callback` — **not** the Apple notification URL.
+**Epic #497–#511** (2026-07-07): Sign in with Apple via Auth0 + Apple server-to-server webhook (`POST /rest/webhooks/apple/sign-in`). ~~#497~~ **done** (Auth0 prod + Apple connection, 2026-07-07). ~~#498–#508~~ **done** (PRs [#513](https://github.com/diego-torres/nutriconsultas/pull/513)–[#517](https://github.com/diego-torres/nutriconsultas/pull/517)). **NEXT:** [#509](https://github.com/diego-torres/nutriconsultas/issues/509) integration tests (`apple-signin/509-integration-tests`). Auth0 callback: `https://minutriporcion-prod.us.auth0.com/login/callback` — **not** the Apple notification URL.
 
 ## Resources
 

--- a/ISSUE-APPLE-SIGNIN.md
+++ b/ISSUE-APPLE-SIGNIN.md
@@ -8,7 +8,7 @@ Living index of GitHub issues that implement **Sign in with Apple** through Auth
 **Deletion runbook:** [`docs/auth/apple-signin-deletion-runbook.md`](docs/auth/apple-signin-deletion-runbook.md)  
 **Observability:** [`docs/auth/apple-signin-observability.md`](docs/auth/apple-signin-observability.md)  
 **Epic comment:** [#497](https://github.com/diego-torres/nutriconsultas/issues/497#issuecomment-4904658287)  
-**Last updated:** 2026-07-07 — ~~#507~~ **done** (PR #516); #508 in progress on `apple-signin/508-observability`.
+**Last updated:** 2026-07-07 — ~~#508~~ **done** (PR #517); #509 in progress on `apple-signin/509-integration-tests`.
 
 > **Scope.** Auth0 Apple social connection, backend webhook (`POST /rest/webhooks/apple/sign-in`), signed payload verification, notification persistence, identity mapping, and safe lifecycle handling. **Does not** replace Auth0 with custom Apple OAuth. Patient mobile API: [`ISSUE.md`](ISSUE.md). Auth0 patient gate: [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md).
 
@@ -53,8 +53,8 @@ Suggested order matches [`docs/auth/apple-signin-backend-roadmap.md`](docs/auth/
 | 9 | 505 | Add Auth0 Management API client methods | https://github.com/diego-torres/nutriconsultas/issues/505 | **done** | 497 | PR #514 |
 | 10 | **506** | Add safe account deletion workflow | https://github.com/diego-torres/nutriconsultas/issues/506 | **done** | 503, 504, 505 | PR #515 |
 | 11 | **507** | Handle private relay email changes | https://github.com/diego-torres/nutriconsultas/issues/507 | **done** | 503, 504 | PR #516 |
-| 12 | **508** | Add observability and operational alerts | https://github.com/diego-torres/nutriconsultas/issues/508 | **in-progress** | 499, 503 | Branch `apple-signin/508-observability` **NEXT** |
-| 13 | 509 | Add integration tests | https://github.com/diego-torres/nutriconsultas/issues/509 | open | 499–503 | No live Apple/Auth0 in tests |
+| 12 | **508** | Add observability and operational alerts | https://github.com/diego-torres/nutriconsultas/issues/508 | **done** | 499, 503 | PR #517 |
+| 13 | **509** | Add integration tests | https://github.com/diego-torres/nutriconsultas/issues/509 | **in-progress** | 499–503 | Branch `apple-signin/509-integration-tests` **NEXT** |
 | 14 | 510 | Document Apple Developer Portal setup | https://github.com/diego-torres/nutriconsultas/issues/510 | open | — | Expand [`apple-signin-setup.md`](docs/auth/apple-signin-setup.md) |
 | 15 | 511 | Add production rollout plan | https://github.com/diego-torres/nutriconsultas/issues/511 | open | 497–510 | Phased: observe → metadata → restrict → optional delete |
 

--- a/docs/auth/apple-signin-backend-roadmap.md
+++ b/docs/auth/apple-signin-backend-roadmap.md
@@ -581,8 +581,8 @@ Apple lifecycle handling is security-sensitive. It should be rolled out graduall
 9. ~~[#505](https://github.com/diego-torres/nutriconsultas/issues/505)~~ — Add Auth0 Management API methods (**done**, PR #514).
 10. ~~[#506](https://github.com/diego-torres/nutriconsultas/issues/506)~~ — Add safe account deletion workflow (**done**, PR #515).
 11. ~~[#507](https://github.com/diego-torres/nutriconsultas/issues/507)~~ — Handle private relay email changes (**done**, PR #516).
-12. [#508](https://github.com/diego-torres/nutriconsultas/issues/508) — Add observability (**in progress**).
-13. [#509](https://github.com/diego-torres/nutriconsultas/issues/509) — Add integration tests.
+12. ~~[#508](https://github.com/diego-torres/nutriconsultas/issues/508)~~ — Add observability (**done**, PR #517).
+13. [#509](https://github.com/diego-torres/nutriconsultas/issues/509) — Add integration tests (**in progress**).
 14. [#510](https://github.com/diego-torres/nutriconsultas/issues/510) — Document Apple Developer Portal setup.
 15. [#511](https://github.com/diego-torres/nutriconsultas/issues/511) — Roll out in observe-only mode.
 

--- a/docs/auth/apple-signin-observability.md
+++ b/docs/auth/apple-signin-observability.md
@@ -62,3 +62,15 @@ Environment variable: `APPLE_SIGNIN_VERIFICATION_FAILURE_ALERT_THRESHOLD`
 2. Check `apple.signin.webhook.failed` by `reason` tag in metrics.
 3. Query `apple_signin_notification` for `processing_status` and `identity_mapping_status`.
 4. Review platform admin UI: `/admin/platform/apple-signin`.
+
+---
+
+## Integration tests (#509)
+
+Run the Apple Sign-In integration suite (local RSA keys, mocked Auth0 — no live Apple or Auth0):
+
+```bash
+mvn test -Dtest=AppleSignIn*IntegrationTest,AppleSignInNotificationPersistenceTest
+```
+
+Coverage includes webhook HTTP flows, signed payload verification, idempotency, relay/destructive service paths, and repository uniqueness.

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInDestructiveAutoProcessIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInDestructiveAutoProcessIntegrationTest.java
@@ -1,0 +1,75 @@
+package com.nutriconsultas.auth.apple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import com.nutriconsultas.auth0.Auth0ManagementUserService;
+import com.nutriconsultas.paciente.ApplePacienteLifecycleStatus;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(AppleSignInIntegrationTestSupport.TestJwksConfiguration.class)
+@TestPropertySource(properties = { "nutriconsultas.apple.signin.webhook.enabled=true",
+		"nutriconsultas.apple.signin.expected-audience=com.minutriporcion.app",
+		"nutriconsultas.apple.signin.auto-process-destructive-events=true" })
+class AppleSignInDestructiveAutoProcessIntegrationTest {
+
+	@Autowired
+	private AppleSignInNotificationService notificationService;
+
+	@Autowired
+	private AppleSignInNotificationRepository notificationRepository;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@MockBean
+	private Auth0ManagementUserService auth0ManagementUserService;
+
+	@BeforeEach
+	void setUp() {
+		notificationRepository.deleteAll();
+		pacienteRepository.deleteAll();
+		when(auth0ManagementUserService.isConfigured()).thenReturn(true);
+	}
+
+	@Test
+	void processesAccountDeleteWithDestructiveAutoProcessEnabled() {
+		final Paciente paciente = AppleSignInIntegrationTestSupport.persistApplePaciente(pacienteRepository);
+		final String signedPayload = AppleSignInIntegrationTestSupport.signSampleDestructiveEvent("evt-delete-auto",
+				"account-delete");
+
+		notificationService.handleNotification(signedPayload);
+
+		assertThat(notificationRepository.findByAppleEventId("evt-delete-auto")).isPresent()
+			.get()
+			.satisfies(notification -> {
+				assertThat(notification.getLifecycleAction())
+					.isEqualTo(AppleSignInLifecycleAction.APPLIED_PENDING_DELETION_REVIEW);
+				assertThat(notification.getPacienteId()).isEqualTo(paciente.getId());
+			});
+		final Paciente reloaded = pacienteRepository.findById(paciente.getId()).orElseThrow();
+		assertThat(reloaded.getAppleLifecycleStatus()).isEqualTo(ApplePacienteLifecycleStatus.PENDING_DELETION_REVIEW);
+		verify(auth0ManagementUserService).updateAppMetadata(eq(AppleSignInIntegrationTestSupport.AUTH0_USER_ID),
+				any(Map.class));
+		verify(auth0ManagementUserService, never()).deleteUser(any());
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInIntegrationTestSupport.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInIntegrationTestSupport.java
@@ -1,0 +1,97 @@
+package com.nutriconsultas.auth.apple;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Map;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteStatus;
+
+/**
+ * Shared helpers for Apple Sign-In integration tests (#509). Uses locally generated RSA
+ * keys — no live Apple or Auth0 credentials.
+ */
+public final class AppleSignInIntegrationTestSupport {
+
+	public static final String WEBHOOK_URL = "/rest/webhooks/apple/sign-in";
+
+	public static final String AUDIENCE = "com.minutriporcion.app";
+
+	public static final String ISSUER = "https://appleid.apple.com";
+
+	public static final String APPLE_SUBJECT = "001234.abc";
+
+	public static final String AUTH0_USER_ID = "apple|001234.abc";
+
+	private static final RSAKey RSA_KEY;
+
+	static {
+		try {
+			RSA_KEY = AppleSignInTestJwtSupport.generateRsaKey();
+		}
+		catch (JOSEException ex) {
+			throw new IllegalStateException("Unable to generate Apple Sign-In test RSA key", ex);
+		}
+	}
+
+	private AppleSignInIntegrationTestSupport() {
+	}
+
+	public static String signNotification(final String eventId, final String eventTypeKey,
+			final Map<String, Object> eventPayload) {
+		try {
+			final Instant issuedAt = Instant.now();
+			final Instant expiresAt = issuedAt.plus(1, ChronoUnit.HOURS);
+			return AppleSignInTestJwtSupport.signNotification(new AppleSignInTestJwtSupport.SignNotificationRequest(
+					RSA_KEY, ISSUER, AUDIENCE, eventId, eventTypeKey, eventPayload, issuedAt, expiresAt));
+		}
+		catch (JOSEException ex) {
+			throw new IllegalStateException("Unable to sign Apple Sign-In test notification", ex);
+		}
+	}
+
+	public static String signSampleDestructiveEvent(final String eventId, final String eventTypeKey) {
+		return signNotification(eventId, eventTypeKey, Map.of("type", eventTypeKey, "sub", APPLE_SUBJECT, "email",
+				"relay@privaterelay.appleid.com", "is_private_email", true));
+	}
+
+	public static String webhookJsonBody(final String signedPayload) {
+		return "{\"payload\":\"" + signedPayload + "\"}";
+	}
+
+	public static Paciente persistApplePaciente(final PacienteRepository pacienteRepository) {
+		final Paciente paciente = new Paciente();
+		paciente.setName("Paciente Apple Test");
+		paciente.setUserId("nutritionist-apple-test");
+		paciente.setPatientAuthSub(AUTH0_USER_ID);
+		paciente.setAppleSubject(APPLE_SUBJECT);
+		paciente.setGender("F");
+		paciente.setEmail("relay@privaterelay.appleid.com");
+		paciente.setStatus(PacienteStatus.ACTIVE);
+		final LocalDate dob = LocalDate.of(1992, 3, 10);
+		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		return pacienteRepository.saveAndFlush(paciente);
+	}
+
+	@TestConfiguration
+	public static class TestJwksConfiguration {
+
+		@Bean
+		@Primary
+		AppleSignInJwksKeySource appleSignInTestJwksKeySource() {
+			return AppleSignInTestJwtSupport.keySourceFrom(RSA_KEY);
+		}
+
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationFlowIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationFlowIntegrationTest.java
@@ -1,0 +1,112 @@
+package com.nutriconsultas.auth.apple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import com.nutriconsultas.auth0.Auth0ManagementUserService;
+import com.nutriconsultas.paciente.ApplePacienteLifecycleStatus;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(AppleSignInIntegrationTestSupport.TestJwksConfiguration.class)
+@TestPropertySource(properties = { "nutriconsultas.apple.signin.webhook.enabled=true",
+		"nutriconsultas.apple.signin.expected-audience=com.minutriporcion.app",
+		"nutriconsultas.apple.signin.auto-process-destructive-events=false" })
+class AppleSignInNotificationFlowIntegrationTest {
+
+	@Autowired
+	private AppleSignInNotificationService notificationService;
+
+	@Autowired
+	private AppleSignInNotificationRepository notificationRepository;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@MockBean
+	private Auth0ManagementUserService auth0ManagementUserService;
+
+	@BeforeEach
+	void setUp() {
+		notificationRepository.deleteAll();
+		pacienteRepository.deleteAll();
+		when(auth0ManagementUserService.isConfigured()).thenReturn(false);
+	}
+
+	@Test
+	void processesUnknownEventTypeAsIgnored() {
+		final String signedPayload = AppleSignInIntegrationTestSupport.signNotification("evt-unknown-1",
+				"future-event-type",
+				Map.of("type", "future-event-type", "sub", AppleSignInIntegrationTestSupport.APPLE_SUBJECT));
+
+		final AppleSignInWebhookOutcome outcome = notificationService.handleNotification(signedPayload);
+
+		assertThat(outcome).isEqualTo(AppleSignInWebhookOutcome.PROCESSED);
+		assertThat(notificationRepository.findByAppleEventId("evt-unknown-1")).isPresent()
+			.get()
+			.satisfies(notification -> {
+				assertThat(notification.getEventType()).isEqualTo(AppleSignInEventType.UNKNOWN);
+				assertThat(notification.getProcessingStatus())
+					.isEqualTo(AppleSignInNotificationProcessingStatus.IGNORED);
+			});
+	}
+
+	@Test
+	void processesRelayEmailChangeEventForMappedPaciente() {
+		AppleSignInIntegrationTestSupport.persistApplePaciente(pacienteRepository);
+		final String signedPayload = AppleSignInIntegrationTestSupport.signNotification("evt-relay-1", "email-enabled",
+				Map.of("type", "email-enabled", "sub", AppleSignInIntegrationTestSupport.APPLE_SUBJECT, "email",
+						"relay@privaterelay.appleid.com", "is_private_email", true));
+
+		final AppleSignInWebhookOutcome outcome = notificationService.handleNotification(signedPayload);
+
+		assertThat(outcome).isEqualTo(AppleSignInWebhookOutcome.PROCESSED);
+		assertThat(notificationRepository.findByAppleEventId("evt-relay-1")).isPresent()
+			.get()
+			.satisfies(notification -> {
+				assertThat(notification.getLifecycleAction())
+					.isEqualTo(AppleSignInLifecycleAction.APPLIED_RELAY_FORWARDING_ENABLED);
+				assertThat(notification.getPacienteId()).isNotNull();
+			});
+		final Paciente paciente = pacienteRepository.findByAppleSubject(AppleSignInIntegrationTestSupport.APPLE_SUBJECT)
+			.orElseThrow();
+		assertThat(paciente.getAppleRelayForwardingEnabled()).isTrue();
+		verify(auth0ManagementUserService, never()).findUserByAppleSubject(any());
+	}
+
+	@Test
+	void processesAccountDeleteInObserveOnlyModeWithoutLifecycleMutation() {
+		final Paciente paciente = AppleSignInIntegrationTestSupport.persistApplePaciente(pacienteRepository);
+		final String signedPayload = AppleSignInIntegrationTestSupport.signSampleDestructiveEvent("evt-delete-observe",
+				"account-delete");
+
+		notificationService.handleNotification(signedPayload);
+
+		assertThat(notificationRepository.findByAppleEventId("evt-delete-observe")).isPresent()
+			.get()
+			.satisfies(notification -> {
+				assertThat(notification.getLifecycleAction())
+					.isEqualTo(AppleSignInLifecycleAction.SKIPPED_OBSERVE_ONLY);
+				assertThat(notification.getPacienteId()).isEqualTo(paciente.getId());
+			});
+		final Paciente reloaded = pacienteRepository.findById(paciente.getId()).orElseThrow();
+		assertThat(reloaded.getAppleLifecycleStatus()).isEqualTo(ApplePacienteLifecycleStatus.NONE);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationPersistenceTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationPersistenceTest.java
@@ -1,14 +1,17 @@
 package com.nutriconsultas.auth.apple;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Instant;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceException;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
@@ -29,6 +32,15 @@ class AppleSignInNotificationPersistenceTest {
 		entityManager.clear();
 
 		assertThat(notificationRepository.findByAppleEventId("apple-evt-1")).isPresent();
+	}
+
+	@Test
+	void duplicateAppleEventIdIsRejectedByUniqueConstraint() {
+		notificationRepository.saveAndFlush(sampleNotification("apple-evt-dup"));
+		entityManager.clear();
+
+		assertThatThrownBy(() -> notificationRepository.saveAndFlush(sampleNotification("apple-evt-dup")))
+			.isInstanceOfAny(DataIntegrityViolationException.class, PersistenceException.class);
 	}
 
 	private static AppleSignInNotification sampleNotification(final String appleEventId) {

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookControllerTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookControllerTest.java
@@ -3,7 +3,6 @@ package com.nutriconsultas.auth.apple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookIntegrationTest.java
@@ -1,0 +1,120 @@
+package com.nutriconsultas.auth.apple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import(AppleSignInIntegrationTestSupport.TestJwksConfiguration.class)
+@TestPropertySource(properties = { "nutriconsultas.apple.signin.webhook.enabled=true",
+		"nutriconsultas.apple.signin.expected-audience=com.minutriporcion.app" })
+class AppleSignInWebhookIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private AppleSignInNotificationRepository notificationRepository;
+
+	@BeforeEach
+	void cleanNotifications() {
+		notificationRepository.deleteAll();
+	}
+
+	@Test
+	void webhookIsReachableWithoutAuthentication() throws Exception {
+		final String signedPayload = AppleSignInIntegrationTestSupport.signSampleDestructiveEvent("evt-public-access",
+				"consent-revoked");
+
+		mockMvc
+			.perform(post(AppleSignInIntegrationTestSupport.WEBHOOK_URL).contentType(MediaType.APPLICATION_JSON)
+				.content(AppleSignInIntegrationTestSupport.webhookJsonBody(signedPayload)))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	void returnsBadRequestWhenPayloadMissing() throws Exception {
+		mockMvc
+			.perform(post(AppleSignInIntegrationTestSupport.WEBHOOK_URL).contentType(MediaType.APPLICATION_JSON)
+				.content("{}"))
+			.andExpect(status().isBadRequest());
+
+		assertThat(notificationRepository.count()).isZero();
+	}
+
+	@Test
+	void returnsBadRequestWhenPayloadMalformed() throws Exception {
+		mockMvc
+			.perform(post(AppleSignInIntegrationTestSupport.WEBHOOK_URL).contentType(MediaType.APPLICATION_JSON)
+				.content("{\"payload\":\"not-a-valid-jwt\"}"))
+			.andExpect(status().isBadRequest());
+
+		assertThat(notificationRepository.count()).isZero();
+	}
+
+	@Test
+	void returnsBadRequestWhenSignatureInvalid() throws Exception {
+		final String signedPayload = AppleSignInIntegrationTestSupport.signSampleDestructiveEvent("evt-bad-signature",
+				"consent-revoked");
+		final String tamperedPayload = signedPayload.substring(0, signedPayload.length() - 4) + "xxxx";
+
+		mockMvc
+			.perform(post(AppleSignInIntegrationTestSupport.WEBHOOK_URL).contentType(MediaType.APPLICATION_JSON)
+				.content(AppleSignInIntegrationTestSupport.webhookJsonBody(tamperedPayload)))
+			.andExpect(status().isBadRequest());
+
+		assertThat(notificationRepository.count()).isZero();
+	}
+
+	@Test
+	void acceptsValidPayloadAndPersistsNotification() throws Exception {
+		final String signedPayload = AppleSignInIntegrationTestSupport.signSampleDestructiveEvent("evt-valid-1",
+				"consent-revoked");
+
+		mockMvc
+			.perform(post(AppleSignInIntegrationTestSupport.WEBHOOK_URL).contentType(MediaType.APPLICATION_JSON)
+				.content(AppleSignInIntegrationTestSupport.webhookJsonBody(signedPayload)))
+			.andExpect(status().isOk());
+
+		assertThat(notificationRepository.findByAppleEventId("evt-valid-1")).isPresent()
+			.get()
+			.satisfies(notification -> {
+				assertThat(notification.getEventType()).isEqualTo(AppleSignInEventType.CONSENT_REVOKED);
+				assertThat(notification.getAppleSubject()).isEqualTo(AppleSignInIntegrationTestSupport.APPLE_SUBJECT);
+				assertThat(notification.getProcessingStatus())
+					.isEqualTo(AppleSignInNotificationProcessingStatus.PROCESSED);
+			});
+	}
+
+	@Test
+	void returnsOkForDuplicateWithoutSecondPersistedRow() throws Exception {
+		final String signedPayload = AppleSignInIntegrationTestSupport.signSampleDestructiveEvent("evt-dup-1",
+				"email-enabled");
+
+		mockMvc
+			.perform(post(AppleSignInIntegrationTestSupport.WEBHOOK_URL).contentType(MediaType.APPLICATION_JSON)
+				.content(AppleSignInIntegrationTestSupport.webhookJsonBody(signedPayload)))
+			.andExpect(status().isOk());
+		mockMvc
+			.perform(post(AppleSignInIntegrationTestSupport.WEBHOOK_URL).contentType(MediaType.APPLICATION_JSON)
+				.content(AppleSignInIntegrationTestSupport.webhookJsonBody(signedPayload)))
+			.andExpect(status().isOk());
+
+		assertThat(notificationRepository.findByAppleEventId("evt-dup-1")).isPresent();
+		assertThat(notificationRepository.count()).isEqualTo(1);
+	}
+
+}


### PR DESCRIPTION
## Summary
- Implements #509 integration tests for Apple Sign-In webhooks using locally signed JWTs and a test JWKS key source — no live Apple or Auth0 calls
- Adds full-stack HTTP tests (missing/malformed/invalid/valid/duplicate payloads, public access) and service-flow tests (unknown events, relay email, destructive observe-only and auto-process)
- Extends repository persistence test for duplicate `apple_event_id` constraint idempotency

## Test plan
- [x] `AppleSignInWebhookIntegrationTest` — controller + verifier + persistence
- [x] `AppleSignInNotificationFlowIntegrationTest` — unknown, relay, observe-only delete
- [x] `AppleSignInDestructiveAutoProcessIntegrationTest` — auto-process with mocked Auth0
- [x] `AppleSignInNotificationPersistenceTest` — unique constraint
- [x] `mvn test -Dtest='AppleSignIn*Test'` (all Apple Sign-In tests)


Made with [Cursor](https://cursor.com)