### PR TITLE
Add Apple Sign-In production rollout plan (#511)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -620,7 +620,7 @@ Issue registry: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Epic ~~**#
 
 Issue registry: [`ISSUE-APPLE-SIGNIN.md`](ISSUE-APPLE-SIGNIN.md). Roadmap: [`docs/auth/apple-signin-backend-roadmap.md`](docs/auth/apple-signin-backend-roadmap.md). Setup: [`docs/auth/apple-signin-setup.md`](docs/auth/apple-signin-setup.md).
 
-**Epic #497–#511** (2026-07-07): Sign in with Apple via Auth0 + Apple server-to-server webhook (`POST /rest/webhooks/apple/sign-in`). ~~#497–#510~~ **done** (PRs [#513](https://github.com/diego-torres/nutriconsultas/pull/513)–[#519](https://github.com/diego-torres/nutriconsultas/pull/519)). **NEXT:** [#511](https://github.com/diego-torres/nutriconsultas/issues/511) production rollout plan. Auth0 callback: `https://minutriporcion-prod.us.auth0.com/login/callback` — **not** the Apple notification URL.
+**Epic #497–#511** (2026-07-08): Sign in with Apple via Auth0 + Apple server-to-server webhook (`POST /rest/webhooks/apple/sign-in`). **Track complete** — ~~#497–#511~~ **done** (PRs [#513](https://github.com/diego-torres/nutriconsultas/pull/513)–[#519](https://github.com/diego-torres/nutriconsultas/pull/519); rollout plan [`docs/auth/apple-signin-rollout.md`](docs/auth/apple-signin-rollout.md)). Auth0 callback: `https://minutriporcion-prod.us.auth0.com/login/callback` — **not** the Apple notification URL.
 
 ## Resources
 

--- a/ISSUE-APPLE-SIGNIN.md
+++ b/ISSUE-APPLE-SIGNIN.md
@@ -7,8 +7,9 @@ Living index of GitHub issues that implement **Sign in with Apple** through Auth
 **Setup (maintainer runbook):** [`docs/auth/apple-signin-setup.md`](docs/auth/apple-signin-setup.md)  
 **Deletion runbook:** [`docs/auth/apple-signin-deletion-runbook.md`](docs/auth/apple-signin-deletion-runbook.md)  
 **Observability:** [`docs/auth/apple-signin-observability.md`](docs/auth/apple-signin-observability.md)  
+**Production rollout:** [`docs/auth/apple-signin-rollout.md`](docs/auth/apple-signin-rollout.md)  
 **Epic comment:** [#497](https://github.com/diego-torres/nutriconsultas/issues/497#issuecomment-4904658287)  
-**Last updated:** 2026-07-07 — ~~#510~~ **done** (PR #519); **NEXT:** [#511](https://github.com/diego-torres/nutriconsultas/issues/511) production rollout plan.
+**Last updated:** 2026-07-08 — ~~#511~~ **done** on `apple-signin/511-rollout-plan`. Apple Sign-In backend track **complete** (#497–#511).
 
 > **Scope.** Auth0 Apple social connection, backend webhook (`POST /rest/webhooks/apple/sign-in`), signed payload verification, notification persistence, identity mapping, and safe lifecycle handling. **Does not** replace Auth0 with custom Apple OAuth. Patient mobile API: [`ISSUE.md`](ISSUE.md). Auth0 patient gate: [`docs/auth0/PATIENT-POST-LOGIN-GATE.md`](docs/auth0/PATIENT-POST-LOGIN-GATE.md).
 
@@ -56,18 +57,13 @@ Suggested order matches [`docs/auth/apple-signin-backend-roadmap.md`](docs/auth/
 | 12 | **508** | Add observability and operational alerts | https://github.com/diego-torres/nutriconsultas/issues/508 | **done** | 499, 503 | PR #517 |
 | 13 | **509** | Add integration tests | https://github.com/diego-torres/nutriconsultas/issues/509 | **done** | 499–503 | PR #518 |
 | 14 | **510** | Document Apple Developer Portal setup | https://github.com/diego-torres/nutriconsultas/issues/510 | **done** | — | PR #519 |
-| 15 | **511** | Add production rollout plan | https://github.com/diego-torres/nutriconsultas/issues/511 | **NEXT** | 497–510 | Phased: observe → metadata → restrict → optional delete |
+| 15 | **511** | Add production rollout plan | https://github.com/diego-torres/nutriconsultas/issues/511 | **done** | 497–510 | [`apple-signin-rollout.md`](docs/auth/apple-signin-rollout.md) |
 
 ---
 
 ## Rollout phases (#511)
 
-| Phase | Behavior |
-|-------|----------|
-| **1 — Observe only** | Enable webhook; verify + persist; no Auth0/local mutations |
-| **2 — Metadata** | Mark lifecycle metadata; relay changes; admin visibility |
-| **3 — Restricted automation** | Block revoked users per policy; hard delete still manual |
-| **4 — Optional deletion** | Only after legal/product approval + audit trail |
+Documented in [`docs/auth/apple-signin-rollout.md`](docs/auth/apple-signin-rollout.md).
 
 ---
 

--- a/docs/auth/apple-signin-backend-roadmap.md
+++ b/docs/auth/apple-signin-backend-roadmap.md
@@ -510,40 +510,9 @@ Expanded [`apple-signin-setup.md`](apple-signin-setup.md) with portal steps, ide
 
 ---
 
-## Issue 15: Add production rollout plan — [#511](https://github.com/diego-torres/nutriconsultas/issues/511)
+## Issue 15: Add production rollout plan — [#511](https://github.com/diego-torres/nutriconsultas/issues/511) — **done** (2026-07-08)
 
-### Problem
-
-Apple lifecycle handling is security-sensitive. It should be rolled out gradually.
-
-### Phase 1: Observe only
-
-- Enable webhook.
-- Verify payloads.
-- Persist notifications.
-- Do not mutate Auth0 or local users.
-
-### Phase 2: Metadata updates
-
-- Mark Auth0/local users with Apple lifecycle metadata.
-- Record relay changes.
-- Surface pending deletion events to admins.
-
-### Phase 3: Restricted automation
-
-- Block or disable access for confirmed revoked users if product policy requires it.
-- Keep hard deletion manual.
-
-### Phase 4: Optional deletion automation
-
-- Enable only after legal/product approval.
-- Require idempotency, audit trail, and rollback documentation.
-
-### Acceptance criteria
-
-- Webhook can be enabled without destructive side effects.
-- Operators can monitor real Apple notifications.
-- Destructive actions require explicit configuration and documentation.
+Phased operator checklist: [`apple-signin-rollout.md`](apple-signin-rollout.md). Covers observe-only enablement, destructive auto-process gates, monitoring, rollback, and sign-off.
 
 ---
 
@@ -563,7 +532,7 @@ Apple lifecycle handling is security-sensitive. It should be rolled out graduall
 12. ~~[#508](https://github.com/diego-torres/nutriconsultas/issues/508)~~ — Add observability (**done**, PR #517).
 13. ~~[#509](https://github.com/diego-torres/nutriconsultas/issues/509)~~ — Add integration tests (**done**, PR #518).
 14. ~~[#510](https://github.com/diego-torres/nutriconsultas/issues/510)~~ — Document Apple Developer Portal setup (**done**, 2026-07-07).
-15. [#511](https://github.com/diego-torres/nutriconsultas/issues/511) — Roll out in observe-only mode.
+15. ~~[#511](https://github.com/diego-torres/nutriconsultas/issues/511)~~ — Production rollout plan (**done**, [`apple-signin-rollout.md`](apple-signin-rollout.md)).
 
 ---
 

--- a/docs/auth/apple-signin-deletion-runbook.md
+++ b/docs/auth/apple-signin-deletion-runbook.md
@@ -62,10 +62,7 @@ Repeated Apple notifications for the same subject:
 
 ## Rollout phases (#511)
 
-1. **Observe only** — current production default.
-2. **Metadata** — enable auto-processing to mark lifecycle + Auth0 `app_metadata`.
-3. **Restricted automation** — block mobile access via `apple_lifecycle_status` (implemented in `MobilePatientAccessRules`).
-4. **Optional deletion** — manual only; see above.
+See [`apple-signin-rollout.md`](apple-signin-rollout.md) for operator checklists, env flags, verification steps, and sign-off.
 
 ---
 

--- a/docs/auth/apple-signin-observability.md
+++ b/docs/auth/apple-signin-observability.md
@@ -2,7 +2,7 @@
 
 Operators can detect Apple server-to-server notification problems via structured logs, Micrometer counters, and alert log lines. No emails, Apple subjects, Auth0 user IDs, or signed payloads are logged.
 
-**Related:** [`apple-signin-setup.md`](apple-signin-setup.md), [`ISSUE-APPLE-SIGNIN.md`](../../ISSUE-APPLE-SIGNIN.md)
+**Related:** [`apple-signin-setup.md`](apple-signin-setup.md), [`apple-signin-rollout.md`](apple-signin-rollout.md), [`ISSUE-APPLE-SIGNIN.md`](../../ISSUE-APPLE-SIGNIN.md)
 
 ---
 

--- a/docs/auth/apple-signin-rollout.md
+++ b/docs/auth/apple-signin-rollout.md
@@ -1,0 +1,232 @@
+# Apple Sign-In production rollout plan (#511)
+
+**Issue:** [#511](https://github.com/diego-torres/nutriconsultas/issues/511) · Epic [#497](https://github.com/diego-torres/nutriconsultas/issues/497)  
+**Purpose:** Roll out Apple server-to-server lifecycle handling **gradually** on production. Destructive automation stays off until operators verify real traffic and product/legal sign off.
+
+**Related:** [`apple-signin-setup.md`](apple-signin-setup.md) · [`apple-signin-observability.md`](apple-signin-observability.md) · [`apple-signin-deletion-runbook.md`](apple-signin-deletion-runbook.md) · [`ISSUE-APPLE-SIGNIN.md`](../../ISSUE-APPLE-SIGNIN.md)
+
+---
+
+## Hard blockers (do not enable the webhook without these)
+
+| Gate | Issue | Verify |
+|------|-------|--------|
+| **Auth0 Apple connection** | [#497](https://github.com/diego-torres/nutriconsultas/issues/497) | iOS patient can sign in with Apple via Auth0 prod tenant |
+| **Backend on `main`** | #498–#510 | PRs [#513](https://github.com/diego-torres/nutriconsultas/pull/513)–[#519](https://github.com/diego-torres/nutriconsultas/pull/519) deployed to production EC2 |
+| **Liquibase schema** | #502 | `apple_signin_notification` and relay/lifecycle columns exist on prod PostgreSQL |
+| **Apple notification URL** | #510 | Developer Portal points to `https://minutriporcion.com/rest/webhooks/apple/sign-in` (**not** the Auth0 callback) |
+| **Audience configured** | #501 | `APPLE_SIGNIN_EXPECTED_AUDIENCE` matches JWT `aud` from a test notification |
+| **Integration tests green** | #509 | `mvn test -Dtest=AppleSignIn*IntegrationTest,AppleSignInNotificationPersistenceTest` on release commit |
+
+---
+
+## Phase summary
+
+| Phase | `APPLE_SIGNIN_WEBHOOK_ENABLED` | `APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS` | Destructive events (`consent-revoked`, `account-delete`) | Relay email events (`email-enabled`, `email-disabled`) |
+|-------|-------------------------------|------------------------------------------------|----------------------------------------------------------|--------------------------------------------------------|
+| **0 — Default (pre-rollout)** | `false` | `false` | Webhook returns **503**; nothing persisted | Same |
+| **1 — Observe only** | `true` | `false` | Verified, persisted, mapped; `lifecycle_action=SKIPPED_OBSERVE_ONLY`; **no** lifecycle metadata or access changes | Verified, persisted; **relay metadata applied** when patient is mapped (#507) |
+| **2 — Metadata + restrict** | `true` | `true` | Local `apple_lifecycle_status` + Auth0 `app_metadata`; `consent-revoked` sets `PacienteStatus.REVOKED` and blocks Auth0 login | Same as Phase 1 |
+| **3 — Restricted automation** | `true` | `true` | Mobile API access blocked for non-`NONE` `apple_lifecycle_status` (`MobilePatientAccessRules`) | Same |
+| **4 — Optional hard delete** | `true` | `true` | **Manual only** — see deletion runbook; never enable Auth0 auto-delete from webhook | Same |
+
+Phases **2 and 3** share the same configuration flag today: enabling `APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS=true` applies metadata **and** mobile access restrictions together. Phase **4** is a **process** gate (legal/product), not an additional env var.
+
+---
+
+## Configuration reference
+
+| Variable | Phase 0 | Phase 1+ | Notes |
+|----------|---------|----------|-------|
+| `APPLE_SIGNIN_WEBHOOK_ENABLED` | `false` | `true` | Master switch for `POST /rest/webhooks/apple/sign-in` |
+| `APPLE_SIGNIN_EXPECTED_AUDIENCE` | — | **Required** when webhook enabled | Apple client identifier in notification JWT `aud` |
+| `APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS` | `false` | `false` → `true` for Phase 2+ | Default `false` in `application.properties` |
+| `APPLE_SIGNIN_VERIFICATION_FAILURE_ALERT_THRESHOLD` | `5` | `5` | Consecutive verification failures before ERROR alert |
+| `AUTH0_MGMT_USER_DELETE_ENABLED` | `false` | `false` | **Never** enable for webhook-driven deletion (Phase 4 manual only) |
+
+Deploy runtime changes via SSM (not Terraform):
+
+```bash
+export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+bash infrastructure/scripts/ssm-update-apple-signin.sh
+```
+
+---
+
+## Phase 1 — Observe only (recommended first production step)
+
+### Goals
+
+- Receive and cryptographically verify real Apple notifications.
+- Persist rows in `apple_signin_notification` with identity mapping status.
+- Record destructive events **without** applying lifecycle metadata or revoking access.
+- Surface traffic in metrics, logs, and `/admin/platform/apple-signin`.
+
+### Pre-flight checklist
+
+- [ ] Production JAR includes Apple Sign-In code (CodePipeline deploy from `main`).
+- [ ] Apple **Server-to-Server Notification Endpoint** is `https://minutriporcion.com/rest/webhooks/apple/sign-in`.
+- [ ] Auth0 Management API credentials on EC2 allow `read:users` and `update:users` for relay metadata (#507).
+- [ ] Ops vault has confirmed `APPLE_SIGNIN_EXPECTED_AUDIENCE` (from a staging/test JWT or Apple docs for your App/Services ID).
+- [ ] CloudWatch (or log aggregator) can search for `APPLE_SIGNIN_ALERT` and `apple_signin_webhook stage=`.
+
+### Enable procedure
+
+```bash
+export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+export APPLE_SIGNIN_WEBHOOK_ENABLED=true
+export APPLE_SIGNIN_EXPECTED_AUDIENCE='YOUR_APPLE_CLIENT_IDENTIFIER'
+export APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS=false
+bash infrastructure/scripts/ssm-update-apple-signin.sh
+```
+
+### Verification (within 24–48 h)
+
+- [ ] `curl -sf https://minutriporcion.com/actuator/health` → `UP`.
+- [ ] Disabled webhook smoke no longer applies: empty `POST` to webhook should **not** return `503`.
+- [ ] Trigger or wait for a real Apple event (relay change, test user consent flow, or Apple sandbox where available).
+- [ ] Admin UI **Plataforma → Apple Sign-In** shows new rows with `processing_status=PROCESSED`.
+- [ ] Destructive events show `lifecycle_action=SKIPPED_OBSERVE_ONLY` (not `APPLIED_*`).
+- [ ] Metrics: `apple.signin.webhook.verified` increments; no sustained `apple.signin.webhook.failed`.
+- [ ] Logs: no `APPLE_SIGNIN_ALERT repeated_verification_failures` after initial tuning.
+
+### Soak criteria before Phase 2
+
+- [ ] At least one successfully verified notification per event type you expect in production (or documented “no traffic yet” with monitoring in place).
+- [ ] Identity mapping rate acceptable (`MAPPED` vs `NO_LOCAL_USER` understood).
+- [ ] No false-positive verification failures after audience fix.
+- [ ] On-call knows how to disable webhook (rollback below).
+
+---
+
+## Phase 2 — Metadata updates
+
+### Goals
+
+- Apply `apple_lifecycle_status` on mapped patients for destructive events.
+- Write Auth0 `app_metadata` lifecycle fields.
+- Keep **hard deletion** manual.
+
+### Enable procedure
+
+Only after Phase 1 soak sign-off:
+
+```bash
+export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+export APPLE_SIGNIN_WEBHOOK_ENABLED=true
+export APPLE_SIGNIN_EXPECTED_AUDIENCE='YOUR_APPLE_CLIENT_IDENTIFIER'
+export APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS=true
+bash infrastructure/scripts/ssm-update-apple-signin.sh
+```
+
+### Expected behavior
+
+| Apple event | Local patient | Auth0 | Hard delete |
+|-------------|---------------|-------|-------------|
+| `consent-revoked` | `ACCESS_REVOKED`, `PacienteStatus.REVOKED` | `app_metadata` + block flag | **No** |
+| `account-delete` | `PENDING_DELETION_REVIEW` | `app_metadata` only | **No** |
+
+### Verification
+
+- [ ] Staging integration test green: `AppleSignInDestructiveAutoProcessIntegrationTest`.
+- [ ] Replay or new destructive test event → `lifecycle_action=APPLIED_ACCESS_REVOKED` or `APPLIED_PENDING_DELETION_REVIEW`.
+- [ ] Admin grid shows `paciente_id` and lifecycle action.
+- [ ] Idempotency: duplicate `apple_event_id` → HTTP 200, no double mutation.
+
+---
+
+## Phase 3 — Restricted automation (mobile access)
+
+### Goals
+
+- Block patient mobile API access when `apple_lifecycle_status` is not `NONE`.
+- Keep nutritionist web and manual review paths available per policy.
+
+### Configuration
+
+Same as Phase 2 (`APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS=true`). Access rules are enforced in `MobilePatientAccessRules` when lifecycle status is set.
+
+### Verification
+
+- [ ] Mapped patient with `ACCESS_REVOKED` receives onboarding/block response on `/rest/mobile/patient/**` (except allowed onboarding paths).
+- [ ] `MobilePatientAccessRulesTest` green in CI.
+- [ ] Support runbook updated for “Apple consent revoked” patient tickets.
+
+---
+
+## Phase 4 — Optional hard deletion (manual only)
+
+### Goals
+
+- Satisfy Apple account deletion policy with **human approval**, audit trail, and rollback documentation.
+- **Never** enable automatic Auth0 or local hard-delete from the webhook.
+
+### Requirements before any hard delete
+
+- [ ] Written product/legal approval recorded (ticket link in sign-off table).
+- [ ] Operator followed [`apple-signin-deletion-runbook.md`](apple-signin-deletion-runbook.md) manual steps.
+- [ ] Patient data handled via existing export/deletion tools (`PacienteDeletionService`, MPX).
+- [ ] `AUTH0_MGMT_USER_DELETE_ENABLED` remains `false` unless a **one-off** controlled Auth0 deletion is explicitly approved.
+
+---
+
+## Monitoring (all phases)
+
+| Signal | Where | Action |
+|--------|-------|--------|
+| Verification failures | `APPLE_SIGNIN_ALERT repeated_verification_failures` | Fix audience, JWKS, clock skew |
+| Unmapped destructive events | `APPLE_SIGNIN_ALERT unmapped_destructive_event` | Review identity mapping (#504), admin grid |
+| Throughput / errors | `/actuator/metrics` → `apple.signin.webhook.*` | Dashboard or CloudWatch metric filters |
+| Audit rows | `apple_signin_notification` table | SQL or `/admin/platform/apple-signin` |
+| Auth0 metadata failures | `auth0_update_failed` log stage | Check Management API scopes and rate limits |
+
+See [`apple-signin-observability.md`](apple-signin-observability.md) for full detail.
+
+---
+
+## Rollback
+
+| Situation | Action |
+|-----------|--------|
+| Bad audience / verification storm | `APPLE_SIGNIN_WEBHOOK_ENABLED=false` → SSM script → restart |
+| Destructive false positives | `APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS=false` → SSM script; manually correct affected patients |
+| Login regressions | Disable Auth0 Apple connection in Auth0 Dashboard (users use other connections) |
+| Apple sending to wrong host | Revert notification URL in Developer Portal |
+| Investigation | **Do not** delete `apple_signin_notification` audit rows |
+
+Emergency disable (same as Phase 0):
+
+```bash
+export AWS_PROFILE=minutriporcion AWS_DEFAULT_REGION=us-east-1
+export APPLE_SIGNIN_WEBHOOK_ENABLED=false
+bash infrastructure/scripts/ssm-update-apple-signin.sh
+```
+
+---
+
+## Integration tests (release gate)
+
+Run on the commit before each phase advance:
+
+```bash
+mvn test -Dtest=AppleSignInWebhookIntegrationTest,AppleSignInNotificationFlowIntegrationTest,\
+AppleSignInDestructiveAutoProcessIntegrationTest,AppleSignInNotificationPersistenceTest,\
+AppleSignInWebhookSecurityTest,AppleSignInWebhookMetricsTest
+```
+
+- [ ] All tests pass (local RSA keys; no live Apple or Auth0).
+- [ ] Full CI green on `main`.
+
+---
+
+## Sign-off
+
+| Phase | Engineering | Product / legal | Operations | Date | Notes |
+|-------|-------------|-----------------|------------|------|-------|
+| **1 — Observe** | | | | | CI SHA: |
+| **2 — Metadata** | | | | | |
+| **3 — Restrict** | | | | | |
+| **4 — Hard delete (manual)** | | | | | Ticket: |
+
+**Phase 1 webhook enable authorized:** ☐ Yes · ☐ No — date: ___________  
+**Phase 2+ destructive auto-process authorized:** ☐ Yes · ☐ No — date: ___________

--- a/docs/auth/apple-signin-setup.md
+++ b/docs/auth/apple-signin-setup.md
@@ -8,6 +8,7 @@ Maintainer runbook for **Sign in with Apple** on Minutriporcion (#510). Auth0 re
 - Backend roadmap: [`apple-signin-backend-roadmap.md`](apple-signin-backend-roadmap.md)
 - Observability & alerts: [`apple-signin-observability.md`](apple-signin-observability.md)
 - Deletion runbook: [`apple-signin-deletion-runbook.md`](apple-signin-deletion-runbook.md)
+- Production rollout: [`apple-signin-rollout.md`](apple-signin-rollout.md)
 - Auth0 patient post-login gate: [`../auth0/PATIENT-POST-LOGIN-GATE.md`](../auth0/PATIENT-POST-LOGIN-GATE.md)
 
 ---
@@ -246,4 +247,4 @@ See also [`apple-signin-deletion-runbook.md`](apple-signin-deletion-runbook.md) 
 
 ## Rollout pointer
 
-Phased production rollout (observe → metadata → restrict → optional delete) is documented in issue [#511](https://github.com/diego-torres/nutriconsultas/issues/511). Start with webhook **enabled** and destructive processing **disabled**.
+Phased production rollout is documented in [`apple-signin-rollout.md`](apple-signin-rollout.md) ([#511](https://github.com/diego-torres/nutriconsultas/issues/511)). Start with webhook **enabled** and `APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS=false` (Phase 1 observe-only).

--- a/infrastructure/scripts/ssm-update-apple-signin.sh
+++ b/infrastructure/scripts/ssm-update-apple-signin.sh
@@ -14,6 +14,7 @@
 # Optional: APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS, APPLE_SIGNIN_VERIFICATION_FAILURE_ALERT_THRESHOLD
 #
 # See docs/auth/apple-signin-setup.md (#510).
+# Production rollout phases: docs/auth/apple-signin-rollout.md (#511).
 set -euo pipefail
 
 PROJECT="${1:-nutriconsultas}"

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInRolloutPlanContentTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInRolloutPlanContentTest.java
@@ -1,0 +1,40 @@
+package com.nutriconsultas.auth.apple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Ensures the Apple Sign-In production rollout plan documents required phases (#511).
+ */
+class AppleSignInRolloutPlanContentTest {
+
+	private static final Path ROLLOUT_PLAN = Path.of("docs/auth/apple-signin-rollout.md");
+
+	@Test
+	void rolloutPlanIncludesRequiredPhases() throws IOException {
+		final String markdown = Files.readString(ROLLOUT_PLAN, StandardCharsets.UTF_8);
+
+		assertThat(markdown).contains("Phase 1 — Observe only");
+		assertThat(markdown).contains("Phase 2 — Metadata updates");
+		assertThat(markdown).contains("Phase 3 — Restricted automation");
+		assertThat(markdown).contains("Phase 4 — Optional hard deletion");
+	}
+
+	@Test
+	void rolloutPlanDocumentsSafetyGates() throws IOException {
+		final String markdown = Files.readString(ROLLOUT_PLAN, StandardCharsets.UTF_8);
+
+		assertThat(markdown).contains("APPLE_SIGNIN_WEBHOOK_ENABLED");
+		assertThat(markdown).contains("APPLE_SIGNIN_AUTO_PROCESS_DESTRUCTIVE_EVENTS=false");
+		assertThat(markdown).contains("AUTH0_MGMT_USER_DELETE_ENABLED");
+		assertThat(markdown).contains("ssm-update-apple-signin.sh");
+		assertThat(markdown).contains("#511");
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add [`docs/auth/apple-signin-rollout.md`](docs/auth/apple-signin-rollout.md) with phased operator checklists (observe → metadata → restrict → manual delete)
- Document env flags, SSM enable/rollback procedures, monitoring, soak criteria, and sign-off table
- Link rollout doc from setup, observability, deletion runbook, and issue registry
- Add `AppleSignInRolloutPlanContentTest` to guard required sections

Closes #511.

## Test plan
- [x] `mvn test -Dtest=AppleSignInRolloutPlanContentTest`
- [ ] CI Build and Test


Made with [Cursor](https://cursor.com)