### PR TITLE
[Support] Topbar user menu — Perfil, Soporte, Acerca de, Salir (#541)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -65,7 +65,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (AI assistant):** None — registered implementation track **complete** (#360–#450). Production rollout: [`RELEASE-CHECKLIST.md`](docs/ai/RELEASE-CHECKLIST.md) (#408). See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
-**Current next issue (support):** [#544](https://github.com/diego-torres/nutriconsultas/issues/544) — Support ticket service. ~~#543~~ ~~#548~~ done. See [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md).
+**Current next issue (support):** [#542](https://github.com/diego-torres/nutriconsultas/issues/542) — Acerca de version. ~~#541~~ topbar done. #544 in PR [#551](https://github.com/diego-torres/nutriconsultas/pull/551). See [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -626,7 +626,7 @@ Issue registry: [`ISSUE-APPLE-SIGNIN.md`](ISSUE-APPLE-SIGNIN.md). Roadmap: [`doc
 
 Issue registry: [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md). Plan: [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md). Workflow: [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md).
 
-**Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. ~~#548~~ docs done. ~~#543~~ schema done (`034-support-ticket`). **NEXT:** [#544](https://github.com/diego-torres/nutriconsultas/issues/544) service. Orthogonal to public `ContactInquiry`.
+**Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. ~~#548~~ docs done. ~~#543~~ schema done. ~~#541~~ topbar done. #544 service in PR [#551](https://github.com/diego-torres/nutriconsultas/pull/551). **NEXT:** [#542](https://github.com/diego-torres/nutriconsultas/issues/542) Acerca de version. Orthogonal to public `ContactInquiry`.
 
 ## Resources
 

--- a/ISSUE-SUPPORT.md
+++ b/ISSUE-SUPPORT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for **in-app support tickets** and the topbar user
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md)  
 **Workflow:** [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md)  
-**Last updated:** 2026-07-13 — ~~#543~~ schema **done** (this PR). **NEXT:** [#544](https://github.com/diego-torres/nutriconsultas/issues/544) service.
+**Last updated:** 2026-07-14 — ~~#541~~ topbar **done** (this PR). **NEXT:** [#542](https://github.com/diego-torres/nutriconsultas/issues/542) Acerca de version (∥). #544 service in PR [#551](https://github.com/diego-torres/nutriconsultas/pull/551).
 
 > **Scope.** Authenticated nutritionist web (`/admin/**`): support ticket create/list for users; platform-admin triage (user, subscription, title; update/close; active/closed filter); **Acerca de** version modal. **Does not** replace public `ContactInquiry`. Patient mobile API: [`ISSUE.md`](ISSUE.md). Platform admin patterns: contact inquiries / subscription admin.
 
@@ -42,10 +42,10 @@ Living index of GitHub issues for **in-app support tickets** and the topbar user
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
 | **540** | Epic — In-app support tickets + user menu | https://github.com/diego-torres/nutriconsultas/issues/540 | **open** | — | Umbrella; close when children done |
-| **541** | Topbar user menu — Perfil, Soporte, Acerca de, Salir | https://github.com/diego-torres/nutriconsultas/issues/541 | **open** | 540 | `sbadmin/topbar.html`; remove Settings / Activity Log |
-| **542** | Acerca de modal — app version + README bump process | https://github.com/diego-torres/nutriconsultas/issues/542 | **open** | 540 | Maven `project.version` → UI; README instructions |
+| **541** | Topbar user menu — Perfil, Soporte, Acerca de, Salir | https://github.com/diego-torres/nutriconsultas/issues/541 | **done** | 540 | `#aboutModal` contract; Soporte → `/admin/soporte` |
+| **542** | Acerca de modal — app version + README bump process | https://github.com/diego-torres/nutriconsultas/issues/542 | **NEXT** | 540, ~~541~~ | Maven `project.version` → `appVersion` |
 | **543** | Support ticket schema — Liquibase + entity + repository | https://github.com/diego-torres/nutriconsultas/issues/543 | **done** | 540 | Liquibase `034`; `SupportTicket` + repository |
-| **544** | Support ticket service — create, list, update, close, filter | https://github.com/diego-torres/nutriconsultas/issues/544 | **NEXT** | **543** | Nutritionist own-only; platform admin all |
+| **544** | Support ticket service — create, list, update, close, filter | https://github.com/diego-torres/nutriconsultas/issues/544 | **in-progress** | ~~**543**~~ | PR [#551](https://github.com/diego-torres/nutriconsultas/pull/551) |
 | **545** | Nutritionist Soporte page — own tickets + create form | https://github.com/diego-torres/nutriconsultas/issues/545 | **open** | **544**, 541 | `/admin/soporte` user view |
 | **546** | Platform admin Soporte — list, filter, update, close | https://github.com/diego-torres/nutriconsultas/issues/546 | **open** | **544** | User + subscription + title columns |
 | **547** | Tests + template validators for Soporte / Acerca de | https://github.com/diego-torres/nutriconsultas/issues/547 | **open** | 541–546 | May close incrementally with feature PRs |

--- a/SUPPORT-WORKFLOW.md
+++ b/SUPPORT-WORKFLOW.md
@@ -10,7 +10,7 @@ How AI agents (and humans) ship the **`[Support]`** track on **`diego-torres/nut
 | [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md) | Product/tech plan, data model, version bump |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#544](https://github.com/diego-torres/nutriconsultas/issues/544) — Support ticket service. ~~#543~~ schema **done**. ~~#548~~ docs **done**.
+**Current next issue:** [#542](https://github.com/diego-torres/nutriconsultas/issues/542) — Acerca de version wiring. ~~#541~~ topbar **done**. #544 service in PR [#551](https://github.com/diego-torres/nutriconsultas/pull/551).
 
 ---
 

--- a/src/main/java/com/nutriconsultas/validation/template/BaseTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/validation/template/BaseTemplateValidator.java
@@ -24,6 +24,9 @@ public abstract class BaseTemplateValidator implements TemplateValidator {
 		variables.put("username", "");
 		variables.put("user_picture", "");
 
+		// Acerca de modal (#541); wired from Maven project.version in #542
+		variables.put("appVersion", "2.0-SNAPSHOT");
+
 		// Common menu attribute
 		variables.put("activeMenu", "");
 

--- a/src/main/resources/templates/sbadmin/about-modal.html
+++ b/src/main/resources/templates/sbadmin/about-modal.html
@@ -1,0 +1,26 @@
+<div th:fragment="about">
+  <!-- About Modal — version text filled by appVersion (#542) -->
+  <div class="modal fade" id="aboutModal" tabindex="-1" role="dialog" aria-labelledby="aboutModalLabel"
+    aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="aboutModalLabel">Acerca de</h5>
+          <button class="close" type="button" data-dismiss="modal" aria-label="Cerrar">
+            <span aria-hidden="true">×</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p class="mb-2 font-weight-bold">Minutriporcion</p>
+          <p class="mb-0 text-muted">
+            Versión
+            <span id="appVersionLabel" th:text="${appVersion != null ? appVersion : '—'}">—</span>
+          </p>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-primary" type="button" data-dismiss="modal">Cerrar</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/main/resources/templates/sbadmin/blank.html
+++ b/src/main/resources/templates/sbadmin/blank.html
@@ -333,20 +333,20 @@
                                 aria-labelledby="userDropdown">
                                 <a class="dropdown-item" href="#">
                                     <i class="fas fa-user fa-sm fa-fw mr-2 text-gray-400"></i>
-                                    Profile
+                                    Perfil
                                 </a>
                                 <a class="dropdown-item" href="#">
-                                    <i class="fas fa-cogs fa-sm fa-fw mr-2 text-gray-400"></i>
-                                    Settings
+                                    <i class="fas fa-life-ring fa-sm fa-fw mr-2 text-gray-400"></i>
+                                    Soporte
                                 </a>
-                                <a class="dropdown-item" href="#">
-                                    <i class="fas fa-list fa-sm fa-fw mr-2 text-gray-400"></i>
-                                    Activity Log
+                                <a class="dropdown-item" href="#" data-toggle="modal" data-target="#aboutModal">
+                                    <i class="fas fa-info-circle fa-sm fa-fw mr-2 text-gray-400"></i>
+                                    Acerca de
                                 </a>
                                 <div class="dropdown-divider"></div>
                                 <a class="dropdown-item" href="#" data-toggle="modal" data-target="#logoutModal">
                                     <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray-400"></i>
-                                    Logout
+                                    Salir
                                 </a>
                             </div>
                         </li>
@@ -395,15 +395,37 @@
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="exampleModalLabel">Ready to Leave?</h5>
-                    <button class="close" type="button" data-dismiss="modal" aria-label="Close">
+                    <h5 class="modal-title" id="exampleModalLabel">¿Ya te vas?</h5>
+                    <button class="close" type="button" data-dismiss="modal" aria-label="Cerrar">
                         <span aria-hidden="true">×</span>
                     </button>
                 </div>
-                <div class="modal-body">Select "Logout" below if you are ready to end your current session.</div>
+                <div class="modal-body">Seleccione "Salir" abajo si desea cerrar la sesión del sistema.</div>
                 <div class="modal-footer">
-                    <button class="btn btn-secondary" type="button" data-dismiss="modal">Cancel</button>
-                    <a class="btn btn-primary" href="login.html">Logout</a>
+                    <button class="btn btn-secondary" type="button" data-dismiss="modal">Cancelar</button>
+                    <a class="btn btn-primary" href="login.html">Salir</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- About Modal-->
+    <div class="modal fade" id="aboutModal" tabindex="-1" role="dialog" aria-labelledby="aboutModalLabel"
+        aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="aboutModalLabel">Acerca de</h5>
+                    <button class="close" type="button" data-dismiss="modal" aria-label="Cerrar">
+                        <span aria-hidden="true">×</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p class="mb-2 font-weight-bold">Minutriporcion</p>
+                    <p class="mb-0 text-muted">Versión —</p>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-primary" type="button" data-dismiss="modal">Cerrar</button>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/sbadmin/dietas/sidebar.html
+++ b/src/main/resources/templates/sbadmin/dietas/sidebar.html
@@ -55,4 +55,5 @@
   </a>
 
   <div th:insert="~{sbadmin/logout-modal :: logout}"></div>
+  <div th:insert="~{sbadmin/about-modal :: about}"></div>
 </div>

--- a/src/main/resources/templates/sbadmin/pacientes/sidebar.html
+++ b/src/main/resources/templates/sbadmin/pacientes/sidebar.html
@@ -83,4 +83,5 @@
   </a>
 
   <div th:insert="~{sbadmin/logout-modal :: logout}"></div>
+  <div th:insert="~{sbadmin/about-modal :: about}"></div>
 </div>

--- a/src/main/resources/templates/sbadmin/sidebar.html
+++ b/src/main/resources/templates/sbadmin/sidebar.html
@@ -112,4 +112,5 @@
   </a>
 
   <div th:insert="~{sbadmin/logout-modal :: logout}"></div>
+  <div th:insert="~{sbadmin/about-modal :: about}"></div>
 </div>

--- a/src/main/resources/templates/sbadmin/topbar.html
+++ b/src/main/resources/templates/sbadmin/topbar.html
@@ -61,13 +61,13 @@
             <i class="fas fa-user fa-sm fa-fw mr-2 text-gray-400"></i>
             Perfil
           </a>
-          <a class="dropdown-item" href="#">
-            <i class="fas fa-cogs fa-sm fa-fw mr-2 text-gray-400"></i>
-            Settings
+          <a class="dropdown-item" th:href="@{/admin/soporte}">
+            <i class="fas fa-life-ring fa-sm fa-fw mr-2 text-gray-400"></i>
+            Soporte
           </a>
-          <a class="dropdown-item" href="#">
-            <i class="fas fa-list fa-sm fa-fw mr-2 text-gray-400"></i>
-            Activity Log
+          <a class="dropdown-item" href="#" data-toggle="modal" data-target="#aboutModal">
+            <i class="fas fa-info-circle fa-sm fa-fw mr-2 text-gray-400"></i>
+            Acerca de
           </a>
           <div class="dropdown-divider"></div>
           <a class="dropdown-item" href="#" data-toggle="modal" data-target="#logoutModal">


### PR DESCRIPTION
## Summary
- Replace topbar dropdown placeholders (**Settings**, **Activity Log**) with **Soporte** (`/admin/soporte`) and **Acerca de** (`#aboutModal`).
- Add `sbadmin/about-modal.html` fragment (Minutriporcion + version slot via `appVersion`) and include it beside logout in main / pacientes / dietas sidebars.
- Align `blank.html` demo menu; mock `appVersion` in `BaseTemplateValidator` for Thymeleaf validation.

Fixes #541

## Test plan
- [x] `mvn -Dtest=ThymeleafTemplateValidationTest test` (97/97)
- [x] `mvn checkstyle:check`
- [ ] Open any `/admin/**` page → user circle shows Perfil, Soporte, Acerca de, Salir
- [ ] Acerca de opens `#aboutModal` (version may show `—` until #542)
- [ ] Soporte navigates to `/admin/soporte` (page lands in #545)


Made with [Cursor](https://cursor.com)