### PR TITLE
[Support] Support ticket service — create, list, update, close, filter (#544)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -65,7 +65,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (AI assistant):** None — registered implementation track **complete** (#360–#450). Production rollout: [`RELEASE-CHECKLIST.md`](docs/ai/RELEASE-CHECKLIST.md) (#408). See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
-**Current next issue (support):** [#544](https://github.com/diego-torres/nutriconsultas/issues/544) — Support ticket service. ~~#543~~ ~~#548~~ done. See [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md).
+**Current next issue (support):** [#541](https://github.com/diego-torres/nutriconsultas/issues/541) topbar (∥ #542). ~~#544~~ ~~#543~~ ~~#548~~ done. See [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -626,7 +626,7 @@ Issue registry: [`ISSUE-APPLE-SIGNIN.md`](ISSUE-APPLE-SIGNIN.md). Roadmap: [`doc
 
 Issue registry: [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md). Plan: [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md). Workflow: [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md).
 
-**Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. ~~#548~~ docs done. ~~#543~~ schema done (`034-support-ticket`). **NEXT:** [#544](https://github.com/diego-torres/nutriconsultas/issues/544) service. Orthogonal to public `ContactInquiry`.
+**Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. ~~#548~~ docs done. ~~#543~~ schema done. ~~#544~~ service done. **NEXT:** [#541](https://github.com/diego-torres/nutriconsultas/issues/541) topbar (∥ [#542](https://github.com/diego-torres/nutriconsultas/issues/542)). Orthogonal to public `ContactInquiry`.
 
 ## Resources
 

--- a/ISSUE-SUPPORT.md
+++ b/ISSUE-SUPPORT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for **in-app support tickets** and the topbar user
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md)  
 **Workflow:** [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md)  
-**Last updated:** 2026-07-13 — ~~#543~~ schema **done** (this PR). **NEXT:** [#544](https://github.com/diego-torres/nutriconsultas/issues/544) service.
+**Last updated:** 2026-07-13 — ~~#544~~ service **done** (this PR). **NEXT:** [#541](https://github.com/diego-torres/nutriconsultas/issues/541) topbar (∥ [#542](https://github.com/diego-torres/nutriconsultas/issues/542)).
 
 > **Scope.** Authenticated nutritionist web (`/admin/**`): support ticket create/list for users; platform-admin triage (user, subscription, title; update/close; active/closed filter); **Acerca de** version modal. **Does not** replace public `ContactInquiry`. Patient mobile API: [`ISSUE.md`](ISSUE.md). Platform admin patterns: contact inquiries / subscription admin.
 
@@ -42,10 +42,10 @@ Living index of GitHub issues for **in-app support tickets** and the topbar user
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
 | **540** | Epic — In-app support tickets + user menu | https://github.com/diego-torres/nutriconsultas/issues/540 | **open** | — | Umbrella; close when children done |
-| **541** | Topbar user menu — Perfil, Soporte, Acerca de, Salir | https://github.com/diego-torres/nutriconsultas/issues/541 | **open** | 540 | `sbadmin/topbar.html`; remove Settings / Activity Log |
+| **541** | Topbar user menu — Perfil, Soporte, Acerca de, Salir | https://github.com/diego-torres/nutriconsultas/issues/541 | **NEXT** | 540 | `sbadmin/topbar.html`; remove Settings / Activity Log |
 | **542** | Acerca de modal — app version + README bump process | https://github.com/diego-torres/nutriconsultas/issues/542 | **open** | 540 | Maven `project.version` → UI; README instructions |
 | **543** | Support ticket schema — Liquibase + entity + repository | https://github.com/diego-torres/nutriconsultas/issues/543 | **done** | 540 | Liquibase `034`; `SupportTicket` + repository |
-| **544** | Support ticket service — create, list, update, close, filter | https://github.com/diego-torres/nutriconsultas/issues/544 | **NEXT** | **543** | Nutritionist own-only; platform admin all |
+| **544** | Support ticket service — create, list, update, close, filter | https://github.com/diego-torres/nutriconsultas/issues/544 | **done** | ~~**543**~~ | `SupportTicketService`; admin view with user + plan |
 | **545** | Nutritionist Soporte page — own tickets + create form | https://github.com/diego-torres/nutriconsultas/issues/545 | **open** | **544**, 541 | `/admin/soporte` user view |
 | **546** | Platform admin Soporte — list, filter, update, close | https://github.com/diego-torres/nutriconsultas/issues/546 | **open** | **544** | User + subscription + title columns |
 | **547** | Tests + template validators for Soporte / Acerca de | https://github.com/diego-torres/nutriconsultas/issues/547 | **open** | 541–546 | May close incrementally with feature PRs |

--- a/SUPPORT-WORKFLOW.md
+++ b/SUPPORT-WORKFLOW.md
@@ -10,7 +10,7 @@ How AI agents (and humans) ship the **`[Support]`** track on **`diego-torres/nut
 | [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md) | Product/tech plan, data model, version bump |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#544](https://github.com/diego-torres/nutriconsultas/issues/544) — Support ticket service. ~~#543~~ schema **done**. ~~#548~~ docs **done**.
+**Current next issue:** [#541](https://github.com/diego-torres/nutriconsultas/issues/541) topbar (∥ [#542](https://github.com/diego-torres/nutriconsultas/issues/542) Acerca de). ~~#544~~ service **done**. ~~#543~~ ~~#548~~ done.
 
 ---
 

--- a/src/main/java/com/nutriconsultas/support/SupportTicketAdminView.java
+++ b/src/main/java/com/nutriconsultas/support/SupportTicketAdminView.java
@@ -1,0 +1,26 @@
+package com.nutriconsultas.support;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+import com.nutriconsultas.subscription.PlanTier;
+
+/**
+ * Admin inbox row: ticket plus resolved creator label and subscription plan.
+ */
+public record SupportTicketAdminView(@NonNull SupportTicket ticket, @NonNull String userDisplayLabel,
+		@Nullable PlanTier planTier, @NonNull String subscriptionLabel) {
+
+	public String title() {
+		return ticket.getTitle();
+	}
+
+	public Long id() {
+		return ticket.getId();
+	}
+
+	public SupportTicketStatus status() {
+		return ticket.getStatus();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/support/SupportTicketAdminView.java
+++ b/src/main/java/com/nutriconsultas/support/SupportTicketAdminView.java
@@ -15,7 +15,7 @@ public record SupportTicketAdminView(@NonNull SupportTicket ticket, @NonNull Str
 		return ticket.getTitle();
 	}
 
-	public Long id() {
+	public Long ticketId() {
 		return ticket.getId();
 	}
 

--- a/src/main/java/com/nutriconsultas/support/SupportTicketService.java
+++ b/src/main/java/com/nutriconsultas/support/SupportTicketService.java
@@ -1,0 +1,30 @@
+package com.nutriconsultas.support;
+
+import java.util.List;
+
+import org.springframework.lang.NonNull;
+
+/**
+ * In-app Soporte tickets: nutritionist own-ticket operations and platform-admin triage.
+ */
+public interface SupportTicketService {
+
+	SupportTicket create(@NonNull String userId, @NonNull String title, @NonNull String description);
+
+	List<SupportTicket> findOwnTickets(@NonNull String userId);
+
+	SupportTicket findOwnTicket(@NonNull String userId, @NonNull Long id);
+
+	List<SupportTicketAdminView> findAllForAdmin();
+
+	List<SupportTicketAdminView> findByStatusForAdmin(@NonNull SupportTicketStatus status);
+
+	SupportTicketAdminView findByIdForAdmin(@NonNull Long id);
+
+	SupportTicket updateAdminNotes(@NonNull Long id, String adminNotes);
+
+	SupportTicket close(@NonNull Long id);
+
+	SupportTicket reopen(@NonNull Long id);
+
+}

--- a/src/main/java/com/nutriconsultas/support/SupportTicketServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/support/SupportTicketServiceImpl.java
@@ -1,0 +1,175 @@
+package com.nutriconsultas.support;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nutriconsultas.subscription.PlanTier;
+import com.nutriconsultas.subscription.SubscriptionEntitlementService;
+import com.nutriconsultas.subscription.clinic.ClinicMemberLabelResolver;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class SupportTicketServiceImpl implements SupportTicketService {
+
+	private static final String NO_SUBSCRIPTION_LABEL = "Sin suscripción";
+
+	private final SupportTicketRepository supportTicketRepository;
+
+	private final ClinicMemberLabelResolver clinicMemberLabelResolver;
+
+	private final SubscriptionEntitlementService subscriptionEntitlementService;
+
+	public SupportTicketServiceImpl(final SupportTicketRepository supportTicketRepository,
+			final ClinicMemberLabelResolver clinicMemberLabelResolver,
+			final SubscriptionEntitlementService subscriptionEntitlementService) {
+		this.supportTicketRepository = supportTicketRepository;
+		this.clinicMemberLabelResolver = clinicMemberLabelResolver;
+		this.subscriptionEntitlementService = subscriptionEntitlementService;
+	}
+
+	@Override
+	@Transactional
+	public SupportTicket create(@NonNull final String userId, @NonNull final String title,
+			@NonNull final String description) {
+		requireText(userId, "El usuario es obligatorio");
+		final String trimmedTitle = requireText(title, "El título es obligatorio");
+		final String trimmedDescription = requireText(description, "La descripción es obligatoria");
+		if (trimmedTitle.length() > 200) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "El título es demasiado largo");
+		}
+		if (trimmedDescription.length() > 4000) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "La descripción es demasiado larga");
+		}
+
+		final SupportTicket ticket = new SupportTicket();
+		ticket.setUserId(userId);
+		ticket.setTitle(trimmedTitle);
+		ticket.setDescription(trimmedDescription);
+		ticket.setStatus(SupportTicketStatus.OPEN);
+
+		final SupportTicket saved = supportTicketRepository.save(ticket);
+		if (log.isInfoEnabled()) {
+			log.info("Support ticket created: {} for {}", LogRedaction.redactSupportTicket(saved.getId()),
+					LogRedaction.redactUserId(userId));
+		}
+		return saved;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<SupportTicket> findOwnTickets(@NonNull final String userId) {
+		requireText(userId, "El usuario es obligatorio");
+		return supportTicketRepository.findByUserIdOrderByCreatedAtDesc(userId);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public SupportTicket findOwnTicket(@NonNull final String userId, @NonNull final Long id) {
+		requireText(userId, "El usuario es obligatorio");
+		return supportTicketRepository.findByIdAndUserId(id, userId)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<SupportTicketAdminView> findAllForAdmin() {
+		return supportTicketRepository.findAllByOrderByCreatedAtDesc().stream().map(this::toAdminView).toList();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<SupportTicketAdminView> findByStatusForAdmin(@NonNull final SupportTicketStatus status) {
+		if (status == null) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "El estado es obligatorio");
+		}
+		return supportTicketRepository.findByStatusOrderByCreatedAtDesc(status)
+			.stream()
+			.map(this::toAdminView)
+			.toList();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public SupportTicketAdminView findByIdForAdmin(@NonNull final Long id) {
+		return toAdminView(requireTicket(id));
+	}
+
+	@Override
+	@Transactional
+	public SupportTicket updateAdminNotes(@NonNull final Long id, final String adminNotes) {
+		final SupportTicket ticket = requireTicket(id);
+		final String notes = adminNotes == null ? null : adminNotes.trim();
+		if (notes != null && notes.length() > 2000) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Las notas son demasiado largas");
+		}
+		ticket.setAdminNotes(StringUtils.hasText(notes) ? notes : null);
+		final SupportTicket saved = supportTicketRepository.save(ticket);
+		if (log.isInfoEnabled()) {
+			log.info("Support ticket admin notes updated: {}", LogRedaction.redactSupportTicket(saved.getId()));
+		}
+		return saved;
+	}
+
+	@Override
+	@Transactional
+	public SupportTicket close(@NonNull final Long id) {
+		final SupportTicket ticket = requireTicket(id);
+		if (ticket.getStatus() == SupportTicketStatus.CLOSED) {
+			return ticket;
+		}
+		ticket.setStatus(SupportTicketStatus.CLOSED);
+		ticket.setClosedAt(Instant.now());
+		final SupportTicket saved = supportTicketRepository.save(ticket);
+		if (log.isInfoEnabled()) {
+			log.info("Support ticket closed: {}", LogRedaction.redactSupportTicket(saved.getId()));
+		}
+		return saved;
+	}
+
+	@Override
+	@Transactional
+	public SupportTicket reopen(@NonNull final Long id) {
+		final SupportTicket ticket = requireTicket(id);
+		if (ticket.getStatus() == SupportTicketStatus.OPEN) {
+			return ticket;
+		}
+		ticket.setStatus(SupportTicketStatus.OPEN);
+		ticket.setClosedAt(null);
+		final SupportTicket saved = supportTicketRepository.save(ticket);
+		if (log.isInfoEnabled()) {
+			log.info("Support ticket reopened: {}", LogRedaction.redactSupportTicket(saved.getId()));
+		}
+		return saved;
+	}
+
+	private SupportTicket requireTicket(final Long id) {
+		return supportTicketRepository.findById(id)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+	}
+
+	private SupportTicketAdminView toAdminView(final SupportTicket ticket) {
+		final String userId = ticket.getUserId();
+		final String userLabel = clinicMemberLabelResolver.resolveLabel(userId);
+		final PlanTier planTier = subscriptionEntitlementService.getEffectivePlanTier(userId).orElse(null);
+		final String subscriptionLabel = planTier != null ? planTier.getDisplayName() : NO_SUBSCRIPTION_LABEL;
+		return new SupportTicketAdminView(ticket, userLabel, planTier, subscriptionLabel);
+	}
+
+	private static String requireText(final String value, final String message) {
+		if (!StringUtils.hasText(value)) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, message);
+		}
+		return value.trim();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/util/LogRedaction.java
+++ b/src/main/java/com/nutriconsultas/util/LogRedaction.java
@@ -229,6 +229,19 @@ public final class LogRedaction {
 	}
 
 	/**
+	 * Redacts a support ticket for logging purposes. Returns only the ticket ID.
+	 * <strong>Never log title, description, or admin notes.</strong>
+	 * @param ticketId the support ticket ID
+	 * @return a safe string representation (e.g., "SupportTicket[id=1]")
+	 */
+	public static String redactSupportTicket(final Long ticketId) {
+		if (ticketId == null) {
+			return "SupportTicket[id=null]";
+		}
+		return "SupportTicket[id=" + ticketId + "]";
+	}
+
+	/**
 	 * Redacts a patient message ID for logging purposes.
 	 * @param messageId the message ID
 	 * @return a safe string representation (e.g., "PatientMessage[id=123]")

--- a/src/test/java/com/nutriconsultas/support/SupportTicketServiceTest.java
+++ b/src/test/java/com/nutriconsultas/support/SupportTicketServiceTest.java
@@ -1,0 +1,200 @@
+package com.nutriconsultas.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nutriconsultas.subscription.PlanTier;
+import com.nutriconsultas.subscription.SubscriptionEntitlementService;
+import com.nutriconsultas.subscription.clinic.ClinicMemberLabelResolver;
+
+@ExtendWith(MockitoExtension.class)
+class SupportTicketServiceTest {
+
+	private static final String USER_A = "auth0|support-user-a";
+
+	private static final String USER_B = "auth0|support-user-b";
+
+	@InjectMocks
+	private SupportTicketServiceImpl supportTicketService;
+
+	@Mock
+	private SupportTicketRepository supportTicketRepository;
+
+	@Mock
+	private ClinicMemberLabelResolver clinicMemberLabelResolver;
+
+	@Mock
+	private SubscriptionEntitlementService subscriptionEntitlementService;
+
+	@Test
+	void create_persistsOpenTicketForUser() {
+		when(supportTicketRepository.save(any(SupportTicket.class))).thenAnswer(invocation -> {
+			final SupportTicket ticket = invocation.getArgument(0);
+			ticket.setId(42L);
+			return ticket;
+		});
+
+		final SupportTicket saved = supportTicketService.create(USER_A, "  No abre el PDF  ", " Falla en Safari ");
+
+		final ArgumentCaptor<SupportTicket> captor = ArgumentCaptor.forClass(SupportTicket.class);
+		verify(supportTicketRepository).save(captor.capture());
+		assertThat(saved.getId()).isEqualTo(42L);
+		assertThat(captor.getValue().getUserId()).isEqualTo(USER_A);
+		assertThat(captor.getValue().getTitle()).isEqualTo("No abre el PDF");
+		assertThat(captor.getValue().getDescription()).isEqualTo("Falla en Safari");
+		assertThat(captor.getValue().getStatus()).isEqualTo(SupportTicketStatus.OPEN);
+	}
+
+	@Test
+	void create_whenTitleBlank_throwsBadRequest() {
+		assertThatThrownBy(() -> supportTicketService.create(USER_A, "  ", "Descripción"))
+			.isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+			.isEqualTo(HttpStatus.BAD_REQUEST);
+		verify(supportTicketRepository, never()).save(any());
+	}
+
+	@Test
+	void findOwnTickets_delegatesToRepository() {
+		final SupportTicket ticket = sampleTicket(1L, USER_A, SupportTicketStatus.OPEN);
+		when(supportTicketRepository.findByUserIdOrderByCreatedAtDesc(USER_A)).thenReturn(List.of(ticket));
+
+		assertThat(supportTicketService.findOwnTickets(USER_A)).containsExactly(ticket);
+	}
+
+	@Test
+	void findOwnTicket_whenOwned_returnsTicket() {
+		final SupportTicket ticket = sampleTicket(7L, USER_A, SupportTicketStatus.OPEN);
+		when(supportTicketRepository.findByIdAndUserId(7L, USER_A)).thenReturn(Optional.of(ticket));
+
+		assertThat(supportTicketService.findOwnTicket(USER_A, 7L)).isSameAs(ticket);
+	}
+
+	@Test
+	void findOwnTicket_whenOtherUser_throwsNotFound() {
+		when(supportTicketRepository.findByIdAndUserId(7L, USER_B)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> supportTicketService.findOwnTicket(USER_B, 7L))
+			.isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+			.isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	void findByStatusForAdmin_enrichesUserAndSubscription() {
+		final SupportTicket ticket = sampleTicket(3L, USER_A, SupportTicketStatus.OPEN);
+		when(supportTicketRepository.findByStatusOrderByCreatedAtDesc(SupportTicketStatus.OPEN))
+			.thenReturn(List.of(ticket));
+		when(clinicMemberLabelResolver.resolveLabel(USER_A)).thenReturn("Dra. Ana");
+		when(subscriptionEntitlementService.getEffectivePlanTier(USER_A)).thenReturn(Optional.of(PlanTier.PLUS));
+
+		final List<SupportTicketAdminView> views = supportTicketService.findByStatusForAdmin(SupportTicketStatus.OPEN);
+
+		assertThat(views).hasSize(1);
+		assertThat(views.getFirst().title()).isEqualTo("Asunto");
+		assertThat(views.getFirst().userDisplayLabel()).isEqualTo("Dra. Ana");
+		assertThat(views.getFirst().planTier()).isEqualTo(PlanTier.PLUS);
+		assertThat(views.getFirst().subscriptionLabel()).isEqualTo("Plus");
+	}
+
+	@Test
+	void findAllForAdmin_usesSinSuscripcionWhenNoPlan() {
+		final SupportTicket ticket = sampleTicket(4L, USER_B, SupportTicketStatus.CLOSED);
+		when(supportTicketRepository.findAllByOrderByCreatedAtDesc()).thenReturn(List.of(ticket));
+		when(clinicMemberLabelResolver.resolveLabel(USER_B)).thenReturn("Correo no disponible");
+		when(subscriptionEntitlementService.getEffectivePlanTier(USER_B)).thenReturn(Optional.empty());
+
+		final SupportTicketAdminView view = supportTicketService.findAllForAdmin().getFirst();
+
+		assertThat(view.subscriptionLabel()).isEqualTo("Sin suscripción");
+		assertThat(view.planTier()).isNull();
+	}
+
+	@Test
+	void updateAdminNotes_persistsNotes() {
+		final SupportTicket ticket = sampleTicket(9L, USER_A, SupportTicketStatus.OPEN);
+		when(supportTicketRepository.findById(9L)).thenReturn(Optional.of(ticket));
+		when(supportTicketRepository.save(any(SupportTicket.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		final SupportTicket saved = supportTicketService.updateAdminNotes(9L, "  Revisado  ");
+
+		assertThat(saved.getAdminNotes()).isEqualTo("Revisado");
+		verify(supportTicketRepository).save(ticket);
+	}
+
+	@Test
+	void close_setsClosedStatusAndTimestamp() {
+		final SupportTicket ticket = sampleTicket(11L, USER_A, SupportTicketStatus.OPEN);
+		when(supportTicketRepository.findById(11L)).thenReturn(Optional.of(ticket));
+		when(supportTicketRepository.save(any(SupportTicket.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		final SupportTicket saved = supportTicketService.close(11L);
+
+		assertThat(saved.getStatus()).isEqualTo(SupportTicketStatus.CLOSED);
+		assertThat(saved.getClosedAt()).isNotNull();
+	}
+
+	@Test
+	void close_whenAlreadyClosed_isIdempotent() {
+		final SupportTicket ticket = sampleTicket(12L, USER_A, SupportTicketStatus.CLOSED);
+		ticket.setClosedAt(java.time.Instant.parse("2026-01-01T00:00:00Z"));
+		when(supportTicketRepository.findById(12L)).thenReturn(Optional.of(ticket));
+
+		final SupportTicket saved = supportTicketService.close(12L);
+
+		assertThat(saved.getStatus()).isEqualTo(SupportTicketStatus.CLOSED);
+		verify(supportTicketRepository, never()).save(any());
+	}
+
+	@Test
+	void reopen_clearsClosedAt() {
+		final SupportTicket ticket = sampleTicket(13L, USER_A, SupportTicketStatus.CLOSED);
+		ticket.setClosedAt(java.time.Instant.parse("2026-01-01T00:00:00Z"));
+		when(supportTicketRepository.findById(13L)).thenReturn(Optional.of(ticket));
+		when(supportTicketRepository.save(any(SupportTicket.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		final SupportTicket saved = supportTicketService.reopen(13L);
+
+		assertThat(saved.getStatus()).isEqualTo(SupportTicketStatus.OPEN);
+		assertThat(saved.getClosedAt()).isNull();
+	}
+
+	@Test
+	void findByIdForAdmin_whenMissing_throwsNotFound() {
+		when(supportTicketRepository.findById(99L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> supportTicketService.findByIdForAdmin(99L)).isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+			.isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	private static SupportTicket sampleTicket(final Long id, final String userId, final SupportTicketStatus status) {
+		final SupportTicket ticket = new SupportTicket();
+		ticket.setId(id);
+		ticket.setUserId(userId);
+		ticket.setTitle("Asunto");
+		ticket.setDescription("Detalle");
+		ticket.setStatus(status);
+		return ticket;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `SupportTicketService` / `SupportTicketServiceImpl` for nutritionist own-ticket create/list/get (404 on IDOR) and platform-admin list/filter/update notes/close/reopen.
- Admin list/detail returns `SupportTicketAdminView` with creator display label (`ClinicMemberLabelResolver`) and subscription plan (`SubscriptionEntitlementService`).
- Extend `LogRedaction.redactSupportTicket`; Spanish validation messages for blank/oversized fields.
- Unit tests cover happy paths, IDOR denial, and admin enrichment.

Fixes #544

## Test plan
- [x] `mvn -Dtest=SupportTicketServiceTest test`
- [x] `mvn checkstyle:check pmd:check`
- [ ] CI Build and Test / Lint and Format Check green
- [ ] Confirm no title/description content appears in log statements


Made with [Cursor](https://cursor.com)