### PR TITLE
Expand Apple Sign-In Developer Portal setup documentation (#510)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,11 @@ JDBC_DATABASE_PASSWORD=nutriconsultas
 # AI_MAX_TOOL_CALLS=8
 # AI_MAX_USER_MESSAGE_LENGTH=4000
 # AI_SCOPE_CLASSIFIER_ENABLED=true
+
+# Apple Sign-In server-to-server notifications (#498–#510); see docs/auth/apple-signin-setup.md
+# APPLE_SIGNIN_WEBHOOK_ENABLED=false
+# APPLE_SIGNIN_EXPECTED_AUDIENCE=com.example.app          # Apple client identifier (Services ID or App ID)
+# APPLE_SIGNIN_EXPECTED_ISSUER=https://appleid.apple.com
+# APPLE_SIGNIN_JWKS_URL=https://appleid.apple.com/auth/keys
+# APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS=false     # keep false until rollout Phase 3 (#511)
+# APPLE_SIGNIN_VERIFICATION_FAILURE_ALERT_THRESHOLD=5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -620,7 +620,7 @@ Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic ~~**#
 
 Issue registry: [`ISSUE-APPLE-SIGNIN.md`](ISSUE-APPLE-SIGNIN.md). Roadmap: [`docs/auth/apple-signin-backend-roadmap.md`](docs/auth/apple-signin-backend-roadmap.md). Setup: [`docs/auth/apple-signin-setup.md`](docs/auth/apple-signin-setup.md).
 
-**Epic #497–#511** (2026-07-07): Sign in with Apple via Auth0 + Apple server-to-server webhook (`POST /rest/webhooks/apple/sign-in`). ~~#497~~ **done** (Auth0 prod + Apple connection, 2026-07-07). ~~#498–#508~~ **done** (PRs [#513](https://github.com/diego-torres/nutriconsultas/pull/513)–[#517](https://github.com/diego-torres/nutriconsultas/pull/517)). **NEXT:** [#509](https://github.com/diego-torres/nutriconsultas/issues/509) integration tests (`apple-signin/509-integration-tests`). Auth0 callback: `https://minutriporcion-prod.us.auth0.com/login/callback` — **not** the Apple notification URL.
+**Epic #497–#511** (2026-07-07): Sign in with Apple via Auth0 + Apple server-to-server webhook (`POST /rest/webhooks/apple/sign-in`). ~~#497~~ **done** (Auth0 prod + Apple connection, 2026-07-07). ~~#498–#509~~ **done** (PRs [#513](https://github.com/diego-torres/nutriconsultas/pull/513)–[#518](https://github.com/diego-torres/nutriconsultas/pull/518)). **NEXT:** [#510](https://github.com/diego-torres/nutriconsultas/issues/510) Developer Portal setup docs (`apple-signin/510-setup-docs`). Auth0 callback: `https://minutriporcion-prod.us.auth0.com/login/callback` — **not** the Apple notification URL.
 
 ## Resources
 

--- a/ISSUE-APPLE-SIGNIN.md
+++ b/ISSUE-APPLE-SIGNIN.md
@@ -8,7 +8,7 @@ Living index of GitHub issues that implement **Sign in with Apple** through Auth
 **Deletion runbook:** [`docs/auth/apple-signin-deletion-runbook.md`](docs/auth/apple-signin-deletion-runbook.md)  
 **Observability:** [`docs/auth/apple-signin-observability.md`](docs/auth/apple-signin-observability.md)  
 **Epic comment:** [#497](https://github.com/diego-torres/nutriconsultas/issues/497#issuecomment-4904658287)  
-**Last updated:** 2026-07-07 — ~~#508~~ **done** (PR #517); #509 in progress on `apple-signin/509-integration-tests`.
+**Last updated:** 2026-07-07 — ~~#509~~ **done** (PR #518); #510 in progress on `apple-signin/510-setup-docs`.
 
 > **Scope.** Auth0 Apple social connection, backend webhook (`POST /rest/webhooks/apple/sign-in`), signed payload verification, notification persistence, identity mapping, and safe lifecycle handling. **Does not** replace Auth0 with custom Apple OAuth. Patient mobile API: [`ISSUE.md`](ISSUE.md). Auth0 patient gate: [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md).
 
@@ -54,8 +54,8 @@ Suggested order matches [`docs/auth/apple-signin-backend-roadmap.md`](docs/auth/
 | 10 | **506** | Add safe account deletion workflow | https://github.com/diego-torres/nutriconsultas/issues/506 | **done** | 503, 504, 505 | PR #515 |
 | 11 | **507** | Handle private relay email changes | https://github.com/diego-torres/nutriconsultas/issues/507 | **done** | 503, 504 | PR #516 |
 | 12 | **508** | Add observability and operational alerts | https://github.com/diego-torres/nutriconsultas/issues/508 | **done** | 499, 503 | PR #517 |
-| 13 | **509** | Add integration tests | https://github.com/diego-torres/nutriconsultas/issues/509 | **in-progress** | 499–503 | Branch `apple-signin/509-integration-tests` **NEXT** |
-| 14 | 510 | Document Apple Developer Portal setup | https://github.com/diego-torres/nutriconsultas/issues/510 | open | — | Expand [`apple-signin-setup.md`](docs/auth/apple-signin-setup.md) |
+| 13 | **509** | Add integration tests | https://github.com/diego-torres/nutriconsultas/issues/509 | **done** | 499–503 | PR #518 |
+| 14 | **510** | Document Apple Developer Portal setup | https://github.com/diego-torres/nutriconsultas/issues/510 | **in-progress** | — | Branch `apple-signin/510-setup-docs` **NEXT** |
 | 15 | 511 | Add production rollout plan | https://github.com/diego-torres/nutriconsultas/issues/511 | open | 497–510 | Phased: observe → metadata → restrict → optional delete |
 
 ---

--- a/docs/auth/apple-signin-backend-roadmap.md
+++ b/docs/auth/apple-signin-backend-roadmap.md
@@ -562,7 +562,7 @@ Apple lifecycle handling is security-sensitive. It should be rolled out graduall
 11. ~~[#507](https://github.com/diego-torres/nutriconsultas/issues/507)~~ — Handle private relay email changes (**done**, PR #516).
 12. ~~[#508](https://github.com/diego-torres/nutriconsultas/issues/508)~~ — Add observability (**done**, PR #517).
 13. ~~[#509](https://github.com/diego-torres/nutriconsultas/issues/509)~~ — Add integration tests (**done**, PR #518).
-14. [#510](https://github.com/diego-torres/nutriconsultas/issues/510) — Document Apple Developer Portal setup (**in progress**).
+14. ~~[#510](https://github.com/diego-torres/nutriconsultas/issues/510)~~ — Document Apple Developer Portal setup (**done**, 2026-07-07).
 15. [#511](https://github.com/diego-torres/nutriconsultas/issues/511) — Roll out in observe-only mode.
 
 ---

--- a/docs/auth/apple-signin-backend-roadmap.md
+++ b/docs/auth/apple-signin-backend-roadmap.md
@@ -504,30 +504,9 @@ Webhook and account lifecycle behavior must be tested without relying on live Ap
 
 ---
 
-## Issue 14: Document Apple Developer Portal setup — [#510](https://github.com/diego-torres/nutriconsultas/issues/510)
+## Issue 14: Document Apple Developer Portal setup — [#510](https://github.com/diego-torres/nutriconsultas/issues/510) — **done** (2026-07-07)
 
-### Problem
-
-Future maintainers need exact setup steps and must not confuse the Auth0 callback with the Apple webhook endpoint.
-
-### Tasks
-
-Expand [`apple-signin-setup.md`](apple-signin-setup.md) with:
-
-- Apple App ID setup.
-- Apple Sign in with Apple capability.
-- Apple server-to-server notification endpoint.
-- Auth0 callback URL.
-- Auth0 Apple social connection settings.
-- Production environment variables.
-- Testing limitations.
-- Rollback steps.
-
-### Acceptance criteria
-
-- Documentation clearly separates Auth0 login callback from Apple webhook endpoint.
-- Production setup can be repeated from the docs.
-- Required secrets are listed but not committed.
+Expanded [`apple-signin-setup.md`](apple-signin-setup.md) with portal steps, identifier reference, SSM deploy script, verification checklist, and rollback. See also `infrastructure/scripts/ssm-update-apple-signin.sh`.
 
 ---
 
@@ -582,8 +561,8 @@ Apple lifecycle handling is security-sensitive. It should be rolled out graduall
 10. ~~[#506](https://github.com/diego-torres/nutriconsultas/issues/506)~~ — Add safe account deletion workflow (**done**, PR #515).
 11. ~~[#507](https://github.com/diego-torres/nutriconsultas/issues/507)~~ — Handle private relay email changes (**done**, PR #516).
 12. ~~[#508](https://github.com/diego-torres/nutriconsultas/issues/508)~~ — Add observability (**done**, PR #517).
-13. [#509](https://github.com/diego-torres/nutriconsultas/issues/509) — Add integration tests (**in progress**).
-14. [#510](https://github.com/diego-torres/nutriconsultas/issues/510) — Document Apple Developer Portal setup.
+13. ~~[#509](https://github.com/diego-torres/nutriconsultas/issues/509)~~ — Add integration tests (**done**, PR #518).
+14. [#510](https://github.com/diego-torres/nutriconsultas/issues/510) — Document Apple Developer Portal setup (**in progress**).
 15. [#511](https://github.com/diego-torres/nutriconsultas/issues/511) — Roll out in observe-only mode.
 
 ---

--- a/docs/auth/apple-signin-setup.md
+++ b/docs/auth/apple-signin-setup.md
@@ -1,139 +1,249 @@
 # Apple Sign-In — Developer Portal & Auth0 Setup
 
-Maintainer runbook for **Sign in with Apple** on Minutriporcion. Auth0 remains the identity broker; this doc covers Apple Developer Portal, Auth0, and production environment configuration.
+Maintainer runbook for **Sign in with Apple** on Minutriporcion (#510). Auth0 remains the identity broker; this doc covers Apple Developer Portal, Auth0, backend webhook configuration, and production deployment.
 
 **Related:**
 
 - Issue track: [`ISSUE-APPLE-SIGNIN.md`](../../ISSUE-APPLE-SIGNIN.md) (#497–#511)
-- Full backend roadmap: [`apple-signin-backend-roadmap.md`](apple-signin-backend-roadmap.md)
+- Backend roadmap: [`apple-signin-backend-roadmap.md`](apple-signin-backend-roadmap.md)
+- Observability & alerts: [`apple-signin-observability.md`](apple-signin-observability.md)
+- Deletion runbook: [`apple-signin-deletion-runbook.md`](apple-signin-deletion-runbook.md)
 - Auth0 patient post-login gate: [`../auth0/PATIENT-POST-LOGIN-GATE.md`](../auth0/PATIENT-POST-LOGIN-GATE.md)
+
+---
+
+## Prerequisites
+
+Before enabling Apple Sign-In in production:
+
+- [ ] Apple Developer Program membership with access to **Certificates, Identifiers & Profiles**
+- [ ] Auth0 production tenant (`minutriporcion-prod.us.auth0.com`) with admin access
+- [ ] Minutriporcion backend deployed with Liquibase migrations through `028-apple-signin-relay-email` (or later)
+- [ ] Public HTTPS endpoint reachable at `https://minutriporcion.com/rest/webhooks/apple/sign-in`
+- [ ] Ops vault entry for Apple **Team ID**, **Key ID**, and `.p8` signing key (never commit to git)
 
 ---
 
 ## Critical: two different URLs
 
+Apple and Auth0 use **different** endpoints. Mixing them breaks either login or lifecycle notifications.
+
 | Purpose | URL | Used by |
 |---------|-----|---------|
-| **Auth0 OAuth login callback** | `https://minutriporcion-prod.us.auth0.com/login/callback` | Auth0 ↔ Apple OAuth during user sign-in |
+| **Auth0 OAuth login callback** | `https://minutriporcion-prod.us.auth0.com/login/callback` | Auth0 ↔ Apple during user sign-in |
 | **Apple server-to-server notifications** | `https://minutriporcion.com/rest/webhooks/apple/sign-in` | Apple → Minutriporcion backend lifecycle events |
 
-Do **not** point Apple's server-to-server notification endpoint at the Auth0 callback.
+Do **not** point Apple's **Server-to-Server Notification Endpoint** at the Auth0 callback.
+
+```
+User sign-in flow:     iOS app → Auth0 → Apple → Auth0 callback → app
+Lifecycle webhooks:    Apple  → minutriporcion.com/rest/webhooks/apple/sign-in → backend
+```
+
+---
+
+## Production identifier reference
+
+Store actual values in your **ops vault** (1Password, AWS Secrets Manager, etc.). This table lists what each identifier is for — not secret values.
+
+| Identifier | Where used | Notes |
+|------------|------------|-------|
+| **Apple Team ID** | Auth0 Apple connection, `.p8` key | 10-character team identifier from Apple Developer |
+| **Apple Key ID** | Auth0 Apple connection | From the Sign in with Apple key you create |
+| **iOS Bundle ID** (App ID) | Native iOS app, Auth0 Apple connection | Must match the Flutter/iOS app `PRODUCT_BUNDLE_IDENTIFIER` |
+| **Services ID** (optional) | Web Sign in with Apple via Auth0 | Only if web-based Apple login is required |
+| **`APPLE_SIGNIN_EXPECTED_AUDIENCE`** | Backend JWT verification | Must match the Apple **client identifier** Apple puts in notification JWT `aud` (often the Services ID or primary App ID — confirm from a test notification) |
+| **Auth0 connection** | Social login | Typically named `apple`; enabled on patient mobile and nutritionist apps as needed |
+| **Auth0 `user_id` for Apple users** | Identity mapping (#504) | Pattern: `apple\|{apple_stable_subject}` |
 
 ---
 
 ## Apple Developer Portal
 
-### 1. App ID / Bundle ID
+### 1. App ID (Bundle ID)
 
 1. Open [Apple Developer](https://developer.apple.com/account) → **Certificates, Identifiers & Profiles** → **Identifiers**.
-2. Create or confirm the iOS **App ID** used by the Minutriporcion mobile app.
-3. Enable **Sign in with Apple** capability on the App ID.
+2. Select or create the **App ID** for the Minutriporcion iOS app (native patient app).
+3. Under **Capabilities**, enable **Sign in with Apple**.
+4. Save. Note the **Bundle ID** — it must match the mobile app's bundle identifier and Auth0 Apple connection settings.
 
-### 2. Services ID (if web Sign in with Apple is needed)
+### 2. Sign in with Apple key (`.p8`)
 
-1. Create a **Services ID** if web-based Sign in with Apple is required (optional for native-only iOS).
-2. Enable Sign in with Apple on the Services ID.
-3. Configure domains and return URLs per Apple documentation (Auth0 docs list the exact redirect URIs for your Auth0 tenant).
+1. **Keys** → **+** to create a new key.
+2. Name it (e.g. `Minutriporcion Sign in with Apple`).
+3. Enable **Sign in with Apple** and associate it with your primary App ID.
+4. **Register** → **Download** the `.p8` file **once** (Apple does not allow re-download).
+5. Record **Key ID** (shown on the key detail page) and your **Team ID** (Membership details).
 
-### 3. Sign in with Apple key
+**Never commit** the `.p8` file or paste its contents into git, Terraform, or this documentation.
 
-1. **Keys** → create a key with **Sign in with Apple** enabled.
-2. Download the `.p8` private key once (Apple does not allow re-download).
-3. Record **Key ID** and **Team ID**.
+### 3. Services ID (web / Auth0 only)
+
+Required when Auth0 handles Sign in with Apple for web or when the notification JWT audience is a Services ID.
+
+1. **Identifiers** → **+** → **Services IDs**.
+2. Create an identifier (e.g. `com.minutriporcion.app` or your org's Services ID convention).
+3. Enable **Sign in with Apple** → **Configure**:
+   - **Primary App ID:** select the iOS App ID from step 1.
+   - **Domains and Subdomains:** `minutriporcion-prod.us.auth0.com` (Auth0 tenant host).
+   - **Return URLs:** `https://minutriporcion-prod.us.auth0.com/login/callback` (and any Auth0-documented variants for your tenant).
+4. Save.
 
 ### 4. Server-to-server notification endpoint
 
-In the Apple Developer Portal, configure the **Server-to-Server Notification Endpoint** for Sign in with Apple:
+Apple sends account lifecycle events (email relay changes, consent revoked, account delete) to your **backend**, not Auth0.
+
+1. In Apple Developer Portal, open the **App ID** (or Services ID — follow Apple's current UI for your account type).
+2. Under **Sign in with Apple** configuration, find **Server-to-Server Notification Endpoint**.
+3. Set:
 
 ```text
 https://minutriporcion.com/rest/webhooks/apple/sign-in
 ```
 
-This endpoint is implemented by the backend (#499). Deploy and enable the webhook (#498) before expecting Apple deliveries in production.
+4. Save. Apple may take time to propagate; verify delivery only after the backend webhook is enabled (see below).
+
+**Local development:** Apple cannot POST to `localhost`. Use integration tests (#509) with locally signed JWTs instead of live delivery.
 
 ---
 
-## Auth0 configuration — [#497](https://github.com/diego-torres/nutriconsultas/issues/497) — **done** (2026-07-07)
+## Auth0 configuration
 
-Production tenant: `minutriporcion-prod.us.auth0.com`. Apple social connection enabled for Minutriporcion applications. Auth vars deployed to EC2 via `terraform.tfvars` / SSM.
+Production tenant: **`minutriporcion-prod.us.auth0.com`** ([#497](https://github.com/diego-torres/nutriconsultas/issues/497) done, 2026-07-07).
 
-Reference steps (for new environments):
+### Apple social connection
 
-1. Auth0 Dashboard → **Authentication** → **Social** → **Apple**.
+1. Auth0 Dashboard → **Authentication** → **Social** → **Apple** (connection name is typically `apple`).
 2. Configure:
-   - **Apple Team ID**
-   - **App ID / Bundle ID** (native) and/or **Services ID** (web)
-   - **Key ID**
-   - **Client Secret Signing Key** (contents of the `.p8` file)
-3. Enable the Apple connection for the Minutriporcion application(s).
-4. Confirm the Auth0 **Allowed Callback URL** includes:
+   - **Apple Team ID** — from Membership / ops vault
+   - **App ID / Bundle ID** — iOS native bundle ID
+   - **Services ID** — if using web Apple login (step 3 above)
+   - **Key ID** — from the `.p8` key
+   - **Client Secret Signing Key** — paste contents of the `.p8` file (Auth0 stores it encrypted)
+3. **Applications** tab: enable the connection for:
+   - Patient mobile Auth0 application (`minutriporcion-native` / Flutter `AUTH0_CLIENT_ID`)
+   - Nutritionist web application if Apple login is offered there
+4. **Settings** → confirm **Allowed Callback URLs** include:
 
 ```text
 https://minutriporcion-prod.us.auth0.com/login/callback
 ```
 
-5. Verify existing connections (Google, email/password) still work after enabling Apple.
+5. Test login with an Apple ID on a staging or production build before enabling webhook processing.
 
-### Auth0 Management API (lifecycle handling — ~~#505~~ **done**, PR #514)
+### Auth0 Apple user profile shape (#504)
 
-Create or reuse a Machine-to-Machine application with minimal scopes:
+For this tenant, Apple users are identified by:
+
+| Field | Value |
+|-------|-------|
+| Auth0 `user_id` | `apple\|{apple_stable_subject}` |
+| Apple subject | Stable per user per app; stored on `Paciente.apple_subject` |
+| Email | May be a Hide My Email relay (`*@privaterelay.appleid.com`) — **not** the primary identity key |
+
+Inspect a test user in Auth0 Dashboard → **User Management** → user → **Identities** before relying on email for mapping.
+
+### Auth0 Management API (lifecycle — #505)
+
+Machine-to-Machine application with minimal scopes:
 
 ```text
 read:users
 update:users_app_metadata
 ```
 
-Add `update:users` / `delete:users` only after product/legal approval (#511 Phase 4).
+Configured via `AUTH0_MGMT_CLIENT_ID`, `AUTH0_MGMT_CLIENT_SECRET`, `AUTH0_MGMT_DOMAIN` on the app host.
+
+Add `update:users` / `delete:users` only after product/legal approval ([#511](https://github.com/diego-torres/nutriconsultas/issues/511) Phase 4). User deletion remains disabled by default in application code.
 
 ---
 
 ## Backend environment variables
 
-Set on the production app host (`/opt/nutriconsultas/app.env`) or via SSM remediation script (pattern: `infrastructure/scripts/ssm-update-*.sh`).
+Mapped in `application.properties` from these environment variables. Set on production at `/opt/nutriconsultas/app.env` or via SSM (see below).
 
-| Variable | Purpose | Default (local) |
-|----------|---------|-----------------|
-| `APPLE_SIGNIN_WEBHOOK_ENABLED` | Enable Apple webhook endpoint | `false` |
-| `APPLE_SIGNIN_EXPECTED_ISSUER` | JWT issuer validation | `https://appleid.apple.com` |
-| `APPLE_SIGNIN_EXPECTED_AUDIENCE` | Apple client/app identifier (required when webhook enabled) | — |
-| `APPLE_SIGNIN_JWKS_URL` | Apple JWKS URL | `https://appleid.apple.com/auth/keys` |
-| `APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS` | Allow automated deletion/revocation | `false` |
+| Variable | Purpose | Production start | Default (local) |
+|----------|---------|------------------|-----------------|
+| `APPLE_SIGNIN_WEBHOOK_ENABLED` | Enable `POST /rest/webhooks/apple/sign-in` | `false` → `true` when ready | `false` |
+| `APPLE_SIGNIN_EXPECTED_AUDIENCE` | JWT `aud` validation (Apple client identifier) | **Required** when webhook enabled | — |
+| `APPLE_SIGNIN_EXPECTED_ISSUER` | JWT `iss` validation | `https://appleid.apple.com` | same |
+| `APPLE_SIGNIN_JWKS_URL` | Apple public keys | `https://appleid.apple.com/auth/keys` | same |
+| `APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS` | Auto revoke / pending-deletion metadata | `false` (observe-only) | `false` |
+| `APPLE_SIGNIN_JWKS_CACHE_TTL` | JWKS cache duration | `6h` | `6h` |
+| `APPLE_SIGNIN_VERIFICATION_FAILURE_ALERT_THRESHOLD` | Consecutive failures before ERROR alert | `5` | `5` |
 
-Existing Auth0 variables (`AUTH_ISSUER`, `AUTH_CLIENT`, mobile broker keys, etc.) are unchanged. See `.env.example` for local dev.
+Existing Auth0 variables (`AUTH_ISSUER`, `AUTH_CLIENT`, `AUTH0_MGMT_*`, mobile broker keys) are unchanged. See [`.env.example`](../../.env.example) for local dev.
 
-**Never commit** Apple `.p8` keys, Auth0 client secrets, or Management API credentials to git.
+**Never commit:** Apple `.p8` keys, Auth0 client secrets, or Management API credentials.
+
+### Deploy via SSM (EC2)
+
+From a machine with AWS CLI and `minutriporcion` profile:
+
+```bash
+export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+export APPLE_SIGNIN_WEBHOOK_ENABLED=true
+export APPLE_SIGNIN_EXPECTED_AUDIENCE='YOUR_APPLE_CLIENT_IDENTIFIER'
+export APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS=false
+./infrastructure/scripts/ssm-update-apple-signin.sh
+```
+
+Script: [`infrastructure/scripts/ssm-update-apple-signin.sh`](../../infrastructure/scripts/ssm-update-apple-signin.sh) — updates `app.env`, restarts `nutriconsultas`, prints an env audit.
+
+`APPLE_SIGNIN_*` variables are **not** managed by Terraform (see `terraform.tfvars` comment); use SSM for runtime updates.
+
+---
+
+## Post-deploy verification checklist
+
+1. **Health:** `curl -sf https://minutriporcion.com/actuator/health`
+2. **Webhook disabled smoke:** `POST /rest/webhooks/apple/sign-in` with empty body → `503` when `APPLE_SIGNIN_WEBHOOK_ENABLED=false`
+3. **Webhook enabled:** after enabling, invalid payload → `400`; valid signed test payload → `200` (use integration test JWT helpers locally, or wait for Apple delivery)
+4. **Logs:** search for `Apple Sign-In webhook enabled` on startup and `apple_signin_webhook stage=` after events — see [`apple-signin-observability.md`](apple-signin-observability.md)
+5. **Admin UI:** platform admin → **Apple Sign-In** (`/admin/platform/apple-signin`) lists received notifications
+6. **Metrics:** `apple.signin.webhook.*` counters on `/actuator/metrics` when enabled
+7. **Mobile login:** complete Sign in with Apple on a device build; confirm Auth0 user `apple|…` and patient linkage
 
 ---
 
 ## Local development
 
 - Webhook is **disabled by default** (`APPLE_SIGNIN_WEBHOOK_ENABLED=false`).
-- Use unit/integration tests (#509) with mocked Apple payloads — no live Apple delivery required.
-- Auth0 Apple connection can be tested against a dev/staging tenant before production.
+- Run integration tests with locally signed JWTs — no live Apple or Auth0 calls:
+
+```bash
+mvn test -Dtest='AppleSignIn*IntegrationTest,AppleSignInNotificationPersistenceTest'
+```
+
+- Auth0 Apple connection can be tested against a **dev/staging** tenant before production.
+- To test webhook logic locally with a tunnel (optional): expose port 3000 via ngrok/cloudflared and temporarily point Apple's notification URL at the tunnel — revert immediately after testing.
 
 ---
 
 ## Testing limitations
 
-- Apple server-to-server notifications require a **public HTTPS** endpoint; localhost cannot receive them directly.
-- Use **Phase 1 (observe only)** rollout (#511) in production before enabling destructive processing.
-- Auth0 Apple user profile shape should be inspected in the tenant (#504) before relying on email for mapping.
+| Limitation | Workaround |
+|------------|------------|
+| Apple server notifications require **public HTTPS** | Integration tests (#509); production observe-only phase (#511) |
+| Cannot receive Apple webhooks on `localhost` | Signed JWT tests; optional HTTPS tunnel for manual checks |
+| Auth0 Apple profile shape varies by tenant | Inspect test users in Auth0 Dashboard (#504) |
+| Relay email is not a stable identity key | Map by `apple_subject` / `patientAuthSub` (#507) |
+| Destructive automation is off by default | `APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS=false` until Phase 3+ (#511) |
 
 ---
 
 ## Rollback
 
-1. **Disable webhook:** set `APPLE_SIGNIN_WEBHOOK_ENABLED=false` and restart the app.
-2. **Disable Auth0 Apple connection** in Auth0 Dashboard if login regressions occur.
-3. **Revert Apple notification URL** in Developer Portal if needed (or point to a no-op staging endpoint during investigation).
-4. Review persisted events in `apple_signin_notification` (#502) for audit; do not hard-delete user data as part of rollback.
+1. **Disable webhook:** `APPLE_SIGNIN_WEBHOOK_ENABLED=false` via SSM script or edit `app.env` → `systemctl restart nutriconsultas`.
+2. **Disable Auth0 Apple connection** in Auth0 Dashboard if login regressions occur (users fall back to other connections).
+3. **Revert Apple notification URL** in Developer Portal (or point to a no-op staging endpoint during investigation).
+4. **Review audit data** in `apple_signin_notification` and `/admin/platform/apple-signin` — do not hard-delete patient data as part of rollback.
+5. **Leave** `APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS=false` unless explicitly rolling forward again.
+
+See also [`apple-signin-deletion-runbook.md`](apple-signin-deletion-runbook.md) if destructive events were processed.
 
 ---
 
-## TODO (expand in #510)
+## Rollout pointer
 
-- [ ] Exact Auth0 connection name and application IDs for production
-- [ ] iOS Bundle ID and Apple Team ID values (reference only — store in secure ops vault, not in git)
-- [ ] Auth0 Apple `user_id` / `identities` shape for this tenant
-- [ ] SSM update script for Apple webhook env vars on EC2
-- [x] Operator alert runbook for verification failures (#508) — see [`apple-signin-observability.md`](apple-signin-observability.md)
+Phased production rollout (observe → metadata → restrict → optional delete) is documented in issue [#511](https://github.com/diego-torres/nutriconsultas/issues/511). Start with webhook **enabled** and destructive processing **disabled**.

--- a/infrastructure/scripts/ssm-update-apple-signin.sh
+++ b/infrastructure/scripts/ssm-update-apple-signin.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Update Apple Sign-In webhook env vars in /opt/nutriconsultas/app.env on the app EC2, then restart.
+#
+# Usage (enable webhook — observe-only):
+#   export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+#   export APPLE_SIGNIN_WEBHOOK_ENABLED=true
+#   export APPLE_SIGNIN_EXPECTED_AUDIENCE='com.minutriporcion.app'   # Apple Services ID / client identifier
+#   ./ssm-update-apple-signin.sh [project]
+#
+# Usage (disable webhook):
+#   export APPLE_SIGNIN_WEBHOOK_ENABLED=false
+#   ./ssm-update-apple-signin.sh
+#
+# Optional: APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS, APPLE_SIGNIN_VERIFICATION_FAILURE_ALERT_THRESHOLD
+#
+# See docs/auth/apple-signin-setup.md (#510).
+set -euo pipefail
+
+PROJECT="${1:-nutriconsultas}"
+P="/${PROJECT}/deploy"
+: "${AWS_REGION:-${AWS_DEFAULT_REGION:?Set AWS_DEFAULT_REGION (or use configure)}}"
+: "${APPLE_SIGNIN_WEBHOOK_ENABLED:?Set APPLE_SIGNIN_WEBHOOK_ENABLED (true or false)}"
+
+if [ "$APPLE_SIGNIN_WEBHOOK_ENABLED" = "true" ]; then
+  : "${APPLE_SIGNIN_EXPECTED_AUDIENCE:?Set APPLE_SIGNIN_EXPECTED_AUDIENCE when APPLE_SIGNIN_WEBHOOK_ENABLED=true}"
+fi
+
+INSTANCE_ID="$(aws ssm get-parameter --name "$P/app_instance_id" --query "Parameter.Value" --output text)"
+
+PARAMS="$(jq -n \
+  --arg enabled "$APPLE_SIGNIN_WEBHOOK_ENABLED" \
+  --arg audience "${APPLE_SIGNIN_EXPECTED_AUDIENCE:-}" \
+  --arg autoDestructive "${APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS:-}" \
+  --arg alertThreshold "${APPLE_SIGNIN_VERIFICATION_FAILURE_ALERT_THRESHOLD:-}" \
+  'def upsertPlain($key; $val):
+     [
+       ("grep -v \"^" + $key + "=\" \"$ENV_FILE\" > \"${ENV_FILE}.tmp\" || true"),
+       ("echo " + $key + "=" + $val + " >> \"${ENV_FILE}.tmp\""),
+       "mv \"${ENV_FILE}.tmp\" \"$ENV_FILE\""
+     ];
+   def upsertOptional($key; $val):
+     if ($val | length) == 0 then [] else upsertPlain($key; $val) end;
+   [
+     "set -euo pipefail",
+     "ENV_FILE=/opt/nutriconsultas/app.env",
+     "touch \"$ENV_FILE\""
+   ]
+   + upsertPlain("APPLE_SIGNIN_WEBHOOK_ENABLED"; $enabled)
+   + upsertOptional("APPLE_SIGNIN_EXPECTED_AUDIENCE"; $audience)
+   + upsertOptional("APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS"; $autoDestructive)
+   + upsertOptional("APPLE_SIGNIN_VERIFICATION_FAILURE_ALERT_THRESHOLD"; $alertThreshold)
+   + [
+       "chmod 640 \"$ENV_FILE\"",
+       "chown root:nutri \"$ENV_FILE\"",
+       "systemctl restart nutriconsultas",
+       "for i in $(seq 1 60); do",
+       "  if curl -sf http://127.0.0.1:3000/actuator/health >/dev/null 2>&1; then break; fi",
+       "  sleep 2",
+       "done",
+       "curl -sf http://127.0.0.1:3000/actuator/health >/dev/null",
+       "systemctl is-active --quiet nutriconsultas",
+       "echo \"=== Apple Sign-In env audit ===\"",
+       "grep -E \"^APPLE_SIGNIN_\" \"$ENV_FILE\" || echo \"APPLE_SIGNIN_*=MISSING\"",
+       "journalctl -u nutriconsultas -n 30 --no-pager | grep -i \"Apple Sign-In\" || true"
+     ] | { commands: . }')"
+
+COMMAND_ID="$(aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunShellScript" \
+  --timeout-seconds 180 \
+  --parameters "$PARAMS" \
+  --query 'Command.CommandId' \
+  --output text)"
+
+echo "SSM command: $COMMAND_ID (instance $INSTANCE_ID)"
+aws ssm wait command-executed --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID"
+STATUS="$(aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" --query Status --output text)"
+STDOUT="$(aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" --query StandardOutputContent --output text)"
+if [ "$STATUS" != "Success" ]; then
+  aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+    --query '[Status,StandardErrorContent]' --output text >&2
+  exit 1
+fi
+echo "$STDOUT"
+echo "Apple Sign-In env updated and nutriconsultas restarted."


### PR DESCRIPTION
## Summary
- Completes #510 by expanding `docs/auth/apple-signin-setup.md` with step-by-step Apple Developer Portal, Auth0, and backend configuration
- Adds production identifier reference table, post-deploy verification checklist, testing limitations, and rollback — clearly separating Auth0 callback from Apple webhook URL
- Adds `infrastructure/scripts/ssm-update-apple-signin.sh` and Apple Sign-In env vars to `.env.example`

## Test plan
- [x] Documentation review — no secrets committed; ops vault placeholders only
- [x] SSM script follows existing `ssm-update-ai-openai.sh` pattern


Made with [Cursor](https://cursor.com)