### PR TITLE
[Support] Plan + registry docs for support tickets track (#548)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -47,6 +47,14 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`AI-ASSISTANT-WORKFLOW.md`](AI-ASSISTANT-WORKFLOW.md) | Agent workflow for AI nutrition assistant |
 | [`docs/ai/AI-ASSISTANT-PLAN.md`](docs/ai/AI-ASSISTANT-PLAN.md) | Architecture, security, tools, definition of done |
 
+**Parallel track (in-app support — do not mix into mobile/subscription PRs unless coupled):**
+
+| File | Purpose |
+|------|---------|
+| [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md) | `[Support]` issues (#540–#548), states, dependencies |
+| [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md) | Agent workflow for Soporte / Acerca de |
+| [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md) | Menu, roles, data model, version bump |
+
 **Current next issue (public booking):** None — epic ~~#245~~ **done**; ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~, ~~#300~~, ~~#302~~ done. Deferred follow-ups need new issues. See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
 **Current next issue (mobile):** [#353 — Grocery list for patient diet plan](https://github.com/diego-torres/nutriconsultas/issues/353) (`in-progress`). ~~#354~~ ~~#352~~ **done** (PR [#357](https://github.com/diego-torres/nutriconsultas/pull/357)).
@@ -56,6 +64,8 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 **Current next issue (nutritionist web):** None — all registered epics complete: ~~#271~~ done (PR [#288](https://github.com/diego-torres/nutriconsultas/pull/288)) + ~~#272~~ done (PR [#289](https://github.com/diego-torres/nutriconsultas/pull/289)) system catalog create; ~~#241~~–~~#242~~ patient UX; ~~#232~~–~~#235~~ diet grid; ~~#236~~–~~#240~~ profile/PDF/nutrients; ~~#257~~–~~#259~~ platillo ownership; ~~#275~~, ~~#280~~–~~#281~~, ~~#285~~ diet/ingredient editing. Deferred follow-ups need new issues. See [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md).
 
 **Current next issue (AI assistant):** None — registered implementation track **complete** (#360–#450). Production rollout: [`RELEASE-CHECKLIST.md`](docs/ai/RELEASE-CHECKLIST.md) (#408). See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
+
+**Current next issue (support):** [#543](https://github.com/diego-torres/nutriconsultas/issues/543) — Support ticket schema (after docs #548). See [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -622,6 +622,12 @@ Issue registry: [`ISSUE-APPLE-SIGNIN.md`](ISSUE-APPLE-SIGNIN.md). Roadmap: [`doc
 
 **Epic #497–#511** (2026-07-08): Sign in with Apple via Auth0 + Apple server-to-server webhook (`POST /rest/webhooks/apple/sign-in`). **Track complete** — ~~#497–#511~~ **done** (PRs [#513](https://github.com/diego-torres/nutriconsultas/pull/513)–[#519](https://github.com/diego-torres/nutriconsultas/pull/519); rollout plan [`docs/auth/apple-signin-rollout.md`](docs/auth/apple-signin-rollout.md)). Auth0 callback: `https://minutriporcion-prod.us.auth0.com/login/callback` — **not** the Apple notification URL.
 
+## In-app support / Soporte (tracking)
+
+Issue registry: [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md). Plan: [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md). Workflow: [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md).
+
+**Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. **NEXT:** [#543](https://github.com/diego-torres/nutriconsultas/issues/543) Liquibase schema. Orthogonal to public `ContactInquiry`.
+
 ## Resources
 
 - [Spring Boot Documentation](https://spring.io/projects/spring-boot)

--- a/ISSUE-SUPPORT.md
+++ b/ISSUE-SUPPORT.md
@@ -1,0 +1,80 @@
+# Issue Registry — `[Support]` track
+
+Living index of GitHub issues for **in-app support tickets** and the topbar user menu (**Perfil / Soporte / Acerca de / Salir**). Update when status changes (commit on the PR that closes work).
+
+**Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
+**Plan:** [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md)  
+**Workflow:** [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md)  
+**Last updated:** 2026-07-13 — ~~#548~~ docs **done** (this PR). **NEXT:** [#543](https://github.com/diego-torres/nutriconsultas/issues/543) schema.
+
+> **Scope.** Authenticated nutritionist web (`/admin/**`): support ticket create/list for users; platform-admin triage (user, subscription, title; update/close; active/closed filter); **Acerca de** version modal. **Does not** replace public `ContactInquiry`. Patient mobile API: [`ISSUE.md`](ISSUE.md). Platform admin patterns: contact inquiries / subscription admin.
+
+---
+
+## Legend
+
+| State | Meaning |
+|-------|---------|
+| `NEXT` | Active — pick this up now (if unblocked) |
+| `open` | Not started |
+| `in-progress` | Branch / PR open |
+| `done` | Merged to `main` |
+| `deferred` | Paused |
+
+---
+
+## Epic — In-app support + user menu
+
+| Requirement | Issues |
+|-------------|--------|
+| Epic umbrella | #540 |
+| Topbar: Perfil, Soporte, Acerca de, Salir | #541 |
+| Acerca de modal + version + README bump docs | #542 |
+| Ticket schema (Liquibase) | #543 |
+| Service + access control | #544 |
+| Nutritionist Soporte UI | #545 |
+| Platform admin Soporte UI | #546 |
+| Tests + template validators | #547 |
+| Track registry / plan / workflow docs | #548 |
+
+**Suggested order:** #548 → #543 → #544 → (#541 ∥ #542) → #545 → #546 → #547 (tests also land with each feature PR).
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|------------|-------|
+| **540** | Epic — In-app support tickets + user menu | https://github.com/diego-torres/nutriconsultas/issues/540 | **open** | — | Umbrella; close when children done |
+| **541** | Topbar user menu — Perfil, Soporte, Acerca de, Salir | https://github.com/diego-torres/nutriconsultas/issues/541 | **open** | 540 | `sbadmin/topbar.html`; remove Settings / Activity Log |
+| **542** | Acerca de modal — app version + README bump process | https://github.com/diego-torres/nutriconsultas/issues/542 | **open** | 540 | Maven `project.version` → UI; README instructions |
+| **543** | Support ticket schema — Liquibase + entity + repository | https://github.com/diego-torres/nutriconsultas/issues/543 | **NEXT** | 540 | Incremental changeset only |
+| **544** | Support ticket service — create, list, update, close, filter | https://github.com/diego-torres/nutriconsultas/issues/544 | **open** | **543** | Nutritionist own-only; platform admin all |
+| **545** | Nutritionist Soporte page — own tickets + create form | https://github.com/diego-torres/nutriconsultas/issues/545 | **open** | **544**, 541 | `/admin/soporte` user view |
+| **546** | Platform admin Soporte — list, filter, update, close | https://github.com/diego-torres/nutriconsultas/issues/546 | **open** | **544** | User + subscription + title columns |
+| **547** | Tests + template validators for Soporte / Acerca de | https://github.com/diego-torres/nutriconsultas/issues/547 | **open** | 541–546 | May close incrementally with feature PRs |
+| **548** | Plan + registry docs for support tickets track | https://github.com/diego-torres/nutriconsultas/issues/548 | **done** | 540 | `ISSUE-SUPPORT.md`, plan, workflow, AGENTS/README pointers |
+
+---
+
+## Cross-track links
+
+| Track / area | Interaction |
+|--------------|-------------|
+| Platform admin | `PlatformAdminService`, `AbstractPlatformAdminController` (same as contact inquiries) |
+| Subscription | Resolve creator plan/tier for admin list columns (do not store on ticket in v1) |
+| ContactInquiry | Orthogonal public marketing inbox — keep separate |
+| Liquibase #46 | All schema via incremental changesets |
+
+---
+
+## Definition of done (track-level)
+
+- [ ] User menu: Perfil, Soporte, Acerca de, Salir
+- [ ] Nutritionists create and list only their tickets
+- [ ] Platform admins filter activos/cerrados; update and close; see user + subscription + title
+- [ ] Acerca de shows version; README documents bump for `main` releases
+- [ ] Liquibase + tests + template validators
+- [ ] This registry marked `done` for all children; epic #540 closed
+
+---
+
+**How to update this file**
+
+Same convention as [`ISSUE.md`](ISSUE.md): mark `in-progress` when a PR opens, `done` when merged. Keep **NEXT** on the unblocked issue agents should pick up.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,28 @@ registro de consultorio de nutrición
 
 ### Patient mobile API
 
-**Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
+**Agent workflow:** [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) · **Issue registries:** [`ISSUE.md`](ISSUE.md) (mobile) · [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md) (subscription) · [`ISSUE-NUTRITIONIST-WEB.md`](ISSUE-NUTRITIONIST-WEB.md) (nutritionist web) · [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md) (public booking) · [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md) (in-app support) · **Contract docs:** [`docs/mobile-api/README.md`](docs/mobile-api/README.md)
 
 **On `main` (2026-06-23):** Mobile **Phase 2 invitation onboarding complete** (~~#141~~). Subscription **registered track complete** (~~#244~~ ✓ on `subscription/244-contact-form-prefill`; ~~#314~~ ~~#188~~ ~~#186~~ ~~#220~~ ~~#207~~ ~~#208~~ ~~#209~~ done). Nutritionist web: all registered epics **complete** (#221–#242, #271–#272). Public booking: epic ~~#245~~ **done** (v1); ~~#246~~–~~#302~~ shipped.
+
+### In-app support (Soporte)
+
+**Issue registry:** [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md) · **Plan:** [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md) · **Workflow:** [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md)
+
+Epic [#540](https://github.com/diego-torres/nutriconsultas/issues/540): topbar menu **Perfil / Soporte / Acerca de / Salir**, nutritionist tickets, platform-admin triage, and **Acerca de** version display. **NEXT:** [#543](https://github.com/diego-torres/nutriconsultas/issues/543) schema.
+
+### Application version
+
+The web application version shown in **Acerca de** (once [#542](https://github.com/diego-torres/nutriconsultas/issues/542) lands) comes from Maven `<version>` in [`pom.xml`](pom.xml) (currently `2.0-SNAPSHOT`), exposed at runtime as a filtered property such as `app.version`.
+
+**When shipping a new version to `main`:**
+
+1. Update the `<version>` element in `pom.xml` (project semver or agreed scheme, e.g. `2.1.0`).
+2. Ensure the Maven build still filters that value into `application.properties` / the packaged artifact (`app.version=${project.version}` or equivalent — wired by #542).
+3. Merge the release PR to `main`, deploy, then confirm **Acerca de** in the admin topbar shows the new version.
+4. Optionally create a matching Git tag (e.g. `v2.1.0`) on the release commit.
+
+Do not hardcode the version only in Thymeleaf HTML; keep `pom.xml` as the source of truth.
 
 ## AWS (production infrastructure)
 

--- a/SUPPORT-WORKFLOW.md
+++ b/SUPPORT-WORKFLOW.md
@@ -1,0 +1,74 @@
+# Support tickets — Agent Workflow
+
+How AI agents (and humans) ship the **`[Support]`** track on **`diego-torres/nutriconsultas`**. Separate from mobile API, subscription, AI assistant, and public booking — do not mix support-ticket schema/UI into unrelated PRs unless explicitly coupled (e.g. shared topbar fragment).
+
+**Registries**
+
+| File | Purpose |
+|------|---------|
+| [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md) | `[Support]` issues #540–#548, states, dependencies |
+| [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md) | Product/tech plan, data model, version bump |
+| [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
+
+**Current next issue:** [#543](https://github.com/diego-torres/nutriconsultas/issues/543) — Support ticket schema (Liquibase + entity + repository). ~~#548~~ docs **done**.
+
+---
+
+## Recommended delivery sequence
+
+| Wave | Issues | Outcome |
+|------|--------|---------|
+| **A — Docs** | **#548** | Registry, plan, workflow, README/AGENTS pointers |
+| **B — Schema** | **#543** | Liquibase table + JPA entity + repository |
+| **C — Domain** | **#544** | Service: create, list own, admin list/filter/update/close |
+| **D — Shell** | **#541**, **#542** | Topbar menu + Acerca de version modal (parallel OK) |
+| **E — UI** | **#545** → **#546** | Nutritionist page, then platform admin inbox |
+| **F — Quality** | **#547** | Remaining tests/validators (also ship with each PR) |
+
+---
+
+## Product context (read before every session)
+
+| Topic | Guidance |
+|-------|----------|
+| **Language** | User-facing copy **Spanish (es-MX)** — menu, forms, swal dialogs, empty states |
+| **Audience** | Nutritionists on `/admin/**` + platform admins; not patients / mobile API |
+| **Admin gate** | `PlatformAdminService` / `requirePlatformAdmin` — same family as contact inquiries |
+| **Ownership** | Nutritionist tickets scoped by Auth0 `sub` (`userId`); prefer 404 on miss |
+| **Subscription column** | Resolve at read time from creator’s clinic/subscription — do not denormalize in v1 |
+| **ContactInquiry** | Do **not** reuse for authenticated Soporte — separate product surface |
+| **Dialogs** | bootstrap-sweetalert only — no native `alert`/`confirm` |
+| **Schema gate** | Incremental Liquibase only ([`docs/db/LIQUIBASE.md`](docs/db/LIQUIBASE.md)) |
+| **Version** | Maven `pom.xml` `<version>` → filtered `app.version` (or equivalent) → Acerca de; document bumps in README |
+| **Privacy** | Log ticket ids only; no names/emails in unstructured logs |
+
+---
+
+## Overview
+
+```mermaid
+flowchart LR
+  A[1. Triage registry] --> B[2. Branch & plan]
+  B --> C[3. Implement]
+  C --> D[4. Review]
+  D --> E[5. Tests]
+  E --> F[6. PR & registry]
+```
+
+---
+
+## Phase checklist (per issue)
+
+1. **Triage:** `gh issue view <n>`; confirm dependencies in [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md) are `done`.
+2. **Branch:** `issue-<n>-short-slug` from latest `main`.
+3. **Implement:** Follow [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md); schema changes need Liquibase.
+4. **Tests:** Service + controller tests; template validators for new Thymeleaf.
+5. **Lint:** `mvn spring-javaformat:apply` and project lint/test gates before PR.
+6. **Registry:** Set issue to `in-progress` / `done` in [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md); update **NEXT**.
+7. **PR:** Link `Fixes #<n>`; mention epic #540.
+
+---
+
+## Definition of done (track)
+
+See epic [#540](https://github.com/diego-torres/nutriconsultas/issues/540) and plan DoD. Close #540 only when #541–#547 are `done` (and #548 docs merged).

--- a/docs/support/SUPPORT-TICKETS-PLAN.md
+++ b/docs/support/SUPPORT-TICKETS-PLAN.md
@@ -1,0 +1,142 @@
+# Support tickets — product & technical plan
+
+In-app **Soporte** for authenticated nutritionists and platform administrators, plus an **Acerca de** version modal from the topbar user menu.
+
+**Issue registry:** [`ISSUE-SUPPORT.md`](../../ISSUE-SUPPORT.md)  
+**Workflow:** [`SUPPORT-WORKFLOW.md`](../../SUPPORT-WORKFLOW.md)  
+**Epic:** [#540](https://github.com/diego-torres/nutriconsultas/issues/540)
+
+---
+
+## Goals
+
+1. Replace topbar user-circle menu placeholders (**Settings**, **Activity Log**) with **Soporte** and **Acerca de**.
+2. Let nutritionists open tickets and see **only their own** tickets.
+3. Let platform admins triage all tickets: **user**, **subscription**, **title**; **update** / **close**; filter **activos** vs **cerrados**.
+4. Show the running web app version in **Acerca de**, with a documented bump process for releases to `main`.
+
+## Non-goals (v1)
+
+- Replacing or merging public **ContactInquiry** (`/admin/platform/contact-inquiries`) — that remains the anonymous marketing contact inbox.
+- Email / push notifications when a ticket is created or closed (defer).
+- Patient mobile-app support surface.
+- Rich attachments / screenshots (defer unless a child issue expands scope).
+
+---
+
+## User menu
+
+| Item | Behavior |
+|------|----------|
+| **Perfil** | Existing `/admin/perfil` |
+| **Soporte** | `/admin/soporte` (role-aware page) |
+| **Acerca de** | Opens Bootstrap modal (version + product name) |
+| **Salir** | Existing logout modal |
+
+Copy and labels: **Spanish (es-MX)**. Confirmations: **bootstrap-sweetalert** (`swal`), never native `alert`/`confirm`.
+
+Template entry point: `src/main/resources/templates/sbadmin/topbar.html`.
+
+---
+
+## Roles
+
+| Actor | Capability |
+|-------|------------|
+| Nutritionist (authenticated `/admin` user) | Create ticket; list/view **own** tickets only |
+| Platform admin (`PlatformAdminService`) | List all; filter by status; update (e.g. admin notes); close |
+
+Reuse existing platform-admin patterns (`AbstractPlatformAdminController`, `requirePlatformAdmin`, contact-inquiry style audits where useful).
+
+**Suggested UX routing:** single entry `/admin/soporte` that branches in the controller:
+
+- Non-admin → nutritionist grid + create form
+- Platform admin → admin inbox (user, subscription, title + actions)
+
+Alternatively `/admin/platform/soporte` for admin only and `/admin/soporte` for users — pick one in implementation and keep the topbar link consistent.
+
+---
+
+## Data model
+
+Table (name illustrative): `support_ticket`
+
+| Column | Type / notes |
+|--------|----------------|
+| `id` | PK |
+| `user_id` | Auth0 `sub` of creator (`NOT NULL`) |
+| `title` | Short subject |
+| `description` | Body |
+| `status` | `OPEN` \| `CLOSED` (UI: activos / cerrados) |
+| `admin_notes` | Optional; platform admin updates |
+| `created_at` / `updated_at` | Timestamps |
+| `closed_at` | Set when closed |
+
+**Subscription** is resolved at read time from the creator’s clinic membership / subscription (same sources as platform subscription screens) — do not denormalize plan on the ticket row unless a later issue requires historical freeze.
+
+Ship schema via **incremental Liquibase** only (`docs/db/LIQUIBASE.md`). Never `ddl-auto=update`.
+
+---
+
+## Application version (“Acerca de”)
+
+**Source of truth:** Maven `<version>` in `pom.xml` (today `2.0-SNAPSHOT`).
+
+**Runtime exposure (recommended):**
+
+1. Add `app.version=${project.version}` (or equivalent) with Maven resource filtering into `application.properties`, **or** inject `@Value("${app.version}")` from a filtered property.
+2. Expose to Thymeleaf via `@ControllerAdvice` / model attribute (e.g. `appVersion`) used by the about modal fragment in the admin layout.
+
+Do not hardcode the version only in HTML.
+
+### How to set the version for new releases on `main`
+
+Documented for maintainers in the root [`README.md`](../../README.md) (section **Application version**):
+
+1. Update `<version>` in `pom.xml` before or as part of the release PR to `main`.
+2. Confirm the build filters `app.version` (or the chosen property) into the packaged artifact.
+3. After deploy, open **Acerca de** and verify the new value.
+4. Optionally create a matching Git tag (e.g. `v2.1.0`).
+
+Child issue: [#542](https://github.com/diego-torres/nutriconsultas/issues/542).
+
+---
+
+## Security & privacy
+
+- Nutritionist paths: always scope by `userId` (`findByIdAndUserId` style). Prefer **404** on ownership miss.
+- Platform admin paths: `requirePlatformAdmin` before list/update/close.
+- Logging: ticket **ids** only; no names/emails in unstructured logs; use / extend `LogRedaction` if entities are logged.
+
+---
+
+## UI surfaces
+
+| Surface | Content |
+|---------|---------|
+| Nutritionist Soporte | DataTables-style or simple table of own tickets; create form (title + description) |
+| Admin Soporte | Columns: user, subscription, title; filter activos/cerrados; update + close actions |
+| Acerca de modal | Minutriporcion + version string |
+
+---
+
+## Suggested delivery order
+
+1. [#548](https://github.com/diego-torres/nutriconsultas/issues/548) — registry/plan docs *(this document)*  
+2. [#543](https://github.com/diego-torres/nutriconsultas/issues/543) — Liquibase + entity + repository  
+3. [#544](https://github.com/diego-torres/nutriconsultas/issues/544) — service + access control  
+4. [#541](https://github.com/diego-torres/nutriconsultas/issues/541) + [#542](https://github.com/diego-torres/nutriconsultas/issues/542) — menu + Acerca de (can parallelize with 543)  
+5. [#545](https://github.com/diego-torres/nutriconsultas/issues/545) — nutritionist UI  
+6. [#546](https://github.com/diego-torres/nutriconsultas/issues/546) — platform admin UI  
+7. [#547](https://github.com/diego-torres/nutriconsultas/issues/547) — remaining tests / validators (also land tests with each feature PR)
+
+---
+
+## Definition of done (track)
+
+- Menu: Perfil, Soporte, Acerca de, Salir only  
+- Nutritionists: create + list own tickets  
+- Platform admins: list with user/subscription/title; filter; update; close  
+- Acerca de shows build version; README documents bump process  
+- Liquibase + tests + template validators  
+- Registry [`ISSUE-SUPPORT.md`](../../ISSUE-SUPPORT.md) updated per merge  


### PR DESCRIPTION
## Summary
- Add `[Support]` issue registry (`ISSUE-SUPPORT.md`), agent workflow (`SUPPORT-WORKFLOW.md`), and product/tech plan (`docs/support/SUPPORT-TICKETS-PLAN.md`) for epic #540.
- Wire track pointers into `README.md`, `AGENTS.md`, and `AGENT-WORKFLOW.md`.
- Document how to bump Maven `pom.xml` `<version>` for **Acerca de** when shipping to `main`.

Fixes #548

## Test plan
- [ ] Confirm registry lists #540–#548 with #543 as **NEXT**
- [ ] Confirm README **Application version** section matches the plan
- [ ] Confirm AGENTS / AGENT-WORKFLOW link to the new track files
- [ ] No application code changes in this PR (docs only)


Made with [Cursor](https://cursor.com)