### PR TITLE
Grocery list PDF export for print (#532)

### DIFF
--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -218,9 +218,9 @@ Feedback from the latest published version — diet assignment, authoring UX, cl
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | **525** | Patient diet assignment — weekly day-of-week plans with grocery list | https://github.com/diego-torres/nutriconsultas/issues/525 | **done** | #353 (grocery) | PR [#531](https://github.com/diego-torres/nutriconsultas/pull/531); `paciente_dieta_weekday` + web lista de compras |
-| **532** | Grocery list — downloadable PDF for print | https://github.com/diego-torres/nutriconsultas/issues/532 | **open** | **525** | Flying Saucer PDF from `/lista-compras`; branded logo; DATE_RANGE + WEEKLY |
+| **532** | Grocery list — downloadable PDF for print | https://github.com/diego-torres/nutriconsultas/issues/532 | **in-progress** | **525** | Flying Saucer PDF from `/lista-compras`; branded logo; DATE_RANGE + WEEKLY |
 | **526** | Alimentos ordering — sequence metadata + drag-reorder in diets and platillos | https://github.com/diego-torres/nutriconsultas/issues/526 | **done** | — | `orden` on `AlimentoIngesta` + `Ingrediente`; mirror ingesta drag-reorder |
-| **527** | Diet ingesta — create catalog platillo from selected alimentos combination | https://github.com/diego-torres/nutriconsultas/issues/527 | **in-progress** | #257 | Modal nombre; nutritionist-owned platillo from ingesta selection |
+| **527** | Diet ingesta — create catalog platillo from selected alimentos combination | https://github.com/diego-torres/nutriconsultas/issues/527 | **done** | #257 | PR [#536](https://github.com/diego-torres/nutriconsultas/pull/536); crear platillo + replace selection + active ingesta |
 | **528** | Default portion type to porción (not gramos) when adding alimentos | https://github.com/diego-torres/nutriconsultas/issues/528 | **done** | — | PR [#533](https://github.com/diego-torres/nutriconsultas/pull/533); `#tipoPorcion` default in diet add-alimento modal |
 | **530** | Clinical exam (clínicos) — thyroid indicator fields | https://github.com/diego-torres/nutriconsultas/issues/530 | **open** | #46 | TSH, T4 libre, T3 libre; Liquibase + `clinicos.html` tab |
 

--- a/src/main/java/com/nutriconsultas/paciente/GroceryListPdfService.java
+++ b/src/main/java/com/nutriconsultas/paciente/GroceryListPdfService.java
@@ -1,0 +1,88 @@
+package com.nutriconsultas.paciente;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.xhtmlrenderer.pdf.ITextRenderer;
+
+import com.nutriconsultas.mobile.dto.DietGroceryListItemDto;
+import com.nutriconsultas.profile.NutritionistBrandingHelper;
+import com.nutriconsultas.profile.NutritionistProfile;
+import com.nutriconsultas.profile.NutritionistProfileService;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Generates printable PDF documents for patient diet grocery lists (#532).
+ */
+@Service
+@Slf4j
+public class GroceryListPdfService {
+
+	@Autowired
+	private TemplateEngine templateEngine;
+
+	@Autowired
+	private NutritionistProfileService nutritionistProfileService;
+
+	public byte[] generatePdf(@NonNull final Paciente paciente, @NonNull final PacienteDieta assignment,
+			@NonNull final List<DietGroceryListItemDto> groceryItems, @NonNull final String nutritionistUserId,
+			final String oauthDisplayName) {
+		log.info("Generating grocery list PDF for assignment id: {}", assignment.getId());
+		final Context context = new Context();
+		context.setVariable("paciente", paciente);
+		context.setVariable("pacienteDieta", assignment);
+		context.setVariable("groceryItems", groceryItems);
+		context.setVariable("assignmentLabel", resolveAssignmentLabel(assignment));
+
+		final NutritionistProfile profile = nutritionistProfileService.getOrCreateProfile(nutritionistUserId);
+		final String logoBase64 = nutritionistProfileService.getLogoAsBase64DataUri(nutritionistUserId);
+		NutritionistBrandingHelper.addBrandingVariables(context, profile, logoBase64, oauthDisplayName);
+
+		final String html = templateEngine.process("sbadmin/pacientes/lista-compras-pdf", context);
+		return htmlToPdf(html);
+	}
+
+	public ResponseEntity<byte[]> buildPdfResponse(@NonNull final Paciente paciente,
+			@NonNull final PacienteDieta assignment, @NonNull final List<DietGroceryListItemDto> groceryItems,
+			@NonNull final String nutritionistUserId, final String oauthDisplayName) {
+		final byte[] pdfBytes = generatePdf(paciente, assignment, groceryItems, nutritionistUserId, oauthDisplayName);
+		return ResponseEntity.ok()
+			.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"lista-de-compras.pdf\"")
+			.contentType(MediaType.parseMediaType("application/pdf"))
+			.body(pdfBytes);
+	}
+
+	private String resolveAssignmentLabel(final PacienteDieta assignment) {
+		if (assignment.isWeeklyAssignment()) {
+			return "Plan semanal";
+		}
+		if (assignment.getDieta() != null && assignment.getDieta().getNombre() != null) {
+			return assignment.getDieta().getNombre();
+		}
+		return "Dieta";
+	}
+
+	private byte[] htmlToPdf(final String html) {
+		try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+			final ITextRenderer renderer = new ITextRenderer();
+			renderer.setDocumentFromString(html);
+			renderer.layout();
+			renderer.createPDF(outputStream);
+			return outputStream.toByteArray();
+		}
+		catch (final Exception e) {
+			log.error("Error generating grocery list PDF", e);
+			throw new IllegalStateException("Error generating grocery list PDF", e);
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -42,6 +42,7 @@ import com.nutriconsultas.dieta.DietaNutritionCalculator;
 import com.nutriconsultas.dieta.DietaPdfService;
 import com.nutriconsultas.dieta.DietaRepository;
 import com.nutriconsultas.dieta.DietaService;
+import com.nutriconsultas.profile.NutritionistBrandingHelper;
 import com.nutriconsultas.paciente.calculation.BmrCalculationService;
 import com.nutriconsultas.subscription.SubscriptionErrorResponses;
 import com.nutriconsultas.subscription.SubscriptionLimitExceededException;
@@ -107,6 +108,9 @@ public class PacienteController extends AbstractAuthorizedController {
 
 	@Autowired
 	private DietaPdfService dietaPdfService;
+
+	@Autowired
+	private GroceryListPdfService groceryListPdfService;
 
 	@Autowired
 	private PacienteDietaRepository pacienteDietaRepository;
@@ -1043,6 +1047,27 @@ public class PacienteController extends AbstractAuthorizedController {
 		model.addAttribute("pacienteDieta", assignment);
 		model.addAttribute("groceryItems", groceryItems);
 		return "sbadmin/pacientes/lista-compras";
+	}
+
+	@GetMapping(path = "/admin/pacientes/{pacienteId}/dietas/{id}/lista-compras.pdf")
+	public ResponseEntity<byte[]> listaComprasAsignacionPdf(@PathVariable @NonNull final Long pacienteId,
+			@PathVariable @NonNull final Long id, @AuthenticationPrincipal final OidcUser principal) {
+		log.debug("Generando PDF de lista de compras para asignación {}", id);
+		final String userId = getUserId(principal);
+		if (userId == null) {
+			return ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();
+		}
+		final Paciente paciente = pacienteRepository.findByIdAndUserId(pacienteId, userId)
+			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado paciente con folio " + pacienteId));
+		verifyPatientOwnership(paciente, userId);
+		final PacienteDieta assignment = pacienteDietaService.findById(id);
+		if (assignment.getPaciente() == null || !pacienteId.equals(assignment.getPaciente().getId())) {
+			throw new IllegalArgumentException("La asignación no pertenece al paciente");
+		}
+		assignment.setPaciente(paciente);
+		final List<DietGroceryListItemDto> groceryItems = pacienteDietaService.buildGroceryList(assignment);
+		final String oauthDisplayName = NutritionistBrandingHelper.resolveOAuthDisplayName(principal);
+		return groceryListPdfService.buildPdfResponse(paciente, assignment, groceryItems, userId, oauthDisplayName);
 	}
 
 	@PostMapping(path = "/admin/pacientes/{pacienteId}/dietas/{id}/cancelar")

--- a/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
@@ -14,6 +14,9 @@ import com.nutriconsultas.clinical.exam.AnthropometricMeasurement;
 import com.nutriconsultas.clinical.exam.anthropometric.AnthropometricFieldCatalog;
 import com.nutriconsultas.clinical.exam.ClinicalExam;
 import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.mobile.dto.DietGroceryListItemDto;
+import com.nutriconsultas.profile.NutritionistBrandingHelper;
+import com.nutriconsultas.profile.NutritionistProfile;
 import com.nutriconsultas.validation.template.BaseTemplateValidator;
 import com.nutriconsultas.mobile.PatientMobileAuthStatus;
 import com.nutriconsultas.paciente.invitation.PatientMobileInvitationStatus;
@@ -154,7 +157,21 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 		mondaySlot.setDieta(mockDieta);
 		variables.put("weekdaySlotsByAssignmentId", java.util.Map.of(1L, java.util.List.of(mondaySlot)));
 		variables.put("weekdaySlotsByDay", PacienteDietaWeekdayLabels.slotsByDay(java.util.List.of(mondaySlot)));
-		variables.put("groceryItems", java.util.List.of());
+		variables.put("groceryItems", java.util.List.of(new DietGroceryListItemDto("Manzana", "2", "pieza", "Frutas")));
+		variables.put("assignmentLabel", "Plan semanal");
+		addPdfBrandingMockVariables(variables);
+	}
+
+	private void addPdfBrandingMockVariables(final Map<String, Object> variables) {
+		final NutritionistProfile mockProfile = new NutritionistProfile();
+		mockProfile.setId(1L);
+		mockProfile.setDisplayName("Lic. María García López");
+		mockProfile.setCedulaProfesional("12345678");
+		variables.put("nutritionistProfile", mockProfile);
+		variables.put("nutritionistDisplayName", "Lic. María García López");
+		variables.put("logoBase64", NutritionistBrandingHelper.MOCK_LOGO_DATA_URI);
+		NutritionistBrandingHelper.addPdfLogoDimensionVariables(variables,
+				NutritionistBrandingHelper.MOCK_LOGO_DATA_URI);
 	}
 
 	private void addMockConsulta(final Map<String, Object> variables, final Paciente paciente) {

--- a/src/main/resources/templates/sbadmin/pacientes/lista-compras-pdf.html
+++ b/src/main/resources/templates/sbadmin/pacientes/lista-compras-pdf.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="es">
+<head>
+	<meta charset="UTF-8" />
+	<title>Lista de Compras</title>
+	<style>
+		@page {
+			size: A4 portrait;
+			margin: 1.2cm;
+		}
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 9pt;
+			line-height: 1.25;
+			color: #333;
+		}
+		.header {
+			border-bottom: 2px solid #4e73df;
+			padding-bottom: 8px;
+			margin-bottom: 12px;
+		}
+		.header h1 {
+			color: #4e73df;
+			margin: 0;
+			font-size: 16pt;
+		}
+		.header p {
+			margin: 2px 0;
+			color: #666;
+			font-size: 8pt;
+		}
+		.meta {
+			background-color: #f8f9fc;
+			padding: 8px 10px;
+			border-radius: 4px;
+			margin-bottom: 12px;
+		}
+		.meta p {
+			margin: 2px 0;
+			font-size: 8.5pt;
+		}
+		table.grocery-table {
+			width: 100%;
+			border-collapse: collapse;
+			margin-bottom: 10px;
+		}
+		table.grocery-table th {
+			background-color: #4e73df;
+			color: white;
+			padding: 6px 8px;
+			text-align: left;
+			font-size: 8.5pt;
+		}
+		table.grocery-table td {
+			padding: 5px 8px;
+			border-bottom: 1px solid #e3e6f0;
+			font-size: 8.5pt;
+		}
+		table.grocery-table tr:nth-child(even) td {
+			background-color: #f8f9fc;
+		}
+		.empty-message {
+			color: #666;
+			font-style: italic;
+			font-size: 9pt;
+		}
+		.footer {
+			margin-top: 16px;
+			padding-top: 8px;
+			border-top: 1px solid #e3e6f0;
+			text-align: center;
+			color: #666;
+			font-size: 7.5pt;
+		}
+	</style>
+	<style th:replace="~{sbadmin/fragments/pdf-nutritionist-logo :: logoStyles}"></style>
+</head>
+<body>
+	<div class="header">
+		<table style="width: 100%; border-collapse: collapse;">
+			<tr>
+				<td style="vertical-align: bottom;">
+					<h1>Lista de Compras</h1>
+					<p>Minutriporcion - Consulta Nutricional</p>
+					<div th:replace="~{sbadmin/fragments/pdf-nutritionist-credentials :: credentials}"></div>
+				</td>
+				<td th:replace="~{sbadmin/fragments/pdf-nutritionist-logo :: logoCell}"></td>
+			</tr>
+		</table>
+	</div>
+
+	<div class="meta" th:if="${paciente != null}">
+		<p><strong>Paciente:</strong> <span th:text="${paciente.name}"></span></p>
+		<p th:if="${assignmentLabel != null}">
+			<strong>Plan:</strong> <span th:text="${assignmentLabel}"></span>
+		</p>
+		<p th:if="${pacienteDieta != null && pacienteDieta.startDate != null}">
+			<strong>Inicio:</strong>
+			<span th:text="${#dates.format(pacienteDieta.startDate, 'dd/MM/yyyy')}"></span>
+		</p>
+	</div>
+
+	<div th:if="${groceryItems == null || groceryItems.isEmpty()}" class="empty-message">
+		No hay ingredientes para mostrar en la lista de compras.
+	</div>
+
+	<table th:unless="${groceryItems == null || groceryItems.isEmpty()}" class="grocery-table">
+		<thead>
+			<tr>
+				<th>Alimento</th>
+				<th>Cantidad</th>
+				<th>Unidad</th>
+				<th>Categoría</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr th:each="item : ${groceryItems}">
+				<td th:text="${item.nombre}">Alimento</td>
+				<td th:text="${item.cantidad}">1</td>
+				<td th:text="${item.unidad}">porción</td>
+				<td th:text="${item.categoria != null ? item.categoria : '-'}">-</td>
+			</tr>
+		</tbody>
+	</table>
+
+	<div class="footer">
+		<p>Documento generado por Minutriporcion</p>
+	</div>
+</body>
+</html>

--- a/src/main/resources/templates/sbadmin/pacientes/lista-compras.html
+++ b/src/main/resources/templates/sbadmin/pacientes/lista-compras.html
@@ -26,6 +26,10 @@
             <button type="button" class="btn btn-sm btn-primary d-print-none" onclick="window.print()">
               <i class="fas fa-print"></i> Imprimir
             </button>
+            <a th:href="@{/admin/pacientes/{pacienteId}/dietas/{id}/lista-compras.pdf(pacienteId=${paciente != null ? paciente.id : 0}, id=${pacienteDieta != null ? pacienteDieta.id : 0})}"
+               class="btn btn-sm btn-outline-primary d-print-none ml-2">
+              <i class="fas fa-file-pdf"></i> Descargar PDF
+            </a>
           </div>
 
           <div class="card shadow mb-4">

--- a/src/test/java/com/nutriconsultas/paciente/GroceryListPdfServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/GroceryListPdfServiceTest.java
@@ -1,0 +1,108 @@
+package com.nutriconsultas.paciente;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.mobile.dto.DietGroceryListItemDto;
+import com.nutriconsultas.profile.NutritionistProfile;
+import com.nutriconsultas.profile.NutritionistProfileService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+@ActiveProfiles("test")
+public class GroceryListPdfServiceTest {
+
+	@InjectMocks
+	private GroceryListPdfService groceryListPdfService;
+
+	@Mock
+	private TemplateEngine templateEngine;
+
+	@Mock
+	private NutritionistProfileService nutritionistProfileService;
+
+	private Paciente paciente;
+
+	private PacienteDieta assignment;
+
+	private List<DietGroceryListItemDto> groceryItems;
+
+	@BeforeEach
+	public void setup() {
+		paciente = new Paciente();
+		paciente.setId(1L);
+		paciente.setName("Paciente Prueba");
+
+		final Dieta dieta = new Dieta();
+		dieta.setId(10L);
+		dieta.setNombre("Dieta ejemplo");
+
+		assignment = new PacienteDieta();
+		assignment.setId(5L);
+		assignment.setPaciente(paciente);
+		assignment.setDieta(dieta);
+		assignment.setStartDate(new Date());
+		assignment.setAssignmentType(PacienteDietaAssignmentType.DATE_RANGE);
+
+		groceryItems = List.of(new DietGroceryListItemDto("Avena", "1", "taza", "Cereales"));
+
+		when(nutritionistProfileService.getOrCreateProfile("user-1")).thenReturn(new NutritionistProfile());
+		when(nutritionistProfileService.getLogoAsBase64DataUri("user-1")).thenReturn(null);
+		when(templateEngine.process(eq("sbadmin/pacientes/lista-compras-pdf"), any(Context.class)))
+			.thenReturn("<html><body>Test</body></html>");
+	}
+
+	@Test
+	public void generatePdf_returnsNonEmptyBytes() {
+		final byte[] pdfBytes = groceryListPdfService.generatePdf(paciente, assignment, groceryItems, "user-1",
+				"Lic. Test");
+
+		assertThat(pdfBytes).isNotNull();
+		assertThat(pdfBytes.length).isGreaterThan(0);
+	}
+
+	@Test
+	public void generatePdf_weeklyAssignmentUsesPlanSemanalLabel() {
+		assignment.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
+		assignment.setDieta(null);
+
+		final ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+		groceryListPdfService.generatePdf(paciente, assignment, groceryItems, "user-1", null);
+
+		verify(templateEngine).process(eq("sbadmin/pacientes/lista-compras-pdf"), contextCaptor.capture());
+		assertThat(contextCaptor.getValue().getVariable("assignmentLabel")).isEqualTo("Plan semanal");
+	}
+
+	@Test
+	public void buildPdfResponse_setsAttachmentHeaders() {
+		final ResponseEntity<byte[]> response = groceryListPdfService.buildPdfResponse(paciente, assignment,
+				groceryItems, "user-1", null);
+
+		assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+		assertThat(response.getHeaders().getFirst("Content-Disposition")).contains("lista-de-compras.pdf");
+		assertThat(response.getHeaders().getContentType()).hasToString("application/pdf");
+		assertThat(response.getBody()).isNotNull();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
@@ -31,6 +31,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
+import org.springframework.http.ResponseEntity;
 
 import com.nutriconsultas.calendar.CalendarEvent;
 import com.nutriconsultas.calendar.CalendarEventService;
@@ -43,6 +44,8 @@ import com.nutriconsultas.clinical.exam.anthropometric.Circumferences;
 import com.nutriconsultas.paciente.calculation.ActivityFactorScale;
 import com.nutriconsultas.paciente.calculation.BmrCalculationService;
 import com.nutriconsultas.paciente.calculation.BmrFormulaType;
+
+import com.nutriconsultas.mobile.dto.DietGroceryListItemDto;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -66,6 +69,9 @@ public class PacienteControllerTest {
 
 	@Mock
 	private PacienteDietaService pacienteDietaService;
+
+	@Mock
+	private GroceryListPdfService groceryListPdfService;
 
 	@Mock
 	private com.nutriconsultas.dieta.DietaService dietaService;
@@ -2055,6 +2061,66 @@ public class PacienteControllerTest {
 		assertThat(saved.getActivityFactorScale()).isEqualTo(ActivityFactorScale.FAO_WHO);
 		assertThat(saved.getPreferredBmrFormula()).isEqualTo(BmrFormulaType.MIFFLIN_ST_JEOR);
 		assertThat(saved.getCustomFactorModerate()).isEqualTo(2.05);
+	}
+
+	@Test
+	public void listaComprasAsignacion_returnsListaComprasView() {
+		final PacienteDieta assignment = new PacienteDieta();
+		assignment.setId(7L);
+		assignment.setPaciente(paciente);
+		final List<DietGroceryListItemDto> items = List
+			.of(new DietGroceryListItemDto("Manzana", "1", "pieza", "Frutas"));
+		final Model model = org.mockito.Mockito.mock(Model.class);
+
+		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
+		when(pacienteDietaService.findById(7L)).thenReturn(assignment);
+		when(pacienteDietaService.buildGroceryList(assignment)).thenReturn(items);
+
+		final String result = controller.listaComprasAsignacion(1L, 7L, model, principal);
+
+		assertThat(result).isEqualTo("sbadmin/pacientes/lista-compras");
+		verify(model).addAttribute("groceryItems", items);
+		verify(model).addAttribute("paciente", paciente);
+		verify(model).addAttribute("pacienteDieta", assignment);
+	}
+
+	@Test
+	public void listaComprasAsignacionPdf_returnsPdfResponse() {
+		final PacienteDieta assignment = new PacienteDieta();
+		assignment.setId(7L);
+		assignment.setPaciente(paciente);
+		final List<DietGroceryListItemDto> items = List
+			.of(new DietGroceryListItemDto("Manzana", "1", "pieza", "Frutas"));
+		final byte[] pdfBytes = new byte[] { 1, 2, 3 };
+		final ResponseEntity<byte[]> pdfResponse = ResponseEntity.ok().body(pdfBytes);
+
+		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
+		when(pacienteDietaService.findById(7L)).thenReturn(assignment);
+		when(pacienteDietaService.buildGroceryList(assignment)).thenReturn(items);
+		when(groceryListPdfService.buildPdfResponse(eq(paciente), eq(assignment), eq(items), eq(TEST_USER_ID), any()))
+			.thenReturn(pdfResponse);
+
+		final ResponseEntity<byte[]> result = controller.listaComprasAsignacionPdf(1L, 7L, principal);
+
+		assertThat(result.getBody()).isEqualTo(pdfBytes);
+		verify(groceryListPdfService).buildPdfResponse(eq(paciente), eq(assignment), eq(items), eq(TEST_USER_ID),
+				any());
+	}
+
+	@Test
+	public void listaComprasAsignacionPdf_throwsWhenAssignmentBelongsToOtherPatient() {
+		final Paciente otherPatient = new Paciente();
+		otherPatient.setId(99L);
+		final PacienteDieta assignment = new PacienteDieta();
+		assignment.setId(7L);
+		assignment.setPaciente(otherPatient);
+
+		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
+		when(pacienteDietaService.findById(7L)).thenReturn(assignment);
+
+		assertThatThrownBy(() -> controller.listaComprasAsignacionPdf(1L, 7L, principal))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("no pertenece");
 	}
 
 	private void assertPacienteBmrMatchesPromedio(final double peso, final double estatura) {


### PR DESCRIPTION
## Summary
- Add `GroceryListPdfService` with Flying Saucer PDF generation and nutritionist branding (logo/credentials).
- New endpoint `GET /admin/pacientes/{pacienteId}/dietas/{id}/lista-compras.pdf` with multi-tenant ownership checks.
- **Descargar PDF** button on the lista de compras page; works for DATE_RANGE and WEEKLY assignments.

Closes #532.

## Test plan
- [x] `./lint.sh` (checkstyle, spotbugs, PMD, Thymeleaf)
- [x] `GroceryListPdfServiceTest` — PDF bytes, weekly label, response headers
- [x] `PacienteControllerTest` — lista compras view + PDF endpoint + ownership guard
- [x] Thymeleaf validation (96/96 templates)
- [ ] Manual: open lista de compras → **Descargar PDF** → verify patient name, plan label, grocery rows


Made with [Cursor](https://cursor.com)