### PR TITLE
[Nutritionist Web] Default portion type to porción when adding alimentos (#528)

### DIFF
--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -217,11 +217,11 @@ Feedback from the latest published version — diet assignment, authoring UX, cl
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
-| **525** | Patient diet assignment — weekly day-of-week plans with grocery list | https://github.com/diego-torres/nutriconsultas/issues/525 | **in-progress** | #353 (grocery) | Branch `issue-525-weekly-diet-assignment`; `paciente_dieta_weekday` + web lista de compras |
+| **525** | Patient diet assignment — weekly day-of-week plans with grocery list | https://github.com/diego-torres/nutriconsultas/issues/525 | **done** | #353 (grocery) | PR [#531](https://github.com/diego-torres/nutriconsultas/pull/531); `paciente_dieta_weekday` + web lista de compras |
 | **532** | Grocery list — downloadable PDF for print | https://github.com/diego-torres/nutriconsultas/issues/532 | **open** | **525** | Flying Saucer PDF from `/lista-compras`; branded logo; DATE_RANGE + WEEKLY |
 | **526** | Alimentos ordering — sequence metadata + drag-reorder in diets and platillos | https://github.com/diego-torres/nutriconsultas/issues/526 | **open** | — | `orden` on `AlimentoIngesta` + `Ingrediente`; mirror ingesta drag-reorder |
 | **527** | Diet ingesta — create catalog platillo from selected alimentos combination | https://github.com/diego-torres/nutriconsultas/issues/527 | **open** | #257 | Modal nombre; nutritionist-owned platillo from ingesta selection |
-| **528** | Default portion type to porción (not gramos) when adding alimentos | https://github.com/diego-torres/nutriconsultas/issues/528 | **open** | — | `#tipoPorcion` default in diet/platillo add-alimento modals |
+| **528** | Default portion type to porción (not gramos) when adding alimentos | https://github.com/diego-torres/nutriconsultas/issues/528 | **in-progress** | — | Branch `issue-528-default-porcion`; `#tipoPorcion` default in diet/platillo add-alimento modals |
 | **530** | Clinical exam (clínicos) — thyroid indicator fields | https://github.com/diego-torres/nutriconsultas/issues/530 | **open** | #46 | TSH, T4 libre, T3 libre; Liquibase + `clinicos.html` tab |
 
 ---

--- a/src/main/java/com/nutriconsultas/dieta/AlimentoPortionDefaults.java
+++ b/src/main/java/com/nutriconsultas/dieta/AlimentoPortionDefaults.java
@@ -1,0 +1,21 @@
+package com.nutriconsultas.dieta;
+
+import org.springframework.util.StringUtils;
+
+public final class AlimentoPortionDefaults {
+
+	public static final String PORCION = "porcion";
+
+	public static final String GRAMOS = "gramos";
+
+	private AlimentoPortionDefaults() {
+	}
+
+	public static String resolveTipoPorcion(final String tipoPorcion) {
+		if (StringUtils.hasText(tipoPorcion)) {
+			return tipoPorcion.trim();
+		}
+		return PORCION;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/dieta/DietaController.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaController.java
@@ -326,6 +326,7 @@ public class DietaController extends AbstractAuthorizedController {
 			Model model, @AuthenticationPrincipal final OidcUser principal) {
 		LOGGER.debug("Agregar alimento {} a ingesta con id {}", alimentoModel, id);
 		final Dieta dieta = loadDietaForMutation(id, principal);
+		alimentoModel.setTipoPorcion(AlimentoPortionDefaults.resolveTipoPorcion(alimentoModel.getTipoPorcion()));
 		Ingesta ingesta = dieta.getIngestas()
 			.stream()
 			.filter(i -> i.getId().equals(alimentoModel.getIngestaAlimento()))

--- a/src/main/resources/templates/sbadmin/dietas/formulario.html
+++ b/src/main/resources/templates/sbadmin/dietas/formulario.html
@@ -300,8 +300,8 @@
                       class="form-control"
                       id="tipoPorcion"
                       name="tipoPorcion">
+                      <option value="porcion" selected>Porci&oacute;n</option>
                       <option value="gramos">Gramos</option>
-                      <option value="porcion">Porci&oacute;n</option>
                     </select>
                   </div>
                   <button type="submit" class="btn btn-primary">Guardar</button>
@@ -2074,7 +2074,7 @@
             selectedAlimentoReference = null;
             modal.find('#alimento').val('').trigger('change');
             modal.find('#alimentoPorciones').val('1');
-            modal.find('#tipoPorcion').val('gramos');
+            modal.find('#tipoPorcion').val('porcion');
             $('#alimentoCantidad').val('');
             $('#alimentoUnidad').val('');
             $('#alimentoPeso').val('');

--- a/src/test/java/com/nutriconsultas/dieta/AlimentoPortionDefaultsTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/AlimentoPortionDefaultsTest.java
@@ -1,0 +1,24 @@
+package com.nutriconsultas.dieta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AlimentoPortionDefaultsTest {
+
+	@Test
+	void resolveTipoPorcion_defaultsToPorcionWhenNullOrBlank() {
+		assertThat(AlimentoPortionDefaults.resolveTipoPorcion(null)).isEqualTo(AlimentoPortionDefaults.PORCION);
+		assertThat(AlimentoPortionDefaults.resolveTipoPorcion("")).isEqualTo(AlimentoPortionDefaults.PORCION);
+		assertThat(AlimentoPortionDefaults.resolveTipoPorcion("   ")).isEqualTo(AlimentoPortionDefaults.PORCION);
+	}
+
+	@Test
+	void resolveTipoPorcion_preservesExplicitValue() {
+		assertThat(AlimentoPortionDefaults.resolveTipoPorcion(AlimentoPortionDefaults.GRAMOS))
+			.isEqualTo(AlimentoPortionDefaults.GRAMOS);
+		assertThat(AlimentoPortionDefaults.resolveTipoPorcion(AlimentoPortionDefaults.PORCION))
+			.isEqualTo(AlimentoPortionDefaults.PORCION);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/dieta/DietaControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaControllerTest.java
@@ -450,6 +450,25 @@ public class DietaControllerTest {
 
 	@Test
 	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testSaveAlimentoDefaultsTipoPorcionWhenOmitted() throws Exception {
+		mockMvc
+			.perform(MockMvcRequestBuilders.post("/admin/dietas/1/alimentos/save")
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("ingestaAlimento", "1")
+				.param("alimento", "1")
+				.param("porciones", "1")
+				.with(oidcLogin(TEST_USER_ID))
+				.with(SecurityMockMvcRequestPostProcessors.csrf()))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(MockMvcResultMatchers.redirectedUrl("/admin/dietas/1"));
+
+		verify(dietaService, times(1)).getDietaByIdAndUserId(1L, TEST_USER_ID);
+		verify(alimentoService, times(1)).findById(1L);
+		verify(dietaService, times(1)).saveDieta(any(Dieta.class));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
 	public void testSaveAlimentoWithDefaultPortions() throws Exception {
 		log.info("Starting testSaveAlimento_WithDefaultPortions");
 


### PR DESCRIPTION
## Summary
- Default **Tipo de porción** to `porcion` in the diet add-alimento modal (UI + server-side fallback).
- Add `AlimentoPortionDefaults` helper and controller test when `tipoPorcion` is omitted.
- Mark #525 done and #528 in-progress in `ISSUE-NUTRITIONIST-WEB.md`.

## Test plan
- [x] `AlimentoPortionDefaultsTest`
- [x] `DietaControllerTest#testSaveAlimentoDefaultsTipoPorcionWhenOmitted`
- [x] `./lint.sh` + `mvn pmd:check -Pci`
- [ ] Manual: open add-alimento on diet → **Porción** selected; cantidad/unidad from catalog visible
- [ ] Manual: switch to Gramos → porciones field still works

Fixes #528

Made with [Cursor](https://cursor.com)