### PR TITLE
Sync Apple Sign-In tracking: #510 done, #511 NEXT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -620,7 +620,7 @@ Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic ~~**#
 
 Issue registry: [`ISSUE-APPLE-SIGNIN.md`](ISSUE-APPLE-SIGNIN.md). Roadmap: [`docs/auth/apple-signin-backend-roadmap.md`](docs/auth/apple-signin-backend-roadmap.md). Setup: [`docs/auth/apple-signin-setup.md`](docs/auth/apple-signin-setup.md).
 
-**Epic #497–#511** (2026-07-07): Sign in with Apple via Auth0 + Apple server-to-server webhook (`POST /rest/webhooks/apple/sign-in`). ~~#497~~ **done** (Auth0 prod + Apple connection, 2026-07-07). ~~#498–#509~~ **done** (PRs [#513](https://github.com/diego-torres/nutriconsultas/pull/513)–[#518](https://github.com/diego-torres/nutriconsultas/pull/518)). **NEXT:** [#510](https://github.com/diego-torres/nutriconsultas/issues/510) Developer Portal setup docs (`apple-signin/510-setup-docs`). Auth0 callback: `https://minutriporcion-prod.us.auth0.com/login/callback` — **not** the Apple notification URL.
+**Epic #497–#511** (2026-07-07): Sign in with Apple via Auth0 + Apple server-to-server webhook (`POST /rest/webhooks/apple/sign-in`). ~~#497–#510~~ **done** (PRs [#513](https://github.com/diego-torres/nutriconsultas/pull/513)–[#519](https://github.com/diego-torres/nutriconsultas/pull/519)). **NEXT:** [#511](https://github.com/diego-torres/nutriconsultas/issues/511) production rollout plan. Auth0 callback: `https://minutriporcion-prod.us.auth0.com/login/callback` — **not** the Apple notification URL.
 
 ## Resources
 

--- a/ISSUE-APPLE-SIGNIN.md
+++ b/ISSUE-APPLE-SIGNIN.md
@@ -8,7 +8,7 @@ Living index of GitHub issues that implement **Sign in with Apple** through Auth
 **Deletion runbook:** [`docs/auth/apple-signin-deletion-runbook.md`](docs/auth/apple-signin-deletion-runbook.md)  
 **Observability:** [`docs/auth/apple-signin-observability.md`](docs/auth/apple-signin-observability.md)  
 **Epic comment:** [#497](https://github.com/diego-torres/nutriconsultas/issues/497#issuecomment-4904658287)  
-**Last updated:** 2026-07-07 — ~~#509~~ **done** (PR #518); #510 in progress on `apple-signin/510-setup-docs`.
+**Last updated:** 2026-07-07 — ~~#510~~ **done** (PR #519); **NEXT:** [#511](https://github.com/diego-torres/nutriconsultas/issues/511) production rollout plan.
 
 > **Scope.** Auth0 Apple social connection, backend webhook (`POST /rest/webhooks/apple/sign-in`), signed payload verification, notification persistence, identity mapping, and safe lifecycle handling. **Does not** replace Auth0 with custom Apple OAuth. Patient mobile API: [`ISSUE.md`](ISSUE.md). Auth0 patient gate: [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md).
 
@@ -55,8 +55,8 @@ Suggested order matches [`docs/auth/apple-signin-backend-roadmap.md`](docs/auth/
 | 11 | **507** | Handle private relay email changes | https://github.com/diego-torres/nutriconsultas/issues/507 | **done** | 503, 504 | PR #516 |
 | 12 | **508** | Add observability and operational alerts | https://github.com/diego-torres/nutriconsultas/issues/508 | **done** | 499, 503 | PR #517 |
 | 13 | **509** | Add integration tests | https://github.com/diego-torres/nutriconsultas/issues/509 | **done** | 499–503 | PR #518 |
-| 14 | **510** | Document Apple Developer Portal setup | https://github.com/diego-torres/nutriconsultas/issues/510 | **in-progress** | — | Branch `apple-signin/510-setup-docs` **NEXT** |
-| 15 | 511 | Add production rollout plan | https://github.com/diego-torres/nutriconsultas/issues/511 | open | 497–510 | Phased: observe → metadata → restrict → optional delete |
+| 14 | **510** | Document Apple Developer Portal setup | https://github.com/diego-torres/nutriconsultas/issues/510 | **done** | — | PR #519 |
+| 15 | **511** | Add production rollout plan | https://github.com/diego-torres/nutriconsultas/issues/511 | **NEXT** | 497–510 | Phased: observe → metadata → restrict → optional delete |
 
 ---
 


### PR DESCRIPTION
## Summary
- Mark #510 **done** (PR #519) in `ISSUE-APPLE-SIGNIN.md` and `AGENTS.md`
- Set **#511** (production rollout plan) as **NEXT**

## Test plan
- [x] Docs-only change; no code or template changes


Made with [Cursor](https://cursor.com)