### PR TITLE
[Support] Support ticket schema — Liquibase + entity + repository (#543)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -65,7 +65,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (AI assistant):** None — registered implementation track **complete** (#360–#450). Production rollout: [`RELEASE-CHECKLIST.md`](docs/ai/RELEASE-CHECKLIST.md) (#408). See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
-**Current next issue (support):** [#543](https://github.com/diego-torres/nutriconsultas/issues/543) — Support ticket schema (after docs #548). See [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md).
+**Current next issue (support):** [#544](https://github.com/diego-torres/nutriconsultas/issues/544) — Support ticket service. ~~#543~~ ~~#548~~ done. See [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -626,7 +626,7 @@ Issue registry: [`ISSUE-APPLE-SIGNIN.md`](ISSUE-APPLE-SIGNIN.md). Roadmap: [`doc
 
 Issue registry: [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md). Plan: [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md). Workflow: [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md).
 
-**Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. **NEXT:** [#543](https://github.com/diego-torres/nutriconsultas/issues/543) Liquibase schema. Orthogonal to public `ContactInquiry`.
+**Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. ~~#548~~ docs done. ~~#543~~ schema done (`034-support-ticket`). **NEXT:** [#544](https://github.com/diego-torres/nutriconsultas/issues/544) service. Orthogonal to public `ContactInquiry`.
 
 ## Resources
 

--- a/ISSUE-SUPPORT.md
+++ b/ISSUE-SUPPORT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for **in-app support tickets** and the topbar user
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md)  
 **Workflow:** [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md)  
-**Last updated:** 2026-07-13 — ~~#548~~ docs **done** (this PR). **NEXT:** [#543](https://github.com/diego-torres/nutriconsultas/issues/543) schema.
+**Last updated:** 2026-07-13 — ~~#543~~ schema **done** (this PR). **NEXT:** [#544](https://github.com/diego-torres/nutriconsultas/issues/544) service.
 
 > **Scope.** Authenticated nutritionist web (`/admin/**`): support ticket create/list for users; platform-admin triage (user, subscription, title; update/close; active/closed filter); **Acerca de** version modal. **Does not** replace public `ContactInquiry`. Patient mobile API: [`ISSUE.md`](ISSUE.md). Platform admin patterns: contact inquiries / subscription admin.
 
@@ -44,8 +44,8 @@ Living index of GitHub issues for **in-app support tickets** and the topbar user
 | **540** | Epic — In-app support tickets + user menu | https://github.com/diego-torres/nutriconsultas/issues/540 | **open** | — | Umbrella; close when children done |
 | **541** | Topbar user menu — Perfil, Soporte, Acerca de, Salir | https://github.com/diego-torres/nutriconsultas/issues/541 | **open** | 540 | `sbadmin/topbar.html`; remove Settings / Activity Log |
 | **542** | Acerca de modal — app version + README bump process | https://github.com/diego-torres/nutriconsultas/issues/542 | **open** | 540 | Maven `project.version` → UI; README instructions |
-| **543** | Support ticket schema — Liquibase + entity + repository | https://github.com/diego-torres/nutriconsultas/issues/543 | **NEXT** | 540 | Incremental changeset only |
-| **544** | Support ticket service — create, list, update, close, filter | https://github.com/diego-torres/nutriconsultas/issues/544 | **open** | **543** | Nutritionist own-only; platform admin all |
+| **543** | Support ticket schema — Liquibase + entity + repository | https://github.com/diego-torres/nutriconsultas/issues/543 | **done** | 540 | Liquibase `034`; `SupportTicket` + repository |
+| **544** | Support ticket service — create, list, update, close, filter | https://github.com/diego-torres/nutriconsultas/issues/544 | **NEXT** | **543** | Nutritionist own-only; platform admin all |
 | **545** | Nutritionist Soporte page — own tickets + create form | https://github.com/diego-torres/nutriconsultas/issues/545 | **open** | **544**, 541 | `/admin/soporte` user view |
 | **546** | Platform admin Soporte — list, filter, update, close | https://github.com/diego-torres/nutriconsultas/issues/546 | **open** | **544** | User + subscription + title columns |
 | **547** | Tests + template validators for Soporte / Acerca de | https://github.com/diego-torres/nutriconsultas/issues/547 | **open** | 541–546 | May close incrementally with feature PRs |

--- a/SUPPORT-WORKFLOW.md
+++ b/SUPPORT-WORKFLOW.md
@@ -10,7 +10,7 @@ How AI agents (and humans) ship the **`[Support]`** track on **`diego-torres/nut
 | [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md) | Product/tech plan, data model, version bump |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#543](https://github.com/diego-torres/nutriconsultas/issues/543) — Support ticket schema (Liquibase + entity + repository). ~~#548~~ docs **done**.
+**Current next issue:** [#544](https://github.com/diego-torres/nutriconsultas/issues/544) — Support ticket service. ~~#543~~ schema **done**. ~~#548~~ docs **done**.
 
 ---
 

--- a/docs/db/LIQUIBASE.md
+++ b/docs/db/LIQUIBASE.md
@@ -16,6 +16,7 @@ Nutriconsultas uses [Liquibase](https://www.liquibase.org/) for schema and catal
 | `changes/007-patient-invitation-onboarding.yaml` | `PacienteStatus` columns + `patient_invitation` table (#132, PR #214) |
 | `changes/023-patient-invitation-human-code.yaml` | `human_code` on `patient_invitation` (#336) |
 | `changes/024-ai-chat-schema.yaml` | AI chat thread, message, and draft tables (#369) |
+| `changes/034-support-ticket.yaml` | In-app support ticket table (#543) |
 | `changes/008-platillo-ingesta-source-platillo-id.yaml` | `source_platillo_id` on `platillo_ingesta` + catalog backfill (#250) |
 | `data/alimentos-seed.sql` | SMAE alimentos catalog (from `alimentos.sql`) |
 | `data/platillos-seed.sql` | Catalog `platillo` + `ingrediente` rows |

--- a/src/main/java/com/nutriconsultas/support/SupportTicket.java
+++ b/src/main/java/com/nutriconsultas/support/SupportTicket.java
@@ -1,0 +1,74 @@
+package com.nutriconsultas.support;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "support_ticket")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SupportTicket {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "user_id", nullable = false, length = 255)
+	private String userId;
+
+	@Column(nullable = false, length = 200)
+	private String title;
+
+	@Column(nullable = false, length = 4000)
+	private String description;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private SupportTicketStatus status;
+
+	@Column(name = "admin_notes", length = 2000)
+	private String adminNotes;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private Instant createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private Instant updatedAt;
+
+	@Column(name = "closed_at")
+	private Instant closedAt;
+
+	@PrePersist
+	void onCreate() {
+		final Instant now = Instant.now();
+		if (createdAt == null) {
+			createdAt = now;
+		}
+		if (updatedAt == null) {
+			updatedAt = now;
+		}
+		if (status == null) {
+			status = SupportTicketStatus.OPEN;
+		}
+	}
+
+	@PreUpdate
+	void onUpdate() {
+		updatedAt = Instant.now();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/support/SupportTicketRepository.java
+++ b/src/main/java/com/nutriconsultas/support/SupportTicketRepository.java
@@ -1,0 +1,18 @@
+package com.nutriconsultas.support;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SupportTicketRepository extends JpaRepository<SupportTicket, Long> {
+
+	List<SupportTicket> findByUserIdOrderByCreatedAtDesc(String userId);
+
+	Optional<SupportTicket> findByIdAndUserId(Long id, String userId);
+
+	List<SupportTicket> findByStatusOrderByCreatedAtDesc(SupportTicketStatus status);
+
+	List<SupportTicket> findAllByOrderByCreatedAtDesc();
+
+}

--- a/src/main/java/com/nutriconsultas/support/SupportTicketStatus.java
+++ b/src/main/java/com/nutriconsultas/support/SupportTicketStatus.java
@@ -1,0 +1,11 @@
+package com.nutriconsultas.support;
+
+/**
+ * Lifecycle status for an in-app support ticket. UI labels: activos ({@link #OPEN}) /
+ * cerrados ({@link #CLOSED}).
+ */
+public enum SupportTicketStatus {
+
+	OPEN, CLOSED
+
+}

--- a/src/main/resources/db/changelog/changes/034-support-ticket.yaml
+++ b/src/main/resources/db/changelog/changes/034-support-ticket.yaml
@@ -1,0 +1,80 @@
+databaseChangeLog:
+  - changeSet:
+      id: 034-support-ticket
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            tableExists:
+              tableName: support_ticket
+      changes:
+        - createTable:
+            tableName: support_ticket
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: title
+                  type: VARCHAR(200)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: VARCHAR(4000)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: admin_notes
+                  type: VARCHAR(2000)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: closed_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: true
+        - createIndex:
+            indexName: idx_support_ticket_user_id
+            tableName: support_ticket
+            columns:
+              - column:
+                  name: user_id
+        - createIndex:
+            indexName: idx_support_ticket_status
+            tableName: support_ticket
+            columns:
+              - column:
+                  name: status
+        - createIndex:
+            indexName: idx_support_ticket_status_created_at
+            tableName: support_ticket
+            columns:
+              - column:
+                  name: status
+              - column:
+                  name: created_at

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -98,3 +98,6 @@ databaseChangeLog:
   - include:
       file: changes/033-paciente-photo-extension.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/034-support-ticket.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -89,3 +89,6 @@ databaseChangeLog:
   - include:
       file: changes/033-paciente-photo-extension.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/034-support-ticket.yaml
+      relativeToChangelogFile: true

--- a/src/test/java/com/nutriconsultas/db/LiquibaseMigrationTest.java
+++ b/src/test/java/com/nutriconsultas/db/LiquibaseMigrationTest.java
@@ -128,4 +128,12 @@ public class LiquibaseMigrationTest {
 			.isEqualTo(1L);
 	}
 
+	@Test
+	public void testSupportTicketSchemaTableExists() {
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM support_ticket", Long.class)).isEqualTo(0L);
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM databasechangelog WHERE id = '034-support-ticket'",
+				Long.class))
+			.isEqualTo(1L);
+	}
+
 }

--- a/src/test/java/com/nutriconsultas/support/SupportTicketRepositoryTest.java
+++ b/src/test/java/com/nutriconsultas/support/SupportTicketRepositoryTest.java
@@ -121,8 +121,10 @@ class SupportTicketRepositoryTest {
 		assertThat(loaded.getAdminNotes()).isEqualTo("Revisado por plataforma");
 		assertThat(loaded.getStatus()).isEqualTo(SupportTicketStatus.CLOSED);
 		assertThat(loaded.getClosedAt()).isNotNull();
-		assertThat(loaded.getCreatedAt()).isEqualTo(createdAt);
-		assertThat(loaded.getUpdatedAt()).isAfterOrEqualTo(updatedAtBefore);
+		// H2 TIMESTAMP may truncate Instant nanos; compare at millisecond precision.
+		assertThat(loaded.getCreatedAt().toEpochMilli()).isEqualTo(createdAt.toEpochMilli());
+		assertThat(loaded.getUpdatedAt())
+			.isAfterOrEqualTo(updatedAtBefore.truncatedTo(java.time.temporal.ChronoUnit.MILLIS));
 	}
 
 	private static SupportTicket sampleTicket(final String userId, final String title, final String description) {

--- a/src/test/java/com/nutriconsultas/support/SupportTicketRepositoryTest.java
+++ b/src/test/java/com/nutriconsultas/support/SupportTicketRepositoryTest.java
@@ -1,0 +1,136 @@
+package com.nutriconsultas.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Transactional
+class SupportTicketRepositoryTest {
+
+	private static final String USER_A = "auth0|support-user-a";
+
+	private static final String USER_B = "auth0|support-user-b";
+
+	@Autowired
+	private SupportTicketRepository supportTicketRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	void saveAndLoadRoundTripDefaultsToOpen() {
+		final SupportTicket ticket = sampleTicket(USER_A, "No puedo exportar dieta", "El PDF falla en Safari.");
+		final SupportTicket saved = supportTicketRepository.saveAndFlush(ticket);
+
+		entityManager.clear();
+
+		final SupportTicket loaded = supportTicketRepository.findById(saved.getId()).orElseThrow();
+		assertThat(loaded.getUserId()).isEqualTo(USER_A);
+		assertThat(loaded.getTitle()).isEqualTo("No puedo exportar dieta");
+		assertThat(loaded.getDescription()).isEqualTo("El PDF falla en Safari.");
+		assertThat(loaded.getStatus()).isEqualTo(SupportTicketStatus.OPEN);
+		assertThat(loaded.getCreatedAt()).isNotNull();
+		assertThat(loaded.getUpdatedAt()).isNotNull();
+		assertThat(loaded.getClosedAt()).isNull();
+		assertThat(loaded.getAdminNotes()).isNull();
+	}
+
+	@Test
+	void findByUserIdOrderByCreatedAtDesc_returnsOnlyOwnTicketsNewestFirst() {
+		final SupportTicket older = sampleTicket(USER_A, "Primero", "Detalle 1");
+		older.setCreatedAt(java.time.Instant.parse("2026-01-01T10:00:00Z"));
+		older.setUpdatedAt(older.getCreatedAt());
+		supportTicketRepository.saveAndFlush(older);
+
+		final SupportTicket newer = sampleTicket(USER_A, "Segundo", "Detalle 2");
+		newer.setCreatedAt(java.time.Instant.parse("2026-01-02T10:00:00Z"));
+		newer.setUpdatedAt(newer.getCreatedAt());
+		supportTicketRepository.saveAndFlush(newer);
+
+		supportTicketRepository.saveAndFlush(sampleTicket(USER_B, "Ajeno", "No listar"));
+
+		final List<SupportTicket> tickets = supportTicketRepository.findByUserIdOrderByCreatedAtDesc(USER_A);
+
+		assertThat(tickets).hasSize(2);
+		assertThat(tickets).extracting(SupportTicket::getTitle).containsExactly("Segundo", "Primero");
+		assertThat(tickets).allMatch(ticket -> USER_A.equals(ticket.getUserId()));
+	}
+
+	@Test
+	void findByIdAndUserId_blocksCrossTenantAccess() {
+		final SupportTicket ticket = supportTicketRepository
+			.saveAndFlush(sampleTicket(USER_A, "Solo mío", "Descripción"));
+
+		assertThat(supportTicketRepository.findByIdAndUserId(ticket.getId(), USER_A)).isPresent();
+		assertThat(supportTicketRepository.findByIdAndUserId(ticket.getId(), USER_B)).isEmpty();
+	}
+
+	@Test
+	void findByStatusOrderByCreatedAtDesc_filtersOpenAndClosed() {
+		final SupportTicket openTicket = supportTicketRepository
+			.saveAndFlush(sampleTicket(USER_A, "Abierto", "Activo"));
+		final SupportTicket closedTicket = sampleTicket(USER_B, "Cerrado", "Resuelto");
+		closedTicket.setStatus(SupportTicketStatus.CLOSED);
+		closedTicket.setClosedAt(java.time.Instant.parse("2026-01-03T12:00:00Z"));
+		supportTicketRepository.saveAndFlush(closedTicket);
+
+		assertThat(supportTicketRepository.findByStatusOrderByCreatedAtDesc(SupportTicketStatus.OPEN))
+			.extracting(SupportTicket::getId)
+			.contains(openTicket.getId())
+			.doesNotContain(closedTicket.getId());
+		assertThat(supportTicketRepository.findByStatusOrderByCreatedAtDesc(SupportTicketStatus.CLOSED))
+			.extracting(SupportTicket::getId)
+			.contains(closedTicket.getId())
+			.doesNotContain(openTicket.getId());
+	}
+
+	@Test
+	void findAllByOrderByCreatedAtDesc_listsAllUsers() {
+		supportTicketRepository.saveAndFlush(sampleTicket(USER_A, "A", "a"));
+		supportTicketRepository.saveAndFlush(sampleTicket(USER_B, "B", "b"));
+
+		final List<SupportTicket> all = supportTicketRepository.findAllByOrderByCreatedAtDesc();
+
+		assertThat(all).extracting(SupportTicket::getUserId).contains(USER_A, USER_B);
+	}
+
+	@Test
+	void updateSetsUpdatedAtAndPersistsAdminNotes() {
+		final SupportTicket ticket = supportTicketRepository
+			.saveAndFlush(sampleTicket(USER_A, "Actualizar", "Inicial"));
+		final java.time.Instant createdAt = ticket.getCreatedAt();
+		final java.time.Instant updatedAtBefore = ticket.getUpdatedAt();
+
+		ticket.setAdminNotes("Revisado por plataforma");
+		ticket.setStatus(SupportTicketStatus.CLOSED);
+		ticket.setClosedAt(java.time.Instant.parse("2026-01-04T15:00:00Z"));
+		supportTicketRepository.saveAndFlush(ticket);
+		entityManager.clear();
+
+		final SupportTicket loaded = supportTicketRepository.findById(ticket.getId()).orElseThrow();
+		assertThat(loaded.getAdminNotes()).isEqualTo("Revisado por plataforma");
+		assertThat(loaded.getStatus()).isEqualTo(SupportTicketStatus.CLOSED);
+		assertThat(loaded.getClosedAt()).isNotNull();
+		assertThat(loaded.getCreatedAt()).isEqualTo(createdAt);
+		assertThat(loaded.getUpdatedAt()).isAfterOrEqualTo(updatedAtBefore);
+	}
+
+	private static SupportTicket sampleTicket(final String userId, final String title, final String description) {
+		final SupportTicket ticket = new SupportTicket();
+		ticket.setUserId(userId);
+		ticket.setTitle(title);
+		ticket.setDescription(description);
+		return ticket;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add Liquibase changeset `034-support-ticket` (brownfield-safe `preConditions`) for `support_ticket` with indexes on `user_id`, `status`, and `(status, created_at)`.
- Add `SupportTicket` / `SupportTicketStatus` / `SupportTicketRepository` with own-ticket and status-filter queries.
- Cover persistence via `SupportTicketRepositoryTest` and assert the table in `LiquibaseMigrationTest`; update Support track registry (**NEXT:** #544).

Fixes #543

## Test plan
- [x] `mvn -Dtest=SupportTicketRepositoryTest,LiquibaseMigrationTest test`
- [x] `mvn checkstyle:check pmd:check`
- [ ] CI Build and Test / Lint and Format Check green
- [ ] Confirm H2 and Postgres apply `034-support-ticket` on fresh/boot paths


Made with [Cursor](https://cursor.com)