### PR TITLE
Patient profile photo upload with S3 storage (#529)

### DIFF
--- a/docs/api/openapi-mobile.yaml
+++ b/docs/api/openapi-mobile.yaml
@@ -303,6 +303,61 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/ApiResponsePatientOnboardingProfileDto"
+  /rest/mobile/patient/profile/photo:
+    get:
+      tags:
+      - Mobile
+      summary: Get patient profile photo
+      description: Returns custom photo bytes or redirects to catalog avatar when no custom photo is set.
+      operationId: getProfilePhoto
+      responses:
+        "200":
+          description: Custom profile photo bytes
+          content:
+            image/*:
+              schema:
+                type: string
+                format: binary
+        "302":
+          description: Redirect to catalog avatar when no custom photo is stored
+        "401":
+          description: Missing or invalid JWT
+        "403":
+          description: Patient account not linked to Auth0 sub
+        "404":
+          description: Patient not found
+    put:
+      tags:
+      - Mobile
+      summary: Upload patient profile photo
+      description: Stores a custom profile photo in S3 for the authenticated patient.
+      operationId: uploadProfilePhoto
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+              - photoFile
+              properties:
+                photoFile:
+                  type: string
+                  format: binary
+                  description: Image file (JPG, PNG, GIF, or WebP)
+      responses:
+        "200":
+          description: Upload succeeded
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseMobilePatientPhotoResponse"
+        "400":
+          description: Empty or unreadable file
+        "401":
+          description: Missing or invalid JWT
+        "403":
+          description: Patient account not linked to Auth0 sub
   /rest/mobile/patient/visits:
     get:
       tags:
@@ -1120,6 +1175,10 @@ components:
           type: string
           description: Selected avatar id
           example: avatar_6
+        avatarUrl:
+          type: string
+          description: Profile picture URL (custom S3 photo or catalog avatar)
+          example: /rest/mobile/patient/profile/photo
         assignedId:
           type: string
           description: Clinic-facing identifier
@@ -1135,6 +1194,27 @@ components:
         assignedDietPlan:
           $ref: "#/components/schemas/AssignedDietPlanReferenceDto"
           description: "Primary active diet assignment, when present"
+    ApiResponseMobilePatientPhotoResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/MobilePatientPhotoResponse"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    MobilePatientPhotoResponse:
+      type: object
+      properties:
+        photoUrl:
+          type: string
+          description: Resolver URL for the profile picture
+          example: /rest/mobile/patient/profile/photo
+        photoExtension:
+          type: string
+          description: Stored file extension when a custom photo exists
+          example: png
     ApiResponsePagedResponseVisitSummaryDto:
       type: object
       properties:

--- a/src/main/java/com/nutriconsultas/controller/AdminMultipartExceptionHandler.java
+++ b/src/main/java/com/nutriconsultas/controller/AdminMultipartExceptionHandler.java
@@ -65,7 +65,7 @@ public class AdminMultipartExceptionHandler {
 		}
 		final Matcher patientMatcher = PACIENTE_PHOTO_URI.matcher(requestUri);
 		if (patientMatcher.matches()) {
-			return "redirect:/admin/pacientes/" + patientMatcher.group(1) + "/perfil";
+			return "redirect:/admin/pacientes/" + patientMatcher.group(1);
 		}
 		if ("/admin/perfil/logo".equals(requestUri)) {
 			return "redirect:/admin/perfil";

--- a/src/main/java/com/nutriconsultas/controller/AdminMultipartExceptionHandler.java
+++ b/src/main/java/com/nutriconsultas/controller/AdminMultipartExceptionHandler.java
@@ -21,6 +21,8 @@ public class AdminMultipartExceptionHandler {
 
 	private static final Pattern PLATILLO_PICTURE_URI = Pattern.compile("^/admin/platillos/(\\d+)/picture$");
 
+	private static final Pattern PACIENTE_PHOTO_URI = Pattern.compile("^/admin/pacientes/(\\d+)/photo$");
+
 	private final DataSize maxFileSize;
 
 	public AdminMultipartExceptionHandler(
@@ -41,6 +43,10 @@ public class AdminMultipartExceptionHandler {
 		if ("/admin/perfil/logo".equals(requestUri)) {
 			return "El archivo supera el tamaño máximo permitido (" + sizeLabel + ").";
 		}
+		final Matcher patientMatcher = PACIENTE_PHOTO_URI.matcher(requestUri);
+		if (patientMatcher.matches()) {
+			return "La foto supera el tamaño máximo permitido (" + sizeLabel + ").";
+		}
 		return "La imagen supera el tamaño máximo permitido (" + sizeLabel + ").";
 	}
 
@@ -56,6 +62,10 @@ public class AdminMultipartExceptionHandler {
 		final Matcher platilloMatcher = PLATILLO_PICTURE_URI.matcher(requestUri);
 		if (platilloMatcher.matches()) {
 			return "redirect:/admin/platillos/" + platilloMatcher.group(1);
+		}
+		final Matcher patientMatcher = PACIENTE_PHOTO_URI.matcher(requestUri);
+		if (patientMatcher.matches()) {
+			return "redirect:/admin/pacientes/" + patientMatcher.group(1) + "/perfil";
 		}
 		if ("/admin/perfil/logo".equals(requestUri)) {
 			return "redirect:/admin/perfil";

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientAccessRules.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientAccessRules.java
@@ -15,6 +15,8 @@ public final class MobilePatientAccessRules {
 
 	private static final String ONBOARDING_PROFILE_PATH = "/rest/mobile/patient/me";
 
+	private static final String ONBOARDING_PROFILE_PHOTO_PATH = "/rest/mobile/patient/profile/photo";
+
 	private MobilePatientAccessRules() {
 	}
 
@@ -53,7 +55,8 @@ public final class MobilePatientAccessRules {
 	}
 
 	public static boolean isOnboardingAllowedPath(final String path) {
-		return ONBOARDING_PROFILE_PATH.equals(path) || path.startsWith(ONBOARDING_PROFILE_PATH + "/");
+		return ONBOARDING_PROFILE_PATH.equals(path) || path.startsWith(ONBOARDING_PROFILE_PATH + "/")
+				|| ONBOARDING_PROFILE_PHOTO_PATH.equals(path);
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientPhotoController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientPhotoController.java
@@ -1,0 +1,105 @@
+package com.nutriconsultas.mobile;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nutriconsultas.mobile.config.MobileOpenApiResponses;
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacientePhotoResponses;
+import com.nutriconsultas.paciente.PacientePhotoService;
+import com.nutriconsultas.paciente.PacientePictureSupport;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.util.LogRedaction;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/mobile/patient/profile/photo")
+@Tag(name = "Mobile", description = "Patient mobile API")
+@Slf4j
+public class MobilePatientPhotoController extends AbstractMobilePatientController {
+
+	private final PacientePhotoService pacientePhotoService;
+
+	private final PacienteRepository pacienteRepository;
+
+	public MobilePatientPhotoController(final PatientAuthService patientAuthService,
+			final PacientePhotoService pacientePhotoService, final PacienteRepository pacienteRepository) {
+		super(patientAuthService);
+		this.pacientePhotoService = pacientePhotoService;
+		this.pacienteRepository = pacienteRepository;
+	}
+
+	@GetMapping
+	@Operation(summary = "Get patient profile photo",
+			description = "Returns custom photo bytes or redirects to catalog avatar when no custom photo is set.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	public ResponseEntity<byte[]> getPhoto(@AuthenticationPrincipal final Jwt jwt) {
+		final Long pacienteId = getAuthenticatedPacienteId(jwt);
+		final Paciente paciente = pacienteRepository.findById(pacienteId)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+		return PacientePhotoResponses.buildPictureResponse(paciente, pacientePhotoService);
+	}
+
+	@PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@Operation(summary = "Upload patient profile photo", description = "Stores a custom profile photo in S3.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	@MobileOpenApiResponses.WriteEndpoint
+	public ApiResponse<MobilePatientPhotoResponse> uploadPhoto(@AuthenticationPrincipal final Jwt jwt,
+			@RequestParam("photoFile") final MultipartFile photoFile) {
+		final Long pacienteId = getAuthenticatedPacienteId(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile profile photo upload for patient {}", LogRedaction.redactPaciente(pacienteId));
+		}
+		final byte[] bytes = readBytes(photoFile);
+		final String extension = extractExtension(photoFile);
+		pacientePhotoService.savePhotoForPatient(pacienteId, bytes, extension);
+		final Paciente paciente = pacienteRepository.findById(pacienteId)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+		return ApiResponse.ok(new MobilePatientPhotoResponse(
+				PacientePictureSupport.resolveDisplayUrlForMobile(paciente), paciente.getPhotoExtension()));
+	}
+
+	private byte[] readBytes(final MultipartFile photoFile) {
+		if (photoFile == null || photoFile.isEmpty()) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "El archivo está vacío");
+		}
+		try {
+			return photoFile.getBytes();
+		}
+		catch (final IOException e) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No se pudo leer la imagen");
+		}
+	}
+
+	private String extractExtension(final MultipartFile photoFile) {
+		final String originalName = photoFile.getOriginalFilename();
+		if (originalName == null) {
+			return "png";
+		}
+		final int dotIndex = originalName.lastIndexOf('.');
+		if (dotIndex <= 0 || dotIndex >= originalName.length() - 1) {
+			return "png";
+		}
+		return originalName.substring(dotIndex + 1);
+	}
+
+	record MobilePatientPhotoResponse(String photoUrl, String photoExtension) {
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientPhotoController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientPhotoController.java
@@ -83,7 +83,7 @@ public class MobilePatientPhotoController extends AbstractMobilePatientControlle
 			return photoFile.getBytes();
 		}
 		catch (final IOException e) {
-			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No se pudo leer la imagen");
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No se pudo leer la imagen", e);
 		}
 	}
 

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientProgressService.java
@@ -24,6 +24,7 @@ import com.nutriconsultas.paciente.NivelPeso;
 import com.nutriconsultas.paciente.NivelPesoLabels;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteAvatarCatalog;
+import com.nutriconsultas.paciente.PacientePictureSupport;
 import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.paciente.metrics.BodyMetricRecord;
 import com.nutriconsultas.paciente.metrics.BodyMetricRecordService;
@@ -91,7 +92,7 @@ public class MobilePatientProgressService {
 				toInstant(previousRecord.map(BodyMetricRecord::getRecordedAt).orElse(null)), weightKg, heightM, bmi,
 				nivelPeso, NivelPesoLabels.toImcLabel(nivelPeso), paciente.getBmr(), bodyFatPercentage, deltaPeso,
 				deltaImc, loadCircumferences(pacienteId), PacienteAvatarCatalog.resolveSelectedId(paciente),
-				PacienteAvatarCatalog.resolveImagePath(paciente));
+				PacientePictureSupport.resolveDisplayUrlForMobile(paciente));
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/nutriconsultas/mobile/dto/PatientOnboardingProfileDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/PatientOnboardingProfileDto.java
@@ -10,6 +10,7 @@ import com.nutriconsultas.mobile.PatientOnboardingCompleteness;
 import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaStatus;
+import com.nutriconsultas.paciente.PacientePictureSupport;
 import com.nutriconsultas.paciente.PacienteStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -28,6 +29,8 @@ public record PatientOnboardingProfileDto(@Schema(description = "Paciente id", e
 		@Schema(description = "Contact email", example = "maria@example.com") String email,
 		@Schema(description = "Contact phone", example = "+525512345678") String phone,
 		@Schema(description = "Selected avatar id", example = "avatar_6") String avatarId,
+		@Schema(description = "Profile picture URL (custom S3 photo or catalog avatar)",
+				example = "/rest/mobile/patient/profile/photo") String avatarUrl,
 		@Schema(description = "Clinic-facing identifier", example = "P-CLINIC-001") String assignedId,
 		@Schema(description = "True when all required onboarding fields are present",
 				example = "false") boolean profileComplete,
@@ -39,7 +42,8 @@ public record PatientOnboardingProfileDto(@Schema(description = "Paciente id", e
 			final AssignedDietPlanReferenceDto assignedDietPlan, final String nutritionistDisplayName) {
 		return new PatientOnboardingProfileDto(paciente.getId(), paciente.getStatus(), paciente.getName(),
 				paciente.getDisplayName(), toLocalDate(paciente.getDob()), paciente.getGender(), paciente.getEmail(),
-				paciente.getPhone(), paciente.getAvatarId(), paciente.getAssignedId(),
+				paciente.getPhone(), paciente.getAvatarId(),
+				PacientePictureSupport.resolveDisplayUrlForMobile(paciente), paciente.getAssignedId(),
 				PatientOnboardingCompleteness.isComplete(paciente), nutritionistDisplayName, assignedDietPlan);
 	}
 

--- a/src/main/java/com/nutriconsultas/paciente/Paciente.java
+++ b/src/main/java/com/nutriconsultas/paciente/Paciente.java
@@ -126,6 +126,13 @@ public class Paciente {
 	@Column(name = "avatar_id", length = 32)
 	private String avatarId;
 
+	/**
+	 * Custom profile photo extension in S3 ({@code patients/{id}/photo.{ext}}), #529.
+	 * When null, UI uses {@link PacienteAvatarCatalog}.
+	 */
+	@Column(name = "photo_extension", length = 16)
+	private String photoExtension;
+
 	public static final String DATE_OF_BIRTH_PATTERN = "dd/MM/yyyy";
 
 	@DateTimeFormat(pattern = DATE_OF_BIRTH_PATTERN)

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -1109,7 +1109,7 @@ public class PacienteController extends AbstractAuthorizedController {
 		verifyPatientOwnership(paciente, userId);
 		if (photoFile == null || photoFile.isEmpty()) {
 			redirectAttributes.addFlashAttribute("errorMessage", "El archivo está vacío");
-			return String.format("redirect:/admin/pacientes/%d/perfil", id);
+			return String.format("redirect:/admin/pacientes/%d", id);
 		}
 		try {
 			final String extension = extractPhotoExtension(photoFile.getOriginalFilename());
@@ -1123,7 +1123,7 @@ public class PacienteController extends AbstractAuthorizedController {
 		catch (final IllegalArgumentException e) {
 			redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
 		}
-		return String.format("redirect:/admin/pacientes/%d/perfil", id);
+		return String.format("redirect:/admin/pacientes/%d", id);
 	}
 
 	@PostMapping(path = "/admin/pacientes/{id}/photo/delete")
@@ -1140,7 +1140,7 @@ public class PacienteController extends AbstractAuthorizedController {
 		catch (final IllegalArgumentException e) {
 			redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
 		}
-		return String.format("redirect:/admin/pacientes/%d/perfil", id);
+		return String.format("redirect:/admin/pacientes/%d", id);
 	}
 
 	private String extractPhotoExtension(final String originalFilename) {

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -125,6 +125,9 @@ public class PacienteController extends AbstractAuthorizedController {
 	private PacienteMpxImportService pacienteMpxImportService;
 
 	@Autowired
+	private PacientePhotoService pacientePhotoService;
+
+	@Autowired
 	private com.nutriconsultas.paciente.invitation.PatientMobileInvitationService patientMobileInvitationService;
 
 	/**
@@ -1076,6 +1079,79 @@ public class PacienteController extends AbstractAuthorizedController {
 		log.debug("Cancelando asignación de dieta {}", id);
 		pacienteDietaService.cancelAssignment(id);
 		return String.format("redirect:/admin/pacientes/%d/dietas", pacienteId);
+	}
+
+	@GetMapping(path = "/admin/pacientes/{id}/picture")
+	public ResponseEntity<byte[]> getPacientePicture(@PathVariable @NonNull final Long id,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = getUserId(principal);
+		if (userId == null) {
+			return ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();
+		}
+		final Paciente paciente = pacienteRepository.findByIdAndUserId(id, userId).orElse(null);
+		if (paciente == null) {
+			return ResponseEntity.notFound().build();
+		}
+		verifyPatientOwnership(paciente, userId);
+		return PacientePhotoResponses.buildPictureResponse(paciente, pacientePhotoService);
+	}
+
+	@PostMapping(path = "/admin/pacientes/{id}/photo")
+	public String uploadPacientePhoto(@PathVariable @NonNull final Long id,
+			@RequestParam("photoFile") final MultipartFile photoFile, @AuthenticationPrincipal final OidcUser principal,
+			final RedirectAttributes redirectAttributes) {
+		final String userId = getUserId(principal);
+		if (userId == null) {
+			throw new IllegalArgumentException("No se pudo identificar al usuario");
+		}
+		final Paciente paciente = pacienteRepository.findByIdAndUserId(id, userId)
+			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado paciente con folio " + id));
+		verifyPatientOwnership(paciente, userId);
+		if (photoFile == null || photoFile.isEmpty()) {
+			redirectAttributes.addFlashAttribute("errorMessage", "El archivo está vacío");
+			return String.format("redirect:/admin/pacientes/%d/perfil", id);
+		}
+		try {
+			final String extension = extractPhotoExtension(photoFile.getOriginalFilename());
+			pacientePhotoService.savePhotoForNutritionist(id, userId, photoFile.getBytes(), extension);
+			redirectAttributes.addFlashAttribute("successMessage", "Foto del paciente actualizada.");
+		}
+		catch (final java.io.IOException e) {
+			log.error("Failed to upload photo for patient id {}", id, e);
+			redirectAttributes.addFlashAttribute("errorMessage", "Error al subir la foto");
+		}
+		catch (final IllegalArgumentException e) {
+			redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+		}
+		return String.format("redirect:/admin/pacientes/%d/perfil", id);
+	}
+
+	@PostMapping(path = "/admin/pacientes/{id}/photo/delete")
+	public String deletePacientePhoto(@PathVariable @NonNull final Long id,
+			@AuthenticationPrincipal final OidcUser principal, final RedirectAttributes redirectAttributes) {
+		final String userId = getUserId(principal);
+		if (userId == null) {
+			throw new IllegalArgumentException("No se pudo identificar al usuario");
+		}
+		try {
+			pacientePhotoService.deletePhotoForNutritionist(id, userId);
+			redirectAttributes.addFlashAttribute("successMessage", "Foto personalizada eliminada.");
+		}
+		catch (final IllegalArgumentException e) {
+			redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+		}
+		return String.format("redirect:/admin/pacientes/%d/perfil", id);
+	}
+
+	private String extractPhotoExtension(final String originalFilename) {
+		if (originalFilename == null) {
+			return "png";
+		}
+		final int dotIndex = originalFilename.lastIndexOf('.');
+		if (dotIndex <= 0 || dotIndex >= originalFilename.length() - 1) {
+			return "png";
+		}
+		return originalFilename.substring(dotIndex + 1);
 	}
 
 	/**

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDeletionServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDeletionServiceImpl.java
@@ -2,6 +2,7 @@ package com.nutriconsultas.paciente;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,7 +47,8 @@ public class PacienteDeletionServiceImpl implements PacienteDeletionService {
 
 	private final PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository;
 
-	private final PacientePhotoService pacientePhotoService;
+	@Autowired
+	private PacientePhotoService pacientePhotoService;
 
 	public PacienteDeletionServiceImpl(final PacienteRepository pacienteRepository,
 			final PatientMessageRepository patientMessageRepository,
@@ -55,8 +57,7 @@ public class PacienteDeletionServiceImpl implements PacienteDeletionService {
 			final ClinicalExamService clinicalExamService,
 			final AnthropometricMeasurementService anthropometricMeasurementService,
 			final BodyMetricRecordRepository bodyMetricRecordRepository, final DietaService dietaService,
-			final PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository,
-			final PacientePhotoService pacientePhotoService) {
+			final PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository) {
 		this.pacienteRepository = pacienteRepository;
 		this.patientMessageRepository = patientMessageRepository;
 		this.patientInvitationRepository = patientInvitationRepository;
@@ -67,7 +68,6 @@ public class PacienteDeletionServiceImpl implements PacienteDeletionService {
 		this.bodyMetricRecordRepository = bodyMetricRecordRepository;
 		this.dietaService = dietaService;
 		this.pacienteDietaWeekdayRepository = pacienteDietaWeekdayRepository;
-		this.pacientePhotoService = pacientePhotoService;
 	}
 
 	@Override

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDeletionServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDeletionServiceImpl.java
@@ -46,6 +46,8 @@ public class PacienteDeletionServiceImpl implements PacienteDeletionService {
 
 	private final PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository;
 
+	private final PacientePhotoService pacientePhotoService;
+
 	public PacienteDeletionServiceImpl(final PacienteRepository pacienteRepository,
 			final PatientMessageRepository patientMessageRepository,
 			final PatientInvitationRepository patientInvitationRepository,
@@ -53,7 +55,8 @@ public class PacienteDeletionServiceImpl implements PacienteDeletionService {
 			final ClinicalExamService clinicalExamService,
 			final AnthropometricMeasurementService anthropometricMeasurementService,
 			final BodyMetricRecordRepository bodyMetricRecordRepository, final DietaService dietaService,
-			final PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository) {
+			final PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository,
+			final PacientePhotoService pacientePhotoService) {
 		this.pacienteRepository = pacienteRepository;
 		this.patientMessageRepository = patientMessageRepository;
 		this.patientInvitationRepository = patientInvitationRepository;
@@ -64,6 +67,7 @@ public class PacienteDeletionServiceImpl implements PacienteDeletionService {
 		this.bodyMetricRecordRepository = bodyMetricRecordRepository;
 		this.dietaService = dietaService;
 		this.pacienteDietaWeekdayRepository = pacienteDietaWeekdayRepository;
+		this.pacientePhotoService = pacientePhotoService;
 	}
 
 	@Override
@@ -72,6 +76,7 @@ public class PacienteDeletionServiceImpl implements PacienteDeletionService {
 		final Paciente paciente = pacienteRepository.findByIdAndUserId(pacienteId, userId)
 			.orElseThrow(() -> new IllegalArgumentException("Paciente no encontrado"));
 		logMobileLinkageClear(paciente);
+		pacientePhotoService.deletePhotoFromStorage(pacienteId, paciente.getPhotoExtension());
 		deleteRelatedHistory(pacienteId);
 		pacienteRepository.delete(paciente);
 		if (log.isInfoEnabled()) {

--- a/src/main/java/com/nutriconsultas/paciente/PacientePhotoResponses.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacientePhotoResponses.java
@@ -1,0 +1,36 @@
+package com.nutriconsultas.paciente;
+
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+
+/**
+ * Builds HTTP responses for patient profile picture resolver endpoints (#529).
+ */
+public final class PacientePhotoResponses {
+
+	private PacientePhotoResponses() {
+	}
+
+	public static ResponseEntity<byte[]> buildPictureResponse(@NonNull final Paciente paciente,
+			@NonNull final PacientePhotoService pacientePhotoService) {
+		if (!PacientePictureSupport.hasCustomPhoto(paciente)) {
+			return ResponseEntity.status(HttpStatus.FOUND)
+				.header(HttpHeaders.LOCATION, PacienteAvatarCatalog.resolveImagePath(paciente))
+				.build();
+		}
+		final byte[] bytes = pacientePhotoService.getPhotoBytes(paciente.getId());
+		if (bytes == null) {
+			return ResponseEntity.status(HttpStatus.FOUND)
+				.header(HttpHeaders.LOCATION, PacienteAvatarCatalog.resolveImagePath(paciente))
+				.build();
+		}
+		return ResponseEntity.ok()
+			.cacheControl(CacheControl.noStore())
+			.contentType(PacientePictureSupport.resolveMediaType(paciente.getPhotoExtension()))
+			.body(bytes);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacientePhotoService.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacientePhotoService.java
@@ -1,0 +1,25 @@
+package com.nutriconsultas.paciente;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+public interface PacientePhotoService {
+
+	void savePhotoForNutritionist(@NonNull Long pacienteId, @NonNull String userId, @NonNull byte[] bytes,
+			@NonNull String fileExtension);
+
+	void savePhotoForPatient(@NonNull Long pacienteId, @NonNull byte[] bytes, @NonNull String fileExtension);
+
+	void deletePhotoForNutritionist(@NonNull Long pacienteId, @NonNull String userId);
+
+	void deletePhotoForPatient(@NonNull Long pacienteId);
+
+	@Nullable
+	byte[] getPhotoBytes(@NonNull Long pacienteId);
+
+	@Nullable
+	String getPhotoExtension(@NonNull Long pacienteId);
+
+	void deletePhotoFromStorage(@NonNull Long pacienteId, @Nullable String extension);
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacientePhotoServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacientePhotoServiceImpl.java
@@ -146,7 +146,7 @@ public class PacientePhotoServiceImpl implements PacientePhotoService {
 		}
 		catch (final S3Exception e) {
 			log.error("Error uploading patient photo to S3 for patient id {}", pacienteId, e);
-			throw new IllegalStateException("Error al guardar la foto del paciente");
+			throw new IllegalStateException("Error al guardar la foto del paciente", e);
 		}
 	}
 

--- a/src/main/java/com/nutriconsultas/paciente/PacientePhotoServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacientePhotoServiceImpl.java
@@ -1,0 +1,176 @@
+package com.nutriconsultas.paciente;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@Service
+@Slf4j
+public class PacientePhotoServiceImpl implements PacientePhotoService {
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@Value("${amazon.s3.region}")
+	private String awsRegion;
+
+	@Value("${amazon.s3.bucket}")
+	private String bucketName;
+
+	@Value("${amazon.s3.key}")
+	private String accessKey;
+
+	@Value("${amazon.s3.secret}")
+	private String secretKey;
+
+	@Override
+	@Transactional
+	public void savePhotoForNutritionist(@NonNull final Long pacienteId, @NonNull final String userId,
+			@NonNull final byte[] bytes, @NonNull final String fileExtension) {
+		final Paciente paciente = requireOwnedPaciente(pacienteId, userId);
+		uploadPhoto(paciente, bytes, fileExtension);
+	}
+
+	@Override
+	@Transactional
+	public void savePhotoForPatient(@NonNull final Long pacienteId, @NonNull final byte[] bytes,
+			@NonNull final String fileExtension) {
+		final Paciente paciente = pacienteRepository.findById(pacienteId)
+			.orElseThrow(() -> new IllegalArgumentException("Paciente no encontrado"));
+		uploadPhoto(paciente, bytes, fileExtension);
+	}
+
+	@Override
+	@Transactional
+	public void deletePhotoForNutritionist(@NonNull final Long pacienteId, @NonNull final String userId) {
+		final Paciente paciente = requireOwnedPaciente(pacienteId, userId);
+		clearPhoto(paciente);
+	}
+
+	@Override
+	@Transactional
+	public void deletePhotoForPatient(@NonNull final Long pacienteId) {
+		final Paciente paciente = pacienteRepository.findById(pacienteId)
+			.orElseThrow(() -> new IllegalArgumentException("Paciente no encontrado"));
+		clearPhoto(paciente);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	@Nullable
+	public byte[] getPhotoBytes(@NonNull final Long pacienteId) {
+		final String extension = getPhotoExtension(pacienteId);
+		if (extension == null) {
+			return null;
+		}
+		final String key = PacientePictureSupport.buildPhotoKey(pacienteId, extension);
+		final S3Client s3Client = getClient();
+		try {
+			return s3Client.getObject(GetObjectRequest.builder().bucket(bucketName).key(key).build()).readAllBytes();
+		}
+		catch (final NoSuchKeyException e) {
+			log.warn("Patient photo missing in S3 for patient id {}", pacienteId);
+			return null;
+		}
+		catch (final Exception e) {
+			log.error("Error retrieving patient photo from S3 for patient id {}", pacienteId, e);
+			return null;
+		}
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	@Nullable
+	public String getPhotoExtension(@NonNull final Long pacienteId) {
+		return pacienteRepository.findById(pacienteId)
+			.map(Paciente::getPhotoExtension)
+			.filter(ext -> ext != null && !ext.isBlank())
+			.orElse(null);
+	}
+
+	@Override
+	public void deletePhotoFromStorage(@NonNull final Long pacienteId, @Nullable final String extension) {
+		if (extension == null || extension.isBlank()) {
+			return;
+		}
+		final String key = PacientePictureSupport.buildPhotoKey(pacienteId, extension);
+		final S3Client s3Client = getClient();
+		try {
+			if (keyExists(s3Client, key)) {
+				s3Client.deleteObject(builder -> builder.bucket(bucketName).key(key));
+			}
+		}
+		catch (final S3Exception e) {
+			log.error("Error deleting patient photo from S3 for patient id {}", pacienteId, e);
+		}
+	}
+
+	private Paciente requireOwnedPaciente(final Long pacienteId, final String userId) {
+		return pacienteRepository.findByIdAndUserId(pacienteId, userId)
+			.orElseThrow(() -> new IllegalArgumentException("Paciente no encontrado"));
+	}
+
+	private void uploadPhoto(final Paciente paciente, final byte[] bytes, final String fileExtension) {
+		final String extension = PacientePictureSupport.normalizeExtension(fileExtension);
+		final Long pacienteId = paciente.getId();
+		log.info("Uploading profile photo for patient id {}", pacienteId);
+		final String key = PacientePictureSupport.buildPhotoKey(pacienteId, extension);
+		final S3Client s3Client = getClient();
+		try {
+			if (paciente.getPhotoExtension() != null && !paciente.getPhotoExtension().equals(extension)) {
+				deletePhotoFromStorage(pacienteId, paciente.getPhotoExtension());
+			}
+			else if (keyExists(s3Client, key)) {
+				s3Client.deleteObject(builder -> builder.bucket(bucketName).key(key));
+			}
+			s3Client.putObject(PutObjectRequest.builder().bucket(bucketName).key(key).build(),
+					RequestBody.fromBytes(bytes));
+			paciente.setPhotoExtension(extension);
+			pacienteRepository.save(paciente);
+			log.info("Profile photo uploaded for patient id {}", pacienteId);
+		}
+		catch (final S3Exception e) {
+			log.error("Error uploading patient photo to S3 for patient id {}", pacienteId, e);
+			throw new IllegalStateException("Error al guardar la foto del paciente");
+		}
+	}
+
+	private void clearPhoto(final Paciente paciente) {
+		final Long pacienteId = paciente.getId();
+		deletePhotoFromStorage(pacienteId, paciente.getPhotoExtension());
+		paciente.setPhotoExtension(null);
+		pacienteRepository.save(paciente);
+		log.info("Removed custom profile photo for patient id {}", pacienteId);
+	}
+
+	private boolean keyExists(final S3Client s3Client, final String key) {
+		try {
+			s3Client.headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build());
+			return true;
+		}
+		catch (final NoSuchKeyException e) {
+			return false;
+		}
+	}
+
+	private S3Client getClient() {
+		final AwsCredentialsProvider credentialsProvider = () -> AwsBasicCredentials.create(accessKey, secretKey);
+		return S3Client.builder().region(Region.of(awsRegion)).credentialsProvider(credentialsProvider).build();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacientePictureSupport.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacientePictureSupport.java
@@ -1,0 +1,78 @@
+package com.nutriconsultas.paciente;
+
+import java.util.Locale;
+import java.util.Set;
+
+import org.springframework.http.MediaType;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+/**
+ * Resolves patient profile picture URLs and validates photo extensions (#529).
+ */
+public final class PacientePictureSupport {
+
+	private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif", "webp");
+
+	private PacientePictureSupport() {
+	}
+
+	public static boolean hasCustomPhoto(@Nullable final Paciente paciente) {
+		return paciente != null && paciente.getPhotoExtension() != null && !paciente.getPhotoExtension().isBlank();
+	}
+
+	public static String normalizeExtension(@NonNull final String extension) {
+		final String normalized = extension.trim().toLowerCase(Locale.ROOT);
+		if (!ALLOWED_EXTENSIONS.contains(normalized)) {
+			throw new IllegalArgumentException("Formato de imagen no permitido");
+		}
+		return normalized;
+	}
+
+	public static String adminPicturePath(@NonNull final Long pacienteId) {
+		return "/admin/pacientes/" + pacienteId + "/picture";
+	}
+
+	public static String restPicturePath(@NonNull final Long pacienteId) {
+		return "/rest/pacientes/" + pacienteId + "/picture";
+	}
+
+	public static String mobilePicturePath() {
+		return "/rest/mobile/patient/profile/photo";
+	}
+
+	public static String resolveDisplayUrlForAdmin(@Nullable final Paciente paciente) {
+		if (hasCustomPhoto(paciente)) {
+			return adminPicturePath(paciente.getId());
+		}
+		return PacienteAvatarCatalog.resolveImagePath(paciente);
+	}
+
+	public static String resolveDisplayUrlForRest(@Nullable final Paciente paciente) {
+		if (hasCustomPhoto(paciente)) {
+			return restPicturePath(paciente.getId());
+		}
+		return PacienteAvatarCatalog.resolveImagePath(paciente);
+	}
+
+	public static String resolveDisplayUrlForMobile(@Nullable final Paciente paciente) {
+		if (hasCustomPhoto(paciente)) {
+			return mobilePicturePath();
+		}
+		return PacienteAvatarCatalog.resolveImagePath(paciente);
+	}
+
+	public static MediaType resolveMediaType(@NonNull final String extension) {
+		return switch (extension.toLowerCase(Locale.ROOT)) {
+			case "jpg", "jpeg" -> MediaType.IMAGE_JPEG;
+			case "gif" -> MediaType.IMAGE_GIF;
+			case "webp" -> MediaType.parseMediaType("image/webp");
+			default -> MediaType.IMAGE_PNG;
+		};
+	}
+
+	public static String buildPhotoKey(@NonNull final Long pacienteId, @NonNull final String extension) {
+		return "patients/" + pacienteId + "/photo." + normalizeExtension(extension);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteProfileViewSupport.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteProfileViewSupport.java
@@ -11,7 +11,8 @@ public final class PacienteProfileViewSupport {
 	}
 
 	public static void addAvatarAttributes(final Model model, final Paciente paciente) {
-		model.addAttribute("avatarImageUrl", PacienteAvatarCatalog.resolveImagePath(paciente));
+		model.addAttribute("avatarImageUrl", PacientePictureSupport.resolveDisplayUrlForAdmin(paciente));
+		model.addAttribute("hasCustomPhoto", PacientePictureSupport.hasCustomPhoto(paciente));
 		model.addAttribute("selectedAvatarId", PacienteAvatarCatalog.resolveSelectedId(paciente));
 		model.addAttribute("avatarOptions", PacienteAvatarCatalog.allOptions());
 	}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteRestController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteRestController.java
@@ -23,6 +23,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -53,6 +54,9 @@ public class PacienteRestController extends AbstractGridController<PacienteListV
 
 	@Autowired
 	private PacienteDeletionService pacienteDeletionService;
+
+	@Autowired
+	private PacientePhotoService pacientePhotoService;
 
 	private static final Map<String, String> COLUMN_TO_FIELD_MAP = new HashMap<>();
 
@@ -309,13 +313,27 @@ public class PacienteRestController extends AbstractGridController<PacienteListV
 		try {
 			final Paciente saved = service.updateAvatar(id, userId, request.getAvatarId());
 			return ResponseEntity.ok(Map.of("success", true, "avatarId", saved.getAvatarId(), "avatarUrl",
-					PacienteAvatarCatalog.resolveImagePath(saved)));
+					PacientePictureSupport.resolveDisplayUrlForRest(saved)));
 		}
 		catch (final IllegalArgumentException ex) {
 			final HttpStatus status = ex.getMessage() != null && ex.getMessage().contains("no encontrado")
 					? HttpStatus.NOT_FOUND : HttpStatus.BAD_REQUEST;
 			return ResponseEntity.status(status).body(Map.of("success", false, "error", ex.getMessage()));
 		}
+	}
+
+	@GetMapping("/{id}/picture")
+	public ResponseEntity<byte[]> getPacientePicture(@PathVariable @NonNull final Long id,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = getUserId(principal);
+		if (userId == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
+		final Paciente paciente = service.findByIdAndUserId(id, userId);
+		if (paciente == null) {
+			return ResponseEntity.notFound().build();
+		}
+		return PacientePhotoResponses.buildPictureResponse(paciente, pacientePhotoService);
 	}
 
 	/**

--- a/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteTemplateValidator.java
@@ -42,6 +42,7 @@ public class PacienteTemplateValidator extends BaseTemplateValidator {
 		variables.put("mobileInvitation", new PatientMobileInvitationStatus("NONE", "Sin app", true, false, false, null,
 				null, null, "j***@example.com"));
 		variables.put("avatarImageUrl", PacienteAvatarCatalog.resolveImagePath(paciente));
+		variables.put("hasCustomPhoto", false);
 		variables.put("selectedAvatarId", PacienteAvatarCatalog.resolveSelectedId(paciente));
 		variables.put("avatarOptions", PacienteAvatarCatalog.allOptions());
 

--- a/src/main/resources/db/changelog/changes/033-paciente-photo-extension.yaml
+++ b/src/main/resources/db/changelog/changes/033-paciente-photo-extension.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: 033-paciente-photo-extension
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            columnExists:
+              tableName: paciente
+              columnName: photo_extension
+      changes:
+        - addColumn:
+            tableName: paciente
+            columns:
+              - column:
+                  name: photo_extension
+                  type: VARCHAR(16)

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -95,3 +95,6 @@ databaseChangeLog:
   - include:
       file: changes/032-thyroid-panel.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/033-paciente-photo-extension.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -86,3 +86,6 @@ databaseChangeLog:
   - include:
       file: changes/032-thyroid-panel.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/033-paciente-photo-extension.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/templates/sbadmin/pacientes/perfil.html
+++ b/src/main/resources/templates/sbadmin/pacientes/perfil.html
@@ -54,6 +54,26 @@
                       <i class="fas fa-user-circle"></i> Cambiar avatar
                     </button>
                   </div>
+                  <div class="mt-3 px-2" th:if="${paciente != null}">
+                    <p class="text-muted small mb-2">Sube una foto personalizada (JPG, PNG, GIF o WebP).</p>
+                    <form th:action="@{/admin/pacientes/{id}/photo(id=${paciente.id})}" method="post"
+                      enctype="multipart/form-data" class="mb-2">
+                      <div class="form-group custom-file mb-2">
+                        <input type="file" class="custom-file-input" id="photoFile" name="photoFile"
+                          accept="image/png,image/jpeg,image/gif,image/webp" required />
+                        <label class="custom-file-label text-left" for="photoFile">Seleccionar foto&hellip;</label>
+                      </div>
+                      <button type="submit" class="btn btn-sm btn-primary btn-block">
+                        <i class="fas fa-upload"></i> Subir foto
+                      </button>
+                    </form>
+                    <form th:if="${hasCustomPhoto}"
+                      th:action="@{/admin/pacientes/{id}/photo/delete(id=${paciente.id})}" method="post">
+                      <button type="button" id="btnDeletePacientePhoto" class="btn btn-sm btn-outline-danger btn-block">
+                        <i class="fas fa-trash"></i> Quitar foto personalizada
+                      </button>
+                    </form>
+                  </div>
                   <h5 class="my-3">[[(${paciente != null ? paciente.name : ''})]]</h5>
                   <p class="text-muted mb-1"><i class="fas fa-envelope"></i> [[(${paciente != null ? paciente.email : ''})]]</p>
                   <p class="text-muted mb-4"><i class="fas fa-phone"></i> [[(${paciente != null ? paciente.phone : ''})]]</p>
@@ -323,6 +343,9 @@
           </button>
         </div>
         <div class="modal-body avatar-picker-body">
+          <p th:if="${hasCustomPhoto}" class="alert alert-info small">
+            Hay una foto personalizada activa. Elimínala primero para usar un avatar del catálogo.
+          </p>
           <h6 class="text-muted mb-3">Adultos</h6>
           <div class="row" th:if="${avatarOptions != null}">
             <div class="col-4 col-sm-3 col-md-2 mb-3 text-center"
@@ -565,6 +588,9 @@
     (function () {
       var importSuccess = /*[[${importSuccess}]]*/ null;
       var importDuplicateWarning = /*[[${importDuplicateWarning}]]*/ null;
+      var successMessage = /*[[${successMessage}]]*/ null;
+      var errorMessage = /*[[${errorMessage}]]*/ null;
+      var hasCustomPhoto = /*[[${hasCustomPhoto}]]*/ false;
       var pacienteId = /*[[${paciente != null ? paciente.id : null}]]*/ null;
       if (typeof swal === 'undefined') {
         return;
@@ -586,6 +612,42 @@
           });
         }, importSuccess ? 2600 : 0);
       }
+      if (successMessage) {
+        swal({
+          title: 'Listo',
+          text: successMessage,
+          type: 'success',
+          timer: 2500
+        });
+      }
+      if (errorMessage) {
+        swal({
+          title: 'Error',
+          text: errorMessage,
+          type: 'error',
+          timer: 5000
+        });
+      }
+      $('#photoFile').on('change', function () {
+        var fileName = $(this).val().split('\\').pop();
+        $(this).next('.custom-file-label').text(fileName || 'Seleccionar foto…');
+      });
+      $('#btnDeletePacientePhoto').on('click', function () {
+        var form = $(this).closest('form');
+        swal({
+          title: '¿Quitar foto personalizada?',
+          text: 'Se volverá a mostrar el avatar del catálogo.',
+          type: 'warning',
+          showCancelButton: true,
+          confirmButtonColor: '#d33',
+          confirmButtonText: 'Sí, quitar',
+          cancelButtonText: 'Cancelar'
+        }, function (isConfirm) {
+          if (isConfirm) {
+            form.submit();
+          }
+        });
+      });
       if (window.PacienteMpxActions) {
         PacienteMpxActions.bind({
           onDeleted: function () {
@@ -608,6 +670,15 @@
       }
       $('.avatar-option-btn').on('click', function () {
         if (typeof swal === 'undefined' || !pacienteId) {
+          return;
+        }
+        if (hasCustomPhoto) {
+          swal({
+            title: 'Foto personalizada activa',
+            text: 'Elimina la foto personalizada antes de elegir un avatar del catálogo.',
+            type: 'info',
+            timer: 4000
+          });
           return;
         }
         var avatarId = $(this).data('avatar-id');

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientOnboardingControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientOnboardingControllerTest.java
@@ -40,8 +40,8 @@ class MobilePatientOnboardingControllerTest {
 		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(
 				MobileTestPacienteAuthViews.authView(12L, PATIENT_SUB, "nutritionist-sub", PacienteStatus.ONBOARDING));
 		final PatientOnboardingProfileDto profile = new PatientOnboardingProfileDto(12L, PacienteStatus.ONBOARDING,
-				"María López", "María", LocalDate.of(1990, 5, 15), "F", "maria@example.com", null, null, "P-001", false,
-				"Lic. Ana López", null);
+				"María López", "María", LocalDate.of(1990, 5, 15), "F", "maria@example.com", null, null,
+				"/sbadmin/img/paciente-avatars/avatar_1.png", "P-001", false, "Lic. Ana López", null);
 		when(mobilePatientOnboardingService.getProfile(12L)).thenReturn(profile);
 
 		final ApiResponse<PatientOnboardingProfileDto> response = controller.getProfile(jwt);
@@ -59,7 +59,8 @@ class MobilePatientOnboardingControllerTest {
 				null, null, null, PacienteAvatarCatalog.DEFAULT_FEMALE_ID);
 		final PatientOnboardingProfileDto profile = new PatientOnboardingProfileDto(12L, PacienteStatus.ACTIVE,
 				"María López", "María", LocalDate.of(1990, 5, 15), "F", "maria@example.com", null,
-				PacienteAvatarCatalog.DEFAULT_FEMALE_ID, "P-001", true, "Lic. Ana López", null);
+				PacienteAvatarCatalog.DEFAULT_FEMALE_ID, "/sbadmin/img/paciente-avatars/avatar_6.png", "P-001", true,
+				"Lic. Ana López", null);
 		when(mobilePatientOnboardingService.updateProfile(12L, request)).thenReturn(profile);
 
 		final ApiResponse<PatientOnboardingProfileDto> response = controller.updateProfile(jwt, request);

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientPhotoControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientPhotoControllerTest.java
@@ -1,0 +1,87 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacientePhotoService;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.paciente.PacienteStatus;
+
+@ExtendWith(MockitoExtension.class)
+class MobilePatientPhotoControllerTest {
+
+	private static final String PATIENT_SUB = "auth0|photo-patient";
+
+	@InjectMocks
+	private MobilePatientPhotoController controller;
+
+	@Mock
+	private PatientAuthService patientAuthService;
+
+	@Mock
+	private PacientePhotoService pacientePhotoService;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Test
+	void getPhoto_redirectsWhenNoCustomPhoto() {
+		final Jwt jwt = jwtWithSub(PATIENT_SUB);
+		final Paciente paciente = pacienteWithId(8L);
+		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(
+				MobileTestPacienteAuthViews.authView(8L, PATIENT_SUB, "nutritionist-sub", PacienteStatus.ACTIVE));
+		when(pacienteRepository.findById(8L)).thenReturn(Optional.of(paciente));
+
+		final ResponseEntity<byte[]> response = controller.getPhoto(jwt);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
+	}
+
+	@Test
+	void uploadPhoto_delegatesToServiceAndReturnsUrl() {
+		final Jwt jwt = jwtWithSub(PATIENT_SUB);
+		final Paciente paciente = pacienteWithId(8L);
+		paciente.setPhotoExtension("png");
+		final MockMultipartFile file = new MockMultipartFile("photoFile", "photo.png", "image/png",
+				new byte[] { 9, 8, 7 });
+		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(
+				MobileTestPacienteAuthViews.authView(8L, PATIENT_SUB, "nutritionist-sub", PacienteStatus.ONBOARDING));
+		when(pacienteRepository.findById(8L)).thenReturn(Optional.of(paciente));
+
+		final ApiResponse<MobilePatientPhotoController.MobilePatientPhotoResponse> response = controller
+			.uploadPhoto(jwt, file);
+
+		verify(pacientePhotoService).savePhotoForPatient(eq(8L), any(byte[].class), eq("png"));
+		assertThat(response.data().photoUrl()).isEqualTo("/rest/mobile/patient/profile/photo");
+		assertThat(response.data().photoExtension()).isEqualTo("png");
+	}
+
+	private static Jwt jwtWithSub(final String subject) {
+		return Jwt.withTokenValue("token").header("alg", "none").subject(subject).build();
+	}
+
+	private static Paciente pacienteWithId(final Long id) {
+		final Paciente paciente = new Paciente();
+		paciente.setId(id);
+		paciente.setGender("F");
+		return paciente;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/PacienteDeletionServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteDeletionServiceTest.java
@@ -67,6 +67,9 @@ class PacienteDeletionServiceTest {
 	@Mock
 	private PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository;
 
+	@Mock
+	private PacientePhotoService pacientePhotoService;
+
 	private Paciente paciente;
 
 	@BeforeEach
@@ -112,6 +115,7 @@ class PacienteDeletionServiceTest {
 		verify(clinicalExamService).deleteById(20L);
 		verify(anthropometricMeasurementService).deleteById(30L);
 		verify(bodyMetricRecordRepository).deleteByPacienteId(7L);
+		verify(pacientePhotoService).deletePhotoFromStorage(7L, null);
 		verify(pacienteRepository).delete(paciente);
 	}
 
@@ -140,6 +144,23 @@ class PacienteDeletionServiceTest {
 
 		verify(dietaService).deleteDieta(61L);
 		verify(pacienteDietaRepository).deleteAll(List.of(assignment));
+		verify(pacientePhotoService).deletePhotoFromStorage(7L, null);
+		verify(pacienteRepository).delete(paciente);
+	}
+
+	@Test
+	void deletePatientWithHistory_deletesCustomPhotoFromStorage() {
+		paciente.setPhotoExtension("png");
+		when(pacienteRepository.findByIdAndUserId(7L, USER_ID)).thenReturn(Optional.of(paciente));
+		when(patientInvitationRepository.findByPacienteId(7L)).thenReturn(List.of());
+		when(pacienteDietaRepository.findByPacienteId(7L)).thenReturn(List.of());
+		when(calendarEventService.findByPacienteId(7L)).thenReturn(List.of());
+		when(clinicalExamService.findByPacienteId(7L)).thenReturn(List.of());
+		when(anthropometricMeasurementService.findByPacienteId(7L)).thenReturn(List.of());
+
+		service.deletePatientWithHistory(7L, USER_ID);
+
+		verify(pacientePhotoService).deletePhotoFromStorage(7L, "png");
 		verify(pacienteRepository).delete(paciente);
 	}
 

--- a/src/test/java/com/nutriconsultas/paciente/PacienteDeletionServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteDeletionServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.nutriconsultas.calendar.CalendarEvent;
 import com.nutriconsultas.calendar.CalendarEventService;
@@ -74,6 +75,7 @@ class PacienteDeletionServiceTest {
 
 	@BeforeEach
 	void setUp() {
+		ReflectionTestUtils.setField(service, "pacientePhotoService", pacientePhotoService);
 		paciente = new Paciente();
 		paciente.setId(7L);
 		paciente.setUserId(USER_ID);

--- a/src/test/java/com/nutriconsultas/paciente/PacientePhotoResponsesTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacientePhotoResponsesTest.java
@@ -1,0 +1,47 @@
+package com.nutriconsultas.paciente;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class PacientePhotoResponsesTest {
+
+	@Mock
+	private PacientePhotoService pacientePhotoService;
+
+	@Test
+	void buildPictureResponse_redirectsWhenNoCustomPhoto() {
+		final Paciente paciente = new Paciente();
+		paciente.setGender("F");
+
+		final ResponseEntity<byte[]> response = PacientePhotoResponses.buildPictureResponse(paciente,
+				pacientePhotoService);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
+		assertThat(response.getHeaders().getLocation()).hasToString(PacienteAvatarCatalog.resolveImagePath(paciente));
+	}
+
+	@Test
+	void buildPictureResponse_returnsBytesWhenCustomPhotoExists() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(3L);
+		paciente.setPhotoExtension("png");
+		final byte[] bytes = new byte[] { 1, 2, 3 };
+		when(pacientePhotoService.getPhotoBytes(3L)).thenReturn(bytes);
+
+		final ResponseEntity<byte[]> response = PacientePhotoResponses.buildPictureResponse(paciente,
+				pacientePhotoService);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isEqualTo(bytes);
+		assertThat(response.getHeaders().getContentType()).isEqualTo(PacientePictureSupport.resolveMediaType("png"));
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/PacientePictureSupportTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacientePictureSupportTest.java
@@ -1,0 +1,57 @@
+package com.nutriconsultas.paciente;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+class PacientePictureSupportTest {
+
+	@Test
+	void hasCustomPhoto_whenExtensionPresent() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(5L);
+		paciente.setPhotoExtension("png");
+
+		assertThat(PacientePictureSupport.hasCustomPhoto(paciente)).isTrue();
+	}
+
+	@Test
+	void resolveDisplayUrlForAdmin_usesPictureEndpointWhenCustomPhoto() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(5L);
+		paciente.setPhotoExtension("jpg");
+
+		assertThat(PacientePictureSupport.resolveDisplayUrlForAdmin(paciente)).isEqualTo("/admin/pacientes/5/picture");
+	}
+
+	@Test
+	void resolveDisplayUrlForMobile_usesMobileEndpointWhenCustomPhoto() {
+		final Paciente paciente = new Paciente();
+		paciente.setId(5L);
+		paciente.setPhotoExtension("webp");
+
+		assertThat(PacientePictureSupport.resolveDisplayUrlForMobile(paciente))
+			.isEqualTo("/rest/mobile/patient/profile/photo");
+	}
+
+	@Test
+	void normalizeExtension_rejectsUnsupportedFormat() {
+		assertThatThrownBy(() -> PacientePictureSupport.normalizeExtension("bmp"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("Formato de imagen no permitido");
+	}
+
+	@Test
+	void buildPhotoKey_usesNormalizedExtension() {
+		assertThat(PacientePictureSupport.buildPhotoKey(9L, "JPEG")).isEqualTo("patients/9/photo.jpeg");
+	}
+
+	@Test
+	void resolveMediaType_mapsKnownExtensions() {
+		assertThat(PacientePictureSupport.resolveMediaType("jpg")).isEqualTo(MediaType.IMAGE_JPEG);
+		assertThat(PacientePictureSupport.resolveMediaType("png")).isEqualTo(MediaType.IMAGE_PNG);
+	}
+
+}


### PR DESCRIPTION
## Summary

- Adds custom patient profile photos stored in S3 (`patients/{id}/photo.{ext}`) with `photo_extension` on `Paciente` (Liquibase `033`)
- Picture resolver endpoints for mobile JWT, nutritionist web admin, and REST; falls back to `PacienteAvatarCatalog` when no custom photo
- Mobile: `GET/PUT /rest/mobile/patient/profile/photo`; `PatientOnboardingProfileDto.avatarUrl`
- Web admin: upload/delete on patient perfil + `GET /admin/pacientes/{id}/picture`
- Deletes S3 object when patient is removed

## Mobile follow-up

- [Escanor4323/nutriconsultas-mobile#119](https://github.com/Escanor4323/nutriconsultas-mobile/issues/119) — profile/settings UI to upload photos using the new API

## Test plan

- [x] Unit tests: `PacientePictureSupportTest`, `PacientePhotoResponsesTest`, `MobilePatientPhotoControllerTest`, `PacienteDeletionServiceTest`
- [x] `./lint.sh` passes
- [ ] Manual: upload photo on `/admin/pacientes/{id}/perfil`, verify picture endpoint and catalog fallback after delete
- [ ] Manual: mobile `PUT/GET /rest/mobile/patient/profile/photo` with JWT (after mobile #119)

Closes #529

Made with [Cursor](https://cursor.com)