### PR TITLE
Clinical exam thyroid indicator fields (#530)

### DIFF
--- a/ISSUE-NUTRITIONIST-WEB.md
+++ b/ISSUE-NUTRITIONIST-WEB.md
@@ -218,11 +218,11 @@ Feedback from the latest published version — diet assignment, authoring UX, cl
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|-----------|-------|
 | **525** | Patient diet assignment — weekly day-of-week plans with grocery list | https://github.com/diego-torres/nutriconsultas/issues/525 | **done** | #353 (grocery) | PR [#531](https://github.com/diego-torres/nutriconsultas/pull/531); `paciente_dieta_weekday` + web lista de compras |
-| **532** | Grocery list — downloadable PDF for print | https://github.com/diego-torres/nutriconsultas/issues/532 | **in-progress** | **525** | Flying Saucer PDF from `/lista-compras`; branded logo; DATE_RANGE + WEEKLY |
+| **532** | Grocery list — downloadable PDF for print | https://github.com/diego-torres/nutriconsultas/issues/532 | **done** | **525** | PR [#537](https://github.com/diego-torres/nutriconsultas/pull/537); Flying Saucer PDF + **Descargar PDF** |
 | **526** | Alimentos ordering — sequence metadata + drag-reorder in diets and platillos | https://github.com/diego-torres/nutriconsultas/issues/526 | **done** | — | `orden` on `AlimentoIngesta` + `Ingrediente`; mirror ingesta drag-reorder |
 | **527** | Diet ingesta — create catalog platillo from selected alimentos combination | https://github.com/diego-torres/nutriconsultas/issues/527 | **done** | #257 | PR [#536](https://github.com/diego-torres/nutriconsultas/pull/536); crear platillo + replace selection + active ingesta |
 | **528** | Default portion type to porción (not gramos) when adding alimentos | https://github.com/diego-torres/nutriconsultas/issues/528 | **done** | — | PR [#533](https://github.com/diego-torres/nutriconsultas/pull/533); `#tipoPorcion` default in diet add-alimento modal |
-| **530** | Clinical exam (clínicos) — thyroid indicator fields | https://github.com/diego-torres/nutriconsultas/issues/530 | **open** | #46 | TSH, T4 libre, T3 libre; Liquibase + `clinicos.html` tab |
+| **530** | Clinical exam (clínicos) — thyroid indicator fields | https://github.com/diego-torres/nutriconsultas/issues/530 | **in-progress** | #46 | TSH, T4 libre, T3 libre, Anti-TPO; Liquibase + Tiroides tab |
 
 ---
 

--- a/src/main/java/com/nutriconsultas/clinical/exam/ClinicalExam.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/ClinicalExam.java
@@ -79,6 +79,10 @@ public class ClinicalExam {
 	private OtherIndicators otherTests;
 
 	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+	@JoinColumn(name = "thyroid_panel_id")
+	private ThyroidPanel thyroidPanel;
+
+	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
 	@JoinColumn(name = "body_composition_id")
 	private com.nutriconsultas.clinical.exam.anthropometric.BodyComposition bodyComposition;
 
@@ -422,6 +426,50 @@ public class ClinicalExam {
 			otherTests = new OtherIndicators();
 		}
 		otherTests.setFerritina(ferritina);
+	}
+
+	public Double getTsh() {
+		return thyroidPanel != null ? thyroidPanel.getTsh() : null;
+	}
+
+	public void setTsh(final Double tsh) {
+		if (thyroidPanel == null) {
+			thyroidPanel = new ThyroidPanel();
+		}
+		thyroidPanel.setTsh(tsh);
+	}
+
+	public Double getT4Libre() {
+		return thyroidPanel != null ? thyroidPanel.getT4Libre() : null;
+	}
+
+	public void setT4Libre(final Double t4Libre) {
+		if (thyroidPanel == null) {
+			thyroidPanel = new ThyroidPanel();
+		}
+		thyroidPanel.setT4Libre(t4Libre);
+	}
+
+	public Double getT3Libre() {
+		return thyroidPanel != null ? thyroidPanel.getT3Libre() : null;
+	}
+
+	public void setT3Libre(final Double t3Libre) {
+		if (thyroidPanel == null) {
+			thyroidPanel = new ThyroidPanel();
+		}
+		thyroidPanel.setT3Libre(t3Libre);
+	}
+
+	public Double getAntiTpo() {
+		return thyroidPanel != null ? thyroidPanel.getAntiTpo() : null;
+	}
+
+	public void setAntiTpo(final Double antiTpo) {
+		if (thyroidPanel == null) {
+			thyroidPanel = new ThyroidPanel();
+		}
+		thyroidPanel.setAntiTpo(antiTpo);
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/clinical/exam/ThyroidPanel.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/ThyroidPanel.java
@@ -1,0 +1,34 @@
+package com.nutriconsultas.clinical.exam;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ThyroidPanel {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(precision = 5)
+	private Double tsh;
+
+	@Column(precision = 5)
+	private Double t4Libre;
+
+	@Column(precision = 5)
+	private Double t3Libre;
+
+	@Column(precision = 5)
+	private Double antiTpo;
+
+}

--- a/src/main/resources/db/changelog/changes/032-thyroid-panel.yaml
+++ b/src/main/resources/db/changelog/changes/032-thyroid-panel.yaml
@@ -1,0 +1,58 @@
+databaseChangeLog:
+  - changeSet:
+      id: 032-thyroid-panel-table
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            tableExists:
+              tableName: thyroid_panel
+      changes:
+        - createTable:
+            tableName: thyroid_panel
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: tsh
+                  type: FLOAT
+              - column:
+                  name: t4_libre
+                  type: FLOAT
+              - column:
+                  name: t3_libre
+                  type: FLOAT
+              - column:
+                  name: anti_tpo
+                  type: FLOAT
+  - changeSet:
+      id: 032-clinical-exam-thyroid-panel-fk
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            columnExists:
+              tableName: clinical_exam
+              columnName: thyroid_panel_id
+      changes:
+        - addColumn:
+            tableName: clinical_exam
+            columns:
+              - column:
+                  name: thyroid_panel_id
+                  type: BIGINT
+        - addUniqueConstraint:
+            tableName: clinical_exam
+            columnNames: thyroid_panel_id
+            constraintName: uk_clinical_exam_thyroid_panel_id
+        - addForeignKeyConstraint:
+            baseTableName: clinical_exam
+            baseColumnNames: thyroid_panel_id
+            referencedTableName: thyroid_panel
+            referencedColumnNames: id
+            constraintName: fk_clinical_exam_thyroid_panel

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -92,3 +92,6 @@ databaseChangeLog:
   - include:
       file: changes/031-alimento-ingrediente-orden.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/032-thyroid-panel.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -83,3 +83,6 @@ databaseChangeLog:
   - include:
       file: changes/031-alimento-ingrediente-orden.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/032-thyroid-panel.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/templates/sbadmin/pacientes/clinicos.html
+++ b/src/main/resources/templates/sbadmin/pacientes/clinicos.html
@@ -121,6 +121,11 @@
                           </a>
                         </li>
                         <li class="nav-item">
+                          <a class="nav-link" id="thyroid-panel-tab" data-toggle="tab" href="#thyroid-panel" role="tab" aria-controls="thyroid-panel" aria-selected="false">
+                            <i class="fas fa-notes-medical"></i> Tiroides
+                          </a>
+                        </li>
+                        <li class="nav-item">
                           <a class="nav-link" id="other-tests-tab" data-toggle="tab" href="#other-tests" role="tab" aria-controls="other-tests" aria-selected="false">
                             <i class="fas fa-vial"></i> Otros Exámenes
                           </a>
@@ -348,6 +353,42 @@
                           </div>
                         </div>
 
+                        <!-- Thyroid Panel Tab -->
+                        <div class="tab-pane fade" id="thyroid-panel" role="tabpanel" aria-labelledby="thyroid-panel-tab">
+                          <div class="row">
+                            <div class="col-md-6">
+                              <div class="form-group">
+                                <label>TSH (mUI/L)</label>
+                                <input type="number" step="0.01" th:field="*{tsh}" class="form-control">
+                                <span th:if="${#fields.hasErrors('tsh')}" th:errors="*{tsh}"></span>
+                              </div>
+                            </div>
+                            <div class="col-md-6">
+                              <div class="form-group">
+                                <label>T4 libre (ng/dL)</label>
+                                <input type="number" step="0.01" th:field="*{t4Libre}" class="form-control">
+                                <span th:if="${#fields.hasErrors('t4Libre')}" th:errors="*{t4Libre}"></span>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="row">
+                            <div class="col-md-6">
+                              <div class="form-group">
+                                <label>T3 libre (pg/mL)</label>
+                                <input type="number" step="0.01" th:field="*{t3Libre}" class="form-control">
+                                <span th:if="${#fields.hasErrors('t3Libre')}" th:errors="*{t3Libre}"></span>
+                              </div>
+                            </div>
+                            <div class="col-md-6">
+                              <div class="form-group">
+                                <label>Anti-TPO (UI/mL)</label>
+                                <input type="number" step="0.01" th:field="*{antiTpo}" class="form-control">
+                                <span th:if="${#fields.hasErrors('antiTpo')}" th:errors="*{antiTpo}"></span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+
                         <!-- Other Tests Tab -->
                         <div class="tab-pane fade" id="other-tests" role="tabpanel" aria-labelledby="other-tests-tab">
                           <div class="row">
@@ -478,7 +519,13 @@
           vitaminaD: { min: 30, max: 100, borderlineMin: 20, borderlineMax: 150 },
           vitaminaB12: { min: 200, max: 900, borderlineMin: 150, borderlineMax: 1000 },
           hierro: { min: 60, max: 170, borderlineMin: 40, borderlineMax: 200 },
-          ferritina: { min: 15, max: 200, borderlineMin: 10, borderlineMax: 300 }
+          ferritina: { min: 15, max: 200, borderlineMin: 10, borderlineMax: 300 },
+
+          // Thyroid panel
+          tsh: { min: 0.4, max: 4.0, borderlineMin: 0.27, borderlineMax: 10.0 },
+          t4Libre: { min: 0.8, max: 1.8, borderlineMin: 0.6, borderlineMax: 2.5 },
+          t3Libre: { min: 2.3, max: 4.2, borderlineMin: 1.8, borderlineMax: 5.0 },
+          antiTpo: { min: null, max: 35, borderlineMin: 35, borderlineMax: 100 }
         };
 
         /**

--- a/src/main/resources/templates/sbadmin/pacientes/ver-examen-clinico.html
+++ b/src/main/resources/templates/sbadmin/pacientes/ver-examen-clinico.html
@@ -119,6 +119,11 @@
                       </a>
                     </li>
                     <li class="nav-item">
+                      <a class="nav-link" id="thyroid-panel-tab" data-toggle="tab" href="#thyroid-panel" role="tab" aria-controls="thyroid-panel" aria-selected="false">
+                        <i class="fas fa-notes-medical"></i> Tiroides
+                      </a>
+                    </li>
+                    <li class="nav-item">
                       <a class="nav-link" id="other-tests-tab" data-toggle="tab" href="#other-tests" role="tab" aria-controls="other-tests" aria-selected="false">
                         <i class="fas fa-vial"></i> Otros Exámenes
                       </a>
@@ -237,6 +242,24 @@
                         </div>
                         <div class="col-md-6" th:if="${exam.plaquetas != null}">
                           <p><strong>Plaquetas:</strong> <span th:text="${#numbers.formatDecimal(exam.plaquetas, 2, 2)} + ' x10³/μL'">-</span></p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- Thyroid Panel Tab -->
+                    <div class="tab-pane fade" id="thyroid-panel" role="tabpanel" aria-labelledby="thyroid-panel-tab">
+                      <div class="row">
+                        <div class="col-md-6" th:if="${exam.tsh != null}">
+                          <p><strong>TSH:</strong> <span th:text="${#numbers.formatDecimal(exam.tsh, 2, 2)} + ' mUI/L'">-</span></p>
+                        </div>
+                        <div class="col-md-6" th:if="${exam.t4Libre != null}">
+                          <p><strong>T4 libre:</strong> <span th:text="${#numbers.formatDecimal(exam.t4Libre, 2, 2)} + ' ng/dL'">-</span></p>
+                        </div>
+                        <div class="col-md-6" th:if="${exam.t3Libre != null}">
+                          <p><strong>T3 libre:</strong> <span th:text="${#numbers.formatDecimal(exam.t3Libre, 2, 2)} + ' pg/mL'">-</span></p>
+                        </div>
+                        <div class="col-md-6" th:if="${exam.antiTpo != null}">
+                          <p><strong>Anti-TPO:</strong> <span th:text="${#numbers.formatDecimal(exam.antiTpo, 2, 2)} + ' UI/mL'">-</span></p>
                         </div>
                       </div>
                     </div>

--- a/src/test/java/com/nutriconsultas/clinical/exam/ClinicalExamThyroidPanelTest.java
+++ b/src/test/java/com/nutriconsultas/clinical/exam/ClinicalExamThyroidPanelTest.java
@@ -1,0 +1,37 @@
+package com.nutriconsultas.clinical.exam;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+class ClinicalExamThyroidPanelTest {
+
+	@Test
+	void thyroidConvenienceMethods_createPanelOnSetAndReadBack() {
+		final ClinicalExam exam = new ClinicalExam();
+
+		exam.setTsh(2.5);
+		exam.setT4Libre(1.2);
+		exam.setT3Libre(3.1);
+		exam.setAntiTpo(15.0);
+
+		assertThat(exam.getThyroidPanel()).isNotNull();
+		assertThat(exam.getTsh()).isEqualTo(2.5);
+		assertThat(exam.getT4Libre()).isEqualTo(1.2);
+		assertThat(exam.getT3Libre()).isEqualTo(3.1);
+		assertThat(exam.getAntiTpo()).isEqualTo(15.0);
+	}
+
+	@Test
+	void thyroidConvenienceMethods_returnNullWhenUnset() {
+		final ClinicalExam exam = new ClinicalExam();
+
+		assertThat(exam.getTsh()).isNull();
+		assertThat(exam.getT4Libre()).isNull();
+		assertThat(exam.getT3Libre()).isNull();
+		assertThat(exam.getAntiTpo()).isNull();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/ClinicalExamServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/ClinicalExamServiceTest.java
@@ -300,6 +300,11 @@ public class ClinicalExamServiceTest {
 		completeExam.setVitaminaB12(500.0);
 		completeExam.setHierro(100.0);
 		completeExam.setFerritina(50.0);
+		// Thyroid panel
+		completeExam.setTsh(2.5);
+		completeExam.setT4Libre(1.2);
+		completeExam.setT3Libre(3.1);
+		completeExam.setAntiTpo(12.0);
 
 		when(repository.save(any(ClinicalExam.class))).thenAnswer(invocation -> {
 			final ClinicalExam savedExam = invocation.getArgument(0);
@@ -335,6 +340,11 @@ public class ClinicalExamServiceTest {
 		// Verify other tests
 		assertThat(result.getVitaminaD()).isEqualTo(35.0);
 		assertThat(result.getVitaminaB12()).isEqualTo(500.0);
+		// Verify thyroid panel
+		assertThat(result.getTsh()).isEqualTo(2.5);
+		assertThat(result.getT4Libre()).isEqualTo(1.2);
+		assertThat(result.getT3Libre()).isEqualTo(3.1);
+		assertThat(result.getAntiTpo()).isEqualTo(12.0);
 		verify(repository).save(any(ClinicalExam.class));
 		log.info("finished testSaveWithAllBiochemicalFields");
 	}


### PR DESCRIPTION
## Summary
- Add `ThyroidPanel` entity (TSH, T4 libre, T3 libre, Anti-TPO) linked to `ClinicalExam`.
- Liquibase changeset `032-thyroid-panel.yaml` for `thyroid_panel` table and FK on `clinical_exam`.
- New **Tiroides** tab on clinical exam create/edit and read-only detail view with reference-range color coding.

Closes #530.

## Test plan
- [x] `./lint.sh` (checkstyle, spotbugs, PMD, Thymeleaf)
- [x] `ClinicalExamThyroidPanelTest` — convenience getters/setters
- [x] `ClinicalExamServiceTest#testSaveWithAllBiochemicalFields` — thyroid fields persist
- [x] `LiquibaseMigrationTest` — migration applies cleanly
- [ ] Manual: create exam with thyroid values → save → ver-examen-clinico shows Tiroides tab


Made with [Cursor](https://cursor.com)