### PR TITLE
[Support] Platform admin Soporte — list, filter, update, close (#546)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -65,7 +65,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (AI assistant):** None — registered implementation track **complete** (#360–#450). Production rollout: [`RELEASE-CHECKLIST.md`](docs/ai/RELEASE-CHECKLIST.md) (#408). See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
-**Current next issue (support):** [#546](https://github.com/diego-torres/nutriconsultas/issues/546) — Platform admin Soporte. ~~#545~~ ~~#542~~ ~~#544~~ ~~#541~~ ~~#543~~ ~~#548~~ done. See [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md).
+**Current next issue (support):** [#547](https://github.com/diego-torres/nutriconsultas/issues/547) — Remaining tests/validators. ~~#546~~ ~~#545~~ ~~#542~~ ~~#544~~ ~~#541~~ ~~#543~~ ~~#548~~ done. See [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -626,7 +626,7 @@ Issue registry: [`ISSUE-APPLE-SIGNIN.md`](ISSUE-APPLE-SIGNIN.md). Roadmap: [`doc
 
 Issue registry: [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md). Plan: [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md). Workflow: [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md).
 
-**Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. ~~#548~~ docs done. ~~#543~~ schema done. ~~#541~~ topbar done. ~~#544~~ service done. ~~#542~~ Acerca de version done. ~~#545~~ nutritionist Soporte done. **NEXT:** [#546](https://github.com/diego-torres/nutriconsultas/issues/546) platform admin Soporte. Orthogonal to public `ContactInquiry`.
+**Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. ~~#548~~ docs done. ~~#543~~ schema done. ~~#541~~ topbar done. ~~#544~~ service done. ~~#542~~ Acerca de version done. ~~#545~~ nutritionist Soporte done. ~~#546~~ platform admin Soporte done. **NEXT:** [#547](https://github.com/diego-torres/nutriconsultas/issues/547) remaining tests/validators. Orthogonal to public `ContactInquiry`.
 
 ## Resources
 

--- a/ISSUE-SUPPORT.md
+++ b/ISSUE-SUPPORT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for **in-app support tickets** and the topbar user
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md)  
 **Workflow:** [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md)  
-**Last updated:** 2026-07-14 — ~~#545~~ nutritionist Soporte UI **done** (this PR); ~~#542~~ Acerca de **done**. **NEXT:** [#546](https://github.com/diego-torres/nutriconsultas/issues/546) platform admin Soporte UI.
+**Last updated:** 2026-07-14 — ~~#546~~ platform admin Soporte UI **done** (this PR). **NEXT:** [#547](https://github.com/diego-torres/nutriconsultas/issues/547) remaining tests/validators (or close epic #540 if #547 lands with this PR).
 
 > **Scope.** Authenticated nutritionist web (`/admin/**`): support ticket create/list for users; platform-admin triage (user, subscription, title; update/close; active/closed filter); **Acerca de** version modal. **Does not** replace public `ContactInquiry`. Patient mobile API: [`ISSUE.md`](ISSUE.md). Platform admin patterns: contact inquiries / subscription admin.
 
@@ -47,8 +47,8 @@ Living index of GitHub issues for **in-app support tickets** and the topbar user
 | **543** | Support ticket schema — Liquibase + entity + repository | https://github.com/diego-torres/nutriconsultas/issues/543 | **done** | 540 | Liquibase `034`; `SupportTicket` + repository |
 | **544** | Support ticket service — create, list, update, close, filter | https://github.com/diego-torres/nutriconsultas/issues/544 | **done** | ~~**543**~~ | `SupportTicketService`; admin view with user + plan |
 | **545** | Nutritionist Soporte page — own tickets + create form | https://github.com/diego-torres/nutriconsultas/issues/545 | **done** | ~~**544**~~, ~~541~~ | `/admin/soporte` grid + create form |
-| **546** | Platform admin Soporte — list, filter, update, close | https://github.com/diego-torres/nutriconsultas/issues/546 | **NEXT** | ~~**544**~~ | User + subscription + title columns |
-| **547** | Tests + template validators for Soporte / Acerca de | https://github.com/diego-torres/nutriconsultas/issues/547 | **open** | 541–546 | May close incrementally with feature PRs |
+| **546** | Platform admin Soporte — list, filter, update, close | https://github.com/diego-torres/nutriconsultas/issues/546 | **done** | ~~**544**~~ | `/admin/platform/soporte`; topbar redirects admins |
+| **547** | Tests + template validators for Soporte / Acerca de | https://github.com/diego-torres/nutriconsultas/issues/547 | **NEXT** | 541–546 | May close incrementally with feature PRs |
 | **548** | Plan + registry docs for support tickets track | https://github.com/diego-torres/nutriconsultas/issues/548 | **done** | 540 | `ISSUE-SUPPORT.md`, plan, workflow, AGENTS/README pointers |
 
 ---

--- a/SUPPORT-WORKFLOW.md
+++ b/SUPPORT-WORKFLOW.md
@@ -10,7 +10,7 @@ How AI agents (and humans) ship the **`[Support]`** track on **`diego-torres/nut
 | [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md) | Product/tech plan, data model, version bump |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#546](https://github.com/diego-torres/nutriconsultas/issues/546) — Platform admin Soporte UI. ~~#545~~ nutritionist Soporte **done**. ~~#542~~ Acerca de **done**. ~~#544~~ ~~#541~~ ~~#543~~ ~~#548~~ done.
+**Current next issue:** [#547](https://github.com/diego-torres/nutriconsultas/issues/547) — Remaining tests/validators (or close with feature coverage). ~~#546~~ platform admin Soporte **done**. ~~#545~~ ~~#542~~ ~~#544~~ ~~#541~~ ~~#543~~ ~~#548~~ done.
 
 ---
 

--- a/docs/support/SUPPORT-TICKETS-PLAN.md
+++ b/docs/support/SUPPORT-TICKETS-PLAN.md
@@ -48,12 +48,12 @@ Template entry point: `src/main/resources/templates/sbadmin/topbar.html`.
 
 Reuse existing platform-admin patterns (`AbstractPlatformAdminController`, `requirePlatformAdmin`, contact-inquiry style audits where useful).
 
-**Suggested UX routing:** single entry `/admin/soporte` that branches in the controller:
+**UX routing (implemented):**
 
-- Non-admin → nutritionist grid + create form
-- Platform admin → admin inbox (user, subscription, title + actions)
-
-Alternatively `/admin/platform/soporte` for admin only and `/admin/soporte` for users — pick one in implementation and keep the topbar link consistent.
+- Nutritionists: `/admin/soporte` — own tickets grid + create form
+- Platform admins: `/admin/platform/soporte` — triage inbox (user, subscription, title; filter activos/cerrados; notes/close/reopen)
+- Topbar **Soporte** stays `/admin/soporte`; platform admins are redirected to `/admin/platform/soporte`
+- Sidebar **Plataforma → Soporte** links directly to the admin inbox
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.nutriconsultas</groupId>
   <artifactId>nutriconsultas-web</artifactId>
-  <version>2.0-SNAPSHOT</version>
+  <version>2.0.0</version>
 
   <name>nutriconsultas-web</name>
   <url>https://minutriporcion.com</url>

--- a/src/main/java/com/nutriconsultas/support/SupportTicketAdminController.java
+++ b/src/main/java/com/nutriconsultas/support/SupportTicketAdminController.java
@@ -1,0 +1,105 @@
+package com.nutriconsultas.support;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import com.nutriconsultas.controller.AbstractPlatformAdminController;
+import com.nutriconsultas.platform.PlatformAdminAuthorization;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Platform-admin Soporte inbox: list/filter tickets, update notes, close/reopen.
+ */
+@Controller
+@RequestMapping("/admin/platform/soporte")
+@Slf4j
+public class SupportTicketAdminController extends AbstractPlatformAdminController {
+
+	static final String FILTER_ACTIVOS = "activos";
+
+	static final String FILTER_CERRADOS = "cerrados";
+
+	private final SupportTicketService supportTicketService;
+
+	public SupportTicketAdminController(final PlatformAdminAuthorization platformAdminAuthorization,
+			final SupportTicketService supportTicketService) {
+		super(platformAdminAuthorization);
+		this.supportTicketService = supportTicketService;
+	}
+
+	@GetMapping
+	public String list(@AuthenticationPrincipal final OidcUser principal, final Model model,
+			@RequestParam(name = "estado", defaultValue = FILTER_ACTIVOS) final String estado) {
+		requirePlatformAdmin(principal, "soporte.list");
+		final String filter = normalizeFilter(estado);
+		final SupportTicketStatus status = FILTER_CERRADOS.equals(filter) ? SupportTicketStatus.CLOSED
+				: SupportTicketStatus.OPEN;
+		model.addAttribute("adminTickets", supportTicketService.findByStatusForAdmin(status));
+		model.addAttribute("estado", filter);
+		model.addAttribute("activeMenu", "soporte-admin");
+		return "sbadmin/platform/soporte/listado";
+	}
+
+	@PostMapping("/{id}/notes")
+	public String updateNotes(@AuthenticationPrincipal final OidcUser principal, @PathVariable final Long id,
+			@RequestParam(required = false) final String adminNotes,
+			@RequestParam(name = "estado", defaultValue = FILTER_ACTIVOS) final String estado,
+			final RedirectAttributes redirectAttributes) {
+		requirePlatformAdmin(principal, "soporte.update-notes");
+		final SupportTicket saved = supportTicketService.updateAdminNotes(id, adminNotes);
+		if (log.isInfoEnabled()) {
+			log.info("Admin updated support ticket notes: {}", LogRedaction.redactSupportTicket(saved.getId()));
+		}
+		redirectAttributes.addFlashAttribute("successMessage", "Notas actualizadas correctamente.");
+		return redirectToList(estado);
+	}
+
+	@PostMapping("/{id}/close")
+	public String close(@AuthenticationPrincipal final OidcUser principal, @PathVariable final Long id,
+			@RequestParam(name = "estado", defaultValue = FILTER_ACTIVOS) final String estado,
+			final RedirectAttributes redirectAttributes) {
+		requirePlatformAdmin(principal, "soporte.close");
+		final SupportTicket saved = supportTicketService.close(id);
+		if (log.isInfoEnabled()) {
+			log.info("Admin closed support ticket: {}", LogRedaction.redactSupportTicket(saved.getId()));
+		}
+		redirectAttributes.addFlashAttribute("successMessage", "Ticket cerrado correctamente.");
+		return redirectToList(estado);
+	}
+
+	@PostMapping("/{id}/reopen")
+	public String reopen(@AuthenticationPrincipal final OidcUser principal, @PathVariable final Long id,
+			@RequestParam(name = "estado", defaultValue = FILTER_CERRADOS) final String estado,
+			final RedirectAttributes redirectAttributes) {
+		requirePlatformAdmin(principal, "soporte.reopen");
+		final SupportTicket saved = supportTicketService.reopen(id);
+		if (log.isInfoEnabled()) {
+			log.info("Admin reopened support ticket: {}", LogRedaction.redactSupportTicket(saved.getId()));
+		}
+		redirectAttributes.addFlashAttribute("successMessage", "Ticket reabierto correctamente.");
+		return redirectToList(estado);
+	}
+
+	private static String normalizeFilter(final String estado) {
+		String result = FILTER_ACTIVOS;
+		if (FILTER_CERRADOS.equalsIgnoreCase(estado)) {
+			result = FILTER_CERRADOS;
+		}
+		return result;
+	}
+
+	private static String redirectToList(final String estado) {
+		return "redirect:/admin/platform/soporte?estado=" + normalizeFilter(estado);
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/support/SupportTicketAdminTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/support/SupportTicketAdminTemplateValidator.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.support;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import com.nutriconsultas.subscription.PlanTier;
+import com.nutriconsultas.validation.template.BaseTemplateValidator;
+
+/**
+ * Thymeleaf mocks for the platform-admin Soporte inbox.
+ */
+public class SupportTicketAdminTemplateValidator extends BaseTemplateValidator {
+
+	@Override
+	public String getTemplatePathPattern() {
+		return "sbadmin/platform/soporte/*";
+	}
+
+	@Override
+	public Map<String, Object> createMockModelVariables() {
+		final Map<String, Object> variables = super.createMockModelVariables();
+
+		final SupportTicket openTicket = new SupportTicket();
+		openTicket.setId(1L);
+		openTicket.setUserId("auth0|mock-user");
+		openTicket.setTitle("No puedo guardar una dieta");
+		openTicket.setDescription("Al intentar guardar la dieta aparece un error inesperado.");
+		openTicket.setStatus(SupportTicketStatus.OPEN);
+		openTicket.setAdminNotes("Pendiente de revisión");
+		openTicket.setCreatedAt(Instant.parse("2026-07-10T15:30:00Z"));
+		openTicket.setUpdatedAt(Instant.parse("2026-07-10T15:30:00Z"));
+
+		final SupportTicketAdminView openView = new SupportTicketAdminView(openTicket, "Dra. Prueba",
+				PlanTier.PROFESIONAL, PlanTier.PROFESIONAL.getDisplayName());
+
+		variables.put("adminTickets", List.of(openView));
+		variables.put("estado", "activos");
+		variables.put("activeMenu", "soporte-admin");
+		variables.put("platformAdmin", true);
+		return variables;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/support/SupportTicketController.java
+++ b/src/main/java/com/nutriconsultas/support/SupportTicketController.java
@@ -12,13 +12,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.nutriconsultas.controller.AbstractAuthorizedController;
+import com.nutriconsultas.platform.PlatformAdminService;
 import com.nutriconsultas.util.LogRedaction;
 
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Nutritionist Soporte page: list own tickets and create new ones.
+ * Nutritionist Soporte page: list own tickets and create new ones. Platform admins are
+ * redirected to the triage inbox.
  */
 @Controller
 @RequestMapping("/admin/soporte")
@@ -27,12 +29,19 @@ public class SupportTicketController extends AbstractAuthorizedController {
 
 	private final SupportTicketService supportTicketService;
 
-	public SupportTicketController(final SupportTicketService supportTicketService) {
+	private final PlatformAdminService platformAdminService;
+
+	public SupportTicketController(final SupportTicketService supportTicketService,
+			final PlatformAdminService platformAdminService) {
 		this.supportTicketService = supportTicketService;
+		this.platformAdminService = platformAdminService;
 	}
 
 	@GetMapping
 	public String list(@AuthenticationPrincipal final OidcUser principal, final Model model) {
+		if (platformAdminService.isPlatformAdmin(principal)) {
+			return "redirect:/admin/platform/soporte";
+		}
 		final String userId = principal.getSubject();
 		model.addAttribute("tickets", supportTicketService.findOwnTickets(userId));
 		if (!model.containsAttribute("form")) {

--- a/src/main/java/com/nutriconsultas/validation/template/TemplateValidatorRegistry.java
+++ b/src/main/java/com/nutriconsultas/validation/template/TemplateValidatorRegistry.java
@@ -18,6 +18,7 @@ import com.nutriconsultas.reports.ReportTemplateValidator;
 import com.nutriconsultas.search.SearchTemplateValidator;
 import com.nutriconsultas.subscription.clinic.ClinicDirectorTemplateValidator;
 import com.nutriconsultas.subscription.invitation.InvitationRedeemTemplateValidator;
+import com.nutriconsultas.support.SupportTicketAdminTemplateValidator;
 import com.nutriconsultas.support.SupportTicketTemplateValidator;
 
 /**
@@ -42,6 +43,7 @@ public class TemplateValidatorRegistry {
 		register(new AiChatTemplateValidator());
 		register(new SearchTemplateValidator());
 		register(new ProfileTemplateValidator());
+		register(new SupportTicketAdminTemplateValidator());
 		register(new PlatformAdminTemplateValidator());
 		register(new ClinicDirectorTemplateValidator());
 		register(new SubscriptionBillingTemplateValidator());

--- a/src/main/resources/templates/sbadmin/platform/soporte/listado.html
+++ b/src/main/resources/templates/sbadmin/platform/soporte/listado.html
@@ -131,7 +131,7 @@
 
       if ($('#adminSupportTicketsTable').length) {
         $('#adminSupportTicketsTable').DataTable({
-          order: [[4, 'desc']],
+          order: [ [4, 'desc'] ],
           language: {
             url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/es-ES.json'
           },

--- a/src/main/resources/templates/sbadmin/platform/soporte/listado.html
+++ b/src/main/resources/templates/sbadmin/platform/soporte/listado.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <link th:href="@{/eterna/assets/img/favicon.png}" rel="icon">
+  <title>Minutriporcion - Soporte (plataforma)</title>
+  <link th:href="@{/sbadmin/vendor/fontawesome-free/css/all.min.css}" rel="stylesheet" type="text/css">
+  <link th:href="@{/sbadmin/vendor/datatables/dataTables.bootstrap4.min.css}" rel="stylesheet">
+  <link
+    href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
+    rel="stylesheet">
+  <link th:href="@{/sbadmin/css/sb-admin-2.min.css}" rel="stylesheet">
+  <link th:href="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.css}" rel="stylesheet">
+</head>
+
+<body id="page-top">
+  <div id="wrapper">
+    <div th:insert="~{sbadmin/sidebar :: sidebar}"></div>
+    <div id="content-wrapper" class="d-flex flex-column">
+      <div id="content">
+        <div th:insert="~{sbadmin/topbar :: topbar}"></div>
+        <div class="container-fluid">
+          <div class="d-sm-flex align-items-center justify-content-between mb-4">
+            <h1 class="h3 mb-0 text-gray-800">Soporte</h1>
+          </div>
+
+          <div th:if="${successMessage}" class="alert alert-success alert-dismissible fade show" role="alert">
+            <span th:text="${successMessage}">Éxito</span>
+            <button type="button" class="close" data-dismiss="alert" aria-label="Cerrar">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+
+          <div class="card shadow mb-4">
+            <div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
+              <h6 class="m-0 font-weight-bold text-primary">Tickets de soporte</h6>
+              <div class="btn-group btn-group-sm" role="group" aria-label="Filtro de estado">
+                <a class="btn"
+                  th:classappend="${estado == 'activos'} ? ' btn-primary' : ' btn-outline-primary'"
+                  th:href="@{/admin/platform/soporte(estado='activos')}">Activos</a>
+                <a class="btn"
+                  th:classappend="${estado == 'cerrados'} ? ' btn-primary' : ' btn-outline-primary'"
+                  th:href="@{/admin/platform/soporte(estado='cerrados')}">Cerrados</a>
+              </div>
+            </div>
+            <div class="card-body">
+              <div th:if="${#lists.isEmpty(adminTickets)}" class="text-muted mb-0">
+                <span th:if="${estado == 'activos'}">No hay tickets activos.</span>
+                <span th:unless="${estado == 'activos'}">No hay tickets cerrados.</span>
+              </div>
+              <div th:unless="${#lists.isEmpty(adminTickets)}" class="table-responsive">
+                <table class="table table-bordered" id="adminSupportTicketsTable" width="100%" cellspacing="0">
+                  <thead>
+                    <tr>
+                      <th>Usuario</th>
+                      <th>Suscripción</th>
+                      <th>Título</th>
+                      <th>Descripción</th>
+                      <th>Fecha</th>
+                      <th>Notas admin</th>
+                      <th>Acciones</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr th:each="row : ${adminTickets}">
+                      <td th:text="${row.userDisplayLabel()}">Usuario</td>
+                      <td th:text="${row.subscriptionLabel()}">Plan</td>
+                      <td th:text="${row.title()}">Título</td>
+                      <td th:text="${#strings.abbreviate(row.ticket().description, 100)}">Descripción</td>
+                      <td
+                        th:text="${#temporals.format(row.ticket().createdAt.atZone(T(java.time.ZoneId).of('America/Mexico_City')), 'dd/MM/yyyy HH:mm')}">
+                        01/01/2026 12:00
+                      </td>
+                      <td style="min-width: 220px;">
+                        <form th:action="@{/admin/platform/soporte/{id}/notes(id=${row.ticketId()}, estado=${estado})}"
+                          method="post" class="admin-notes-form">
+                          <textarea class="form-control form-control-sm mb-1" name="adminNotes" rows="2"
+                            maxlength="2000" th:text="${row.ticket().adminNotes}"></textarea>
+                          <button type="submit" class="btn btn-sm btn-outline-primary">Guardar notas</button>
+                        </form>
+                      </td>
+                      <td class="text-nowrap">
+                        <form th:if="${row.status().name() == 'OPEN'}"
+                          th:action="@{/admin/platform/soporte/{id}/close(id=${row.ticketId()}, estado=${estado})}"
+                          method="post" class="d-inline close-support-ticket-form">
+                          <button type="button" class="btn btn-sm btn-danger close-support-ticket-btn"
+                            title="Cerrar ticket">
+                            <i class="fas fa-times"></i> Cerrar
+                          </button>
+                        </form>
+                        <form th:if="${row.status().name() == 'CLOSED'}"
+                          th:action="@{/admin/platform/soporte/{id}/reopen(id=${row.ticketId()}, estado=${estado})}"
+                          method="post" class="d-inline">
+                          <button type="submit" class="btn btn-sm btn-success" title="Reabrir ticket">
+                            <i class="fas fa-undo"></i> Reabrir
+                          </button>
+                        </form>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div th:insert="~{sbadmin/footer :: footer}"></div>
+    </div>
+  </div>
+  <script th:src="@{/sbadmin/vendor/jquery/jquery.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/bootstrap/js/bootstrap.bundle.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/jquery-easing/jquery.easing.min.js}"></script>
+  <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.js}"></script>
+  <script th:src="@{/sbadmin/vendor/datatables/jquery.dataTables.min.js}"></script>
+  <script th:src="@{/sbadmin/vendor/datatables/dataTables.bootstrap4.min.js}"></script>
+  <script th:inline="javascript">
+    $(document).ready(function () {
+      var successMessage = /*[[${successMessage}]]*/ null;
+      if (successMessage) {
+        swal({
+          title: 'Listo',
+          text: successMessage,
+          type: 'success',
+          timer: 2000
+        });
+      }
+
+      if ($('#adminSupportTicketsTable').length) {
+        $('#adminSupportTicketsTable').DataTable({
+          order: [[4, 'desc']],
+          language: {
+            url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/es-ES.json'
+          },
+          columnDefs: [
+            { orderable: false, targets: [5, 6] }
+          ]
+        });
+      }
+
+      $(document).on('click', '.close-support-ticket-btn', function () {
+        var $form = $(this).closest('.close-support-ticket-form');
+        swal({
+          title: 'Cerrar ticket',
+          text: '¿Cerrar este ticket de soporte? El usuario lo verá como cerrado.',
+          type: 'warning',
+          showCancelButton: true,
+          confirmButtonColor: '#d33',
+          cancelButtonColor: '#6c757d',
+          confirmButtonText: 'Sí, cerrar',
+          cancelButtonText: 'Cancelar',
+          closeOnConfirm: true
+        }, function (isConfirm) {
+          if (isConfirm) {
+            $form.submit();
+          }
+        });
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/src/main/resources/templates/sbadmin/sidebar.html
+++ b/src/main/resources/templates/sbadmin/sidebar.html
@@ -68,16 +68,16 @@
         <i class="fas fa-fw fa-clinic-medical"></i>
         <span>Mi Consultorio</span></a>
     </li>
-    <li class="nav-item" th:if="${platformAdmin}" th:classappend="${activeMenu == 'platform' || activeMenu == 'contact-inquiries' || activeMenu == 'apple-signin' || activeMenu == 'invitations' || activeMenu == 'subscriptions' || activeMenu == 'maintenance' ? 'active' : ''}">
+    <li class="nav-item" th:if="${platformAdmin}" th:classappend="${activeMenu == 'platform' || activeMenu == 'contact-inquiries' || activeMenu == 'apple-signin' || activeMenu == 'invitations' || activeMenu == 'subscriptions' || activeMenu == 'maintenance' || activeMenu == 'soporte-admin' ? 'active' : ''}">
       <a class="nav-link" href="#" data-toggle="collapse" data-target="#collapsePlatform"
-        th:classappend="${activeMenu == 'platform' || activeMenu == 'contact-inquiries' || activeMenu == 'apple-signin' || activeMenu == 'invitations' || activeMenu == 'subscriptions' || activeMenu == 'maintenance' ? '' : ' collapsed'}"
-        th:attr="aria-expanded=${activeMenu == 'platform' || activeMenu == 'contact-inquiries' || activeMenu == 'apple-signin' || activeMenu == 'invitations' || activeMenu == 'subscriptions' || activeMenu == 'maintenance' ? 'true' : 'false'}"
+        th:classappend="${activeMenu == 'platform' || activeMenu == 'contact-inquiries' || activeMenu == 'apple-signin' || activeMenu == 'invitations' || activeMenu == 'subscriptions' || activeMenu == 'maintenance' || activeMenu == 'soporte-admin' ? '' : ' collapsed'}"
+        th:attr="aria-expanded=${activeMenu == 'platform' || activeMenu == 'contact-inquiries' || activeMenu == 'apple-signin' || activeMenu == 'invitations' || activeMenu == 'subscriptions' || activeMenu == 'maintenance' || activeMenu == 'soporte-admin' ? 'true' : 'false'}"
         aria-controls="collapsePlatform">
         <i class="fas fa-fw fa-shield-alt"></i>
         <span>Plataforma</span>
       </a>
       <div id="collapsePlatform" class="collapse"
-        th:classappend="${activeMenu == 'platform' || activeMenu == 'contact-inquiries' || activeMenu == 'apple-signin' || activeMenu == 'invitations' || activeMenu == 'subscriptions' || activeMenu == 'maintenance' ? ' show' : ''}"
+        th:classappend="${activeMenu == 'platform' || activeMenu == 'contact-inquiries' || activeMenu == 'apple-signin' || activeMenu == 'invitations' || activeMenu == 'subscriptions' || activeMenu == 'maintenance' || activeMenu == 'soporte-admin' ? ' show' : ''}"
         aria-labelledby="headingPlatform" data-parent="#accordionSidebar">
         <div class="bg-white py-2 collapse-inner rounded">
           <h6 class="collapse-header">Administración:</h6>
@@ -89,6 +89,8 @@
             th:classappend="${activeMenu == 'subscriptions' ? ' active' : ''}">Suscripciones</a>
           <a class="collapse-item" th:href="@{/admin/platform/contact-inquiries}"
             th:classappend="${activeMenu == 'contact-inquiries' ? ' active' : ''}">Mensajes de contacto</a>
+          <a class="collapse-item" th:href="@{/admin/platform/soporte}"
+            th:classappend="${activeMenu == 'soporte-admin' ? ' active' : ''}">Soporte</a>
           <a class="collapse-item" th:href="@{/admin/platform/apple-signin}"
             th:classappend="${activeMenu == 'apple-signin' ? ' active' : ''}">Apple Sign-In</a>
           <a class="collapse-item" th:href="@{/admin/platform/maintenance}"

--- a/src/main/resources/templates/sbadmin/soporte/listado.html
+++ b/src/main/resources/templates/sbadmin/soporte/listado.html
@@ -134,7 +134,7 @@
 
       if ($('#supportTicketsTable').length) {
         $('#supportTicketsTable').DataTable({
-          order: [[1, 'desc']],
+          order: [ [1, 'desc'] ],
           language: {
             url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/es-ES.json'
           }

--- a/src/test/java/com/nutriconsultas/support/SupportTicketAdminControllerTest.java
+++ b/src/test/java/com/nutriconsultas/support/SupportTicketAdminControllerTest.java
@@ -1,0 +1,146 @@
+package com.nutriconsultas.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import com.nutriconsultas.platform.PlatformAdminAuthorization;
+import com.nutriconsultas.subscription.PlanTier;
+
+@ExtendWith(MockitoExtension.class)
+class SupportTicketAdminControllerTest {
+
+	@InjectMocks
+	private SupportTicketAdminController controller;
+
+	@Mock
+	private SupportTicketService supportTicketService;
+
+	@Mock
+	private PlatformAdminAuthorization platformAdminAuthorization;
+
+	@Mock
+	private OidcUser principal;
+
+	@Test
+	void list_whenNotPlatformAdmin_throwsForbidden() {
+		doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN)).when(platformAdminAuthorization)
+			.requirePlatformAdmin(principal, "soporte.list");
+
+		assertThatThrownBy(() -> controller.list(principal, new ExtendedModelMap(), "activos"))
+			.isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode().value())
+			.isEqualTo(403);
+	}
+
+	@Test
+	void list_defaultsToOpenTickets() {
+		final SupportTicketAdminView view = sampleView(SupportTicketStatus.OPEN);
+		when(supportTicketService.findByStatusForAdmin(SupportTicketStatus.OPEN)).thenReturn(List.of(view));
+		final ExtendedModelMap model = new ExtendedModelMap();
+
+		final String result = controller.list(principal, model, "activos");
+
+		assertThat(result).isEqualTo("sbadmin/platform/soporte/listado");
+		assertThat(model.getAttribute("adminTickets")).isEqualTo(List.of(view));
+		assertThat(model.getAttribute("estado")).isEqualTo("activos");
+		assertThat(model.getAttribute("activeMenu")).isEqualTo("soporte-admin");
+		verify(platformAdminAuthorization).requirePlatformAdmin(principal, "soporte.list");
+	}
+
+	@Test
+	void list_filtersClosedTickets() {
+		when(supportTicketService.findByStatusForAdmin(SupportTicketStatus.CLOSED)).thenReturn(List.of());
+		final ExtendedModelMap model = new ExtendedModelMap();
+
+		final String result = controller.list(principal, model, "cerrados");
+
+		assertThat(result).isEqualTo("sbadmin/platform/soporte/listado");
+		assertThat(model.getAttribute("estado")).isEqualTo("cerrados");
+		verify(supportTicketService).findByStatusForAdmin(SupportTicketStatus.CLOSED);
+	}
+
+	@Test
+	void updateNotes_whenPlatformAdmin_redirects() {
+		when(supportTicketService.updateAdminNotes(1L, "Revisado")).thenReturn(sampleTicket(SupportTicketStatus.OPEN));
+		final RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
+
+		final String result = controller.updateNotes(principal, 1L, "Revisado", "activos", redirectAttributes);
+
+		assertThat(result).isEqualTo("redirect:/admin/platform/soporte?estado=activos");
+		assertThat(redirectAttributes.getFlashAttributes().get("successMessage"))
+			.isEqualTo("Notas actualizadas correctamente.");
+		verify(platformAdminAuthorization).requirePlatformAdmin(principal, "soporte.update-notes");
+	}
+
+	@Test
+	void close_whenNotPlatformAdmin_throwsForbidden() {
+		doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN)).when(platformAdminAuthorization)
+			.requirePlatformAdmin(principal, "soporte.close");
+
+		assertThatThrownBy(() -> controller.close(principal, 1L, "activos", new RedirectAttributesModelMap()))
+			.isInstanceOf(ResponseStatusException.class)
+			.extracting(ex -> ((ResponseStatusException) ex).getStatusCode().value())
+			.isEqualTo(403);
+	}
+
+	@Test
+	void close_whenPlatformAdmin_redirects() {
+		when(supportTicketService.close(1L)).thenReturn(sampleTicket(SupportTicketStatus.CLOSED));
+		final RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
+
+		final String result = controller.close(principal, 1L, "activos", redirectAttributes);
+
+		assertThat(result).isEqualTo("redirect:/admin/platform/soporte?estado=activos");
+		assertThat(redirectAttributes.getFlashAttributes().get("successMessage"))
+			.isEqualTo("Ticket cerrado correctamente.");
+		verify(supportTicketService).close(1L);
+	}
+
+	@Test
+	void reopen_whenPlatformAdmin_redirects() {
+		when(supportTicketService.reopen(2L)).thenReturn(sampleTicket(SupportTicketStatus.OPEN));
+		final RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
+
+		final String result = controller.reopen(principal, 2L, "cerrados", redirectAttributes);
+
+		assertThat(result).isEqualTo("redirect:/admin/platform/soporte?estado=cerrados");
+		assertThat(redirectAttributes.getFlashAttributes().get("successMessage"))
+			.isEqualTo("Ticket reabierto correctamente.");
+		verify(supportTicketService).reopen(2L);
+	}
+
+	private static SupportTicketAdminView sampleView(final SupportTicketStatus status) {
+		return new SupportTicketAdminView(sampleTicket(status), "Nutrióloga Demo", PlanTier.PLUS,
+				PlanTier.PLUS.getDisplayName());
+	}
+
+	private static SupportTicket sampleTicket(final SupportTicketStatus status) {
+		final SupportTicket ticket = new SupportTicket();
+		ticket.setId(1L);
+		ticket.setUserId("auth0|user");
+		ticket.setTitle("Ayuda");
+		ticket.setDescription("Detalle");
+		ticket.setStatus(status);
+		ticket.setCreatedAt(Instant.parse("2026-07-10T12:00:00Z"));
+		ticket.setUpdatedAt(Instant.parse("2026-07-10T12:00:00Z"));
+		return ticket;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/support/SupportTicketControllerTest.java
+++ b/src/test/java/com/nutriconsultas/support/SupportTicketControllerTest.java
@@ -22,6 +22,8 @@ import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
 
+import com.nutriconsultas.platform.PlatformAdminService;
+
 @ExtendWith(MockitoExtension.class)
 class SupportTicketControllerTest {
 
@@ -33,19 +35,34 @@ class SupportTicketControllerTest {
 	@Mock
 	private SupportTicketService supportTicketService;
 
+	@Mock
+	private PlatformAdminService platformAdminService;
+
 	@Test
 	void list_addsOwnTicketsAndEmptyForm() {
+		final DefaultOidcUser principal = principal();
 		final SupportTicket ticket = sampleTicket(1L, SupportTicketStatus.OPEN);
+		when(platformAdminService.isPlatformAdmin(principal)).thenReturn(false);
 		when(supportTicketService.findOwnTickets(USER_ID)).thenReturn(List.of(ticket));
 		final ExtendedModelMap model = new ExtendedModelMap();
 
-		final String view = controller.list(principal(), model);
+		final String view = controller.list(principal, model);
 
 		assertThat(view).isEqualTo("sbadmin/soporte/listado");
 		assertThat(model.getAttribute("tickets")).isEqualTo(List.of(ticket));
 		assertThat(model.getAttribute("form")).isInstanceOf(SupportTicketForm.class);
 		assertThat(model.getAttribute("activeMenu")).isEqualTo("soporte");
 		verify(supportTicketService).findOwnTickets(USER_ID);
+	}
+
+	@Test
+	void list_whenPlatformAdmin_redirectsToAdminInbox() {
+		final DefaultOidcUser principal = principal();
+		when(platformAdminService.isPlatformAdmin(principal)).thenReturn(true);
+
+		final String view = controller.list(principal, new ExtendedModelMap());
+
+		assertThat(view).isEqualTo("redirect:/admin/platform/soporte");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Add `SupportTicketAdminController` at `/admin/platform/soporte` with activos/cerrados filter, admin notes update, close (swal confirm), and reopen.
- Redirect platform admins from topbar `/admin/soporte` to the triage inbox; keep nutritionist create/list unchanged for non-admins.
- Sidebar **Plataforma → Soporte**; template validator + controller tests; Support track **NEXT:** #547.

Fixes #546

## Test plan
- [x] `mvn -Dtest=SupportTicketControllerTest,SupportTicketAdminControllerTest,ThymeleafTemplateValidationTest test` (Java 21)
- [x] `mvn checkstyle:check pmd:check -Pci`
- [x] As platform admin: Soporte menu → inbox with user, subscription, title
- [x] Filter activos / cerrados; save notes; close with swal; reopen
- [x] As non-admin: `/admin/platform/soporte` → 403; `/admin/soporte` still own tickets only
- [ ] CI green


Made with [Cursor](https://cursor.com)