### PR TITLE
[Support] Nutritionist Soporte page — own tickets grid + create form (#545)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -65,7 +65,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (AI assistant):** None — registered implementation track **complete** (#360–#450). Production rollout: [`RELEASE-CHECKLIST.md`](docs/ai/RELEASE-CHECKLIST.md) (#408). See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
-**Current next issue (support):** [#542](https://github.com/diego-torres/nutriconsultas/issues/542) — Acerca de version. ~~#544~~ ~~#541~~ ~~#543~~ ~~#548~~ done. See [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md).
+**Current next issue (support):** [#546](https://github.com/diego-torres/nutriconsultas/issues/546) — Platform admin Soporte. ~~#545~~ ~~#544~~ ~~#541~~ ~~#543~~ ~~#548~~ done. See [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -626,7 +626,7 @@ Issue registry: [`ISSUE-APPLE-SIGNIN.md`](ISSUE-APPLE-SIGNIN.md). Roadmap: [`doc
 
 Issue registry: [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md). Plan: [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md). Workflow: [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md).
 
-**Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. ~~#548~~ docs done. ~~#543~~ schema done. ~~#541~~ topbar done. ~~#544~~ service done. **NEXT:** [#542](https://github.com/diego-torres/nutriconsultas/issues/542) Acerca de version. Orthogonal to public `ContactInquiry`.
+**Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. ~~#548~~ docs done. ~~#543~~ schema done. ~~#541~~ topbar done. ~~#544~~ service done. ~~#545~~ nutritionist Soporte done. **NEXT:** [#546](https://github.com/diego-torres/nutriconsultas/issues/546) platform admin Soporte. Orthogonal to public `ContactInquiry`.
 
 ## Resources
 

--- a/ISSUE-SUPPORT.md
+++ b/ISSUE-SUPPORT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for **in-app support tickets** and the topbar user
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md)  
 **Workflow:** [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md)  
-**Last updated:** 2026-07-14 — ~~#544~~ service **done** (this PR); ~~#541~~ topbar **done**. **NEXT:** [#542](https://github.com/diego-torres/nutriconsultas/issues/542) Acerca de version.
+**Last updated:** 2026-07-14 — ~~#545~~ nutritionist Soporte UI **done** (this PR). **NEXT:** [#546](https://github.com/diego-torres/nutriconsultas/issues/546) platform admin Soporte UI.
 
 > **Scope.** Authenticated nutritionist web (`/admin/**`): support ticket create/list for users; platform-admin triage (user, subscription, title; update/close; active/closed filter); **Acerca de** version modal. **Does not** replace public `ContactInquiry`. Patient mobile API: [`ISSUE.md`](ISSUE.md). Platform admin patterns: contact inquiries / subscription admin.
 
@@ -43,11 +43,11 @@ Living index of GitHub issues for **in-app support tickets** and the topbar user
 |---|-------|-----|-------|------------|-------|
 | **540** | Epic — In-app support tickets + user menu | https://github.com/diego-torres/nutriconsultas/issues/540 | **open** | — | Umbrella; close when children done |
 | **541** | Topbar user menu — Perfil, Soporte, Acerca de, Salir | https://github.com/diego-torres/nutriconsultas/issues/541 | **done** | 540 | `#aboutModal` contract; Soporte → `/admin/soporte` |
-| **542** | Acerca de modal — app version + README bump process | https://github.com/diego-torres/nutriconsultas/issues/542 | **NEXT** | 540, ~~541~~ | Maven `project.version` → `appVersion` |
+| **542** | Acerca de modal — app version + README bump process | https://github.com/diego-torres/nutriconsultas/issues/542 | **in-progress** | 540, ~~541~~ | PR [#553](https://github.com/diego-torres/nutriconsultas/pull/553) |
 | **543** | Support ticket schema — Liquibase + entity + repository | https://github.com/diego-torres/nutriconsultas/issues/543 | **done** | 540 | Liquibase `034`; `SupportTicket` + repository |
 | **544** | Support ticket service — create, list, update, close, filter | https://github.com/diego-torres/nutriconsultas/issues/544 | **done** | ~~**543**~~ | `SupportTicketService`; admin view with user + plan |
-| **545** | Nutritionist Soporte page — own tickets + create form | https://github.com/diego-torres/nutriconsultas/issues/545 | **open** | **544**, 541 | `/admin/soporte` user view |
-| **546** | Platform admin Soporte — list, filter, update, close | https://github.com/diego-torres/nutriconsultas/issues/546 | **open** | **544** | User + subscription + title columns |
+| **545** | Nutritionist Soporte page — own tickets + create form | https://github.com/diego-torres/nutriconsultas/issues/545 | **done** | ~~**544**~~, ~~541~~ | `/admin/soporte` grid + create form |
+| **546** | Platform admin Soporte — list, filter, update, close | https://github.com/diego-torres/nutriconsultas/issues/546 | **NEXT** | ~~**544**~~ | User + subscription + title columns |
 | **547** | Tests + template validators for Soporte / Acerca de | https://github.com/diego-torres/nutriconsultas/issues/547 | **open** | 541–546 | May close incrementally with feature PRs |
 | **548** | Plan + registry docs for support tickets track | https://github.com/diego-torres/nutriconsultas/issues/548 | **done** | 540 | `ISSUE-SUPPORT.md`, plan, workflow, AGENTS/README pointers |
 

--- a/SUPPORT-WORKFLOW.md
+++ b/SUPPORT-WORKFLOW.md
@@ -10,7 +10,7 @@ How AI agents (and humans) ship the **`[Support]`** track on **`diego-torres/nut
 | [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md) | Product/tech plan, data model, version bump |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#542](https://github.com/diego-torres/nutriconsultas/issues/542) — Acerca de version wiring. ~~#544~~ service **done**. ~~#541~~ topbar **done**. ~~#543~~ ~~#548~~ done.
+**Current next issue:** [#546](https://github.com/diego-torres/nutriconsultas/issues/546) — Platform admin Soporte UI. ~~#545~~ nutritionist Soporte **done**. #542 Acerca de in PR [#553](https://github.com/diego-torres/nutriconsultas/pull/553). ~~#544~~ ~~#541~~ ~~#543~~ ~~#548~~ done.
 
 ---
 

--- a/src/main/java/com/nutriconsultas/support/SupportTicketController.java
+++ b/src/main/java/com/nutriconsultas/support/SupportTicketController.java
@@ -1,0 +1,63 @@
+package com.nutriconsultas.support;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import com.nutriconsultas.controller.AbstractAuthorizedController;
+import com.nutriconsultas.util.LogRedaction;
+
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Nutritionist Soporte page: list own tickets and create new ones.
+ */
+@Controller
+@RequestMapping("/admin/soporte")
+@Slf4j
+public class SupportTicketController extends AbstractAuthorizedController {
+
+	private final SupportTicketService supportTicketService;
+
+	public SupportTicketController(final SupportTicketService supportTicketService) {
+		this.supportTicketService = supportTicketService;
+	}
+
+	@GetMapping
+	public String list(@AuthenticationPrincipal final OidcUser principal, final Model model) {
+		final String userId = principal.getSubject();
+		model.addAttribute("tickets", supportTicketService.findOwnTickets(userId));
+		if (!model.containsAttribute("form")) {
+			model.addAttribute("form", new SupportTicketForm());
+		}
+		model.addAttribute("activeMenu", "soporte");
+		return "sbadmin/soporte/listado";
+	}
+
+	@PostMapping
+	public String create(@AuthenticationPrincipal final OidcUser principal,
+			@Valid @ModelAttribute("form") final SupportTicketForm form, final BindingResult bindingResult,
+			final Model model, final RedirectAttributes redirectAttributes) {
+		final String userId = principal.getSubject();
+		if (bindingResult.hasErrors()) {
+			model.addAttribute("tickets", supportTicketService.findOwnTickets(userId));
+			model.addAttribute("activeMenu", "soporte");
+			return "sbadmin/soporte/listado";
+		}
+		final SupportTicket saved = supportTicketService.create(userId, form.getTitle(), form.getDescription());
+		if (log.isInfoEnabled()) {
+			log.info("Support ticket submitted from Soporte UI: {}", LogRedaction.redactSupportTicket(saved.getId()));
+		}
+		redirectAttributes.addFlashAttribute("successMessage", "Ticket creado correctamente.");
+		return "redirect:/admin/soporte";
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/support/SupportTicketForm.java
+++ b/src/main/java/com/nutriconsultas/support/SupportTicketForm.java
@@ -1,0 +1,35 @@
+package com.nutriconsultas.support;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Create-ticket form for the nutritionist Soporte page.
+ */
+public class SupportTicketForm {
+
+	@NotBlank(message = "El título es obligatorio")
+	@Size(max = 200, message = "El título no puede exceder 200 caracteres")
+	private String title;
+
+	@NotBlank(message = "La descripción es obligatoria")
+	@Size(max = 4000, message = "La descripción no puede exceder 4000 caracteres")
+	private String description;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(final String title) {
+		this.title = title;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(final String description) {
+		this.description = description;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/support/SupportTicketTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/support/SupportTicketTemplateValidator.java
@@ -1,0 +1,48 @@
+package com.nutriconsultas.support;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import com.nutriconsultas.validation.template.BaseTemplateValidator;
+
+/**
+ * Thymeleaf mocks for the nutritionist Soporte page.
+ */
+public class SupportTicketTemplateValidator extends BaseTemplateValidator {
+
+	@Override
+	public String getTemplatePathPattern() {
+		return "sbadmin/soporte/*";
+	}
+
+	@Override
+	public Map<String, Object> createMockModelVariables() {
+		final Map<String, Object> variables = super.createMockModelVariables();
+
+		final SupportTicket openTicket = new SupportTicket();
+		openTicket.setId(1L);
+		openTicket.setUserId("auth0|mock-user");
+		openTicket.setTitle("No puedo guardar una dieta");
+		openTicket.setDescription("Al intentar guardar la dieta aparece un error inesperado.");
+		openTicket.setStatus(SupportTicketStatus.OPEN);
+		openTicket.setCreatedAt(Instant.parse("2026-07-10T15:30:00Z"));
+		openTicket.setUpdatedAt(Instant.parse("2026-07-10T15:30:00Z"));
+
+		final SupportTicket closedTicket = new SupportTicket();
+		closedTicket.setId(2L);
+		closedTicket.setUserId("auth0|mock-user");
+		closedTicket.setTitle("Duda sobre suscripción");
+		closedTicket.setDescription("¿Cómo se renueva el plan Profesional?");
+		closedTicket.setStatus(SupportTicketStatus.CLOSED);
+		closedTicket.setCreatedAt(Instant.parse("2026-07-01T10:00:00Z"));
+		closedTicket.setUpdatedAt(Instant.parse("2026-07-02T12:00:00Z"));
+		closedTicket.setClosedAt(Instant.parse("2026-07-02T12:00:00Z"));
+
+		variables.put("tickets", List.of(openTicket, closedTicket));
+		variables.put("form", new SupportTicketForm());
+		variables.put("activeMenu", "soporte");
+		return variables;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/validation/template/TemplateValidatorRegistry.java
+++ b/src/main/java/com/nutriconsultas/validation/template/TemplateValidatorRegistry.java
@@ -18,6 +18,7 @@ import com.nutriconsultas.reports.ReportTemplateValidator;
 import com.nutriconsultas.search.SearchTemplateValidator;
 import com.nutriconsultas.subscription.clinic.ClinicDirectorTemplateValidator;
 import com.nutriconsultas.subscription.invitation.InvitationRedeemTemplateValidator;
+import com.nutriconsultas.support.SupportTicketTemplateValidator;
 
 /**
  * Registry for template validators. Manages all available validators and provides a way
@@ -45,6 +46,7 @@ public class TemplateValidatorRegistry {
 		register(new ClinicDirectorTemplateValidator());
 		register(new SubscriptionBillingTemplateValidator());
 		register(new ContactInquiryTemplateValidator());
+		register(new SupportTicketTemplateValidator());
 		register(new AppleSignInNotificationTemplateValidator());
 		register(new InvitationRedeemTemplateValidator());
 		register(new EternaTemplateValidator());

--- a/src/main/resources/templates/sbadmin/soporte/listado.html
+++ b/src/main/resources/templates/sbadmin/soporte/listado.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <link th:href="@{/eterna/assets/img/favicon.png}" rel="icon">
+  <title>Minutriporcion - Soporte</title>
+  <link th:href="@{/sbadmin/vendor/fontawesome-free/css/all.min.css}" rel="stylesheet" type="text/css">
+  <link th:href="@{/sbadmin/vendor/datatables/dataTables.bootstrap4.min.css}" rel="stylesheet">
+  <link
+    href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
+    rel="stylesheet">
+  <link th:href="@{/sbadmin/css/sb-admin-2.min.css}" rel="stylesheet">
+  <link th:href="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.css}" rel="stylesheet">
+</head>
+
+<body id="page-top">
+  <div id="wrapper">
+    <div th:insert="~{sbadmin/sidebar :: sidebar}"></div>
+    <div id="content-wrapper" class="d-flex flex-column">
+      <div id="content">
+        <div th:insert="~{sbadmin/topbar :: topbar}"></div>
+        <div class="container-fluid">
+          <div class="d-sm-flex align-items-center justify-content-between mb-4">
+            <h1 class="h3 mb-0 text-gray-800">Soporte</h1>
+          </div>
+
+          <div th:if="${successMessage}" class="alert alert-success alert-dismissible fade show" role="alert">
+            <span th:text="${successMessage}">Éxito</span>
+            <button type="button" class="close" data-dismiss="alert" aria-label="Cerrar">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+
+          <div class="row">
+            <div class="col-lg-5">
+              <div class="card shadow mb-4">
+                <div class="card-header py-3">
+                  <h6 class="m-0 font-weight-bold text-primary">Nuevo ticket</h6>
+                </div>
+                <div class="card-body">
+                  <form th:action="@{/admin/soporte}" th:object="${form}" method="post" id="supportTicketForm">
+                    <div class="form-group">
+                      <label for="title">Título</label>
+                      <input type="text" class="form-control" id="title" th:field="*{title}" maxlength="200"
+                        th:classappend="${#fields.hasErrors('title')} ? ' is-invalid' : ''" required>
+                      <div class="invalid-feedback" th:if="${#fields.hasErrors('title')}" th:errors="*{title}">
+                        Error de título
+                      </div>
+                    </div>
+                    <div class="form-group">
+                      <label for="description">Descripción</label>
+                      <textarea class="form-control" id="description" th:field="*{description}" rows="5"
+                        maxlength="4000"
+                        th:classappend="${#fields.hasErrors('description')} ? ' is-invalid' : ''"
+                        required></textarea>
+                      <div class="invalid-feedback" th:if="${#fields.hasErrors('description')}"
+                        th:errors="*{description}">
+                        Error de descripción
+                      </div>
+                    </div>
+                    <button type="submit" class="btn btn-primary">
+                      <i class="fas fa-paper-plane fa-sm"></i> Enviar ticket
+                    </button>
+                  </form>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-7">
+              <div class="card shadow mb-4">
+                <div class="card-header py-3">
+                  <h6 class="m-0 font-weight-bold text-primary">Mis tickets</h6>
+                </div>
+                <div class="card-body">
+                  <div th:if="${#lists.isEmpty(tickets)}" class="text-muted mb-0">
+                    No tienes tickets de soporte todavía. Usa el formulario para crear uno.
+                  </div>
+                  <div th:unless="${#lists.isEmpty(tickets)}" class="table-responsive">
+                    <table class="table table-bordered" id="supportTicketsTable" width="100%" cellspacing="0">
+                      <thead>
+                        <tr>
+                          <th>Estado</th>
+                          <th>Fecha</th>
+                          <th>Título</th>
+                          <th>Descripción</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr th:each="ticket : ${tickets}">
+                          <td>
+                            <span th:if="${ticket.status.name() == 'OPEN'}" class="badge badge-success">Abierto</span>
+                            <span th:if="${ticket.status.name() == 'CLOSED'}" class="badge badge-secondary">Cerrado</span>
+                          </td>
+                          <td
+                            th:text="${#temporals.format(ticket.createdAt.atZone(T(java.time.ZoneId).of('America/Mexico_City')), 'dd/MM/yyyy HH:mm')}">
+                            01/01/2026 12:00
+                          </td>
+                          <td th:text="${ticket.title}">Título</td>
+                          <td th:text="${#strings.abbreviate(ticket.description, 80)}">Descripción</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div th:insert="~{sbadmin/footer :: footer}"></div>
+    </div>
+  </div>
+  <script th:src="@{/sbadmin/vendor/jquery/jquery.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/bootstrap/js/bootstrap.bundle.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/jquery-easing/jquery.easing.min.js}"></script>
+  <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.js}"></script>
+  <script th:src="@{/sbadmin/vendor/datatables/jquery.dataTables.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/datatables/dataTables.bootstrap4.min.js}"></script>
+  <script th:inline="javascript">
+    $(document).ready(function () {
+      var successMessage = /*[[${successMessage}]]*/ null;
+      if (successMessage) {
+        swal({
+          title: 'Listo',
+          text: successMessage,
+          type: 'success',
+          timer: 2000
+        });
+      }
+
+      if ($('#supportTicketsTable').length) {
+        $('#supportTicketsTable').DataTable({
+          order: [[1, 'desc']],
+          language: {
+            url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/es-ES.json'
+          }
+        });
+      }
+
+      $('#supportTicketForm').on('submit', function (e) {
+        var title = $.trim($('#title').val());
+        var description = $.trim($('#description').val());
+        if (!title || !description) {
+          e.preventDefault();
+          swal({
+            title: 'Datos incompletos',
+            text: 'El título y la descripción son obligatorios.',
+            type: 'warning',
+            timer: 4000
+          });
+        }
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/src/test/java/com/nutriconsultas/support/SupportTicketControllerTest.java
+++ b/src/test/java/com/nutriconsultas/support/SupportTicketControllerTest.java
@@ -1,0 +1,107 @@
+package com.nutriconsultas.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+@ExtendWith(MockitoExtension.class)
+class SupportTicketControllerTest {
+
+	private static final String USER_ID = "auth0|nutritionist-1";
+
+	@InjectMocks
+	private SupportTicketController controller;
+
+	@Mock
+	private SupportTicketService supportTicketService;
+
+	@Test
+	void list_addsOwnTicketsAndEmptyForm() {
+		final SupportTicket ticket = sampleTicket(1L, SupportTicketStatus.OPEN);
+		when(supportTicketService.findOwnTickets(USER_ID)).thenReturn(List.of(ticket));
+		final ExtendedModelMap model = new ExtendedModelMap();
+
+		final String view = controller.list(principal(), model);
+
+		assertThat(view).isEqualTo("sbadmin/soporte/listado");
+		assertThat(model.getAttribute("tickets")).isEqualTo(List.of(ticket));
+		assertThat(model.getAttribute("form")).isInstanceOf(SupportTicketForm.class);
+		assertThat(model.getAttribute("activeMenu")).isEqualTo("soporte");
+		verify(supportTicketService).findOwnTickets(USER_ID);
+	}
+
+	@Test
+	void create_whenValid_redirectsWithSuccessFlash() {
+		final SupportTicketForm form = new SupportTicketForm();
+		form.setTitle("Problema con dietas");
+		form.setDescription("No puedo editar ingredientes.");
+		final BindingResult bindingResult = new BeanPropertyBindingResult(form, "form");
+		final SupportTicket saved = sampleTicket(9L, SupportTicketStatus.OPEN);
+		when(supportTicketService.create(eq(USER_ID), eq("Problema con dietas"), eq("No puedo editar ingredientes.")))
+			.thenReturn(saved);
+		final RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
+
+		final String view = controller.create(principal(), form, bindingResult, new ExtendedModelMap(),
+				redirectAttributes);
+
+		assertThat(view).isEqualTo("redirect:/admin/soporte");
+		assertThat(redirectAttributes.getFlashAttributes().get("successMessage"))
+			.isEqualTo("Ticket creado correctamente.");
+		verify(supportTicketService).create(USER_ID, "Problema con dietas", "No puedo editar ingredientes.");
+	}
+
+	@Test
+	void create_whenValidationErrors_returnsListViewWithTickets() {
+		final SupportTicketForm form = new SupportTicketForm();
+		final BindingResult bindingResult = new BeanPropertyBindingResult(form, "form");
+		bindingResult.rejectValue("title", "NotBlank", "El título es obligatorio");
+		final SupportTicket existing = sampleTicket(3L, SupportTicketStatus.CLOSED);
+		when(supportTicketService.findOwnTickets(USER_ID)).thenReturn(List.of(existing));
+		final ExtendedModelMap model = new ExtendedModelMap();
+
+		final String view = controller.create(principal(), form, bindingResult, model,
+				new RedirectAttributesModelMap());
+
+		assertThat(view).isEqualTo("sbadmin/soporte/listado");
+		assertThat(model.getAttribute("tickets")).isEqualTo(List.of(existing));
+		assertThat(model.getAttribute("activeMenu")).isEqualTo("soporte");
+	}
+
+	private static DefaultOidcUser principal() {
+		final Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject(USER_ID).build();
+		final OidcIdToken idToken = new OidcIdToken(jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(),
+				Map.of("sub", USER_ID));
+		return new DefaultOidcUser(List.of(), idToken);
+	}
+
+	private static SupportTicket sampleTicket(final Long id, final SupportTicketStatus status) {
+		final SupportTicket ticket = new SupportTicket();
+		ticket.setId(id);
+		ticket.setUserId(USER_ID);
+		ticket.setTitle("Título de prueba");
+		ticket.setDescription("Descripción de prueba");
+		ticket.setStatus(status);
+		ticket.setCreatedAt(Instant.parse("2026-07-10T12:00:00Z"));
+		ticket.setUpdatedAt(Instant.parse("2026-07-10T12:00:00Z"));
+		return ticket;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `SupportTicketController` at `/admin/soporte` to list the current user's tickets and create new ones via `SupportTicketForm` (title + description).
- New Thymeleaf page `sbadmin/soporte/listado.html` (Spanish UI, empty state, Abierto/Cerrado badges, DataTables, bootstrap-sweetalert).
- Register `SupportTicketTemplateValidator` and controller unit tests; update Support track registry — **NEXT:** #546.

Fixes #545

## Test plan
- [x] `mvn -Dtest=SupportTicketControllerTest,ThymeleafTemplateValidationTest test` (Java 21)
- [x] `mvn checkstyle:check pmd:check`
- [ ] Log in as nutritionist → Soporte → create ticket → appears in Mis tickets
- [ ] Confirm another user's tickets are not listed
- [ ] Validation errors for empty title/description
- [ ] CI green


Made with [Cursor](https://cursor.com)