### PR TITLE
[Nutritionist Web] Weekly day-of-week diet assignment with grocery list (#525)

### DIFF
--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -207,6 +207,7 @@ Feedback from the latest published version — diet assignment, authoring UX, cl
 | Requirement | Issues |
 |-------------|--------|
 | Weekly day-of-week diet assignment + grocery list | #525 |
+| Grocery list PDF export for print | #532 |
 | Alimentos sequence + drag-reorder in diets and platillos | #526 |
 | Create catalog platillo from ingesta alimento combination | #527 |
 | Default portion type to porción when adding alimentos | #528 |
@@ -217,6 +218,7 @@ Feedback from the latest published version — diet assignment, authoring UX, cl
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | **525** | Patient diet assignment — weekly day-of-week plans with grocery list | https://github.com/diego-torres/nutriconsultas/issues/525 | **in-progress** | #353 (grocery) | Branch `issue-525-weekly-diet-assignment`; `paciente_dieta_weekday` + web lista de compras |
+| **532** | Grocery list — downloadable PDF for print | https://github.com/diego-torres/nutriconsultas/issues/532 | **open** | **525** | Flying Saucer PDF from `/lista-compras`; branded logo; DATE_RANGE + WEEKLY |
 | **526** | Alimentos ordering — sequence metadata + drag-reorder in diets and platillos | https://github.com/diego-torres/nutriconsultas/issues/526 | **open** | — | `orden` on `AlimentoIngesta` + `Ingrediente`; mirror ingesta drag-reorder |
 | **527** | Diet ingesta — create catalog platillo from selected alimentos combination | https://github.com/diego-torres/nutriconsultas/issues/527 | **open** | #257 | Modal nombre; nutritionist-owned platillo from ingesta selection |
 | **528** | Default portion type to porción (not gramos) when adding alimentos | https://github.com/diego-torres/nutriconsultas/issues/528 | **open** | — | `#tipoPorcion` default in diet/platillo add-alimento modals |
@@ -257,7 +259,7 @@ Feedback from the latest published version — diet assignment, authoring UX, cl
 | ~~#285~~ Platillo form | Inline cantidad edit on catalog `#ingredientesGrid` + diet ingesta grid — branch `issue-285-platillo-inline-cantidad` |
 | ~~#243~~ / ~~#244~~ Subscription | reCAPTCHA **done**; Solicitar acceso pre-fill **done** — public funnel complete |
 | #245–#248 Public booking | ~~#245~~ epic **done**; ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~, ~~#300~~, ~~#302~~ **done** — separate track complete (v1) |
-| **#525–#528**, **#530** Nutritionist feedback | Weekly diet (#525); alimento order (#526); crear platillo (#527); porción default (#528); thyroid labs (#530) |
+| **#525–#528**, **#530**, **#532** Nutritionist feedback | Weekly diet (#525); grocery PDF (#532); alimento order (#526); crear platillo (#527); porción default (#528); thyroid labs (#530) |
 | **#529** Patient photo | S3 upload + resolver — mobile track; complements #241 static avatars |
 
 ---

--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -4,7 +4,7 @@ Living index of GitHub issues for the **nutritionist Thymeleaf web app** (`/admi
 
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan (MPX):** [`docs/paciente/PATIENT-MPX-PLAN.md`](docs/paciente/PATIENT-MPX-PLAN.md)  
-**Last updated:** 2026-06-26 — ~~#341~~ **done** (branch `issue-341-web-mobile-invitation`, 38f358e). ~~#242~~ **done** (branch `issue-242-anthropometric-field-edit`). ~~#241~~ **done** (PR [#291](https://github.com/diego-torres/nutriconsultas/pull/291)). Patient UX epic **complete** (#241–#242). ~~#272~~ **done** (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)). ~~#271~~ **done** (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)).
+**Last updated:** 2026-07-11 — Registered nutritionist feedback batch **#525–#528**, **#530** (published-version UX). ~~#341~~ **done** (branch `issue-341-web-mobile-invitation`, 38f358e). Patient UX epic **complete** (#241–#242).
 
 > **Scope.** Nutritionist web features only. Patient mobile API: [`ISSUE.md`](ISSUE.md). Subscription enforcement: [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md). Public booking: [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md). Do not mix mobile JWT, subscription billing, or public booking into unrelated PRs unless explicitly coupled.
 
@@ -200,6 +200,30 @@ Nutritionist sends patient mobile onboarding invitations from the **patient grid
 
 ---
 
+## Epic — Nutritionist feedback (published version, 2026-07-11)
+
+Feedback from the latest published version — diet assignment, authoring UX, clinical exams.
+
+| Requirement | Issues |
+|-------------|--------|
+| Weekly day-of-week diet assignment + grocery list | #525 |
+| Alimentos sequence + drag-reorder in diets and platillos | #526 |
+| Create catalog platillo from ingesta alimento combination | #527 |
+| Default portion type to porción when adding alimentos | #528 |
+| Clinical exam thyroid indicator fields | #530 |
+
+**Suggested order:** #528 (quick UX) → #526 → #527 → #525 (schema) → #530. **#529** (patient photo S3) tracked in [`ISSUE.md`](ISSUE.md) (mobile API).
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|-----------|-------|
+| **525** | Patient diet assignment — weekly day-of-week plans with grocery list | https://github.com/diego-torres/nutriconsultas/issues/525 | **in-progress** | #353 (grocery) | Branch `issue-525-weekly-diet-assignment`; `paciente_dieta_weekday` + web lista de compras |
+| **526** | Alimentos ordering — sequence metadata + drag-reorder in diets and platillos | https://github.com/diego-torres/nutriconsultas/issues/526 | **open** | — | `orden` on `AlimentoIngesta` + `Ingrediente`; mirror ingesta drag-reorder |
+| **527** | Diet ingesta — create catalog platillo from selected alimentos combination | https://github.com/diego-torres/nutriconsultas/issues/527 | **open** | #257 | Modal nombre; nutritionist-owned platillo from ingesta selection |
+| **528** | Default portion type to porción (not gramos) when adding alimentos | https://github.com/diego-torres/nutriconsultas/issues/528 | **open** | — | `#tipoPorcion` default in diet/platillo add-alimento modals |
+| **530** | Clinical exam (clínicos) — thyroid indicator fields | https://github.com/diego-torres/nutriconsultas/issues/530 | **open** | #46 | TSH, T4 libre, T3 libre; Liquibase + `clinicos.html` tab |
+
+---
+
 ## Bugs
 
 | # | Title | URL | State | Depends on | Notes |
@@ -233,6 +257,8 @@ Nutritionist sends patient mobile onboarding invitations from the **patient grid
 | ~~#285~~ Platillo form | Inline cantidad edit on catalog `#ingredientesGrid` + diet ingesta grid — branch `issue-285-platillo-inline-cantidad` |
 | ~~#243~~ / ~~#244~~ Subscription | reCAPTCHA **done**; Solicitar acceso pre-fill **done** — public funnel complete |
 | #245–#248 Public booking | ~~#245~~ epic **done**; ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~, ~~#300~~, ~~#302~~ **done** — separate track complete (v1) |
+| **#525–#528**, **#530** Nutritionist feedback | Weekly diet (#525); alimento order (#526); crear platillo (#527); porción default (#528); thyroid labs (#530) |
+| **#529** Patient photo | S3 upload + resolver — mobile track; complements #241 static avatars |
 
 ---
 

--- a/ISSUE.md
+++ b/ISSUE.md
@@ -6,7 +6,7 @@ Living index of the GitHub issues that build the **patient mobile API** (`/rest/
 **Workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Subscription (parallel):** [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) · **Nutritionist web (parallel):** [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md)
 **Mobile consumer:** [Escanor4323/nutriconsultas-mobile](https://github.com/Escanor4323/nutriconsultas-mobile) (Flutter/GetX, patient app)
 **Canonical contract:** [`docs/mobile-api/ALIGNMENT-SPEC.md`](docs/mobile-api/ALIGNMENT-SPEC.md) (§F8 schema) · [`docs/mobile-api/mobile-api-roadmap-v2.md`](docs/mobile-api/mobile-api-roadmap-v2.md) (endpoint specs)
-**Last updated:** 2026-06-30 — #353 grocery list endpoint (`mobile-api/353-grocery-list`). ~~#354~~ ~~#352~~ **done** (PR [#357](https://github.com/diego-torres/nutriconsultas/pull/357)). ~~#349~~ **done** (PR [#356](https://github.com/diego-torres/nutriconsultas/pull/356)).
+**Last updated:** 2026-07-11 — Registered **#529** patient profile photo (S3 + mobile). #353 grocery list endpoint (`mobile-api/353-grocery-list`). ~~#354~~ ~~#352~~ **done** (PR [#357](https://github.com/diego-torres/nutriconsultas/pull/357)).
 
 > **Scope of this file.** This registry tracks the `[Mobile API]` issues (#91–#99, #107–#116, #132–#141 invitation onboarding) plus the directly-related `[Dashboard]` IMC gauge (#106) and **integration prerequisites** that gate schema work (#156, #46). The repo's many closed web/admin issues (#1–#90) are nutritionist-web features and are **out of scope** here except where a mobile endpoint reuses their code (cross-referenced in [Data contracts](#data-contracts)).
 
@@ -169,6 +169,7 @@ Extended diet plan DTOs and endpoints for mobile home/diet detail flows.
 | 352 | Patient platillo detail endpoint (ingredients, prep, nutrition) | https://github.com/diego-torres/nutriconsultas/issues/352 | **done** | ~~94~~ ✓, ~~354~~ ✓ | Merged PR [#357](https://github.com/diego-torres/nutriconsultas/pull/357) |
 | 353 | Grocery list for patient diet plan | https://github.com/diego-torres/nutriconsultas/issues/353 | **in-progress** | ~~94~~ ✓ | `GET /rest/mobile/patient/diet-plans/{assignmentId}/grocery-list` |
 | 355 | Add default platillo image `plato-vacio.jpg` to static resources | https://github.com/diego-torres/nutriconsultas/issues/355 | **in-progress** | — | Serves `/sbadmin/img/plato-vacio.jpg`; OpenAPI `imageUrl` documented |
+| 529 | Patient profile photo — S3 upload API + picture resolver for mobile | https://github.com/diego-torres/nutriconsultas/issues/529 | **open** | #241, #107 | Custom photo in S3; falls back to `PacienteAvatarCatalog`; mobile + web upload |
 
 ---
 

--- a/src/main/java/com/nutriconsultas/mobile/DietGroceryListAggregator.java
+++ b/src/main/java/com/nutriconsultas/mobile/DietGroceryListAggregator.java
@@ -26,9 +26,21 @@ public final class DietGroceryListAggregator {
 		if (dieta == null || dieta.getIngestas() == null) {
 			return List.of();
 		}
+		return aggregate(List.of(dieta));
+	}
+
+	public static List<DietGroceryListItemDto> aggregate(final List<Dieta> diets) {
+		if (diets == null || diets.isEmpty()) {
+			return List.of();
+		}
 		final Map<String, MutableGroceryItem> items = new LinkedHashMap<>();
-		for (final Ingesta ingesta : dieta.getIngestas()) {
-			aggregateIngesta(ingesta, items);
+		for (final Dieta dieta : diets) {
+			if (dieta == null || dieta.getIngestas() == null) {
+				continue;
+			}
+			for (final Ingesta ingesta : dieta.getIngestas()) {
+				aggregateIngesta(ingesta, items);
+			}
 		}
 		return items.values()
 			.stream()

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDietPlanService.java
@@ -1,5 +1,8 @@
 package com.nutriconsultas.mobile;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -25,6 +28,7 @@ import com.nutriconsultas.mobile.dto.DietPlatilloDetailDto;
 import com.nutriconsultas.mobile.dto.PagedResponse;
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
+import com.nutriconsultas.paciente.PacienteDietaService;
 import com.nutriconsultas.paciente.PacienteDietaStatus;
 import com.nutriconsultas.util.LogRedaction;
 
@@ -38,13 +42,17 @@ public class MobilePatientDietPlanService {
 
 	private final PacienteDietaRepository pacienteDietaRepository;
 
+	private final PacienteDietaService pacienteDietaService;
+
 	private final PlatilloIngestaRepository platilloIngestaRepository;
 
 	private final DietaPdfService dietaPdfService;
 
 	public MobilePatientDietPlanService(final PacienteDietaRepository pacienteDietaRepository,
-			final PlatilloIngestaRepository platilloIngestaRepository, final DietaPdfService dietaPdfService) {
+			final PacienteDietaService pacienteDietaService, final PlatilloIngestaRepository platilloIngestaRepository,
+			final DietaPdfService dietaPdfService) {
 		this.pacienteDietaRepository = pacienteDietaRepository;
+		this.pacienteDietaService = pacienteDietaService;
 		this.platilloIngestaRepository = platilloIngestaRepository;
 		this.dietaPdfService = dietaPdfService;
 	}
@@ -70,12 +78,13 @@ public class MobilePatientDietPlanService {
 	public DietPlanDetailDto getDietPlanDetail(final Long pacienteId, final Long assignmentId) {
 		final PacienteDieta assignment = pacienteDietaRepository.findByIdAndPacienteId(assignmentId, pacienteId)
 			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-		initializeDietaTree(assignment.getDieta());
+		final Dieta effectiveDieta = resolveEffectiveDieta(assignment);
+		initializeDietaTree(effectiveDieta);
 		if (log.isDebugEnabled()) {
 			log.debug("Loaded mobile diet plan detail assignmentId={} for patient {}",
 					LogRedaction.redactPacienteDieta(assignmentId), LogRedaction.redactPaciente(pacienteId));
 		}
-		return DietPlanDetailDto.fromEntity(assignment);
+		return DietPlanDetailDto.fromEntity(assignment, effectiveDieta);
 	}
 
 	@Transactional(readOnly = true)
@@ -100,12 +109,14 @@ public class MobilePatientDietPlanService {
 		if (week != null && !week.isBlank() && !"current".equalsIgnoreCase(week)) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
 		}
-		initializeGroceryTree(assignment.getDieta());
+		for (final Dieta dieta : pacienteDietaService.resolveDietsForGroceryList(assignment)) {
+			initializeGroceryTree(dieta);
+		}
 		if (log.isDebugEnabled()) {
 			log.debug("Loaded mobile grocery list assignmentId={} for patient {}",
 					LogRedaction.redactPacienteDieta(assignmentId), LogRedaction.redactPaciente(pacienteId));
 		}
-		return new DietGroceryListDto(DietGroceryListAggregator.aggregate(assignment.getDieta()));
+		return new DietGroceryListDto(pacienteDietaService.buildGroceryList(assignment));
 	}
 
 	@Transactional(readOnly = true)
@@ -120,6 +131,17 @@ public class MobilePatientDietPlanService {
 					LogRedaction.redactPacienteDieta(assignmentId), LogRedaction.redactPaciente(pacienteId));
 		}
 		return new DietPlanPdfResult(pdfBytes, filename);
+	}
+
+	private Dieta resolveEffectiveDieta(final PacienteDieta assignment) {
+		Dieta effectiveDieta = pacienteDietaService.resolveDietaForDate(assignment, LocalDate.now());
+		if (effectiveDieta == null && assignment.isWeeklyAssignment()) {
+			final List<Dieta> weeklyDiets = pacienteDietaService.resolveDietsForGroceryList(assignment);
+			if (!weeklyDiets.isEmpty()) {
+				effectiveDieta = weeklyDiets.get(0);
+			}
+		}
+		return effectiveDieta;
 	}
 
 	private static void initializeGroceryTree(final Dieta dieta) {

--- a/src/main/java/com/nutriconsultas/mobile/dto/DietPlanDetailDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DietPlanDetailDto.java
@@ -21,17 +21,22 @@ public record DietPlanDetailDto(Long assignmentId, PacienteDietaStatus status, L
 		Double totalCarbohidratos, List<DietIngestaDto> ingestas) {
 
 	public static DietPlanDetailDto fromEntity(final PacienteDieta assignment) {
+		return fromEntity(assignment, assignment != null ? assignment.getDieta() : null);
+	}
+
+	public static DietPlanDetailDto fromEntity(final PacienteDieta assignment, final Dieta dieta) {
 		if (assignment == null) {
 			return null;
 		}
-		final Dieta dieta = assignment.getDieta();
+		final String dietaName = assignment.isWeeklyAssignment() ? "Plan semanal"
+				: (dieta != null ? dieta.getNombre() : null);
 		final List<DietIngestaDto> ingestas = dieta != null && dieta.getIngestas() != null ? dieta.getIngestas()
 			.stream()
 			.sorted(IngestaComparators.BY_DISPLAY_ORDER)
 			.map(DietIngestaDto::fromEntity)
 			.toList() : List.of();
 		return new DietPlanDetailDto(assignment.getId(), assignment.getStatus(), toLocalDate(assignment.getStartDate()),
-				toLocalDate(assignment.getEndDate()), assignment.getNotes(), dieta != null ? dieta.getNombre() : null,
+				toLocalDate(assignment.getEndDate()), assignment.getNotes(), dietaName,
 				dieta != null ? dieta.getEnergia() : null, dieta != null ? dieta.getProteina() : null,
 				dieta != null ? dieta.getLipidos() : null, dieta != null ? dieta.getHidratosDeCarbono() : null,
 				ingestas);

--- a/src/main/java/com/nutriconsultas/mobile/dto/DietPlanSummaryDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DietPlanSummaryDto.java
@@ -21,6 +21,11 @@ public record DietPlanSummaryDto(Long assignmentId, PacienteDietaStatus status, 
 		if (assignment == null) {
 			return null;
 		}
+		if (assignment.isWeeklyAssignment()) {
+			return new DietPlanSummaryDto(assignment.getId(), assignment.getStatus(),
+					toLocalDate(assignment.getStartDate()), toLocalDate(assignment.getEndDate()), assignment.getNotes(),
+					"Plan semanal", null, null, null, null);
+		}
 		final Dieta dieta = assignment.getDieta();
 		return new DietPlanSummaryDto(assignment.getId(), assignment.getStatus(),
 				toLocalDate(assignment.getStartDate()), toLocalDate(assignment.getEndDate()), assignment.getNotes(),

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -939,7 +939,8 @@ public class PacienteController extends AbstractAuthorizedController {
 		model.addAttribute("paciente", paciente);
 		model.addAttribute("pacienteDieta", pacienteDieta);
 		if (pacienteDieta.isWeeklyAssignment()) {
-			model.addAttribute("weekdaySlots", pacienteDietaService.findWeekdaySlots(id));
+			model.addAttribute("weekdaySlotsByDay",
+					PacienteDietaWeekdayLabels.slotsByDay(pacienteDietaService.findWeekdaySlots(id)));
 		}
 		model.addAttribute("weekdayLabels", PacienteDietaWeekdayLabels.ISO_DAYS_MONDAY_FIRST.stream()
 			.collect(Collectors.toMap(day -> day, PacienteDietaWeekdayLabels::labelForDay)));
@@ -998,7 +999,8 @@ public class PacienteController extends AbstractAuthorizedController {
 			model.addAttribute("paciente", paciente);
 			model.addAttribute("pacienteDieta", pacienteDieta);
 			if (existing.isWeeklyAssignment()) {
-				model.addAttribute("weekdaySlots", pacienteDietaService.findWeekdaySlots(id));
+				model.addAttribute("weekdaySlotsByDay",
+						PacienteDietaWeekdayLabels.slotsByDay(pacienteDietaService.findWeekdaySlots(id)));
 			}
 			model.addAttribute("weekdayLabels", PacienteDietaWeekdayLabels.ISO_DAYS_MONDAY_FIRST.stream()
 				.collect(Collectors.toMap(day -> day, PacienteDietaWeekdayLabels::labelForDay)));

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -63,6 +63,7 @@ import java.time.ZoneId;
 
 @Controller
 @Slf4j
+@SuppressWarnings("PMD.NcssCount")
 public class PacienteController extends AbstractAuthorizedController {
 
 	@Autowired

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -4,10 +4,13 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
@@ -47,6 +50,7 @@ import com.nutriconsultas.paciente.mpx.MpxImportException;
 import com.nutriconsultas.paciente.mpx.MpxImportResult;
 import com.nutriconsultas.paciente.mpx.PacienteMpxExportService;
 import com.nutriconsultas.paciente.mpx.PacienteMpxImportService;
+import com.nutriconsultas.mobile.dto.DietGroceryListItemDto;
 import com.nutriconsultas.util.LogRedaction;
 
 import org.springframework.http.HttpHeaders;
@@ -539,6 +543,16 @@ public class PacienteController extends AbstractAuthorizedController {
 			}
 		}
 		model.addAttribute("dietasActivas", dietasActivas);
+		final Map<Long, List<PacienteDietaWeekday>> weekdaySlotsByAssignmentId = new HashMap<>();
+		for (final PacienteDieta assignment : dietasAsignadas) {
+			if (assignment.isWeeklyAssignment() && assignment.getId() != null) {
+				weekdaySlotsByAssignmentId.put(assignment.getId(),
+						pacienteDietaService.findWeekdaySlots(assignment.getId()));
+			}
+		}
+		model.addAttribute("weekdaySlotsByAssignmentId", weekdaySlotsByAssignmentId);
+		model.addAttribute("weekdayLabels", PacienteDietaWeekdayLabels.ISO_DAYS_MONDAY_FIRST.stream()
+			.collect(Collectors.toMap(day -> day, PacienteDietaWeekdayLabels::labelForDay)));
 		// obtener todas las dietas disponibles para asignar (legacy attribute for dietas
 		// template)
 		model.addAttribute("dietasDisponibles", getDietasDisponiblesWithCalculatedNutrients());
@@ -821,15 +835,17 @@ public class PacienteController extends AbstractAuthorizedController {
 		model.addAttribute("paciente", paciente);
 		model.addAttribute("requerimientoKcal", resolveRequerimientoKcal(paciente));
 		model.addAttribute("pacienteDieta", new PacienteDieta());
+		model.addAttribute("weekdayLabels", PacienteDietaWeekdayLabels.ISO_DAYS_MONDAY_FIRST.stream()
+			.collect(Collectors.toMap(day -> day, PacienteDietaWeekdayLabels::labelForDay)));
 		return "sbadmin/pacientes/asignar-dieta";
 	}
 
 	@PostMapping(path = "/admin/pacientes/{id}/dietas/asignar")
 	public String guardarAsignacionDieta(@PathVariable @NonNull final Long id, final PacienteDieta pacienteDieta,
-			final BindingResult result, final Model model,
-			@org.springframework.web.bind.annotation.RequestParam(required = true) @NonNull final Long dietaId,
+			final BindingResult result, final Model model, @RequestParam(required = false) final String assignmentType,
+			@RequestParam(required = false) final Long dietaId, final HttpServletRequest request,
 			@AuthenticationPrincipal final OidcUser principal) {
-		log.debug("Guardando asignación de dieta {} para paciente {}", dietaId, id);
+		log.debug("Guardando asignación de dieta para paciente {}", id);
 		final String userId = getUserId(principal);
 		if (userId == null) {
 			throw new IllegalArgumentException("No se pudo identificar al usuario");
@@ -840,21 +856,12 @@ public class PacienteController extends AbstractAuthorizedController {
 			throw new IllegalArgumentException("PacienteDieta cannot be null");
 		}
 
-		// Set paciente and dieta from parameters before validation
-		// This is necessary because paciente and dieta are validated as @NotNull but come
-		// from
-		// path variable and request parameter, not from form binding
+		final PacienteDietaAssignmentType parsedType = PacienteDietaWeekdayRequestSupport
+			.parseAssignmentType(assignmentType);
 		final Paciente paciente = pacienteRepository.findByIdAndUserId(id, userId)
 			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado paciente con folio " + id));
 		verifyPatientOwnership(paciente, userId);
-		final com.nutriconsultas.dieta.Dieta dieta = dietaRepository.findById(dietaId)
-			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado dieta con id " + dietaId));
 
-		pacienteDieta.setPaciente(paciente);
-		pacienteDieta.setDieta(dieta);
-
-		// Manual validation since paciente and dieta come from parameters, not form
-		// binding
 		boolean hasErrors = false;
 		if (pacienteDieta.getStartDate() == null) {
 			result.rejectValue("startDate", "NotNull", "La fecha de inicio es requerida");
@@ -864,13 +871,27 @@ public class PacienteController extends AbstractAuthorizedController {
 			result.rejectValue("status", "NotNull", "El estado es requerido");
 			hasErrors = true;
 		}
-		if (pacienteDieta.getPaciente() == null) {
-			result.rejectValue("paciente", "NotNull", "El paciente es requerido");
-			hasErrors = true;
+
+		if (parsedType == PacienteDietaAssignmentType.DATE_RANGE) {
+			if (dietaId == null) {
+				result.rejectValue("dieta", "NotNull", "La dieta es requerida");
+				hasErrors = true;
+			}
+			else {
+				final com.nutriconsultas.dieta.Dieta dieta = dietaRepository.findById(dietaId)
+					.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado dieta con id " + dietaId));
+				pacienteDieta.setPaciente(paciente);
+				pacienteDieta.setDieta(dieta);
+			}
 		}
-		if (pacienteDieta.getDieta() == null) {
-			result.rejectValue("dieta", "NotNull", "La dieta es requerida");
-			hasErrors = true;
+		else {
+			final Map<Integer, Long> weekdayDietaIds = PacienteDietaWeekdayRequestSupport
+				.parseWeekdayCatalogDietaIds(request);
+			if (weekdayDietaIds.isEmpty()) {
+				result.reject("weekdayDietaIds", "Seleccione al menos un día con dieta para el plan semanal");
+				hasErrors = true;
+			}
+			pacienteDieta.setPaciente(paciente);
 		}
 
 		if (hasErrors) {
@@ -880,9 +901,19 @@ public class PacienteController extends AbstractAuthorizedController {
 			model.addAttribute("activeMenu", "perfil");
 			model.addAttribute("paciente", paciente);
 			model.addAttribute("requerimientoKcal", resolveRequerimientoKcal(paciente));
+			model.addAttribute("weekdayLabels", PacienteDietaWeekdayLabels.ISO_DAYS_MONDAY_FIRST.stream()
+				.collect(Collectors.toMap(day -> day, PacienteDietaWeekdayLabels::labelForDay)));
 			return "sbadmin/pacientes/asignar-dieta";
 		}
-		final PacienteDieta saved = pacienteDietaService.assignDieta(id, dietaId, pacienteDieta, userId);
+
+		final PacienteDieta saved;
+		if (parsedType == PacienteDietaAssignmentType.WEEKLY) {
+			saved = pacienteDietaService.assignWeeklyDieta(id,
+					PacienteDietaWeekdayRequestSupport.parseWeekdayCatalogDietaIds(request), pacienteDieta, userId);
+		}
+		else {
+			saved = pacienteDietaService.assignDieta(id, dietaId, pacienteDieta, userId);
+		}
 		log.debug("Dieta asignada exitosamente: {}", LogRedaction.redactPacienteDieta(saved));
 		return String.format("redirect:/admin/pacientes/%d/dietas", id);
 	}
@@ -907,34 +938,35 @@ public class PacienteController extends AbstractAuthorizedController {
 		model.addAttribute("activeMenu", "perfil");
 		model.addAttribute("paciente", paciente);
 		model.addAttribute("pacienteDieta", pacienteDieta);
+		if (pacienteDieta.isWeeklyAssignment()) {
+			model.addAttribute("weekdaySlots", pacienteDietaService.findWeekdaySlots(id));
+		}
+		model.addAttribute("weekdayLabels", PacienteDietaWeekdayLabels.ISO_DAYS_MONDAY_FIRST.stream()
+			.collect(Collectors.toMap(day -> day, PacienteDietaWeekdayLabels::labelForDay)));
+		model.addAttribute("requerimientoKcal", resolveRequerimientoKcal(paciente));
 		return "sbadmin/pacientes/editar-dieta";
 	}
 
 	@PostMapping(path = "/admin/pacientes/{pacienteId}/dietas/{id}/editar")
 	public String actualizarAsignacionDieta(@PathVariable @NonNull final Long pacienteId,
 			@PathVariable @NonNull final Long id, final PacienteDieta pacienteDieta, final BindingResult result,
-			final Model model, @AuthenticationPrincipal final OidcUser principal) {
+			final Model model, final HttpServletRequest request, @AuthenticationPrincipal final OidcUser principal) {
 		log.debug("Actualizando asignación de dieta {}", id);
 		final String userId = getUserId(principal);
 		if (userId == null) {
 			throw new IllegalArgumentException("No se pudo identificar al usuario");
 		}
 
-		// Load existing assignment to preserve paciente and dieta relationships
-		// These are not in the form, so they need to be set from the existing entity
 		final PacienteDieta existing = pacienteDietaService.findById(id);
 		if (existing == null) {
 			throw new IllegalArgumentException("No se ha encontrado asignación de dieta con id " + id);
 		}
 
-		// Set paciente and dieta from existing entity
-		// This prevents validation errors since these fields are @NotNull but not in the
-		// form
 		pacienteDieta.setPaciente(existing.getPaciente());
 		pacienteDieta.setDieta(existing.getDieta());
 		pacienteDieta.setId(existing.getId());
+		pacienteDieta.setAssignmentType(existing.getAssignmentType());
 
-		// Manual validation for fields that come from the form
 		boolean hasErrors = false;
 		if (pacienteDieta.getStartDate() == null) {
 			result.rejectValue("startDate", "NotNull", "La fecha de inicio es requerida");
@@ -943,6 +975,15 @@ public class PacienteController extends AbstractAuthorizedController {
 		if (pacienteDieta.getStatus() == null) {
 			result.rejectValue("status", "NotNull", "El estado es requerido");
 			hasErrors = true;
+		}
+		if (existing.isWeeklyAssignment()) {
+			final Map<Integer, Long> weekdayDietaIds = PacienteDietaWeekdayRequestSupport
+				.parseWeekdayCatalogDietaIds(request);
+			final List<PacienteDietaWeekday> existingSlots = pacienteDietaService.findWeekdaySlots(id);
+			if (weekdayDietaIds.isEmpty() && existingSlots.isEmpty()) {
+				result.reject("weekdayDietaIds", "Seleccione al menos un día con dieta para el plan semanal");
+				hasErrors = true;
+			}
 		}
 
 		if (hasErrors) {
@@ -956,11 +997,49 @@ public class PacienteController extends AbstractAuthorizedController {
 			model.addAttribute("activeMenu", "perfil");
 			model.addAttribute("paciente", paciente);
 			model.addAttribute("pacienteDieta", pacienteDieta);
+			if (existing.isWeeklyAssignment()) {
+				model.addAttribute("weekdaySlots", pacienteDietaService.findWeekdaySlots(id));
+			}
+			model.addAttribute("weekdayLabels", PacienteDietaWeekdayLabels.ISO_DAYS_MONDAY_FIRST.stream()
+				.collect(Collectors.toMap(day -> day, PacienteDietaWeekdayLabels::labelForDay)));
+			model.addAttribute("requerimientoKcal", resolveRequerimientoKcal(paciente));
 			return "sbadmin/pacientes/editar-dieta";
 		}
-		final PacienteDieta updated = pacienteDietaService.updateAssignment(id, pacienteDieta);
+
+		final PacienteDieta updated;
+		if (existing.isWeeklyAssignment()) {
+			updated = pacienteDietaService.updateWeeklyAssignment(id,
+					PacienteDietaWeekdayRequestSupport.parseWeekdayCatalogDietaIds(request), pacienteDieta);
+		}
+		else {
+			updated = pacienteDietaService.updateAssignment(id, pacienteDieta);
+		}
 		log.info("Asignación de dieta actualizada exitosamente: {}", LogRedaction.redactPacienteDieta(updated));
 		return String.format("redirect:/admin/pacientes/%d/dietas", pacienteId);
+	}
+
+	@GetMapping(path = "/admin/pacientes/{pacienteId}/dietas/{id}/lista-compras")
+	public String listaComprasAsignacion(@PathVariable @NonNull final Long pacienteId,
+			@PathVariable @NonNull final Long id, final Model model,
+			@AuthenticationPrincipal final OidcUser principal) {
+		log.debug("Cargando lista de compras para asignación {}", id);
+		final String userId = getUserId(principal);
+		if (userId == null) {
+			throw new IllegalArgumentException("No se pudo identificar al usuario");
+		}
+		final Paciente paciente = pacienteRepository.findByIdAndUserId(pacienteId, userId)
+			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado paciente con folio " + pacienteId));
+		verifyPatientOwnership(paciente, userId);
+		final PacienteDieta assignment = pacienteDietaService.findById(id);
+		if (assignment.getPaciente() == null || !pacienteId.equals(assignment.getPaciente().getId())) {
+			throw new IllegalArgumentException("La asignación no pertenece al paciente");
+		}
+		final List<DietGroceryListItemDto> groceryItems = pacienteDietaService.buildGroceryList(assignment);
+		model.addAttribute("activeMenu", "plan-alimentario");
+		model.addAttribute("paciente", paciente);
+		model.addAttribute("pacienteDieta", assignment);
+		model.addAttribute("groceryItems", groceryItems);
+		return "sbadmin/pacientes/lista-compras";
 	}
 
 	@PostMapping(path = "/admin/pacientes/{pacienteId}/dietas/{id}/cancelar")

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDeletionServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDeletionServiceImpl.java
@@ -44,13 +44,16 @@ public class PacienteDeletionServiceImpl implements PacienteDeletionService {
 
 	private final DietaService dietaService;
 
+	private final PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository;
+
 	public PacienteDeletionServiceImpl(final PacienteRepository pacienteRepository,
 			final PatientMessageRepository patientMessageRepository,
 			final PatientInvitationRepository patientInvitationRepository,
 			final PacienteDietaRepository pacienteDietaRepository, final CalendarEventService calendarEventService,
 			final ClinicalExamService clinicalExamService,
 			final AnthropometricMeasurementService anthropometricMeasurementService,
-			final BodyMetricRecordRepository bodyMetricRecordRepository, final DietaService dietaService) {
+			final BodyMetricRecordRepository bodyMetricRecordRepository, final DietaService dietaService,
+			final PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository) {
 		this.pacienteRepository = pacienteRepository;
 		this.patientMessageRepository = patientMessageRepository;
 		this.patientInvitationRepository = patientInvitationRepository;
@@ -60,6 +63,7 @@ public class PacienteDeletionServiceImpl implements PacienteDeletionService {
 		this.anthropometricMeasurementService = anthropometricMeasurementService;
 		this.bodyMetricRecordRepository = bodyMetricRecordRepository;
 		this.dietaService = dietaService;
+		this.pacienteDietaWeekdayRepository = pacienteDietaWeekdayRepository;
 	}
 
 	@Override
@@ -91,10 +95,13 @@ public class PacienteDeletionServiceImpl implements PacienteDeletionService {
 		}
 		final List<PacienteDieta> dietAssignments = pacienteDietaRepository.findByPacienteId(pacienteId);
 		for (final PacienteDieta assignment : dietAssignments) {
-			final Dieta dieta = assignment.getDieta();
-			if (dieta != null && dieta.getId() != null && DietaCatalogConstants.isPatientAssignment(dieta)) {
-				dietaService.deleteDieta(dieta.getId());
+			if (assignment.isWeeklyAssignment() && assignment.getId() != null) {
+				for (final PacienteDietaWeekday slot : pacienteDietaWeekdayRepository
+					.findByPacienteDietaIdOrderByDayOfWeekAsc(assignment.getId())) {
+					deletePatientDietaCopy(slot.getDieta());
+				}
 			}
+			deletePatientDietaCopy(assignment.getDieta());
 		}
 		if (!dietAssignments.isEmpty()) {
 			pacienteDietaRepository.deleteAll(dietAssignments);
@@ -110,6 +117,12 @@ public class PacienteDeletionServiceImpl implements PacienteDeletionService {
 			anthropometricMeasurementService.deleteById(measurement.getId());
 		}
 		bodyMetricRecordRepository.deleteByPacienteId(pacienteId);
+	}
+
+	private void deletePatientDietaCopy(final Dieta dieta) {
+		if (dieta != null && dieta.getId() != null && DietaCatalogConstants.isPatientAssignment(dieta)) {
+			dietaService.deleteDieta(dieta.getId());
+		}
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDieta.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDieta.java
@@ -1,16 +1,22 @@
 package com.nutriconsultas.paciente;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import com.nutriconsultas.dieta.Dieta;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 import jakarta.validation.constraints.NotNull;
@@ -35,10 +41,21 @@ public class PacienteDieta {
 	@NotNull(message = "El paciente es requerido")
 	private Paciente paciente;
 
-	@ManyToOne(optional = false)
+	@ManyToOne(optional = true)
 	@JoinColumn(name = "dieta_id")
-	@NotNull(message = "La dieta es requerida")
 	private Dieta dieta;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "assignment_type", nullable = false, length = 16)
+	@NotNull(message = "El tipo de asignación es requerido")
+	private PacienteDietaAssignmentType assignmentType = PacienteDietaAssignmentType.DATE_RANGE;
+
+	@OneToMany(mappedBy = "pacienteDieta", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PacienteDietaWeekday> weekdaySlots = new ArrayList<>();
+
+	public boolean isWeeklyAssignment() {
+		return assignmentType == PacienteDietaAssignmentType.WEEKLY;
+	}
 
 	@DateTimeFormat(pattern = "yyyy-MM-dd")
 	@Temporal(TemporalType.DATE)

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaAssignmentType.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaAssignmentType.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.paciente;
+
+/**
+ * How a {@link PacienteDieta} binds menus to calendar time (#525).
+ */
+public enum PacienteDietaAssignmentType {
+
+	/** Single diet for the whole assignment period (legacy default). */
+	DATE_RANGE,
+
+	/** One diet per weekday (lunes–domingo). */
+	WEEKLY
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaService.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaService.java
@@ -1,15 +1,27 @@
 package com.nutriconsultas.paciente;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.mobile.dto.DietGroceryListItemDto;
 
 public interface PacienteDietaService {
 
 	PacienteDieta assignDieta(@NonNull Long pacienteId, @NonNull Long dietaId, @NonNull PacienteDieta pacienteDieta,
 			@NonNull String userId);
 
+	PacienteDieta assignWeeklyDieta(@NonNull Long pacienteId, @NonNull Map<Integer, Long> weekdayCatalogDietaIds,
+			@NonNull PacienteDieta pacienteDieta, @NonNull String userId);
+
 	PacienteDieta updateAssignment(@NonNull Long id, @NonNull PacienteDieta pacienteDieta);
+
+	PacienteDieta updateWeeklyAssignment(@NonNull Long id, @NonNull Map<Integer, Long> weekdayCatalogDietaIds,
+			@NonNull PacienteDieta pacienteDieta);
 
 	void cancelAssignment(@NonNull Long id);
 
@@ -18,5 +30,14 @@ public interface PacienteDietaService {
 	List<PacienteDieta> findActiveByPacienteId(@NonNull Long pacienteId);
 
 	PacienteDieta findById(@NonNull Long id);
+
+	List<PacienteDietaWeekday> findWeekdaySlots(@NonNull Long assignmentId);
+
+	List<Dieta> resolveDietsForGroceryList(@NonNull PacienteDieta assignment);
+
+	List<DietGroceryListItemDto> buildGroceryList(@NonNull PacienteDieta assignment);
+
+	@Nullable
+	Dieta resolveDietaForDate(@NonNull PacienteDieta assignment, @NonNull LocalDate date);
 
 }

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaServiceImpl.java
@@ -1,9 +1,15 @@
 package com.nutriconsultas.paciente;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,6 +17,8 @@ import com.nutriconsultas.dieta.Dieta;
 import com.nutriconsultas.dieta.DietaCatalogConstants;
 import com.nutriconsultas.dieta.DietaRepository;
 import com.nutriconsultas.dieta.DietaService;
+import com.nutriconsultas.mobile.DietGroceryListAggregator;
+import com.nutriconsultas.mobile.dto.DietGroceryListItemDto;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,6 +29,8 @@ public class PacienteDietaServiceImpl implements PacienteDietaService {
 
 	private final PacienteDietaRepository pacienteDietaRepository;
 
+	private final PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository;
+
 	private final PacienteRepository pacienteRepository;
 
 	private final DietaRepository dietaRepository;
@@ -28,9 +38,11 @@ public class PacienteDietaServiceImpl implements PacienteDietaService {
 	private final DietaService dietaService;
 
 	public PacienteDietaServiceImpl(final PacienteDietaRepository pacienteDietaRepository,
+			final PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository,
 			final PacienteRepository pacienteRepository, final DietaRepository dietaRepository,
 			final DietaService dietaService) {
 		this.pacienteDietaRepository = pacienteDietaRepository;
+		this.pacienteDietaWeekdayRepository = pacienteDietaWeekdayRepository;
 		this.pacienteRepository = pacienteRepository;
 		this.dietaRepository = dietaRepository;
 		this.dietaService = dietaService;
@@ -44,44 +56,59 @@ public class PacienteDietaServiceImpl implements PacienteDietaService {
 			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado paciente con id " + pacienteId));
 		final Dieta sourceDieta = dietaRepository.findById(dietaId)
 			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado dieta con id " + dietaId));
-		if (DietaCatalogConstants.isPatientAssignment(sourceDieta)) {
-			throw new IllegalArgumentException("No se puede asignar una dieta exclusiva de otro paciente");
-		}
+		assertAssignableCatalogDieta(sourceDieta);
 
 		final Dieta patientCopy = dietaService.copyDietaForPatientAssignment(dietaId, pacienteId, userId);
 
-		final PacienteDieta newAssignment = new PacienteDieta();
-		newAssignment.setPaciente(paciente);
+		final PacienteDieta newAssignment = buildAssignmentShell(paciente, pacienteDieta);
+		newAssignment.setAssignmentType(PacienteDietaAssignmentType.DATE_RANGE);
 		newAssignment.setDieta(patientCopy);
-		newAssignment.setStartDate(pacienteDieta.getStartDate());
-		newAssignment.setEndDate(pacienteDieta.getEndDate());
-		newAssignment
-			.setStatus(pacienteDieta.getStatus() != null ? pacienteDieta.getStatus() : PacienteDietaStatus.ACTIVE);
-		newAssignment.setNotes(pacienteDieta.getNotes());
 
 		return pacienteDietaRepository.save(newAssignment);
 	}
 
 	@Override
+	public PacienteDieta assignWeeklyDieta(@NonNull final Long pacienteId,
+			@NonNull final Map<Integer, Long> weekdayCatalogDietaIds, @NonNull final PacienteDieta pacienteDieta,
+			@NonNull final String userId) {
+		log.info("Assigning weekly dieta plan to paciente {} for user {}", pacienteId, userId);
+		if (weekdayCatalogDietaIds.isEmpty()) {
+			throw new IllegalArgumentException("Seleccione al menos un día con dieta para el plan semanal");
+		}
+		final Paciente paciente = pacienteRepository.findByIdAndUserId(pacienteId, userId)
+			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado paciente con id " + pacienteId));
+
+		final PacienteDieta newAssignment = buildAssignmentShell(paciente, pacienteDieta);
+		newAssignment.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
+		newAssignment.setDieta(null);
+
+		final PacienteDieta saved = pacienteDietaRepository.save(newAssignment);
+		replaceWeekdaySlots(saved, weekdayCatalogDietaIds, pacienteId, userId);
+		return pacienteDietaRepository.findById(saved.getId())
+			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado asignación con id " + saved.getId()));
+	}
+
+	@Override
 	public PacienteDieta updateAssignment(@NonNull final Long id, @NonNull final PacienteDieta pacienteDieta) {
 		log.info("Updating dieta assignment {}", id);
-		final PacienteDieta existing = Objects.requireNonNull(pacienteDietaRepository.findById(id)
-			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado asignación con id " + id)));
-
-		if (pacienteDieta.getStartDate() != null) {
-			existing.setStartDate(pacienteDieta.getStartDate());
-		}
-		if (pacienteDieta.getEndDate() != null) {
-			existing.setEndDate(pacienteDieta.getEndDate());
-		}
-		if (pacienteDieta.getStatus() != null) {
-			existing.setStatus(pacienteDieta.getStatus());
-		}
-		if (pacienteDieta.getNotes() != null) {
-			existing.setNotes(pacienteDieta.getNotes());
-		}
-
+		final PacienteDieta existing = loadAssignment(id);
+		applyMetadataUpdate(existing, pacienteDieta);
 		return Objects.requireNonNull(pacienteDietaRepository.save(existing));
+	}
+
+	@Override
+	public PacienteDieta updateWeeklyAssignment(@NonNull final Long id,
+			@NonNull final Map<Integer, Long> weekdayCatalogDietaIds, @NonNull final PacienteDieta pacienteDieta) {
+		log.info("Updating weekly dieta assignment {}", id);
+		final PacienteDieta existing = loadAssignment(id);
+		if (!existing.isWeeklyAssignment()) {
+			throw new IllegalArgumentException("La asignación no es un plan semanal");
+		}
+		applyMetadataUpdate(existing, pacienteDieta);
+		final PacienteDieta saved = pacienteDietaRepository.save(existing);
+		mergeWeekdaySlots(saved, weekdayCatalogDietaIds, saved.getPaciente().getId(), saved.getPaciente().getUserId());
+		return pacienteDietaRepository.findById(saved.getId())
+			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado asignación con id " + saved.getId()));
 	}
 
 	@Override
@@ -114,6 +141,152 @@ public class PacienteDietaServiceImpl implements PacienteDietaService {
 		log.info("Finding dieta assignment {}", id);
 		return pacienteDietaRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado asignación con id " + id));
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<PacienteDietaWeekday> findWeekdaySlots(@NonNull final Long assignmentId) {
+		return pacienteDietaWeekdayRepository.findByPacienteDietaIdOrderByDayOfWeekAsc(assignmentId);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<Dieta> resolveDietsForGroceryList(@NonNull final PacienteDieta assignment) {
+		if (assignment.isWeeklyAssignment()) {
+			final List<Dieta> diets = new ArrayList<>();
+			for (final PacienteDietaWeekday slot : findWeekdaySlots(assignment.getId())) {
+				if (slot.getDieta() != null) {
+					diets.add(slot.getDieta());
+				}
+			}
+			return diets;
+		}
+		if (assignment.getDieta() != null) {
+			return List.of(assignment.getDieta());
+		}
+		return List.of();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<DietGroceryListItemDto> buildGroceryList(@NonNull final PacienteDieta assignment) {
+		return DietGroceryListAggregator.aggregate(resolveDietsForGroceryList(assignment));
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	@Nullable
+	public Dieta resolveDietaForDate(@NonNull final PacienteDieta assignment, @NonNull final LocalDate date) {
+		if (!assignment.isWeeklyAssignment()) {
+			return assignment.getDieta();
+		}
+		final int isoDay = toIsoDayOfWeek(date.getDayOfWeek());
+		return findWeekdaySlots(assignment.getId()).stream()
+			.filter(slot -> slot.getDayOfWeek() != null && slot.getDayOfWeek() == isoDay)
+			.map(PacienteDietaWeekday::getDieta)
+			.findFirst()
+			.orElse(null);
+	}
+
+	private PacienteDieta buildAssignmentShell(final Paciente paciente, final PacienteDieta pacienteDieta) {
+		final PacienteDieta newAssignment = new PacienteDieta();
+		newAssignment.setPaciente(paciente);
+		newAssignment.setStartDate(pacienteDieta.getStartDate());
+		newAssignment.setEndDate(pacienteDieta.getEndDate());
+		newAssignment
+			.setStatus(pacienteDieta.getStatus() != null ? pacienteDieta.getStatus() : PacienteDietaStatus.ACTIVE);
+		newAssignment.setNotes(pacienteDieta.getNotes());
+		return newAssignment;
+	}
+
+	private void applyMetadataUpdate(final PacienteDieta existing, final PacienteDieta pacienteDieta) {
+		if (pacienteDieta.getStartDate() != null) {
+			existing.setStartDate(pacienteDieta.getStartDate());
+		}
+		if (pacienteDieta.getEndDate() != null) {
+			existing.setEndDate(pacienteDieta.getEndDate());
+		}
+		if (pacienteDieta.getStatus() != null) {
+			existing.setStatus(pacienteDieta.getStatus());
+		}
+		if (pacienteDieta.getNotes() != null) {
+			existing.setNotes(pacienteDieta.getNotes());
+		}
+	}
+
+	private PacienteDieta loadAssignment(final Long id) {
+		return pacienteDietaRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado asignación con id " + id));
+	}
+
+	private void mergeWeekdaySlots(final PacienteDieta assignment, final Map<Integer, Long> weekdayCatalogDietaIds,
+			final Long pacienteId, final String userId) {
+		final Map<Integer, PacienteDietaWeekday> existingByDay = new LinkedHashMap<>();
+		for (final PacienteDietaWeekday slot : pacienteDietaWeekdayRepository
+			.findByPacienteDietaIdOrderByDayOfWeekAsc(assignment.getId())) {
+			if (slot.getDayOfWeek() != null) {
+				existingByDay.put(slot.getDayOfWeek(), slot);
+			}
+		}
+		pacienteDietaWeekdayRepository.deleteByPacienteDietaId(assignment.getId());
+		final Map<Integer, Long> normalized = normalizeWeekdayMap(weekdayCatalogDietaIds);
+		for (final int day : PacienteDietaWeekdayLabels.ISO_DAYS_MONDAY_FIRST) {
+			final Long catalogDietaId = normalized.get(day);
+			if (catalogDietaId != null) {
+				persistWeekdaySlot(assignment, day, catalogDietaId, pacienteId, userId);
+			}
+			else if (existingByDay.containsKey(day)) {
+				final PacienteDietaWeekday retained = existingByDay.get(day);
+				final PacienteDietaWeekday slot = new PacienteDietaWeekday();
+				slot.setPacienteDieta(assignment);
+				slot.setDayOfWeek(day);
+				slot.setDieta(retained.getDieta());
+				pacienteDietaWeekdayRepository.save(slot);
+			}
+		}
+	}
+
+	private void replaceWeekdaySlots(final PacienteDieta assignment, final Map<Integer, Long> weekdayCatalogDietaIds,
+			final Long pacienteId, final String userId) {
+		pacienteDietaWeekdayRepository.deleteByPacienteDietaId(assignment.getId());
+		final Map<Integer, Long> normalized = normalizeWeekdayMap(weekdayCatalogDietaIds);
+		for (final Map.Entry<Integer, Long> entry : normalized.entrySet()) {
+			persistWeekdaySlot(assignment, entry.getKey(), entry.getValue(), pacienteId, userId);
+		}
+	}
+
+	private void persistWeekdaySlot(final PacienteDieta assignment, final int day, final Long catalogDietaId,
+			final Long pacienteId, final String userId) {
+		final Dieta sourceDieta = dietaRepository.findById(catalogDietaId)
+			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado dieta con id " + catalogDietaId));
+		assertAssignableCatalogDieta(sourceDieta);
+		final Dieta patientCopy = dietaService.copyDietaForPatientAssignment(catalogDietaId, pacienteId, userId);
+		final PacienteDietaWeekday slot = new PacienteDietaWeekday();
+		slot.setPacienteDieta(assignment);
+		slot.setDayOfWeek(day);
+		slot.setDieta(patientCopy);
+		pacienteDietaWeekdayRepository.save(slot);
+	}
+
+	private static Map<Integer, Long> normalizeWeekdayMap(final Map<Integer, Long> weekdayCatalogDietaIds) {
+		final Map<Integer, Long> normalized = new LinkedHashMap<>();
+		for (final int day : PacienteDietaWeekdayLabels.ISO_DAYS_MONDAY_FIRST) {
+			final Long dietaId = weekdayCatalogDietaIds.get(day);
+			if (dietaId != null) {
+				normalized.put(day, dietaId);
+			}
+		}
+		return normalized;
+	}
+
+	private static void assertAssignableCatalogDieta(final Dieta sourceDieta) {
+		if (DietaCatalogConstants.isPatientAssignment(sourceDieta)) {
+			throw new IllegalArgumentException("No se puede asignar una dieta exclusiva de otro paciente");
+		}
+	}
+
+	private static int toIsoDayOfWeek(final DayOfWeek dayOfWeek) {
+		return dayOfWeek.getValue();
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaWeekday.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaWeekday.java
@@ -1,0 +1,47 @@
+package com.nutriconsultas.paciente;
+
+import com.nutriconsultas.dieta.Dieta;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "paciente_dieta_weekday",
+		uniqueConstraints = { @UniqueConstraint(name = "uk_paciente_dieta_weekday_day",
+				columnNames = { "paciente_dieta_id", "day_of_week" }) })
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PacienteDietaWeekday {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "paciente_dieta_id")
+	@ToString.Exclude
+	@EqualsAndHashCode.Exclude
+	private PacienteDieta pacienteDieta;
+
+	/** ISO-8601 day: 1 = Monday … 7 = Sunday (matches booking working hours). */
+	@Column(name = "day_of_week", nullable = false)
+	private Integer dayOfWeek;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "dieta_id")
+	private Dieta dieta;
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaWeekdayLabels.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaWeekdayLabels.java
@@ -1,0 +1,23 @@
+package com.nutriconsultas.paciente;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Spanish weekday labels for weekly diet assignment UI (#525).
+ */
+public final class PacienteDietaWeekdayLabels {
+
+	public static final List<Integer> ISO_DAYS_MONDAY_FIRST = List.of(1, 2, 3, 4, 5, 6, 7);
+
+	private static final Map<Integer, String> SPANISH_LABELS = Map.of(1, "Lunes", 2, "Martes", 3, "Miércoles", 4,
+			"Jueves", 5, "Viernes", 6, "Sábado", 7, "Domingo");
+
+	private PacienteDietaWeekdayLabels() {
+	}
+
+	public static String labelForDay(final int dayOfWeek) {
+		return SPANISH_LABELS.getOrDefault(dayOfWeek, "Día " + dayOfWeek);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaWeekdayLabels.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaWeekdayLabels.java
@@ -1,5 +1,6 @@
 package com.nutriconsultas.paciente;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -18,6 +19,19 @@ public final class PacienteDietaWeekdayLabels {
 
 	public static String labelForDay(final int dayOfWeek) {
 		return SPANISH_LABELS.getOrDefault(dayOfWeek, "Día " + dayOfWeek);
+	}
+
+	public static Map<Integer, PacienteDietaWeekday> slotsByDay(final List<PacienteDietaWeekday> slots) {
+		final Map<Integer, PacienteDietaWeekday> byDay = new LinkedHashMap<>();
+		if (slots == null) {
+			return byDay;
+		}
+		for (final PacienteDietaWeekday slot : slots) {
+			if (slot.getDayOfWeek() != null) {
+				byDay.put(slot.getDayOfWeek(), slot);
+			}
+		}
+		return byDay;
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaWeekdayRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaWeekdayRepository.java
@@ -1,0 +1,15 @@
+package com.nutriconsultas.paciente;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PacienteDietaWeekdayRepository extends JpaRepository<PacienteDietaWeekday, Long> {
+
+	List<PacienteDietaWeekday> findByPacienteDietaIdOrderByDayOfWeekAsc(Long pacienteDietaId);
+
+	void deleteByPacienteDietaId(Long pacienteDietaId);
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaWeekdayRequestSupport.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaWeekdayRequestSupport.java
@@ -1,0 +1,48 @@
+package com.nutriconsultas.paciente;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Parses weekday catalog diet ids from assign/edit forms (#525).
+ */
+public final class PacienteDietaWeekdayRequestSupport {
+
+	private PacienteDietaWeekdayRequestSupport() {
+	}
+
+	public static Map<Integer, Long> parseWeekdayCatalogDietaIds(final HttpServletRequest request) {
+		final Map<Integer, Long> result = new LinkedHashMap<>();
+		if (request == null) {
+			return result;
+		}
+		for (final int day : PacienteDietaWeekdayLabels.ISO_DAYS_MONDAY_FIRST) {
+			final String raw = request.getParameter("weekdayDietaId_" + day);
+			if (raw == null || raw.isBlank()) {
+				continue;
+			}
+			try {
+				result.put(day, Long.parseLong(raw.trim()));
+			}
+			catch (final NumberFormatException ignored) {
+				// skip invalid day entry
+			}
+		}
+		return result;
+	}
+
+	public static PacienteDietaAssignmentType parseAssignmentType(final String raw) {
+		if (raw == null || raw.isBlank()) {
+			return PacienteDietaAssignmentType.DATE_RANGE;
+		}
+		try {
+			return PacienteDietaAssignmentType.valueOf(raw.trim().toUpperCase());
+		}
+		catch (final IllegalArgumentException ex) {
+			return PacienteDietaAssignmentType.DATE_RANGE;
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
@@ -126,6 +126,7 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 		mockPacienteDieta.setEndDate(null);
 		mockPacienteDieta.setStatus(PacienteDietaStatus.ACTIVE);
 		mockPacienteDieta.setNotes("");
+		mockPacienteDieta.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
 		mockDietasAsignadas.add(mockPacienteDieta);
 
 		variables.put("dietasAsignadas", mockDietasAsignadas);
@@ -149,7 +150,10 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 		variables.put("weekdayLabels", PacienteDietaWeekdayLabels.ISO_DAYS_MONDAY_FIRST.stream()
 			.collect(java.util.stream.Collectors.toMap(day -> day, PacienteDietaWeekdayLabels::labelForDay)));
 		variables.put("weekdaySlotsByAssignmentId", java.util.Map.of());
-		variables.put("weekdaySlots", java.util.List.of());
+		final PacienteDietaWeekday mondaySlot = new PacienteDietaWeekday();
+		mondaySlot.setDayOfWeek(1);
+		mondaySlot.setDieta(mockDieta);
+		variables.put("weekdaySlotsByDay", PacienteDietaWeekdayLabels.slotsByDay(java.util.List.of(mondaySlot)));
 		variables.put("groceryItems", java.util.List.of());
 	}
 

--- a/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
@@ -149,10 +149,11 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 		variables.put("requerimientoKcal", 2000.0);
 		variables.put("weekdayLabels", PacienteDietaWeekdayLabels.ISO_DAYS_MONDAY_FIRST.stream()
 			.collect(java.util.stream.Collectors.toMap(day -> day, PacienteDietaWeekdayLabels::labelForDay)));
-		variables.put("weekdaySlotsByAssignmentId", java.util.Map.of());
 		final PacienteDietaWeekday mondaySlot = new PacienteDietaWeekday();
 		mondaySlot.setDayOfWeek(1);
 		mondaySlot.setDieta(mockDieta);
+		variables.put("weekdaySlotsByAssignmentId",
+				java.util.Map.of(1L, java.util.List.of(mondaySlot)));
 		variables.put("weekdaySlotsByDay", PacienteDietaWeekdayLabels.slotsByDay(java.util.List.of(mondaySlot)));
 		variables.put("groceryItems", java.util.List.of());
 	}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
@@ -146,6 +146,11 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 		mockDietasDisponibles.add(dietaBaja);
 		variables.put("dietasDisponibles", mockDietasDisponibles);
 		variables.put("requerimientoKcal", 2000.0);
+		variables.put("weekdayLabels", PacienteDietaWeekdayLabels.ISO_DAYS_MONDAY_FIRST.stream()
+			.collect(java.util.stream.Collectors.toMap(day -> day, PacienteDietaWeekdayLabels::labelForDay)));
+		variables.put("weekdaySlotsByAssignmentId", java.util.Map.of());
+		variables.put("weekdaySlots", java.util.List.of());
+		variables.put("groceryItems", java.util.List.of());
 	}
 
 	private void addMockConsulta(final Map<String, Object> variables, final Paciente paciente) {

--- a/src/main/resources/db/changelog/changes/029-paciente-dieta-weekly.yaml
+++ b/src/main/resources/db/changelog/changes/029-paciente-dieta-weekly.yaml
@@ -1,0 +1,92 @@
+databaseChangeLog:
+  - changeSet:
+      id: 029-paciente-dieta-assignment-type
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            columnExists:
+              tableName: paciente_dieta
+              columnName: assignment_type
+      changes:
+        - addColumn:
+            tableName: paciente_dieta
+            columns:
+              - column:
+                  name: assignment_type
+                  type: VARCHAR(16)
+                  defaultValue: DATE_RANGE
+                  constraints:
+                    nullable: false
+        - sql:
+            sql: UPDATE paciente_dieta SET assignment_type = 'DATE_RANGE' WHERE assignment_type IS NULL
+  - changeSet:
+      id: 029-paciente-dieta-nullable-dieta-id
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: paciente_dieta
+            columnName: dieta_id
+      changes:
+        - dropNotNullConstraint:
+            tableName: paciente_dieta
+            columnName: dieta_id
+            columnDataType: BIGINT
+  - changeSet:
+      id: 029-paciente-dieta-weekday-table
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            tableExists:
+              tableName: paciente_dieta_weekday
+      changes:
+        - createTable:
+            tableName: paciente_dieta_weekday
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: paciente_dieta_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: day_of_week
+                  type: SMALLINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: dieta_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: paciente_dieta_weekday
+            baseColumnNames: paciente_dieta_id
+            referencedTableName: paciente_dieta
+            referencedColumnNames: id
+            constraintName: fk_paciente_dieta_weekday_assignment
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            baseTableName: paciente_dieta_weekday
+            baseColumnNames: dieta_id
+            referencedTableName: dieta
+            referencedColumnNames: id
+            constraintName: fk_paciente_dieta_weekday_dieta
+        - addUniqueConstraint:
+            tableName: paciente_dieta_weekday
+            columnNames: paciente_dieta_id, day_of_week
+            constraintName: uk_paciente_dieta_weekday_day
+        - createIndex:
+            tableName: paciente_dieta_weekday
+            indexName: idx_paciente_dieta_weekday_assignment
+            columns:
+              - column:
+                  name: paciente_dieta_id

--- a/src/main/resources/db/changelog/changes/030-resync-diet-assignment-sequences.yaml
+++ b/src/main/resources/db/changelog/changes/030-resync-diet-assignment-sequences.yaml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: 030-resync-diet-assignment-sequences
+      author: nutriconsultas
+      comment: >-
+        Resync diet-copy identity sequences after catalog seed explicit IDs (#525).
+        PostgreSQL uses GREATEST(MAX(id), last_value) so production sequences never regress.
+      changes:
+        - sqlFile:
+            path: classpath:db/changelog/data/resync-diet-assignment-sequences.postgresql.sql
+            dbms: postgresql
+            splitStatements: true
+            stripComments: true
+        - sqlFile:
+            path: classpath:db/changelog/data/resync-diet-assignment-sequences.h2.sql
+            dbms: h2
+            splitStatements: true
+            stripComments: true

--- a/src/main/resources/db/changelog/data/resync-diet-assignment-sequences.h2.sql
+++ b/src/main/resources/db/changelog/data/resync-diet-assignment-sequences.h2.sql
@@ -1,0 +1,8 @@
+-- H2 identity restart floors after catalog seed (matches 020/021 high-water marks).
+ALTER TABLE dieta ALTER COLUMN id RESTART WITH 56;
+ALTER TABLE ingesta ALTER COLUMN id RESTART WITH 221;
+ALTER TABLE platillo_ingesta ALTER COLUMN id RESTART WITH 228;
+ALTER TABLE alimento_ingesta ALTER COLUMN id RESTART WITH 34;
+ALTER TABLE ingrediente_platillo_ingesta ALTER COLUMN id RESTART WITH 22709;
+ALTER TABLE platillo ALTER COLUMN id RESTART WITH 112;
+ALTER TABLE ingrediente ALTER COLUMN id RESTART WITH 549;

--- a/src/main/resources/db/changelog/data/resync-diet-assignment-sequences.postgresql.sql
+++ b/src/main/resources/db/changelog/data/resync-diet-assignment-sequences.postgresql.sql
@@ -1,0 +1,26 @@
+-- Resync identity sequences after catalog seed rows inserted with explicit IDs.
+-- Uses GREATEST(MAX(id), last_value) so brownfield/production sequences never regress.
+SELECT setval(pg_get_serial_sequence('dieta', 'id'),
+    GREATEST(COALESCE((SELECT MAX(id) FROM dieta), 1), COALESCE((SELECT last_value FROM dieta_id_seq), 1)));
+SELECT setval(pg_get_serial_sequence('ingesta', 'id'),
+    GREATEST(COALESCE((SELECT MAX(id) FROM ingesta), 1), COALESCE((SELECT last_value FROM ingesta_id_seq), 1)));
+SELECT setval(pg_get_serial_sequence('platillo_ingesta', 'id'),
+    GREATEST(COALESCE((SELECT MAX(id) FROM platillo_ingesta), 1),
+        COALESCE((SELECT last_value FROM platillo_ingesta_id_seq), 1)));
+SELECT setval(pg_get_serial_sequence('alimento_ingesta', 'id'),
+    GREATEST(COALESCE((SELECT MAX(id) FROM alimento_ingesta), 1),
+        COALESCE((SELECT last_value FROM alimento_ingesta_id_seq), 1)));
+SELECT setval(pg_get_serial_sequence('ingrediente_platillo_ingesta', 'id'),
+    GREATEST(COALESCE((SELECT MAX(id) FROM ingrediente_platillo_ingesta), 1),
+        COALESCE((SELECT last_value FROM ingrediente_platillo_ingesta_id_seq), 1)));
+SELECT setval(pg_get_serial_sequence('platillo', 'id'),
+    GREATEST(COALESCE((SELECT MAX(id) FROM platillo), 1), COALESCE((SELECT last_value FROM platillo_id_seq), 1)));
+SELECT setval(pg_get_serial_sequence('ingrediente', 'id'),
+    GREATEST(COALESCE((SELECT MAX(id) FROM ingrediente), 1),
+        COALESCE((SELECT last_value FROM ingrediente_id_seq), 1)));
+SELECT setval(pg_get_serial_sequence('paciente_dieta', 'id'),
+    GREATEST(COALESCE((SELECT MAX(id) FROM paciente_dieta), 1),
+        COALESCE((SELECT last_value FROM paciente_dieta_id_seq), 1)));
+SELECT setval(pg_get_serial_sequence('paciente_dieta_weekday', 'id'),
+    GREATEST(COALESCE((SELECT MAX(id) FROM paciente_dieta_weekday), 1),
+        COALESCE((SELECT last_value FROM paciente_dieta_weekday_id_seq), 1)));

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -86,3 +86,6 @@ databaseChangeLog:
   - include:
       file: changes/029-paciente-dieta-weekly.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/030-resync-diet-assignment-sequences.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -83,3 +83,6 @@ databaseChangeLog:
   - include:
       file: changes/028-apple-signin-relay-email.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/029-paciente-dieta-weekly.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -74,3 +74,9 @@ databaseChangeLog:
   - include:
       file: changes/028-apple-signin-relay-email.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/029-paciente-dieta-weekly.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: changes/030-resync-diet-assignment-sequences.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/templates/sbadmin/pacientes/asignar-dieta.html
+++ b/src/main/resources/templates/sbadmin/pacientes/asignar-dieta.html
@@ -120,6 +120,21 @@
                           th:action="@{/admin/pacientes/{id}/dietas/asignar(id=${paciente != null ? paciente.id : 0})}" 
                           th:object="${pacienteDieta}" method="POST">
                       <div class="form-group">
+                        <label>Tipo de asignación<span style="color:red;">*</span></label>
+                        <div class="custom-control custom-radio">
+                          <input type="radio" id="assignmentTypeDateRange" name="assignmentType"
+                                 class="custom-control-input" value="DATE_RANGE" checked>
+                          <label class="custom-control-label" for="assignmentTypeDateRange">Rango de fechas (una dieta)</label>
+                        </div>
+                        <div class="custom-control custom-radio">
+                          <input type="radio" id="assignmentTypeWeekly" name="assignmentType"
+                                 class="custom-control-input" value="WEEKLY">
+                          <label class="custom-control-label" for="assignmentTypeWeekly">Plan semanal (lunes a domingo)</label>
+                        </div>
+                      </div>
+
+                      <div id="dateRangeSection">
+                      <div class="form-group">
                         <label>Dieta<span style="color:red;">*</span></label>
                         <input type="hidden" name="dietaId" id="dietaIdInput" value="">
                         <div id="dietaSelectionError" class="alert alert-danger py-2 d-none" role="alert">
@@ -156,6 +171,43 @@
                         </div>
                         <span th:if="${#fields.hasErrors('dieta')}" th:errors="*{dieta}"></span>
                       </div>
+                      </div>
+
+                      <div id="weeklySection" class="d-none">
+                        <div class="d-flex justify-content-between align-items-center mb-2">
+                          <label class="mb-0">Menú por día de la semana</label>
+                          <button type="button" class="btn btn-sm btn-outline-primary" id="repeatMondayBtn">
+                            Repetir lunes en todos los días
+                          </button>
+                        </div>
+                        <div id="weeklySelectionError" class="alert alert-danger py-2 d-none" role="alert">
+                          Seleccione al menos un día con dieta.
+                        </div>
+                        <div class="list-group mb-3" id="weeklyDayRows">
+                          <div class="list-group-item weekly-day-row" th:each="dayNum : ${#numbers.sequence(1, 7)}"
+                               th:attr="data-day=${dayNum}">
+                            <div class="d-flex justify-content-between align-items-center">
+                              <div>
+                                <strong th:text="${weekdayLabels != null ? weekdayLabels[dayNum] : dayNum}">Lunes</strong>
+                                <div class="small text-muted weekly-selected-label">Sin dieta</div>
+                              </div>
+                              <div>
+                                <input type="hidden" th:name="${'weekdayDietaId_' + dayNum}" value=""
+                                       class="weekday-dieta-input">
+                                <button type="button" class="btn btn-sm btn-outline-secondary weekly-pick-btn"
+                                        th:attr="data-day=${dayNum}">
+                                  Seleccionar dieta
+                                </button>
+                                <button type="button" class="btn btn-sm btn-link text-danger weekly-clear-btn d-none"
+                                        th:attr="data-day=${dayNum}">
+                                  Quitar
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+
                       <div class="form-group">
                         <label>Fecha de Inicio<span style="color:red;">*</span></label>
                         <input type="date" th:field="*{startDate}" class="form-control" required>
@@ -241,6 +293,12 @@
         let searchTerm = '';
         let searchDebounceTimer = null;
         let selectedDietaId = null;
+        let activeWeeklyDay = null;
+
+        const assignmentTypeDateRange = document.getElementById('assignmentTypeDateRange');
+        const assignmentTypeWeekly = document.getElementById('assignmentTypeWeekly');
+        const dateRangeSection = document.getElementById('dateRangeSection');
+        const weeklySection = document.getElementById('weeklySection');
 
         function formatKcal(value) {
           if (value === null || value === undefined || isNaN(value)) {
@@ -404,6 +462,15 @@
         }
 
         function selectDieta(item, dieta) {
+          if (assignmentTypeWeeklyEl && assignmentTypeWeeklyEl.checked && activeWeeklyDay) {
+            setWeeklyDaySelection(activeWeeklyDay, dieta);
+            const weeklyError = document.getElementById('weeklySelectionError');
+            if (weeklyError) {
+              weeklyError.classList.add('d-none');
+            }
+            activeWeeklyDay = null;
+            return;
+          }
           pickerList.querySelectorAll('.dieta-picker-item').forEach(function(el) {
             el.classList.remove('selected');
           });
@@ -418,6 +485,27 @@
             selectedLabel.textContent = (dieta.nombre || '') + ' — ' + formatKcal(dieta.energiaKcal)
               + ' kcal (' + fitInfo.label + ')';
             selectedSummary.classList.remove('d-none');
+          }
+        }
+
+        function setWeeklyDaySelection(day, dieta) {
+          const row = document.querySelector('.weekly-day-row[data-day="' + day + '"]');
+          if (!row) {
+            return;
+          }
+          const input = row.querySelector('.weekday-dieta-input');
+          const label = row.querySelector('.weekly-selected-label');
+          const clearBtn = row.querySelector('.weekly-clear-btn');
+          if (input) {
+            input.value = dieta ? String(dieta.id) : '';
+          }
+          if (label) {
+            label.textContent = dieta
+              ? (dieta.nombre || '') + ' — ' + formatKcal(dieta.energiaKcal) + ' kcal'
+              : 'Sin dieta';
+          }
+          if (clearBtn) {
+            clearBtn.classList.toggle('d-none', !dieta);
           }
         }
 
@@ -446,6 +534,19 @@
 
         if (form) {
           form.addEventListener('submit', function(e) {
+            const isWeekly = document.getElementById('assignmentTypeWeekly').checked;
+            if (isWeekly) {
+              const hasDay = Array.from(document.querySelectorAll('.weekday-dieta-input'))
+                .some(function(input) { return input.value; });
+              if (!hasDay) {
+                e.preventDefault();
+                const weeklyError = document.getElementById('weeklySelectionError');
+                if (weeklyError) {
+                  weeklyError.classList.remove('d-none');
+                }
+              }
+              return;
+            }
             if (!dietaIdInput.value) {
               e.preventDefault();
               if (selectionError) {
@@ -453,6 +554,76 @@
               }
               if (searchInput) {
                 searchInput.focus();
+              }
+            }
+          });
+        }
+
+        const assignmentTypeDateRangeEl = assignmentTypeDateRange;
+        const assignmentTypeWeeklyEl = assignmentTypeWeekly;
+
+        function toggleAssignmentSections() {
+          const isWeekly = assignmentTypeWeeklyEl && assignmentTypeWeeklyEl.checked;
+          if (dateRangeSection) {
+            dateRangeSection.classList.toggle('d-none', isWeekly);
+          }
+          if (weeklySection) {
+            weeklySection.classList.toggle('d-none', !isWeekly);
+          }
+        }
+
+        if (assignmentTypeDateRangeEl) {
+          assignmentTypeDateRangeEl.addEventListener('change', toggleAssignmentSections);
+        }
+        if (assignmentTypeWeeklyEl) {
+          assignmentTypeWeeklyEl.addEventListener('change', toggleAssignmentSections);
+        }
+
+        document.querySelectorAll('.weekly-pick-btn').forEach(function(btn) {
+          btn.addEventListener('click', function() {
+            activeWeeklyDay = btn.getAttribute('data-day');
+            if (searchInput) {
+              searchInput.focus();
+            }
+            pickerList.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+          });
+        });
+
+        document.querySelectorAll('.weekly-clear-btn').forEach(function(btn) {
+          btn.addEventListener('click', function() {
+            setWeeklyDaySelection(btn.getAttribute('data-day'), null);
+          });
+        });
+
+        const repeatMondayBtn = document.getElementById('repeatMondayBtn');
+        if (repeatMondayBtn) {
+          repeatMondayBtn.addEventListener('click', function() {
+            const mondayRow = document.querySelector('.weekly-day-row[data-day="1"]');
+            if (!mondayRow) {
+              return;
+            }
+            const mondayInput = mondayRow.querySelector('.weekday-dieta-input');
+            const mondayLabel = mondayRow.querySelector('.weekly-selected-label');
+            if (!mondayInput || !mondayInput.value) {
+              return;
+            }
+            const labelText = mondayLabel ? mondayLabel.textContent : '';
+            for (let day = 2; day <= 7; day++) {
+              const row = document.querySelector('.weekly-day-row[data-day="' + day + '"]');
+              if (!row) {
+                continue;
+              }
+              const input = row.querySelector('.weekday-dieta-input');
+              const label = row.querySelector('.weekly-selected-label');
+              const clearBtn = row.querySelector('.weekly-clear-btn');
+              if (input) {
+                input.value = mondayInput.value;
+              }
+              if (label) {
+                label.textContent = labelText;
+              }
+              if (clearBtn) {
+                clearBtn.classList.remove('d-none');
               }
             }
           });

--- a/src/main/resources/templates/sbadmin/pacientes/asignar-dieta.html
+++ b/src/main/resources/templates/sbadmin/pacientes/asignar-dieta.html
@@ -73,6 +73,11 @@
     .dieta-picker-status {
       font-size: 0.875rem;
     }
+
+    .weekly-day-row.active-picking {
+      border-left: 4px solid #4e73df;
+      background-color: #f8f9fc;
+    }
   </style>
 
 </head>
@@ -133,17 +138,69 @@
                         </div>
                       </div>
 
+                      <input type="hidden" name="dietaId" id="dietaIdInput" value="">
+
                       <div id="dateRangeSection">
-                      <div class="form-group">
-                        <label>Dieta<span style="color:red;">*</span></label>
-                        <input type="hidden" name="dietaId" id="dietaIdInput" value="">
-                        <div id="dietaSelectionError" class="alert alert-danger py-2 d-none" role="alert">
-                          Seleccione una dieta de la lista.
+                        <div class="form-group">
+                          <label>Dieta<span style="color:red;">*</span></label>
+                          <div id="dietaSelectionError" class="alert alert-danger py-2 d-none" role="alert">
+                            Seleccione una dieta de la lista.
+                          </div>
+                          <div id="dietaSelectedSummary" class="alert alert-primary py-2 d-none mb-2" role="status">
+                            <i class="fas fa-check-circle"></i>
+                            <strong>Seleccionada:</strong> <span id="dietaSelectedLabel">-</span>
+                          </div>
+                          <span th:if="${#fields.hasErrors('dieta')}" th:errors="*{dieta}"></span>
                         </div>
-                        <div id="dietaSelectedSummary" class="alert alert-primary py-2 d-none mb-2" role="status">
-                          <i class="fas fa-check-circle"></i>
-                          <strong>Seleccionada:</strong> <span id="dietaSelectedLabel">-</span>
+                      </div>
+
+                      <div id="weeklySection" class="d-none">
+                        <div class="d-flex justify-content-between align-items-center mb-2">
+                          <label class="mb-0">Menú por día de la semana<span style="color:red;">*</span></label>
+                          <button type="button" class="btn btn-sm btn-outline-primary" id="repeatMondayBtn">
+                            Repetir lunes en todos los días
+                          </button>
                         </div>
+                        <div id="weeklyPickerHint" class="alert alert-light border py-2 mb-3" role="status">
+                          <i class="fas fa-hand-pointer"></i>
+                          <strong>Paso 1:</strong> pulse <em>Seleccionar dieta</em> en el día deseado.
+                          <strong>Paso 2:</strong> elija una dieta del catálogo en la lista de abajo.
+                          No se requiere calcular GET/TEF para asignar un plan semanal.
+                        </div>
+                        <div id="weeklyActiveDayHint" class="alert alert-primary py-2 mb-3 d-none" role="status">
+                          <i class="fas fa-arrow-down"></i>
+                          Elija una dieta de la lista para <strong id="weeklyActiveDayLabel">-</strong>.
+                        </div>
+                        <div id="weeklySelectionError" class="alert alert-danger py-2 d-none" role="alert">
+                          Seleccione al menos un día con dieta.
+                        </div>
+                        <div class="list-group mb-3" id="weeklyDayRows">
+                          <div class="list-group-item weekly-day-row" th:each="dayNum : ${#numbers.sequence(1, 7)}"
+                               th:attr="data-day=${dayNum}">
+                            <div class="d-flex justify-content-between align-items-center">
+                              <div>
+                                <strong th:text="${weekdayLabels != null ? weekdayLabels.get(dayNum) : dayNum}">Lunes</strong>
+                                <div class="small text-muted weekly-selected-label">Sin dieta</div>
+                              </div>
+                              <div>
+                                <input type="hidden" th:name="${'weekdayDietaId_' + dayNum}" value=""
+                                       class="weekday-dieta-input">
+                                <button type="button" class="btn btn-sm btn-outline-secondary weekly-pick-btn"
+                                        th:attr="data-day=${dayNum}">
+                                  Seleccionar dieta
+                                </button>
+                                <button type="button" class="btn btn-sm btn-link text-danger weekly-clear-btn d-none"
+                                        th:attr="data-day=${dayNum}">
+                                  Quitar
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div id="dietaPickerSection" class="form-group">
+                        <label id="dietaPickerSectionLabel">Catálogo de dietas</label>
                         <div class="input-group mb-2">
                           <div class="input-group-prepend">
                             <span class="input-group-text"><i class="fas fa-search"></i></span>
@@ -168,43 +225,6 @@
                         </div>
                         <div id="dietaSearchNoResults" class="alert alert-secondary mt-2 mb-0 d-none">
                           No hay dietas que coincidan con la búsqueda.
-                        </div>
-                        <span th:if="${#fields.hasErrors('dieta')}" th:errors="*{dieta}"></span>
-                      </div>
-                      </div>
-
-                      <div id="weeklySection" class="d-none">
-                        <div class="d-flex justify-content-between align-items-center mb-2">
-                          <label class="mb-0">Menú por día de la semana</label>
-                          <button type="button" class="btn btn-sm btn-outline-primary" id="repeatMondayBtn">
-                            Repetir lunes en todos los días
-                          </button>
-                        </div>
-                        <div id="weeklySelectionError" class="alert alert-danger py-2 d-none" role="alert">
-                          Seleccione al menos un día con dieta.
-                        </div>
-                        <div class="list-group mb-3" id="weeklyDayRows">
-                          <div class="list-group-item weekly-day-row" th:each="dayNum : ${#numbers.sequence(1, 7)}"
-                               th:attr="data-day=${dayNum}">
-                            <div class="d-flex justify-content-between align-items-center">
-                              <div>
-                                <strong th:text="${weekdayLabels != null ? weekdayLabels[dayNum] : dayNum}">Lunes</strong>
-                                <div class="small text-muted weekly-selected-label">Sin dieta</div>
-                              </div>
-                              <div>
-                                <input type="hidden" th:name="${'weekdayDietaId_' + dayNum}" value=""
-                                       class="weekday-dieta-input">
-                                <button type="button" class="btn btn-sm btn-outline-secondary weekly-pick-btn"
-                                        th:attr="data-day=${dayNum}">
-                                  Seleccionar dieta
-                                </button>
-                                <button type="button" class="btn btn-sm btn-link text-danger weekly-clear-btn d-none"
-                                        th:attr="data-day=${dayNum}">
-                                  Quitar
-                                </button>
-                              </div>
-                            </div>
-                          </div>
                         </div>
                       </div>
 
@@ -270,6 +290,7 @@
     <script th:inline="javascript">
       document.addEventListener('DOMContentLoaded', function() {
         const requerimientoKcal = /*[[${requerimientoKcal}]]*/ null;
+        const weekdayLabels = /*[[${weekdayLabels}]]*/ {};
         const pickerPageSize = 20;
         const dietaIdInput = document.getElementById('dietaIdInput');
         const searchInput = document.getElementById('dietaSearchInput');
@@ -282,6 +303,14 @@
         const selectionError = document.getElementById('dietaSelectionError');
         const noResults = document.getElementById('dietaSearchNoResults');
         const form = document.getElementById('asignarDietaForm');
+        const assignmentTypeDateRangeEl = document.getElementById('assignmentTypeDateRange');
+        const assignmentTypeWeeklyEl = document.getElementById('assignmentTypeWeekly');
+        const dateRangeSection = document.getElementById('dateRangeSection');
+        const weeklySection = document.getElementById('weeklySection');
+        const weeklyPickerHint = document.getElementById('weeklyPickerHint');
+        const weeklyActiveDayHint = document.getElementById('weeklyActiveDayHint');
+        const weeklyActiveDayLabel = document.getElementById('weeklyActiveDayLabel');
+        const dietaPickerSectionLabel = document.getElementById('dietaPickerSectionLabel');
 
         if (!pickerList) {
           return;
@@ -294,11 +323,6 @@
         let searchDebounceTimer = null;
         let selectedDietaId = null;
         let activeWeeklyDay = null;
-
-        const assignmentTypeDateRange = document.getElementById('assignmentTypeDateRange');
-        const assignmentTypeWeekly = document.getElementById('assignmentTypeWeekly');
-        const dateRangeSection = document.getElementById('dateRangeSection');
-        const weeklySection = document.getElementById('weeklySection');
 
         function formatKcal(value) {
           if (value === null || value === undefined || isNaN(value)) {
@@ -461,14 +485,73 @@
           loadPickerPage(0, false);
         }
 
+        function weekdayLabelFor(day) {
+          if (weekdayLabels && weekdayLabels[day]) {
+            return weekdayLabels[day];
+          }
+          return 'Día ' + day;
+        }
+
+        function clearActiveWeeklyDayUi() {
+          document.querySelectorAll('.weekly-day-row').forEach(function(row) {
+            row.classList.remove('active-picking');
+          });
+          document.querySelectorAll('.weekly-pick-btn').forEach(function(btn) {
+            btn.classList.remove('btn-primary');
+            btn.classList.add('btn-outline-secondary');
+            btn.textContent = 'Seleccionar dieta';
+          });
+          if (weeklyPickerHint) {
+            weeklyPickerHint.classList.remove('d-none');
+          }
+          if (weeklyActiveDayHint) {
+            weeklyActiveDayHint.classList.add('d-none');
+          }
+        }
+
+        function setActiveWeeklyDay(day) {
+          activeWeeklyDay = day;
+          clearActiveWeeklyDayUi();
+          const row = document.querySelector('.weekly-day-row[data-day="' + day + '"]');
+          const pickBtn = row ? row.querySelector('.weekly-pick-btn') : null;
+          if (row) {
+            row.classList.add('active-picking');
+          }
+          if (pickBtn) {
+            pickBtn.classList.remove('btn-outline-secondary');
+            pickBtn.classList.add('btn-primary');
+            pickBtn.textContent = 'Seleccionando…';
+          }
+          if (weeklyPickerHint) {
+            weeklyPickerHint.classList.add('d-none');
+          }
+          if (weeklyActiveDayHint && weeklyActiveDayLabel) {
+            weeklyActiveDayLabel.textContent = weekdayLabelFor(day);
+            weeklyActiveDayHint.classList.remove('d-none');
+          }
+        }
+
         function selectDieta(item, dieta) {
-          if (assignmentTypeWeeklyEl && assignmentTypeWeeklyEl.checked && activeWeeklyDay) {
+          if (assignmentTypeWeeklyEl && assignmentTypeWeeklyEl.checked) {
+            if (!activeWeeklyDay) {
+              const weeklyError = document.getElementById('weeklySelectionError');
+              if (weeklyError) {
+                weeklyError.textContent = 'Primero pulse «Seleccionar dieta» en el día que desea configurar.';
+                weeklyError.classList.remove('d-none');
+              }
+              if (weeklySection) {
+                weeklySection.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+              }
+              return;
+            }
             setWeeklyDaySelection(activeWeeklyDay, dieta);
             const weeklyError = document.getElementById('weeklySelectionError');
             if (weeklyError) {
               weeklyError.classList.add('d-none');
+              weeklyError.textContent = 'Seleccione al menos un día con dieta.';
             }
             activeWeeklyDay = null;
+            clearActiveWeeklyDayUi();
             return;
           }
           pickerList.querySelectorAll('.dieta-picker-item').forEach(function(el) {
@@ -559,9 +642,6 @@
           });
         }
 
-        const assignmentTypeDateRangeEl = assignmentTypeDateRange;
-        const assignmentTypeWeeklyEl = assignmentTypeWeekly;
-
         function toggleAssignmentSections() {
           const isWeekly = assignmentTypeWeeklyEl && assignmentTypeWeeklyEl.checked;
           if (dateRangeSection) {
@@ -569,6 +649,15 @@
           }
           if (weeklySection) {
             weeklySection.classList.toggle('d-none', !isWeekly);
+          }
+          if (dietaPickerSectionLabel) {
+            dietaPickerSectionLabel.textContent = isWeekly
+              ? 'Catálogo de dietas (elija para el día activo)'
+              : 'Catálogo de dietas';
+          }
+          if (!isWeekly) {
+            activeWeeklyDay = null;
+            clearActiveWeeklyDayUi();
           }
         }
 
@@ -581,11 +670,14 @@
 
         document.querySelectorAll('.weekly-pick-btn').forEach(function(btn) {
           btn.addEventListener('click', function() {
-            activeWeeklyDay = btn.getAttribute('data-day');
+            setActiveWeeklyDay(btn.getAttribute('data-day'));
             if (searchInput) {
               searchInput.focus();
             }
-            pickerList.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            const pickerSection = document.getElementById('dietaPickerSection');
+            if (pickerSection) {
+              pickerSection.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            }
           });
         });
 
@@ -630,6 +722,7 @@
         }
 
         resetAndLoad();
+        toggleAssignmentSections();
       });
     </script>
 

--- a/src/main/resources/templates/sbadmin/pacientes/dietas.html
+++ b/src/main/resources/templates/sbadmin/pacientes/dietas.html
@@ -84,7 +84,7 @@
                                 <ul class="small mb-0 pl-3"
                                     th:if="${weekdaySlotsByAssignmentId != null && weekdaySlotsByAssignmentId[dietaAsignada.id] != null}">
                                   <li th:each="slot : ${weekdaySlotsByAssignmentId[dietaAsignada.id]}"
-                                      th:text="${(weekdayLabels != null ? weekdayLabels[slot.dayOfWeek] : slot.dayOfWeek) + ': ' + (slot.dieta != null ? slot.dieta.nombre : '-')}"></li>
+                                      th:text="${(weekdayLabels != null ? weekdayLabels.get(slot.dayOfWeek) : slot.dayOfWeek) + ': ' + (slot.dieta != null ? slot.dieta.nombre : '-')}"></li>
                                 </ul>
                               </div>
                               <a th:unless="${dietaAsignada.weeklyAssignment}"

--- a/src/main/resources/templates/sbadmin/pacientes/dietas.html
+++ b/src/main/resources/templates/sbadmin/pacientes/dietas.html
@@ -79,19 +79,33 @@
                         <tbody>
                           <tr th:each="dietaAsignada : ${dietasActivas}">
                             <td>
-                              <a th:href="@{/admin/dietas/{id}(id=${dietaAsignada.dieta.id})}" 
+                              <div th:if="${dietaAsignada.weeklyAssignment}">
+                                <span class="badge badge-primary mb-1">Plan semanal</span>
+                                <ul class="small mb-0 pl-3"
+                                    th:if="${weekdaySlotsByAssignmentId != null && weekdaySlotsByAssignmentId[dietaAsignada.id] != null}">
+                                  <li th:each="slot : ${weekdaySlotsByAssignmentId[dietaAsignada.id]}"
+                                      th:text="${(weekdayLabels != null ? weekdayLabels[slot.dayOfWeek] : slot.dayOfWeek) + ': ' + (slot.dieta != null ? slot.dieta.nombre : '-')}"></li>
+                                </ul>
+                              </div>
+                              <a th:unless="${dietaAsignada.weeklyAssignment}"
+                                 th:if="${dietaAsignada.dieta != null}"
+                                 th:href="@{/admin/dietas/{id}(id=${dietaAsignada.dieta.id})}"
                                  th:text="${dietaAsignada.dieta.nombre}"
                                  title="Ver detalles de la dieta"></a>
                             </td>
                             <td>
-                              <small>
+                              <small th:if="${!dietaAsignada.weeklyAssignment && dietaAsignada.dieta != null}">
                                 <strong>P:</strong> <span th:text="${#numbers.formatDecimal(dietaAsignada.dieta.proteina, 1, 1)} + 'g'">0.0g</span>
                                 <strong>L:</strong> <span th:text="${#numbers.formatDecimal(dietaAsignada.dieta.lipidos, 1, 1)} + 'g'">0.0g</span>
                                 <strong>H:</strong> <span th:text="${#numbers.formatDecimal(dietaAsignada.dieta.hidratosDeCarbono, 1, 1)} + 'g'">0.0g</span>
                               </small>
+                              <span th:if="${dietaAsignada.weeklyAssignment}" class="text-muted">Varía por día</span>
                             </td>
                             <td>
-                              <span th:text="${dietaAsignada.dieta.energia != null ? dietaAsignada.dieta.energia : 0}">0</span> kcal
+                              <span th:if="${!dietaAsignada.weeklyAssignment && dietaAsignada.dieta != null}"
+                                    th:text="${dietaAsignada.dieta.energia != null ? dietaAsignada.dieta.energia : 0}">0</span>
+                              <span th:if="${dietaAsignada.weeklyAssignment}" class="text-muted">—</span>
+                              <span th:if="${!dietaAsignada.weeklyAssignment}"> kcal</span>
                             </td>
                             <td>[[(${#dates.format(dietaAsignada.startDate, 'dd/MM/yyyy')})]]</td>
                             <td>
@@ -108,11 +122,17 @@
                               <span th:if="${dietaAsignada.notes == null || dietaAsignada.notes.isEmpty()}" class="text-muted">-</span>
                             </td>
                             <td>
-                              <a th:href="@{/admin/pacientes/{pacienteId}/dietas/{dietaId}/print(pacienteId=${paciente.id}, dietaId=${dietaAsignada.dieta.id})}" 
-                                 class="btn btn-sm btn-primary" 
+                              <a th:if="${!dietaAsignada.weeklyAssignment && dietaAsignada.dieta != null}"
+                                 th:href="@{/admin/pacientes/{pacienteId}/dietas/{dietaId}/print(pacienteId=${paciente.id}, dietaId=${dietaAsignada.dieta.id})}"
+                                 class="btn btn-sm btn-primary"
                                  target="_blank"
                                  title="Imprimir PDF">
                                 <i class="fas fa-file-pdf"></i> PDF
+                              </a>
+                              <a th:href="@{/admin/pacientes/{pacienteId}/dietas/{id}/lista-compras(pacienteId=${paciente.id}, id=${dietaAsignada.id})}"
+                                 class="btn btn-sm btn-secondary"
+                                 title="Lista de compras">
+                                <i class="fas fa-shopping-basket"></i> Compras
                               </a>
                               <a th:href="@{/admin/pacientes/{pacienteId}/dietas/{id}/editar(pacienteId=${paciente.id}, id=${dietaAsignada.id})}" 
                                  class="btn btn-sm btn-info">
@@ -152,19 +172,27 @@
                           <tr th:each="dietaAsignada : ${dietasAsignadas}" 
                               th:classappend="${dietaAsignada.status.name() == 'ACTIVE'} ? 'table-success' : (${dietaAsignada.status.name() == 'COMPLETED'} ? 'table-info' : 'table-secondary')">
                             <td>
-                              <a th:href="@{/admin/dietas/{id}(id=${dietaAsignada.dieta.id})}" 
+                              <div th:if="${dietaAsignada.weeklyAssignment}">
+                                <span class="badge badge-primary">Plan semanal</span>
+                              </div>
+                              <a th:unless="${dietaAsignada.weeklyAssignment}"
+                                 th:if="${dietaAsignada.dieta != null}"
+                                 th:href="@{/admin/dietas/{id}(id=${dietaAsignada.dieta.id})}"
                                  th:text="${dietaAsignada.dieta.nombre}"
                                  title="Ver detalles de la dieta"></a>
                             </td>
                             <td>
-                              <small>
+                              <small th:if="${!dietaAsignada.weeklyAssignment && dietaAsignada.dieta != null}">
                                 <strong>P:</strong> <span th:text="${#numbers.formatDecimal(dietaAsignada.dieta.proteina, 1, 1)} + 'g'">0.0g</span>
                                 <strong>L:</strong> <span th:text="${#numbers.formatDecimal(dietaAsignada.dieta.lipidos, 1, 1)} + 'g'">0.0g</span>
                                 <strong>H:</strong> <span th:text="${#numbers.formatDecimal(dietaAsignada.dieta.hidratosDeCarbono, 1, 1)} + 'g'">0.0g</span>
                               </small>
+                              <span th:if="${dietaAsignada.weeklyAssignment}" class="text-muted">—</span>
                             </td>
                             <td>
-                              <span th:text="${dietaAsignada.dieta.energia != null ? dietaAsignada.dieta.energia : 0}">0</span> kcal
+                              <span th:if="${!dietaAsignada.weeklyAssignment && dietaAsignada.dieta != null}"
+                                    th:text="${dietaAsignada.dieta.energia != null ? dietaAsignada.dieta.energia : 0} + ' kcal'">0 kcal</span>
+                              <span th:if="${dietaAsignada.weeklyAssignment}" class="text-muted">—</span>
                             </td>
                             <td>[[(${#dates.format(dietaAsignada.startDate, 'dd/MM/yyyy')})]]</td>
                             <td>

--- a/src/main/resources/templates/sbadmin/pacientes/dietas.html
+++ b/src/main/resources/templates/sbadmin/pacientes/dietas.html
@@ -83,8 +83,14 @@
                                 <span class="badge badge-primary mb-1">Plan semanal</span>
                                 <ul class="small mb-0 pl-3"
                                     th:if="${weekdaySlotsByAssignmentId != null && weekdaySlotsByAssignmentId[dietaAsignada.id] != null}">
-                                  <li th:each="slot : ${weekdaySlotsByAssignmentId[dietaAsignada.id]}"
-                                      th:text="${(weekdayLabels != null ? weekdayLabels.get(slot.dayOfWeek) : slot.dayOfWeek) + ': ' + (slot.dieta != null ? slot.dieta.nombre : '-')}"></li>
+                                  <li th:each="slot : ${weekdaySlotsByAssignmentId[dietaAsignada.id]}">
+                                    <span th:text="${(weekdayLabels != null ? weekdayLabels.get(slot.dayOfWeek) : slot.dayOfWeek) + ': '}">Lunes: </span>
+                                    <a th:if="${slot.dieta != null}"
+                                       th:href="@{/admin/dietas/{id}(id=${slot.dieta.id})}"
+                                       th:text="${slot.dieta.nombre}"
+                                       title="Modificar dieta del paciente"></a>
+                                    <span th:unless="${slot.dieta != null}" class="text-muted">-</span>
+                                  </li>
                                 </ul>
                               </div>
                               <a th:unless="${dietaAsignada.weeklyAssignment}"
@@ -173,7 +179,18 @@
                               th:classappend="${dietaAsignada.status.name() == 'ACTIVE'} ? 'table-success' : (${dietaAsignada.status.name() == 'COMPLETED'} ? 'table-info' : 'table-secondary')">
                             <td>
                               <div th:if="${dietaAsignada.weeklyAssignment}">
-                                <span class="badge badge-primary">Plan semanal</span>
+                                <span class="badge badge-primary mb-1">Plan semanal</span>
+                                <ul class="small mb-0 pl-3"
+                                    th:if="${weekdaySlotsByAssignmentId != null && weekdaySlotsByAssignmentId[dietaAsignada.id] != null}">
+                                  <li th:each="slot : ${weekdaySlotsByAssignmentId[dietaAsignada.id]}">
+                                    <span th:text="${(weekdayLabels != null ? weekdayLabels.get(slot.dayOfWeek) : slot.dayOfWeek) + ': '}">Lunes: </span>
+                                    <a th:if="${slot.dieta != null}"
+                                       th:href="@{/admin/dietas/{id}(id=${slot.dieta.id})}"
+                                       th:text="${slot.dieta.nombre}"
+                                       title="Modificar dieta del paciente"></a>
+                                    <span th:unless="${slot.dieta != null}" class="text-muted">-</span>
+                                  </li>
+                                </ul>
                               </div>
                               <a th:unless="${dietaAsignada.weeklyAssignment}"
                                  th:if="${dietaAsignada.dieta != null}"

--- a/src/main/resources/templates/sbadmin/pacientes/editar-dieta.html
+++ b/src/main/resources/templates/sbadmin/pacientes/editar-dieta.html
@@ -54,14 +54,16 @@
                                th:attr="data-day=${dayNum}">
                             <div class="d-flex justify-content-between align-items-center">
                               <div>
-                                <strong th:text="${weekdayLabels != null ? weekdayLabels[dayNum] : dayNum}">Lunes</strong>
+                                <strong th:text="${weekdayLabels != null ? weekdayLabels.get(dayNum) : dayNum}">Lunes</strong>
                                 <div class="small text-muted weekly-selected-label"
-                                     th:with="slot=${weekdaySlots != null ? weekdaySlots.?[dayOfWeek == dayNum][0] : null}"
+                                     th:with="slot=${weekdaySlotsByDay != null ? weekdaySlotsByDay.get(dayNum) : null}"
                                      th:text="${slot != null && slot.dieta != null ? slot.dieta.nombre : 'Sin dieta'}">Sin dieta</div>
                               </div>
                               <div>
                                 <input type="hidden" th:name="${'weekdayDietaId_' + dayNum}"
-                                       class="weekday-dieta-input" value="">
+                                       class="weekday-dieta-input"
+                                       th:with="slot=${weekdaySlotsByDay != null ? weekdaySlotsByDay.get(dayNum) : null}"
+                                       th:value="${slot != null && slot.dieta != null ? slot.dieta.id : ''}">
                                 <button type="button" class="btn btn-sm btn-outline-secondary weekly-pick-btn"
                                         th:attr="data-day=${dayNum}">Cambiar</button>
                               </div>
@@ -73,7 +75,7 @@
                           <select class="form-control" id="activeWeeklyDaySelect">
                             <option th:each="dayNum : ${#numbers.sequence(1, 7)}"
                                     th:value="${dayNum}"
-                                    th:text="${weekdayLabels != null ? weekdayLabels[dayNum] : dayNum}">Lunes</option>
+                                    th:text="${weekdayLabels != null ? weekdayLabels.get(dayNum) : dayNum}">Lunes</option>
                           </select>
                         </div>
                         <div id="dietaPickerList" class="list-group dieta-picker-list mb-2"></div>

--- a/src/main/resources/templates/sbadmin/pacientes/editar-dieta.html
+++ b/src/main/resources/templates/sbadmin/pacientes/editar-dieta.html
@@ -2,72 +2,91 @@
 <html lang="en">
 
 <head>
-
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta name="description" content="">
-  <meta name="author" content="">
-  <!-- Favicons -->
   <link th:href="@{/eterna/assets/img/favicon.png}" rel="icon">
-  <link th:href="@{/eterna/assets/img/apple-touch-icon.png}" rel="apple-touch-icon">
-
   <title>Minutriporcion - Editar Asignación de Dieta</title>
-
-  <!-- Custom fonts for this template-->
   <link th:href="@{/sbadmin/vendor/fontawesome-free/css/all.min.css}" rel="stylesheet" type="text/css">
-  <link
-    href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
-    rel="stylesheet">
-
-  <!-- Custom styles for this template-->
+  <link href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i" rel="stylesheet">
   <link th:href="@{/sbadmin/css/sb-admin-2.min.css}" rel="stylesheet">
-
+  <style>
+    .dieta-picker-list { max-height: 280px; overflow-y: auto; border: 1px solid #e3e6f0; border-radius: 0.35rem; }
+    .dieta-picker-item { cursor: pointer; }
+    .dieta-picker-item.selected { background-color: #eaecf4; }
+  </style>
 </head>
 
 <body id="page-top">
-
-  <!-- Page Wrapper -->
   <div id="wrapper">
     <div th:insert="~{sbadmin/pacientes/sidebar :: sidebar}"></div>
-    <!-- Content Wrapper -->
     <div id="content-wrapper" class="d-flex flex-column">
-
-      <!-- Main Content -->
       <div id="content">
         <div th:insert="~{sbadmin/topbar :: topbar}"></div>
-        <!-- Begin Page Content -->
         <div class="container-fluid">
-
-          <!-- Page Heading -->
           <div class="d-sm-flex align-items-center justify-content-between mb-4">
             <h1 class="h3 mb-0 text-gray-800">Editar Asignación de Dieta - [[${paciente != null ? paciente.name : ''}]]</h1>
           </div>
-
-          <!-- Content Row -->
           <div class="row">
-            <!-- EDIT DIETA ASSIGNMENT FORM -->
             <div class="col-12">
               <div class="card shadow mb-4">
                 <div class="col-sm-10 offset-sm-1">
-
                   <div class="info-form p-5">
                     <div class="alert alert-info">
-                      <strong>Dieta:</strong> [[${pacienteDieta != null && pacienteDieta.dieta != null ? pacienteDieta.dieta.nombre : 'N/A'}]]<br>
+                      <span th:if="${pacienteDieta != null && pacienteDieta.weeklyAssignment}">
+                        <strong>Plan semanal</strong>
+                      </span>
+                      <span th:unless="${pacienteDieta != null && pacienteDieta.weeklyAssignment}">
+                        <strong>Dieta:</strong> [[${pacienteDieta != null && pacienteDieta.dieta != null ? pacienteDieta.dieta.nombre : 'N/A'}]]
+                      </span>
+                      <br>
                       <strong>Paciente:</strong> [[${paciente != null ? paciente.name : 'N/A'}]]
                     </div>
-                    <form th:action="@{/admin/pacientes/{pacienteId}/dietas/{id}/editar(pacienteId=${paciente != null ? paciente.id : 0}, id=${pacienteDieta != null ? pacienteDieta.id : 0})}" 
-                          th:object="${pacienteDieta}" method="POST">
+                    <form th:action="@{/admin/pacientes/{pacienteId}/dietas/{id}/editar(pacienteId=${paciente != null ? paciente.id : 0}, id=${pacienteDieta != null ? pacienteDieta.id : 0})}"
+                          th:object="${pacienteDieta}" method="POST" id="editarDietaForm">
                       <input type="hidden" th:field="*{id}" />
+
+                      <div th:if="${pacienteDieta != null && pacienteDieta.weeklyAssignment}" class="mb-4">
+                        <label class="d-block">Menú por día</label>
+                        <p class="small text-muted">Seleccione una dieta del catálogo para cada día. Use la lista inferior y pulse «Aplicar al día activo».</p>
+                        <div class="list-group mb-2">
+                          <div class="list-group-item weekly-day-row" th:each="dayNum : ${#numbers.sequence(1, 7)}"
+                               th:attr="data-day=${dayNum}">
+                            <div class="d-flex justify-content-between align-items-center">
+                              <div>
+                                <strong th:text="${weekdayLabels != null ? weekdayLabels[dayNum] : dayNum}">Lunes</strong>
+                                <div class="small text-muted weekly-selected-label"
+                                     th:with="slot=${weekdaySlots != null ? weekdaySlots.?[dayOfWeek == dayNum][0] : null}"
+                                     th:text="${slot != null && slot.dieta != null ? slot.dieta.nombre : 'Sin dieta'}">Sin dieta</div>
+                              </div>
+                              <div>
+                                <input type="hidden" th:name="${'weekdayDietaId_' + dayNum}"
+                                       class="weekday-dieta-input" value="">
+                                <button type="button" class="btn btn-sm btn-outline-secondary weekly-pick-btn"
+                                        th:attr="data-day=${dayNum}">Cambiar</button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="form-group">
+                          <label>Día activo para selección</label>
+                          <select class="form-control" id="activeWeeklyDaySelect">
+                            <option th:each="dayNum : ${#numbers.sequence(1, 7)}"
+                                    th:value="${dayNum}"
+                                    th:text="${weekdayLabels != null ? weekdayLabels[dayNum] : dayNum}">Lunes</option>
+                          </select>
+                        </div>
+                        <div id="dietaPickerList" class="list-group dieta-picker-list mb-2"></div>
+                        <button type="button" class="btn btn-sm btn-primary" id="applyPickerSelectionBtn">Aplicar al día activo</button>
+                      </div>
+
                       <div class="form-group">
                         <label>Fecha de Inicio<span style="color:red;">*</span></label>
                         <input type="date" th:field="*{startDate}" class="form-control" required>
-                        <span th:if="${#fields.hasErrors('startDate')}" th:errors="*{startDate}"></span>
                       </div>
                       <div class="form-group">
                         <label>Fecha de Fin (Opcional)</label>
                         <input type="date" th:field="*{endDate}" class="form-control">
-                        <span th:if="${#fields.hasErrors('endDate')}" th:errors="*{endDate}"></span>
                       </div>
                       <div class="form-group">
                         <label>Estado<span style="color:red;">*</span></label>
@@ -76,49 +95,77 @@
                           <option th:value="COMPLETED">COMPLETADA</option>
                           <option th:value="CANCELLED">CANCELADA</option>
                         </select>
-                        <span th:if="${#fields.hasErrors('status')}" th:errors="*{status}"></span>
                       </div>
                       <div class="form-group">
                         <label>Notas</label>
-                        <textarea class="form-control" rows="3" th:field="*{notes}" placeholder="Notas adicionales sobre la asignación de la dieta..."></textarea>
-                        <span th:if="${#fields.hasErrors('notes')}" th:errors="*{notes}"></span>
+                        <textarea class="form-control" rows="3" th:field="*{notes}"></textarea>
                       </div>
                       <button type="submit" class="btn btn-success">Guardar Cambios</button>
-                      <a th:href="@{/admin/pacientes/{id}(id=${paciente.id})}" class="btn btn-secondary">Cancelar</a>
+                      <a th:href="@{/admin/pacientes/{id}/dietas(id=${paciente.id})}" class="btn btn-secondary">Cancelar</a>
                     </form>
                   </div>
-                  <br>
-
-                  <a href="#nav-main" class="btn btn-secondary-outline btn-sm" role="button">↓</a>
                 </div>
               </div>
             </div>
-
           </div>
-          <!-- /.container-fluid -->
-
         </div>
-        <!-- End of Main Content -->
-
-        <div th:insert="~{sbadmin/footer :: footer}"></div>
-
       </div>
-      <!-- End of Content Wrapper -->
-
+      <div th:insert="~{sbadmin/footer :: footer}"></div>
     </div>
-    <!-- End of Page Wrapper -->
+  </div>
+  <script th:src="@{/sbadmin/vendor/jquery/jquery.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/bootstrap/js/bootstrap.bundle.min.js}"></script>
+  <script th:inline="javascript">
+    document.addEventListener('DOMContentLoaded', function() {
+      const pickerList = document.getElementById('dietaPickerList');
+      const applyBtn = document.getElementById('applyPickerSelectionBtn');
+      const activeDaySelect = document.getElementById('activeWeeklyDaySelect');
+      if (!pickerList || !applyBtn) {
+        return;
+      }
+      let selectedPickerDieta = null;
 
-    <!-- Bootstrap core JavaScript-->
-    <script th:src="@{/sbadmin/vendor/jquery/jquery.min.js}"></script>
-    <script th:src="@{/sbadmin/vendor/bootstrap/js/bootstrap.bundle.min.js}"></script>
+      function setWeeklyDaySelection(day, dieta) {
+        const row = document.querySelector('.weekly-day-row[data-day="' + day + '"]');
+        if (!row) {
+          return;
+        }
+        const input = row.querySelector('.weekday-dieta-input');
+        const label = row.querySelector('.weekly-selected-label');
+        if (input) {
+          input.value = dieta ? String(dieta.id) : '';
+        }
+        if (label) {
+          label.textContent = dieta ? (dieta.nombre || '') : 'Sin dieta';
+        }
+      }
 
-    <!-- Core plugin JavaScript-->
-    <script th:src="@{/sbadmin/vendor/jquery-easing/jquery.easing.min.js}"></script>
+      fetch('/rest/dietas/picker?page=0&size=50', { headers: { 'Accept': 'application/json' } })
+        .then(function(response) { return response.json(); })
+        .then(function(data) {
+          (data.items || []).forEach(function(dieta) {
+            const item = document.createElement('button');
+            item.type = 'button';
+            item.className = 'list-group-item list-group-item-action dieta-picker-item';
+            item.textContent = (dieta.nombre || '') + ' — ' + (dieta.energiaKcal || 0) + ' kcal';
+            item.addEventListener('click', function() {
+              pickerList.querySelectorAll('.dieta-picker-item').forEach(function(el) {
+                el.classList.remove('selected');
+              });
+              item.classList.add('selected');
+              selectedPickerDieta = dieta;
+            });
+            pickerList.appendChild(item);
+          });
+        });
 
-    <!-- Custom scripts for all pages-->
-    <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
-
+      applyBtn.addEventListener('click', function() {
+        if (!selectedPickerDieta || !activeDaySelect) {
+          return;
+        }
+        setWeeklyDaySelection(activeDaySelect.value, selectedPickerDieta);
+      });
+    });
+  </script>
 </body>
-
 </html>
-

--- a/src/main/resources/templates/sbadmin/pacientes/lista-compras.html
+++ b/src/main/resources/templates/sbadmin/pacientes/lista-compras.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <link th:href="@{/eterna/assets/img/favicon.png}" rel="icon">
+  <title>Minutriporcion - Lista de Compras</title>
+  <link th:href="@{/sbadmin/vendor/fontawesome-free/css/all.min.css}" rel="stylesheet" type="text/css">
+  <link th:href="@{/sbadmin/css/sb-admin-2.min.css}" rel="stylesheet">
+</head>
+
+<body id="page-top">
+  <div id="wrapper">
+    <div th:insert="~{sbadmin/pacientes/sidebar :: sidebar}"></div>
+    <div id="content-wrapper" class="d-flex flex-column">
+      <div id="content">
+        <div th:insert="~{sbadmin/topbar :: topbar}"></div>
+        <div class="container-fluid">
+          <div class="d-sm-flex align-items-center justify-content-between mb-4">
+            <h1 class="h3 mb-0 text-gray-800">
+              Lista de compras —
+              [[${paciente != null ? paciente.name : ''}]]
+            </h1>
+            <button type="button" class="btn btn-sm btn-primary d-print-none" onclick="window.print()">
+              <i class="fas fa-print"></i> Imprimir
+            </button>
+          </div>
+
+          <div class="card shadow mb-4">
+            <div class="card-body">
+              <p class="text-muted mb-3" th:if="${pacienteDieta != null}">
+                <span th:if="${pacienteDieta.weeklyAssignment}">Plan semanal</span>
+                <span th:unless="${pacienteDieta.weeklyAssignment}"
+                      th:text="${pacienteDieta.dieta != null ? pacienteDieta.dieta.nombre : 'Dieta'}">Dieta</span>
+                · Inicio [[${#dates.format(pacienteDieta.startDate, 'dd/MM/yyyy')}]]
+              </p>
+
+              <div th:if="${groceryItems == null || groceryItems.isEmpty()}" class="alert alert-secondary mb-0">
+                No hay ingredientes para mostrar en la lista de compras.
+              </div>
+
+              <div th:unless="${groceryItems == null || groceryItems.isEmpty()}" class="table-responsive">
+                <table class="table table-bordered table-sm">
+                  <thead class="thead-light">
+                    <tr>
+                      <th>Alimento</th>
+                      <th>Cantidad</th>
+                      <th>Unidad</th>
+                      <th>Categoría</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr th:each="item : ${groceryItems}">
+                      <td th:text="${item.nombre}">Alimento</td>
+                      <td th:text="${item.cantidad}">1</td>
+                      <td th:text="${item.unidad}">porción</td>
+                      <td th:text="${item.categoria != null ? item.categoria : '-'}">-</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <a th:href="@{/admin/pacientes/{id}/dietas(id=${paciente != null ? paciente.id : 0})}"
+                 class="btn btn-secondary mt-3 d-print-none">Volver al plan alimentario</a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div th:insert="~{sbadmin/footer :: footer}"></div>
+    </div>
+  </div>
+  <script th:src="@{/sbadmin/vendor/jquery/jquery.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/bootstrap/js/bootstrap.bundle.min.js}"></script>
+</body>
+
+</html>

--- a/src/test/java/com/nutriconsultas/db/LiquibaseMigrationTest.java
+++ b/src/test/java/com/nutriconsultas/db/LiquibaseMigrationTest.java
@@ -109,4 +109,14 @@ public class LiquibaseMigrationTest {
 		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM ai_generated_draft", Long.class)).isEqualTo(0L);
 	}
 
+	@Test
+	public void testDietAssignmentSequenceResyncChangesetApplied() {
+		assertThat(jdbc.queryForObject(
+				"SELECT COUNT(*) FROM databasechangelog WHERE id = '030-resync-diet-assignment-sequences'",
+				Long.class))
+			.isEqualTo(1L);
+		final Long maxDietaId = jdbc.queryForObject("SELECT COALESCE(MAX(id), 0) FROM dieta", Long.class);
+		assertThat(maxDietaId).isGreaterThan(0L);
+	}
+
 }

--- a/src/test/java/com/nutriconsultas/mobile/DietGroceryListAggregatorTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/DietGroceryListAggregatorTest.java
@@ -60,6 +60,27 @@ class DietGroceryListAggregatorTest {
 	}
 
 	@Test
+	void aggregate_mergesMultipleDiets() {
+		final Alimento avena = alimento(1L, "Avena", "Cereales");
+		final Alimento manzana = alimento(2L, "Manzana", "Frutas");
+
+		final Dieta lunes = new Dieta();
+		final Ingesta lunesIngesta = ingesta("Desayuno");
+		lunesIngesta.setAlimentos(List.of(standaloneAlimento(avena, 1)));
+		lunes.setIngestas(List.of(lunesIngesta));
+
+		final Dieta martes = new Dieta();
+		final Ingesta martesIngesta = ingesta("Colación");
+		martesIngesta.setAlimentos(List.of(standaloneAlimento(manzana, 2)));
+		martes.setIngestas(List.of(martesIngesta));
+
+		final List<DietGroceryListItemDto> items = DietGroceryListAggregator.aggregate(List.of(lunes, martes));
+
+		assertThat(items).hasSize(2);
+		assertThat(items).extracting(DietGroceryListItemDto::nombre).containsExactlyInAnyOrder("Avena", "Manzana");
+	}
+
+	@Test
 	void aggregate_returnsEmptyListWhenPlanHasNoIngredients() {
 		final Dieta dieta = new Dieta();
 		final Ingesta ingesta = ingesta("Desayuno");
@@ -67,6 +88,15 @@ class DietGroceryListAggregatorTest {
 		dieta.setIngestas(List.of(ingesta));
 
 		assertThat(DietGroceryListAggregator.aggregate(dieta)).isEmpty();
+	}
+
+	private static AlimentoIngesta standaloneAlimento(final Alimento alimento, final int portions) {
+		final AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
+		alimentoIngesta.setName(alimento.getNombreAlimento());
+		alimentoIngesta.setPortions(portions);
+		alimentoIngesta.setUnidad("pieza");
+		alimentoIngesta.setAlimento(alimento);
+		return alimentoIngesta;
 	}
 
 	private static Alimento alimento(final Long id, final String nombre, final String categoria) {

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanServiceTest.java
@@ -25,6 +25,7 @@ import com.nutriconsultas.dieta.DietaPdfService;
 import com.nutriconsultas.dieta.Ingesta;
 import com.nutriconsultas.dieta.PlatilloIngesta;
 import com.nutriconsultas.dieta.PlatilloIngestaRepository;
+import com.nutriconsultas.mobile.dto.DietGroceryListItemDto;
 import com.nutriconsultas.mobile.dto.DietGroceryListDto;
 import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
 import com.nutriconsultas.mobile.dto.DietPlanPdfResult;
@@ -32,6 +33,7 @@ import com.nutriconsultas.mobile.dto.DietPlatilloDetailDto;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
+import com.nutriconsultas.paciente.PacienteDietaService;
 import com.nutriconsultas.paciente.PacienteDietaStatus;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,12 +49,18 @@ class MobilePatientDietPlanServiceTest {
 	private DietaPdfService dietaPdfService;
 
 	@Mock
+	private PacienteDietaService pacienteDietaService;
+
+	@Mock
 	private PlatilloIngestaRepository platilloIngestaRepository;
 
 	@Test
 	void getGroceryList_returnsAggregatedItemsWhenOwnedByPatient() {
 		final PacienteDieta assignment = sampleAssignment(5L, 1L);
 		when(pacienteDietaRepository.findByIdAndPacienteId(5L, 1L)).thenReturn(Optional.of(assignment));
+		when(pacienteDietaService.resolveDietsForGroceryList(assignment)).thenReturn(List.of(assignment.getDieta()));
+		when(pacienteDietaService.buildGroceryList(assignment))
+			.thenReturn(List.of(new DietGroceryListItemDto("Manzana", "1", "pieza", "Frutas")));
 
 		final DietGroceryListDto result = service.getGroceryList(1L, 5L, "current");
 
@@ -110,6 +118,7 @@ class MobilePatientDietPlanServiceTest {
 	void getDietPlanDetail_returnsStructuredMealTreeWhenOwnedByPatient() {
 		final PacienteDieta assignment = sampleAssignment(5L, 1L);
 		when(pacienteDietaRepository.findByIdAndPacienteId(5L, 1L)).thenReturn(Optional.of(assignment));
+		when(pacienteDietaService.resolveDietaForDate(assignment, LocalDate.now())).thenReturn(assignment.getDieta());
 
 		final DietPlanDetailDto result = service.getDietPlanDetail(1L, 5L);
 

--- a/src/test/java/com/nutriconsultas/paciente/AsignarDietaWeeklyUiIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/AsignarDietaWeeklyUiIntegrationTest.java
@@ -1,0 +1,65 @@
+package com.nutriconsultas.paciente;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AsignarDietaWeeklyUiIntegrationTest {
+
+	private static final String OWNER_SUB = "auth0|weekly-ui-owner";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	private Paciente paciente;
+
+	@BeforeEach
+	void seedPatient() {
+		paciente = new Paciente();
+		paciente.setName("Ana Bravo");
+		paciente.setUserId(OWNER_SUB);
+		paciente.setGender("F");
+		paciente.setDob(Date.from(LocalDate.of(1990, 1, 1).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		paciente = pacienteRepository.saveAndFlush(paciente);
+	}
+
+	@Test
+	void asignarDietaPage_exposesWeeklyPickerAndSharedCatalog() throws Exception {
+		final MvcResult result = mockMvc
+			.perform(get("/admin/pacientes/{id}/dietas/asignar", paciente.getId())
+				.with(oidcLogin().idToken(token -> token.subject(OWNER_SUB).claim("name", "Tester"))))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		final String html = result.getResponse().getContentAsString();
+		assertThat(html).contains("id=\"weeklySection\"");
+		assertThat(html).contains("id=\"dietaPickerSection\"");
+		assertThat(html).contains("id=\"weeklyPickerHint\"");
+		assertThat(html).contains("id=\"dietaPickerList\"");
+		assertThat(html).contains("Seleccionar dieta");
+		assertThat(html).contains("No se requiere calcular GET/TEF");
+		assertThat(html.indexOf("id=\"dietaPickerSection\""))
+			.isGreaterThan(html.indexOf("id=\"dateRangeSection\""));
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/EditarDietaWeeklyUiIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/EditarDietaWeeklyUiIntegrationTest.java
@@ -1,0 +1,98 @@
+package com.nutriconsultas.paciente;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.dieta.DietaRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = { "spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml" })
+class EditarDietaWeeklyUiIntegrationTest {
+
+	private static final String OWNER_SUB = "auth0|weekly-edit-owner";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@Autowired
+	private PacienteDietaRepository pacienteDietaRepository;
+
+	@Autowired
+	private PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository;
+
+	@Autowired
+	private DietaRepository dietaRepository;
+
+	private Paciente paciente;
+
+	private PacienteDieta assignment;
+
+	@BeforeEach
+	void seedWeeklyAssignment() {
+		paciente = new Paciente();
+		paciente.setName("Ana Bravo");
+		paciente.setUserId(OWNER_SUB);
+		paciente.setGender("F");
+		paciente.setDob(Date.from(LocalDate.of(1990, 1, 1).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		paciente = pacienteRepository.saveAndFlush(paciente);
+
+		final Dieta dieta = new Dieta();
+		dieta.setNombre("Dieta semanal prueba");
+		dieta.setUserId(OWNER_SUB);
+		dieta.setEnergia(1800);
+		dieta.setProteina(90.0);
+		dieta.setLipidos(50.0);
+		dieta.setHidratosDeCarbono(200.0);
+		final Dieta savedDieta = dietaRepository.saveAndFlush(dieta);
+
+		assignment = new PacienteDieta();
+		assignment.setPaciente(paciente);
+		assignment.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
+		assignment.setStartDate(Date.from(LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		assignment.setStatus(PacienteDietaStatus.ACTIVE);
+		assignment = pacienteDietaRepository.saveAndFlush(assignment);
+
+		final PacienteDietaWeekday monday = new PacienteDietaWeekday();
+		monday.setPacienteDieta(assignment);
+		monday.setDayOfWeek(1);
+		monday.setDieta(savedDieta);
+		pacienteDietaWeekdayRepository.saveAndFlush(monday);
+	}
+
+	@Test
+	void editarDietaPage_rendersWeeklyDayLabels() throws Exception {
+		final MvcResult result = mockMvc
+			.perform(get("/admin/pacientes/{pacienteId}/dietas/{id}/editar", paciente.getId(), assignment.getId())
+				.with(oidcLogin().idToken(token -> token.subject(OWNER_SUB).claim("name", "Tester"))))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		final String html = result.getResponse().getContentAsString();
+		assertThat(html).contains("Plan semanal");
+		assertThat(html).contains("Menú por día");
+		assertThat(html).contains("Dieta semanal prueba");
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
@@ -917,6 +917,38 @@ public class PacienteControllerTest {
 	}
 
 	@Test
+	public void testEditarAsignacionDietaWeeklyIncludesSlotsByDay() {
+		log.info("starting testEditarAsignacionDietaWeeklyIncludesSlotsByDay");
+		final PacienteDieta pacienteDieta = new PacienteDieta();
+		pacienteDieta.setId(6L);
+		pacienteDieta.setPaciente(paciente);
+		pacienteDieta.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
+
+		final PacienteDietaWeekday mondaySlot = new PacienteDietaWeekday();
+		mondaySlot.setDayOfWeek(1);
+		final com.nutriconsultas.dieta.Dieta dieta = new com.nutriconsultas.dieta.Dieta();
+		dieta.setId(22L);
+		dieta.setNombre("Dieta Hope 1");
+		mondaySlot.setDieta(dieta);
+
+		when(pacienteRepository.findByIdAndUserId(7L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
+		when(pacienteDietaService.findById(6L)).thenReturn(pacienteDieta);
+		when(pacienteDietaService.findWeekdaySlots(6L)).thenReturn(java.util.List.of(mondaySlot));
+
+		final Model model = org.mockito.Mockito.mock(Model.class);
+
+		final String result = controller.editarAsignacionDieta(7L, 6L, model, principal);
+
+		assertThat(result).isEqualTo("sbadmin/pacientes/editar-dieta");
+		verify(model).addAttribute(eq("weekdaySlotsByDay"), org.mockito.ArgumentMatchers.argThat(map -> {
+			@SuppressWarnings("unchecked")
+			final java.util.Map<Integer, PacienteDietaWeekday> slots = (java.util.Map<Integer, PacienteDietaWeekday>) map;
+			return slots.containsKey(1) && slots.get(1).getDieta().getNombre().equals("Dieta Hope 1");
+		}));
+		log.info("finished testEditarAsignacionDietaWeeklyIncludesSlotsByDay");
+	}
+
+	@Test
 	public void testActualizarAsignacionDieta() {
 		log.info("starting testActualizarAsignacionDieta");
 		// Arrange

--- a/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
@@ -85,6 +85,9 @@ public class PacienteControllerTest {
 	@Mock
 	private BindingResult bindingResult;
 
+	@Mock
+	private jakarta.servlet.http.HttpServletRequest httpServletRequest;
+
 	private Paciente paciente;
 
 	private CalendarEvent evento;
@@ -717,7 +720,8 @@ public class PacienteControllerTest {
 		final Model model = org.mockito.Mockito.mock(Model.class);
 
 		// Act
-		final String result = controller.guardarAsignacionDieta(1L, pacienteDieta, bindingResult, model, 1L, principal);
+		final String result = controller.guardarAsignacionDieta(1L, pacienteDieta, bindingResult, model, "DATE_RANGE",
+				1L, httpServletRequest, principal);
 
 		// Assert
 		assertThat(result).isEqualTo("redirect:/admin/pacientes/1/dietas");
@@ -747,7 +751,8 @@ public class PacienteControllerTest {
 		final Model model = org.mockito.Mockito.mock(Model.class);
 
 		// Act
-		final String result = controller.guardarAsignacionDieta(1L, pacienteDieta, bindingResult, model, 1L, principal);
+		final String result = controller.guardarAsignacionDieta(1L, pacienteDieta, bindingResult, model, "DATE_RANGE",
+				1L, httpServletRequest, principal);
 
 		// Assert
 		assertThat(result).isEqualTo("sbadmin/pacientes/asignar-dieta");
@@ -782,7 +787,8 @@ public class PacienteControllerTest {
 		final Model model = org.mockito.Mockito.mock(Model.class);
 
 		// Act
-		final String result = controller.guardarAsignacionDieta(1L, pacienteDieta, bindingResult, model, 1L, principal);
+		final String result = controller.guardarAsignacionDieta(1L, pacienteDieta, bindingResult, model, "DATE_RANGE",
+				1L, httpServletRequest, principal);
 
 		// Assert
 		assertThat(result).isEqualTo("sbadmin/pacientes/asignar-dieta");
@@ -812,7 +818,8 @@ public class PacienteControllerTest {
 		final Model model = org.mockito.Mockito.mock(Model.class);
 
 		// Act
-		final String result = controller.guardarAsignacionDieta(1L, pacienteDieta, bindingResult, model, 1L, principal);
+		final String result = controller.guardarAsignacionDieta(1L, pacienteDieta, bindingResult, model, "DATE_RANGE",
+				1L, httpServletRequest, principal);
 
 		// Assert
 		assertThat(result).isEqualTo("sbadmin/pacientes/asignar-dieta");
@@ -835,8 +842,8 @@ public class PacienteControllerTest {
 		final Model model = org.mockito.Mockito.mock(Model.class);
 
 		// Act & Assert
-		assertThatThrownBy(
-				() -> controller.guardarAsignacionDieta(1L, pacienteDieta, bindingResult, model, 1L, principal))
+		assertThatThrownBy(() -> controller.guardarAsignacionDieta(1L, pacienteDieta, bindingResult, model,
+				"DATE_RANGE", 1L, httpServletRequest, principal))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("No se ha encontrado paciente con folio");
 		verify(pacienteRepository).findByIdAndUserId(1L, TEST_USER_ID);
@@ -859,8 +866,8 @@ public class PacienteControllerTest {
 		final Model model = org.mockito.Mockito.mock(Model.class);
 
 		// Act & Assert
-		assertThatThrownBy(
-				() -> controller.guardarAsignacionDieta(1L, pacienteDieta, bindingResult, model, 1L, principal))
+		assertThatThrownBy(() -> controller.guardarAsignacionDieta(1L, pacienteDieta, bindingResult, model,
+				"DATE_RANGE", 1L, httpServletRequest, principal))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("No se ha encontrado dieta con id");
 		verify(pacienteRepository).findByIdAndUserId(1L, TEST_USER_ID);
@@ -877,7 +884,8 @@ public class PacienteControllerTest {
 		final Model model = org.mockito.Mockito.mock(Model.class);
 
 		// Act & Assert
-		assertThatThrownBy(() -> controller.guardarAsignacionDieta(1L, null, bindingResult, model, 1L, principal))
+		assertThatThrownBy(() -> controller.guardarAsignacionDieta(1L, null, bindingResult, model, "DATE_RANGE", 1L,
+				httpServletRequest, principal))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("PacienteDieta cannot be null");
 		verify(pacienteDietaService, org.mockito.Mockito.never()).assignDieta(any(Long.class), any(Long.class),
@@ -939,7 +947,7 @@ public class PacienteControllerTest {
 
 		// Act
 		final String result = controller.actualizarAsignacionDieta(1L, 1L, pacienteDieta, bindingResult, model,
-				principal);
+				httpServletRequest, principal);
 
 		// Assert
 		assertThat(result).isEqualTo("redirect:/admin/pacientes/1/dietas");
@@ -976,7 +984,7 @@ public class PacienteControllerTest {
 
 		// Act
 		final String result = controller.actualizarAsignacionDieta(1L, 1L, pacienteDieta, bindingResult, model,
-				principal);
+				httpServletRequest, principal);
 
 		// Assert
 		assertThat(result).isEqualTo("sbadmin/pacientes/editar-dieta");
@@ -1014,7 +1022,7 @@ public class PacienteControllerTest {
 
 		// Act
 		final String result = controller.actualizarAsignacionDieta(1L, 1L, pacienteDieta, bindingResult, model,
-				principal);
+				httpServletRequest, principal);
 
 		// Assert
 		assertThat(result).isEqualTo("sbadmin/pacientes/editar-dieta");
@@ -1041,8 +1049,8 @@ public class PacienteControllerTest {
 		final Model model = org.mockito.Mockito.mock(Model.class);
 
 		// Act & Assert
-		assertThatThrownBy(
-				() -> controller.actualizarAsignacionDieta(1L, 1L, pacienteDieta, bindingResult, model, principal))
+		assertThatThrownBy(() -> controller.actualizarAsignacionDieta(1L, 1L, pacienteDieta, bindingResult, model,
+				httpServletRequest, principal))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("No se ha encontrado asignación de dieta con id");
 

--- a/src/test/java/com/nutriconsultas/paciente/PacienteDeletionServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteDeletionServiceTest.java
@@ -64,6 +64,9 @@ class PacienteDeletionServiceTest {
 	@Mock
 	private DietaService dietaService;
 
+	@Mock
+	private PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository;
+
 	private Paciente paciente;
 
 	@BeforeEach
@@ -109,6 +112,34 @@ class PacienteDeletionServiceTest {
 		verify(clinicalExamService).deleteById(20L);
 		verify(anthropometricMeasurementService).deleteById(30L);
 		verify(bodyMetricRecordRepository).deleteByPacienteId(7L);
+		verify(pacienteRepository).delete(paciente);
+	}
+
+	@Test
+	void deletePatientWithHistory_removesWeeklyAssignmentDietCopies() {
+		final PacienteDieta assignment = new PacienteDieta();
+		assignment.setId(40L);
+		assignment.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
+		final Dieta mondayDieta = new Dieta();
+		mondayDieta.setId(61L);
+		mondayDieta.setPacienteId(7L);
+		final PacienteDietaWeekday mondaySlot = new PacienteDietaWeekday();
+		mondaySlot.setDayOfWeek(1);
+		mondaySlot.setDieta(mondayDieta);
+
+		when(pacienteRepository.findByIdAndUserId(7L, USER_ID)).thenReturn(Optional.of(paciente));
+		when(patientInvitationRepository.findByPacienteId(7L)).thenReturn(List.of());
+		when(pacienteDietaRepository.findByPacienteId(7L)).thenReturn(List.of(assignment));
+		when(pacienteDietaWeekdayRepository.findByPacienteDietaIdOrderByDayOfWeekAsc(40L))
+			.thenReturn(List.of(mondaySlot));
+		when(calendarEventService.findByPacienteId(7L)).thenReturn(List.of());
+		when(clinicalExamService.findByPacienteId(7L)).thenReturn(List.of());
+		when(anthropometricMeasurementService.findByPacienteId(7L)).thenReturn(List.of());
+
+		service.deletePatientWithHistory(7L, USER_ID);
+
+		verify(dietaService).deleteDieta(61L);
+		verify(pacienteDietaRepository).deleteAll(List.of(assignment));
 		verify(pacienteRepository).delete(paciente);
 	}
 

--- a/src/test/java/com/nutriconsultas/paciente/PacienteDietaServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteDietaServiceTest.java
@@ -8,7 +8,9 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +38,9 @@ public class PacienteDietaServiceTest {
 
 	@Mock
 	private PacienteDietaRepository pacienteDietaRepository;
+
+	@Mock
+	private PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository;
 
 	@Mock
 	private PacienteRepository pacienteRepository;
@@ -386,6 +391,51 @@ public class PacienteDietaServiceTest {
 		assertThat(result).isEqualTo(pacienteDieta);
 		verify(pacienteDietaRepository).findById(1L);
 		log.info("finished testFindById");
+	}
+
+	@Test
+	public void testAssignWeeklyDieta() {
+		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(Optional.of(paciente));
+		when(dietaRepository.findById(1L)).thenReturn(Optional.of(sourceDieta));
+		when(dietaService.copyDietaForPatientAssignment(1L, 1L, TEST_USER_ID)).thenReturn(patientCopyDieta);
+		when(pacienteDietaRepository.save(any(PacienteDieta.class))).thenAnswer(invocation -> {
+			final PacienteDieta pd = invocation.getArgument(0);
+			pd.setId(10L);
+			return pd;
+		});
+		when(pacienteDietaRepository.findById(10L)).thenAnswer(invocation -> {
+			final PacienteDieta saved = new PacienteDieta();
+			saved.setId(10L);
+			saved.setPaciente(paciente);
+			saved.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
+			return Optional.of(saved);
+		});
+		when(pacienteDietaWeekdayRepository.save(any(PacienteDietaWeekday.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		final Map<Integer, Long> weekdayIds = new LinkedHashMap<>();
+		weekdayIds.put(1, 1L);
+		weekdayIds.put(3, 1L);
+		final PacienteDieta metadata = new PacienteDieta();
+		metadata.setStartDate(new Date());
+		metadata.setStatus(PacienteDietaStatus.ACTIVE);
+
+		final PacienteDieta result = service.assignWeeklyDieta(1L, weekdayIds, metadata, TEST_USER_ID);
+
+		assertThat(result).isNotNull();
+		assertThat(result.getAssignmentType()).isEqualTo(PacienteDietaAssignmentType.WEEKLY);
+		verify(pacienteDietaWeekdayRepository).deleteByPacienteDietaId(10L);
+		verify(pacienteDietaWeekdayRepository, org.mockito.Mockito.times(2)).save(any(PacienteDietaWeekday.class));
+	}
+
+	@Test
+	public void testAssignWeeklyDietaRequiresAtLeastOneDay() {
+		final PacienteDieta metadata = new PacienteDieta();
+		metadata.setStartDate(new Date());
+
+		assertThatThrownBy(() -> service.assignWeeklyDieta(1L, Map.of(), metadata, TEST_USER_ID))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("al menos un día");
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/paciente/PacienteDietaWeekdayLabelsTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteDietaWeekdayLabelsTest.java
@@ -1,0 +1,38 @@
+package com.nutriconsultas.paciente;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.dieta.Dieta;
+
+class PacienteDietaWeekdayLabelsTest {
+
+	@Test
+	void slotsByDay_mapsSlotsByIsoDay() {
+		final Dieta dieta = new Dieta();
+		dieta.setId(10L);
+		dieta.setNombre("Lunes");
+
+		final PacienteDietaWeekday monday = new PacienteDietaWeekday();
+		monday.setDayOfWeek(1);
+		monday.setDieta(dieta);
+
+		final PacienteDietaWeekday wednesday = new PacienteDietaWeekday();
+		wednesday.setDayOfWeek(3);
+		wednesday.setDieta(dieta);
+
+		assertThat(PacienteDietaWeekdayLabels.slotsByDay(List.of(monday, wednesday)))
+			.containsEntry(1, monday)
+			.containsEntry(3, wednesday)
+			.hasSize(2);
+	}
+
+	@Test
+	void slotsByDay_returnsEmptyMapWhenNull() {
+		assertThat(PacienteDietaWeekdayLabels.slotsByDay(null)).isEmpty();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/PlanAlimentarioWeeklyUiIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PlanAlimentarioWeeklyUiIntegrationTest.java
@@ -1,0 +1,99 @@
+package com.nutriconsultas.paciente;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.dieta.DietaRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = { "spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml" })
+class PlanAlimentarioWeeklyUiIntegrationTest {
+
+	private static final String OWNER_SUB = "auth0|plan-alimentario-weekly-owner";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@Autowired
+	private PacienteDietaRepository pacienteDietaRepository;
+
+	@Autowired
+	private PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository;
+
+	@Autowired
+	private DietaRepository dietaRepository;
+
+	private Paciente paciente;
+
+	private Dieta patientMondayDieta;
+
+	private PacienteDieta assignment;
+
+	@BeforeEach
+	void seedWeeklyAssignment() {
+		paciente = new Paciente();
+		paciente.setName("Ana Bravo");
+		paciente.setUserId(OWNER_SUB);
+		paciente.setGender("F");
+		paciente.setDob(Date.from(LocalDate.of(1990, 1, 1).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		paciente = pacienteRepository.saveAndFlush(paciente);
+
+		patientMondayDieta = new Dieta();
+		patientMondayDieta.setNombre("Dieta lunes paciente");
+		patientMondayDieta.setUserId(OWNER_SUB);
+		patientMondayDieta.setPacienteId(paciente.getId());
+		patientMondayDieta.setEnergia(1800);
+		patientMondayDieta = dietaRepository.saveAndFlush(patientMondayDieta);
+
+		assignment = new PacienteDieta();
+		assignment.setPaciente(paciente);
+		assignment.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
+		assignment.setStartDate(Date.from(LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		assignment.setStatus(PacienteDietaStatus.ACTIVE);
+		assignment = pacienteDietaRepository.saveAndFlush(assignment);
+
+		final PacienteDietaWeekday monday = new PacienteDietaWeekday();
+		monday.setPacienteDieta(assignment);
+		monday.setDayOfWeek(1);
+		monday.setDieta(patientMondayDieta);
+		pacienteDietaWeekdayRepository.saveAndFlush(monday);
+	}
+
+	@Test
+	void planAlimentario_rendersWeeklyDietLinksToPatientCopy() throws Exception {
+		final MvcResult result = mockMvc
+			.perform(get("/admin/pacientes/{id}/dietas", paciente.getId())
+				.with(oidcLogin().idToken(token -> token.subject(OWNER_SUB).claim("name", "Tester"))))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		final String html = result.getResponse().getContentAsString();
+		assertThat(html).contains("Plan semanal");
+		assertThat(html).contains("Dieta lunes paciente");
+		assertThat(html).contains("/admin/dietas/" + patientMondayDieta.getId());
+		assertThat(html).contains("Modificar dieta del paciente");
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds **weekly diet assignments** (`PacienteDietaAssignmentType.WEEKLY`) with `paciente_dieta_weekday` child rows (ISO Monday–Sunday) while preserving legacy **date-range** single-diet assignments.
- Web UX: assign form toggle (rango vs plan semanal), seven-day diet picker with “repetir lunes”, plan list badge/summary, edit support, and printable **lista de compras** (`/admin/pacientes/{id}/dietas/{assignmentId}/lista-compras`).
- Extends `DietGroceryListAggregator` and mobile grocery API to aggregate ingredients across all weekday menus in a weekly plan.

## Schema
- Liquibase `029-paciente-dieta-weekly.yaml`: `assignment_type` on `paciente_dieta`, nullable `dieta_id`, new `paciente_dieta_weekday` table.

## Test plan
- [x] `PacienteDietaServiceTest` — weekly assign + validation
- [x] `PacienteControllerTest` — date-range assign/update (signature updates)
- [x] `DietGroceryListAggregatorTest` — multi-diet merge
- [x] `MobilePatientDietPlanServiceTest` — grocery + detail with weekly resolver
- [x] `ThymeleafTemplateValidationTest`
- [ ] Manual: assign weekly plan with 2+ days → verify plan list + lista de compras
- [ ] Manual: legacy single-diet assignment still works

Fixes #525

Made with [Cursor](https://cursor.com)