### PR TITLE
[Support] Acerca de modal — app version display + README bump process (#542)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -65,7 +65,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (AI assistant):** None — registered implementation track **complete** (#360–#450). Production rollout: [`RELEASE-CHECKLIST.md`](docs/ai/RELEASE-CHECKLIST.md) (#408). See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
-**Current next issue (support):** [#542](https://github.com/diego-torres/nutriconsultas/issues/542) — Acerca de version. ~~#544~~ ~~#541~~ ~~#543~~ ~~#548~~ done. See [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md).
+**Current next issue (support):** [#545](https://github.com/diego-torres/nutriconsultas/issues/545) — Nutritionist Soporte UI. ~~#542~~ ~~#544~~ ~~#541~~ ~~#543~~ ~~#548~~ done. See [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -626,7 +626,7 @@ Issue registry: [`ISSUE-APPLE-SIGNIN.md`](ISSUE-APPLE-SIGNIN.md). Roadmap: [`doc
 
 Issue registry: [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md). Plan: [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md). Workflow: [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md).
 
-**Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. ~~#548~~ docs done. ~~#543~~ schema done. ~~#541~~ topbar done. ~~#544~~ service done. **NEXT:** [#542](https://github.com/diego-torres/nutriconsultas/issues/542) Acerca de version. Orthogonal to public `ContactInquiry`.
+**Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. ~~#548~~ docs done. ~~#543~~ schema done. ~~#541~~ topbar done. ~~#544~~ service done. ~~#542~~ Acerca de version done. **NEXT:** [#545](https://github.com/diego-torres/nutriconsultas/issues/545) nutritionist Soporte UI. Orthogonal to public `ContactInquiry`.
 
 ## Resources
 

--- a/ISSUE-SUPPORT.md
+++ b/ISSUE-SUPPORT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for **in-app support tickets** and the topbar user
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md)  
 **Workflow:** [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md)  
-**Last updated:** 2026-07-14 — ~~#544~~ service **done** (this PR); ~~#541~~ topbar **done**. **NEXT:** [#542](https://github.com/diego-torres/nutriconsultas/issues/542) Acerca de version.
+**Last updated:** 2026-07-14 — ~~#542~~ Acerca de version **done** (this PR). **NEXT:** [#545](https://github.com/diego-torres/nutriconsultas/issues/545) nutritionist Soporte UI.
 
 > **Scope.** Authenticated nutritionist web (`/admin/**`): support ticket create/list for users; platform-admin triage (user, subscription, title; update/close; active/closed filter); **Acerca de** version modal. **Does not** replace public `ContactInquiry`. Patient mobile API: [`ISSUE.md`](ISSUE.md). Platform admin patterns: contact inquiries / subscription admin.
 
@@ -43,11 +43,11 @@ Living index of GitHub issues for **in-app support tickets** and the topbar user
 |---|-------|-----|-------|------------|-------|
 | **540** | Epic — In-app support tickets + user menu | https://github.com/diego-torres/nutriconsultas/issues/540 | **open** | — | Umbrella; close when children done |
 | **541** | Topbar user menu — Perfil, Soporte, Acerca de, Salir | https://github.com/diego-torres/nutriconsultas/issues/541 | **done** | 540 | `#aboutModal` contract; Soporte → `/admin/soporte` |
-| **542** | Acerca de modal — app version + README bump process | https://github.com/diego-torres/nutriconsultas/issues/542 | **NEXT** | 540, ~~541~~ | Maven `project.version` → `appVersion` |
+| **542** | Acerca de modal — app version + README bump process | https://github.com/diego-torres/nutriconsultas/issues/542 | **done** | 540, ~~541~~ | `app.version=@project.version@` + `AppVersionModelAdvice` |
 | **543** | Support ticket schema — Liquibase + entity + repository | https://github.com/diego-torres/nutriconsultas/issues/543 | **done** | 540 | Liquibase `034`; `SupportTicket` + repository |
 | **544** | Support ticket service — create, list, update, close, filter | https://github.com/diego-torres/nutriconsultas/issues/544 | **done** | ~~**543**~~ | `SupportTicketService`; admin view with user + plan |
-| **545** | Nutritionist Soporte page — own tickets + create form | https://github.com/diego-torres/nutriconsultas/issues/545 | **open** | **544**, 541 | `/admin/soporte` user view |
-| **546** | Platform admin Soporte — list, filter, update, close | https://github.com/diego-torres/nutriconsultas/issues/546 | **open** | **544** | User + subscription + title columns |
+| **545** | Nutritionist Soporte page — own tickets + create form | https://github.com/diego-torres/nutriconsultas/issues/545 | **NEXT** | ~~**544**~~, ~~541~~ | `/admin/soporte` user view |
+| **546** | Platform admin Soporte — list, filter, update, close | https://github.com/diego-torres/nutriconsultas/issues/546 | **open** | ~~**544**~~ | User + subscription + title columns |
 | **547** | Tests + template validators for Soporte / Acerca de | https://github.com/diego-torres/nutriconsultas/issues/547 | **open** | 541–546 | May close incrementally with feature PRs |
 | **548** | Plan + registry docs for support tickets track | https://github.com/diego-torres/nutriconsultas/issues/548 | **done** | 540 | `ISSUE-SUPPORT.md`, plan, workflow, AGENTS/README pointers |
 

--- a/README.md
+++ b/README.md
@@ -19,20 +19,22 @@ registro de consultorio de nutrición
 
 **Issue registry:** [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md) · **Plan:** [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md) · **Workflow:** [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md)
 
-Epic [#540](https://github.com/diego-torres/nutriconsultas/issues/540): topbar menu **Perfil / Soporte / Acerca de / Salir**, nutritionist tickets, platform-admin triage, and **Acerca de** version display. **NEXT:** [#543](https://github.com/diego-torres/nutriconsultas/issues/543) schema.
+Epic [#540](https://github.com/diego-torres/nutriconsultas/issues/540): topbar menu **Perfil / Soporte / Acerca de / Salir**, nutritionist tickets, platform-admin triage, and **Acerca de** version display. **NEXT:** [#545](https://github.com/diego-torres/nutriconsultas/issues/545) nutritionist Soporte UI (after ~~#542~~).
 
 ### Application version
 
-The web application version shown in **Acerca de** (once [#542](https://github.com/diego-torres/nutriconsultas/issues/542) lands) comes from Maven `<version>` in [`pom.xml`](pom.xml) (currently `2.0-SNAPSHOT`), exposed at runtime as a filtered property such as `app.version`.
+The web application version shown in **Acerca de** (admin topbar → user menu) comes from Maven `<version>` in [`pom.xml`](pom.xml) (currently `2.0-SNAPSHOT`).
+
+At build time, Spring Boot resource filtering substitutes `app.version=@project.version@` in [`src/main/resources/application.properties`](src/main/resources/application.properties). `AppVersionModelAdvice` exposes that value to Thymeleaf as `appVersion` for `sbadmin/about-modal.html`.
 
 **When shipping a new version to `main`:**
 
 1. Update the `<version>` element in `pom.xml` (project semver or agreed scheme, e.g. `2.1.0`).
-2. Ensure the Maven build still filters that value into `application.properties` / the packaged artifact (`app.version=${project.version}` or equivalent — wired by #542).
-3. Merge the release PR to `main`, deploy, then confirm **Acerca de** in the admin topbar shows the new version.
+2. Run a normal Maven package/deploy (`mvn -DskipTests package` or CI). Confirm `target/classes/application.properties` contains `app.version=2.1.0` (not the `@project.version@` placeholder).
+3. Merge the release PR to `main`, deploy, then open **Acerca de** in the admin topbar and confirm the new version.
 4. Optionally create a matching Git tag (e.g. `v2.1.0`) on the release commit.
 
-Do not hardcode the version only in Thymeleaf HTML; keep `pom.xml` as the source of truth.
+Do not hardcode the version only in Thymeleaf HTML; keep `pom.xml` as the source of truth. Use `@…@` delimiters (not `${…}`) so Spring Boot’s resource filtering does not collide with runtime `${ENV}` placeholders.
 
 ## AWS (production infrastructure)
 

--- a/SUPPORT-WORKFLOW.md
+++ b/SUPPORT-WORKFLOW.md
@@ -10,7 +10,7 @@ How AI agents (and humans) ship the **`[Support]`** track on **`diego-torres/nut
 | [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md) | Product/tech plan, data model, version bump |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#542](https://github.com/diego-torres/nutriconsultas/issues/542) — Acerca de version wiring. ~~#544~~ service **done**. ~~#541~~ topbar **done**. ~~#543~~ ~~#548~~ done.
+**Current next issue:** [#545](https://github.com/diego-torres/nutriconsultas/issues/545) — Nutritionist Soporte UI. ~~#542~~ Acerca de **done**. ~~#544~~ ~~#541~~ ~~#543~~ ~~#548~~ done.
 
 ---
 

--- a/docs/support/SUPPORT-TICKETS-PLAN.md
+++ b/docs/support/SUPPORT-TICKETS-PLAN.md
@@ -82,10 +82,10 @@ Ship schema via **incremental Liquibase** only (`docs/db/LIQUIBASE.md`). Never `
 
 **Source of truth:** Maven `<version>` in `pom.xml` (today `2.0-SNAPSHOT`).
 
-**Runtime exposure (recommended):**
+**Runtime exposure (implemented in #542):**
 
-1. Add `app.version=${project.version}` (or equivalent) with Maven resource filtering into `application.properties`, **or** inject `@Value("${app.version}")` from a filtered property.
-2. Expose to Thymeleaf via `@ControllerAdvice` / model attribute (e.g. `appVersion`) used by the about modal fragment in the admin layout.
+1. `app.version=@project.version@` in `application.properties` (Spring Boot `@` resource filtering).
+2. `AppVersionModelAdvice` adds `appVersion` for Thymeleaf (`sbadmin/about-modal.html`).
 
 Do not hardcode the version only in HTML.
 
@@ -94,11 +94,11 @@ Do not hardcode the version only in HTML.
 Documented for maintainers in the root [`README.md`](../../README.md) (section **Application version**):
 
 1. Update `<version>` in `pom.xml` before or as part of the release PR to `main`.
-2. Confirm the build filters `app.version` (or the chosen property) into the packaged artifact.
+2. Confirm `target/classes/application.properties` has the substituted `app.version=…` value after package.
 3. After deploy, open **Acerca de** and verify the new value.
 4. Optionally create a matching Git tag (e.g. `v2.1.0`).
 
-Child issue: [#542](https://github.com/diego-torres/nutriconsultas/issues/542).
+Child issue: ~~[#542](https://github.com/diego-torres/nutriconsultas/issues/542)~~.
 
 ---
 

--- a/src/main/java/com/nutriconsultas/controller/AppVersionModelAdvice.java
+++ b/src/main/java/com/nutriconsultas/controller/AppVersionModelAdvice.java
@@ -12,15 +12,15 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 @ControllerAdvice
 public class AppVersionModelAdvice {
 
-	private final String appVersion;
+	private final String configuredVersion;
 
-	public AppVersionModelAdvice(@Value("${app.version:unknown}") final String appVersion) {
-		this.appVersion = appVersion;
+	public AppVersionModelAdvice(@Value("${app.version:unknown}") final String configuredVersion) {
+		this.configuredVersion = configuredVersion;
 	}
 
 	@ModelAttribute("appVersion")
 	public String appVersion() {
-		return this.appVersion;
+		return this.configuredVersion;
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/controller/AppVersionModelAdvice.java
+++ b/src/main/java/com/nutriconsultas/controller/AppVersionModelAdvice.java
@@ -1,0 +1,26 @@
+package com.nutriconsultas.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+/**
+ * Exposes the Maven-filtered application version to admin Thymeleaf layouts (Acerca de).
+ */
+@Component
+@ControllerAdvice
+public class AppVersionModelAdvice {
+
+	private final String appVersion;
+
+	public AppVersionModelAdvice(@Value("${app.version:unknown}") final String appVersion) {
+		this.appVersion = appVersion;
+	}
+
+	@ModelAttribute("appVersion")
+	public String appVersion() {
+		return this.appVersion;
+	}
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 server.port=3000
 server.error.include-stacktrace=always
+# Shown in Acerca de (#542); filtered from Maven project.version at build time (@ delimiters).
+app.version=@project.version@
 # Platillo/profile image uploads (#275); nginx allows up to 50M
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=50MB

--- a/src/test/java/com/nutriconsultas/controller/AppVersionModelAdviceTest.java
+++ b/src/test/java/com/nutriconsultas/controller/AppVersionModelAdviceTest.java
@@ -1,0 +1,28 @@
+package com.nutriconsultas.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+
+class AppVersionModelAdviceTest {
+
+	@Test
+	void appVersion_returnsConfiguredValue() {
+		final AppVersionModelAdvice advice = new AppVersionModelAdvice("2.0-SNAPSHOT");
+
+		assertThat(advice.appVersion()).isEqualTo("2.0-SNAPSHOT");
+	}
+
+	@Test
+	void appVersion_canBeAddedAsModelAttribute() {
+		final AppVersionModelAdvice advice = new AppVersionModelAdvice("2.1.0");
+		final Model model = new ExtendedModelMap();
+
+		model.addAttribute("appVersion", advice.appVersion());
+
+		assertThat(model.getAttribute("appVersion")).isEqualTo("2.1.0");
+	}
+
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -51,3 +51,5 @@ springdoc.api-docs.enabled=true
 springdoc.swagger-ui.enabled=true
 # AI assistant disabled in tests unless explicitly enabled (#365)
 nutriconsultas.ai.enabled=false
+# Acerca de (#542) — explicit value in tests (main uses Maven @project.version@ filtering)
+app.version=2.0-SNAPSHOT

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -7,3 +7,5 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=none
 spring.liquibase.change-log=classpath:db/changelog/db.changelog-test-master.yaml
 spring.session.store-type=none
+# Acerca de (#542)
+app.version=2.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Add `app.version=@project.version@` (Spring Boot `@` resource filtering) and `AppVersionModelAdvice` so Acerca de shows the Maven version as `appVersion`.
- Document the bump process in README / support plan; keep test resources on an explicit `app.version`.
- Update Support track registry — **NEXT:** #545 nutritionist Soporte UI.

Fixes #542

## Test plan
- [x] `mvn process-resources` → `target/classes/application.properties` has `app.version=2.0-SNAPSHOT`
- [x] `mvn -Dtest=AppVersionModelAdviceTest,ThymeleafTemplateValidationTest test`
- [x] `mvn checkstyle:check pmd:check`
- [ ] After deploy/local boot, open Acerca de and confirm version matches `pom.xml`
- [ ] CI green


Made with [Cursor](https://cursor.com)