### PR TITLE
Add platillos grid image column and sin-imagen filter

### DIFF
--- a/src/main/java/com/nutriconsultas/dataTables/paging/PagingRequest.java
+++ b/src/main/java/com/nutriconsultas/dataTables/paging/PagingRequest.java
@@ -28,4 +28,9 @@ public class PagingRequest {
 	 */
 	private String ownershipFilter;
 
+	/**
+	 * Optional picture filter for platillos grid (e.g. sin-imagen).
+	 */
+	private String pictureFilter;
+
 }

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloComparators.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloComparators.java
@@ -19,6 +19,14 @@ public final class PlatilloComparators {
 		MAP.put(new ComparatorKey("platillo", Direction.asc), Comparator.comparing(Platillo::getName));
 		MAP.put(new ComparatorKey("platillo", Direction.desc), Comparator.comparing(Platillo::getName).reversed());
 
+		// compare by picture presence, then name
+		MAP.put(new ComparatorKey("imagen", Direction.asc),
+				Comparator.comparing(PlatilloImageSupport::hasAssignedPicture).thenComparing(Platillo::getName));
+		MAP.put(new ComparatorKey("imagen", Direction.desc),
+				Comparator.comparing(PlatilloImageSupport::hasAssignedPicture)
+					.reversed()
+					.thenComparing(Platillo::getName));
+
 		// compare by ingestaSugerida
 		MAP.put(new ComparatorKey("ingestas", Direction.asc), Comparator.comparing(Platillo::getIngestasSugeridas));
 		MAP.put(new ComparatorKey("ingestas", Direction.desc),

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloImageSupport.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloImageSupport.java
@@ -1,0 +1,45 @@
+package com.nutriconsultas.platillos;
+
+/**
+ * Helpers for platillo picture URLs and presence checks.
+ */
+public final class PlatilloImageSupport {
+
+	private static final String PLACEHOLDER_IMAGE_PATH = "/sbadmin/img/plato-vacio.jpg";
+
+	private PlatilloImageSupport() {
+	}
+
+	public static boolean hasAssignedPicture(final Platillo platillo) {
+		return platillo != null && platillo.getImageUrl() != null && !platillo.getImageUrl().isBlank();
+	}
+
+	public static String resolveGridImageUrl(final Platillo platillo) {
+		if (!hasAssignedPicture(platillo)) {
+			return PLACEHOLDER_IMAGE_PATH;
+		}
+		final String fileName = extractPictureFileName(platillo.getImageUrl());
+		return "/admin/platillos/platillo/" + platillo.getId() + "/" + fileName;
+	}
+
+	public static String buildGridImageColumn(final Platillo platillo) {
+		if (!hasAssignedPicture(platillo)) {
+			return "<div class='text-center'>" + "<img src='" + PLACEHOLDER_IMAGE_PATH
+					+ "' alt='Sin imagen' class='rounded platillo-grid-thumb platillo-grid-thumb-missing' "
+					+ "title='Sin imagen asignada'>"
+					+ "<span class='badge badge-warning d-block mt-1'>Sin imagen</span>" + "</div>";
+		}
+		final String imageUrl = resolveGridImageUrl(platillo);
+		return "<div class='text-center'>" + "<img src='" + imageUrl + "' alt='Imagen del platillo' "
+				+ "class='rounded platillo-grid-thumb' title='Imagen asignada'>" + "</div>";
+	}
+
+	private static String extractPictureFileName(final String imageUrl) {
+		final int slashIndex = imageUrl.lastIndexOf('/');
+		if (slashIndex >= 0 && slashIndex < imageUrl.length() - 1) {
+			return imageUrl.substring(slashIndex + 1);
+		}
+		return imageUrl;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloPictureFilter.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloPictureFilter.java
@@ -1,0 +1,21 @@
+package com.nutriconsultas.platillos;
+
+/**
+ * Picture filter for the platillo catalog grid.
+ */
+public enum PlatilloPictureFilter {
+
+	TODAS, SIN_IMAGEN;
+
+	public static PlatilloPictureFilter fromRequestValue(final String value) {
+		if (value == null || value.isBlank()) {
+			return TODAS;
+		}
+		final String normalized = value.trim().toLowerCase();
+		if ("sin-imagen".equals(normalized) || "sin_imagen".equals(normalized) || "no-picture".equals(normalized)) {
+			return SIN_IMAGEN;
+		}
+		return TODAS;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloRestController.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloRestController.java
@@ -100,9 +100,20 @@ public class PlatilloRestController extends AbstractGridController<Platillo> {
 		log.debug("starting getRows with pagingRequest: {}", pagingRequest);
 		final PlatilloCatalogFilter catalogFilter = PlatilloCatalogFilter
 			.fromRequestValue(pagingRequest.getOwnershipFilter());
+		final PlatilloPictureFilter pictureFilter = PlatilloPictureFilter
+			.fromRequestValue(pagingRequest.getPictureFilter());
 		final String userId = principal != null ? principal.getSubject() : null;
 		final List<Platillo> data = service.getPlatillosForCatalogFilter(catalogFilter, userId);
-		return getPage(pagingRequest, data);
+		final List<Platillo> filteredData = applyPictureFilter(data, pictureFilter);
+		return getPage(pagingRequest, filteredData);
+	}
+
+	private List<Platillo> applyPictureFilter(final List<Platillo> platillos,
+			final PlatilloPictureFilter pictureFilter) {
+		if (pictureFilter != PlatilloPictureFilter.SIN_IMAGEN) {
+			return platillos;
+		}
+		return platillos.stream().filter(platillo -> !PlatilloImageSupport.hasAssignedPicture(platillo)).toList();
 	}
 
 	private OidcUser resolveGridPrincipal() {
@@ -320,7 +331,7 @@ public class PlatilloRestController extends AbstractGridController<Platillo> {
 	@Override
 	protected List<Column> getColumns() {
 		log.debug("getting Platillo columns.");
-		return Stream.of("acciones", "platillo", "ingestas", "kcal", "prot", "lip", "hc")
+		return Stream.of("acciones", "imagen", "platillo", "ingestas", "kcal", "prot", "lip", "hc")
 			.map(Column::new)
 			.collect(Collectors.toList());
 	}
@@ -332,7 +343,7 @@ public class PlatilloRestController extends AbstractGridController<Platillo> {
 
 	private List<String> toStringList(final Platillo row, final OidcUser principal) {
 		log.debug("converting Platillo row {} to string list.", row);
-		return Arrays.asList(buildActionsColumn(row, principal),
+		return Arrays.asList(buildActionsColumn(row, principal), PlatilloImageSupport.buildGridImageColumn(row),
 				"<a href='/admin/platillos/" + row.getId() + "'>" + row.getName() + "</a>",
 				row.getIngestasSugeridas() == null ? "" : row.getIngestasSugeridas(),
 				row.getEnergia() == null ? "" : row.getEnergia().toString(), String.format("%.1f", row.getProteina()),

--- a/src/main/resources/templates/sbadmin/platillos/listado.html
+++ b/src/main/resources/templates/sbadmin/platillos/listado.html
@@ -24,6 +24,19 @@
 
   <!-- Custom styles for this template-->
   <link th:href="@{/sbadmin/css/sb-admin-2.min.css}" rel="stylesheet">
+  <style>
+    .platillo-grid-thumb {
+      width: 48px;
+      height: 48px;
+      object-fit: cover;
+      border: 1px solid #e3e6f0;
+    }
+
+    .platillo-grid-thumb-missing {
+      opacity: 0.65;
+      border-style: dashed;
+    }
+  </style>
 </head>
 
 <body id="page-top">
@@ -84,11 +97,18 @@
               <div class="card shadow mb-4">
                 <div class="card-header py-3 d-flex flex-wrap align-items-center justify-content-between">
                   <h6 class="m-0 font-weight-bold text-primary">Catálogo de platillos</h6>
-                  <div class="btn-group btn-group-sm mt-2 mt-md-0" role="group" aria-label="Filtrar platillos"
-                    id="platilloCatalogFilter">
-                    <button type="button" class="btn btn-primary active" data-filter="todas">Todas</button>
-                    <button type="button" class="btn btn-outline-primary" data-filter="sistema">De sistema</button>
-                    <button type="button" class="btn btn-outline-primary" data-filter="propias">Mis platillos</button>
+                  <div class="d-flex flex-wrap align-items-center mt-2 mt-md-0">
+                    <div class="btn-group btn-group-sm mr-2 mb-2" role="group" aria-label="Filtrar platillos"
+                      id="platilloCatalogFilter">
+                      <button type="button" class="btn btn-primary active" data-filter="todas">Todas</button>
+                      <button type="button" class="btn btn-outline-primary" data-filter="sistema">De sistema</button>
+                      <button type="button" class="btn btn-outline-primary" data-filter="propias">Mis platillos</button>
+                    </div>
+                    <div class="btn-group btn-group-sm mb-2" role="group" aria-label="Filtrar por imagen"
+                      id="platilloPictureFilter">
+                      <button type="button" class="btn btn-secondary active" data-filter="todas">Todas las imágenes</button>
+                      <button type="button" class="btn btn-outline-secondary" data-filter="sin-imagen">Sin imagen</button>
+                    </div>
                   </div>
                 </div>
                 <table id="mainGrid" class="table table-striped table-bordered dt-responsive nowrap"
@@ -96,6 +116,7 @@
                     <thead>
                       <tr>
                         <th>Acciones</th>
+                        <th>Imagen</th>
                         <th>Platillo</th>
                         <th>Ingestas</th>
                         <th>Kcal</th>
@@ -145,14 +166,16 @@
 
         jQuery(document).ready(function ($) {
           var platilloCatalogFilter = 'todas';
+          var platilloPictureFilter = 'todas';
           var mainGrid = $('#mainGrid').DataTable({
             "processing": true,
             "serverSide": true,
             "scrollX": true,
             "columnDefs": [
-              { "targets": 0, "orderable": false }
+              { "targets": 0, "orderable": false },
+              { "targets": 1, "orderable": true, "searchable": false }
             ],
-            "order": [[1, "asc"]],
+            "order": [[2, "asc"]],
             "language": {
               "emptyTable": "No hay registros",
               "lengthMenu": "Mostrar _MENU_ registros por página",
@@ -176,6 +199,7 @@
               "contentType": "application/json",
               "data": function (d) {
                 d.ownershipFilter = platilloCatalogFilter;
+                d.pictureFilter = platilloPictureFilter;
                 return JSON.stringify(d);
               }
             },
@@ -189,6 +213,17 @@
             platilloCatalogFilter = filter;
             $('#platilloCatalogFilter button').removeClass('active btn-primary').addClass('btn-outline-primary');
             $(this).removeClass('btn-outline-primary').addClass('active btn-primary');
+            mainGrid.ajax.reload();
+          });
+
+          $('#platilloPictureFilter button').click(function () {
+            var filter = $(this).data('filter');
+            if (filter === platilloPictureFilter) {
+              return;
+            }
+            platilloPictureFilter = filter;
+            $('#platilloPictureFilter button').removeClass('active btn-secondary').addClass('btn-outline-secondary');
+            $(this).removeClass('btn-outline-secondary').addClass('active btn-secondary');
             mainGrid.ajax.reload();
           });
 

--- a/src/test/java/com/nutriconsultas/platillos/PlatilloImageSupportTest.java
+++ b/src/test/java/com/nutriconsultas/platillos/PlatilloImageSupportTest.java
@@ -1,0 +1,54 @@
+package com.nutriconsultas.platillos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PlatilloImageSupportTest {
+
+	@Test
+	void hasAssignedPictureFalseWhenMissingOrBlank() {
+		final Platillo withoutImage = new Platillo();
+		withoutImage.setImageUrl(null);
+
+		final Platillo blankImage = new Platillo();
+		blankImage.setImageUrl("   ");
+
+		assertThat(PlatilloImageSupport.hasAssignedPicture(withoutImage)).isFalse();
+		assertThat(PlatilloImageSupport.hasAssignedPicture(blankImage)).isFalse();
+	}
+
+	@Test
+	void resolveGridImageUrlBuildsAdminPicturePath() {
+		final Platillo platillo = new Platillo();
+		platillo.setId(12L);
+		platillo.setImageUrl("platillo/12/picture.jpg");
+
+		assertThat(PlatilloImageSupport.resolveGridImageUrl(platillo))
+			.isEqualTo("/admin/platillos/platillo/12/picture.jpg");
+	}
+
+	@Test
+	void buildGridImageColumnShowsMissingBadgeWhenNoPicture() {
+		final Platillo platillo = new Platillo();
+		platillo.setId(3L);
+
+		final String column = PlatilloImageSupport.buildGridImageColumn(platillo);
+
+		assertThat(column).contains("Sin imagen");
+		assertThat(column).contains("platillo-grid-thumb-missing");
+	}
+
+	@Test
+	void buildGridImageColumnShowsThumbnailWhenPictureExists() {
+		final Platillo platillo = new Platillo();
+		platillo.setId(4L);
+		platillo.setImageUrl("platillo/4/picture.png");
+
+		final String column = PlatilloImageSupport.buildGridImageColumn(platillo);
+
+		assertThat(column).contains("/admin/platillos/platillo/4/picture.png");
+		assertThat(column).doesNotContain("Sin imagen");
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/platillos/PlatilloPictureFilterTest.java
+++ b/src/test/java/com/nutriconsultas/platillos/PlatilloPictureFilterTest.java
@@ -1,0 +1,23 @@
+package com.nutriconsultas.platillos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PlatilloPictureFilterTest {
+
+	@Test
+	void fromRequestValueDefaultsToTodas() {
+		assertThat(PlatilloPictureFilter.fromRequestValue(null)).isEqualTo(PlatilloPictureFilter.TODAS);
+		assertThat(PlatilloPictureFilter.fromRequestValue("")).isEqualTo(PlatilloPictureFilter.TODAS);
+		assertThat(PlatilloPictureFilter.fromRequestValue("unknown")).isEqualTo(PlatilloPictureFilter.TODAS);
+	}
+
+	@Test
+	void fromRequestValueParsesSinImagenVariants() {
+		assertThat(PlatilloPictureFilter.fromRequestValue("sin-imagen")).isEqualTo(PlatilloPictureFilter.SIN_IMAGEN);
+		assertThat(PlatilloPictureFilter.fromRequestValue("sin_imagen")).isEqualTo(PlatilloPictureFilter.SIN_IMAGEN);
+		assertThat(PlatilloPictureFilter.fromRequestValue("no-picture")).isEqualTo(PlatilloPictureFilter.SIN_IMAGEN);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/platillos/PlatilloRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/platillos/PlatilloRestControllerTest.java
@@ -199,6 +199,7 @@ public class PlatilloRestControllerTest {
 		PagingRequest pagingRequest = new PagingRequest();
 		List<Column> columnList = new ArrayList<>();
 		columnList.add(new Column("acciones", "", true, true, new Search("", "false")));
+		columnList.add(new Column("imagen", "", true, true, new Search("", "false")));
 		columnList.add(new Column("platillo", "", true, true, new Search("", "false")));
 		columnList.add(new Column("ingestas", "", true, true, new Search("", "false")));
 		columnList.add(new Column("kcal", "", true, true, new Search("", "false")));
@@ -210,7 +211,7 @@ public class PlatilloRestControllerTest {
 		pagingRequest.setStart(0);
 		pagingRequest.setLength(10);
 		pagingRequest.setDraw(1);
-		pagingRequest.setOrder(Arrays.asList(new Order(1, Direction.asc)));
+		pagingRequest.setOrder(Arrays.asList(new Order(2, Direction.asc)));
 		pagingRequest.setSearch(new Search("", "false"));
 		pagingRequest.setOwnershipFilter("todas");
 		log.debug("arrange paging request {}.", pagingRequest);
@@ -242,6 +243,7 @@ public class PlatilloRestControllerTest {
 		PagingRequest pagingRequest = new PagingRequest();
 		List<Column> columnList = new ArrayList<>();
 		columnList.add(new Column("acciones", "", true, true, new Search("", "false")));
+		columnList.add(new Column("imagen", "", true, true, new Search("", "false")));
 		columnList.add(new Column("platillo", "", true, true, new Search("", "false")));
 		columnList.add(new Column("ingestas", "", true, true, new Search("", "false")));
 		columnList.add(new Column("kcal", "", true, true, new Search("", "false")));
@@ -252,7 +254,7 @@ public class PlatilloRestControllerTest {
 		pagingRequest.setStart(0);
 		pagingRequest.setLength(10);
 		pagingRequest.setDraw(1);
-		pagingRequest.setOrder(Arrays.asList(new Order(1, Direction.asc)));
+		pagingRequest.setOrder(Arrays.asList(new Order(2, Direction.asc)));
 		pagingRequest.setSearch(new Search(searchTerm, "false"));
 		pagingRequest.setOwnershipFilter("todas");
 		log.debug("arrange paging request {}.", pagingRequest);
@@ -276,6 +278,7 @@ public class PlatilloRestControllerTest {
 		PagingRequest pagingRequest = new PagingRequest();
 		List<Column> columnList = new ArrayList<>();
 		columnList.add(new Column("acciones", "", true, true, new Search("", "false")));
+		columnList.add(new Column("imagen", "", true, true, new Search("", "false")));
 		columnList.add(new Column("platillo", "", true, true, new Search("", "false")));
 		columnList.add(new Column("ingestas", "", true, true, new Search("", "false")));
 		columnList.add(new Column("kcal", "", true, true, new Search("", "false")));
@@ -419,6 +422,38 @@ public class PlatilloRestControllerTest {
 	}
 
 	@Test
+	public void testArrayWithSinImagenFilter() {
+		final Platillo withImage = new Platillo();
+		withImage.setId(10L);
+		withImage.setName("Con imagen");
+		withImage.setImageUrl("platillo/10/picture.jpg");
+		withImage.setEnergia(100);
+		withImage.setProteina(1.0);
+		withImage.setLipidos(1.0);
+		withImage.setHidratosDeCarbono(1.0);
+
+		final Platillo withoutImage = new Platillo();
+		withoutImage.setId(11L);
+		withoutImage.setName("Sin imagen");
+		withoutImage.setEnergia(100);
+		withoutImage.setProteina(1.0);
+		withoutImage.setLipidos(1.0);
+		withoutImage.setHidratosDeCarbono(1.0);
+
+		when(platilloService.getPlatillosForCatalogFilter(PlatilloCatalogFilter.TODAS, TEST_USER_ID))
+			.thenReturn(List.of(withImage, withoutImage));
+
+		final PagingRequest pagingRequest = buildPagingRequest("sin-imagen");
+
+		final PageArray result = platilloRestController.getPageArray(pagingRequest);
+
+		assertThat(result.getRecordsTotal()).isEqualTo(1);
+		assertThat(result.getRecordsFiltered()).isEqualTo(1);
+		assertThat(result.getData().get(0).get(2)).contains("Sin imagen");
+		assertThat(result.getData().get(0).get(1)).contains("Sin imagen");
+	}
+
+	@Test
 	public void testToStringListIncludesCopyButtonForSystemPlatillo() {
 		final Platillo systemPlatillo = new Platillo();
 		systemPlatillo.setId(97L);
@@ -439,6 +474,7 @@ public class PlatilloRestControllerTest {
 		final PagingRequest pagingRequest = new PagingRequest();
 		final List<Column> columnList = new ArrayList<>();
 		columnList.add(new Column("acciones", "", true, true, new Search("", "false")));
+		columnList.add(new Column("imagen", "", true, true, new Search("", "false")));
 		columnList.add(new Column("platillo", "", true, true, new Search("", "false")));
 		columnList.add(new Column("ingestas", "", true, true, new Search("", "false")));
 		columnList.add(new Column("kcal", "", true, true, new Search("", "false")));
@@ -449,7 +485,7 @@ public class PlatilloRestControllerTest {
 		pagingRequest.setStart(0);
 		pagingRequest.setLength(10);
 		pagingRequest.setDraw(1);
-		pagingRequest.setOrder(Arrays.asList(new Order(1, Direction.asc)));
+		pagingRequest.setOrder(Arrays.asList(new Order(2, Direction.asc)));
 		pagingRequest.setSearch(new Search("", "false"));
 		pagingRequest.setOwnershipFilter("todas");
 
@@ -459,6 +495,28 @@ public class PlatilloRestControllerTest {
 		assertThat(actions).contains("duplicatePlatillo(97)");
 		assertThat(actions).doesNotContain("fa-edit");
 		assertThat(actions).doesNotContain("deletePlatillo");
+	}
+
+	private PagingRequest buildPagingRequest(final String pictureFilter) {
+		final PagingRequest pagingRequest = new PagingRequest();
+		final List<Column> columnList = new ArrayList<>();
+		columnList.add(new Column("acciones", "", true, true, new Search("", "false")));
+		columnList.add(new Column("imagen", "", true, true, new Search("", "false")));
+		columnList.add(new Column("platillo", "", true, true, new Search("", "false")));
+		columnList.add(new Column("ingestas", "", true, true, new Search("", "false")));
+		columnList.add(new Column("kcal", "", true, true, new Search("", "false")));
+		columnList.add(new Column("prot", "", true, true, new Search("", "false")));
+		columnList.add(new Column("lip", "", true, true, new Search("", "false")));
+		columnList.add(new Column("hc", "", true, true, new Search("", "false")));
+		pagingRequest.setColumns(columnList);
+		pagingRequest.setStart(0);
+		pagingRequest.setLength(10);
+		pagingRequest.setDraw(1);
+		pagingRequest.setOrder(Arrays.asList(new Order(2, Direction.asc)));
+		pagingRequest.setSearch(new Search("", "false"));
+		pagingRequest.setOwnershipFilter("todas");
+		pagingRequest.setPictureFilter(pictureFilter);
+		return pagingRequest;
 	}
 
 }


### PR DESCRIPTION
## Summary
- Adds an **Imagen** column to the platillos DataTables grid with thumbnails or a **Sin imagen** badge when `imageUrl` is missing.
- Adds **Todas las imágenes** / **Sin imagen** filter buttons that pass `pictureFilter` to the REST grid endpoint.
- Includes unit tests for image helpers, filter parsing, and REST controller filtering.

## Test plan
- [x] `./lint.sh` (checkstyle, spotbugs, PMD, Thymeleaf validation)
- [x] `PlatilloImageSupportTest`, `PlatilloPictureFilterTest`, `PlatilloRestControllerTest`
- [x] Manual browser check on `/admin/platillos`: image column, filter toggle, pagination change


Made with [Cursor](https://cursor.com)