### PR TITLE
[Support] Tests + template validators for Soporte / Acerca de (#547)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -65,7 +65,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 
 **Current next issue (AI assistant):** None — registered implementation track **complete** (#360–#450). Production rollout: [`RELEASE-CHECKLIST.md`](docs/ai/RELEASE-CHECKLIST.md) (#408). See [`ISSUE-AI-ASSISTANT.md`](ISSUE-AI-ASSISTANT.md).
 
-**Current next issue (support):** [#547](https://github.com/diego-torres/nutriconsultas/issues/547) — Remaining tests/validators. ~~#546~~ ~~#545~~ ~~#542~~ ~~#544~~ ~~#541~~ ~~#543~~ ~~#548~~ done. See [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md).
+**Current next issue (support):** None — `[Support]` track **complete** (#540–#548). See [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -626,7 +626,7 @@ Issue registry: [`ISSUE-APPLE-SIGNIN.md`](ISSUE-APPLE-SIGNIN.md). Roadmap: [`doc
 
 Issue registry: [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md). Plan: [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md). Workflow: [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md).
 
-**Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. ~~#548~~ docs done. ~~#543~~ schema done. ~~#541~~ topbar done. ~~#544~~ service done. ~~#542~~ Acerca de version done. ~~#545~~ nutritionist Soporte done. ~~#546~~ platform admin Soporte done. **NEXT:** [#547](https://github.com/diego-torres/nutriconsultas/issues/547) remaining tests/validators. Orthogonal to public `ContactInquiry`.
+**Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. **Track complete** — ~~#540–#548~~ **done**. Orthogonal to public `ContactInquiry`.
 
 ## Resources
 

--- a/ISSUE-SUPPORT.md
+++ b/ISSUE-SUPPORT.md
@@ -5,7 +5,7 @@ Living index of GitHub issues for **in-app support tickets** and the topbar user
 **Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
 **Plan:** [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md)  
 **Workflow:** [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md)  
-**Last updated:** 2026-07-14 — ~~#546~~ platform admin Soporte UI **done** (this PR). **NEXT:** [#547](https://github.com/diego-torres/nutriconsultas/issues/547) remaining tests/validators (or close epic #540 if #547 lands with this PR).
+**Last updated:** 2026-07-14 — ~~#547~~ tests/validators **done** (this PR). Track complete — epic [#540](https://github.com/diego-torres/nutriconsultas/issues/540) closed.
 
 > **Scope.** Authenticated nutritionist web (`/admin/**`): support ticket create/list for users; platform-admin triage (user, subscription, title; update/close; active/closed filter); **Acerca de** version modal. **Does not** replace public `ContactInquiry`. Patient mobile API: [`ISSUE.md`](ISSUE.md). Platform admin patterns: contact inquiries / subscription admin.
 
@@ -41,14 +41,14 @@ Living index of GitHub issues for **in-app support tickets** and the topbar user
 
 | # | Title | URL | State | Depends on | Notes |
 |---|-------|-----|-------|------------|-------|
-| **540** | Epic — In-app support tickets + user menu | https://github.com/diego-torres/nutriconsultas/issues/540 | **open** | — | Umbrella; close when children done |
+| **540** | Epic — In-app support tickets + user menu | https://github.com/diego-torres/nutriconsultas/issues/540 | **done** | — | All children #541–#548 done |
 | **541** | Topbar user menu — Perfil, Soporte, Acerca de, Salir | https://github.com/diego-torres/nutriconsultas/issues/541 | **done** | 540 | `#aboutModal` contract; Soporte → `/admin/soporte` |
 | **542** | Acerca de modal — app version + README bump process | https://github.com/diego-torres/nutriconsultas/issues/542 | **done** | 540, ~~541~~ | `app.version=@project.version@` + `AppVersionModelAdvice` |
 | **543** | Support ticket schema — Liquibase + entity + repository | https://github.com/diego-torres/nutriconsultas/issues/543 | **done** | 540 | Liquibase `034`; `SupportTicket` + repository |
 | **544** | Support ticket service — create, list, update, close, filter | https://github.com/diego-torres/nutriconsultas/issues/544 | **done** | ~~**543**~~ | `SupportTicketService`; admin view with user + plan |
 | **545** | Nutritionist Soporte page — own tickets + create form | https://github.com/diego-torres/nutriconsultas/issues/545 | **done** | ~~**544**~~, ~~541~~ | `/admin/soporte` grid + create form |
 | **546** | Platform admin Soporte — list, filter, update, close | https://github.com/diego-torres/nutriconsultas/issues/546 | **done** | ~~**544**~~ | `/admin/platform/soporte`; topbar redirects admins |
-| **547** | Tests + template validators for Soporte / Acerca de | https://github.com/diego-torres/nutriconsultas/issues/547 | **NEXT** | 541–546 | May close incrementally with feature PRs |
+| **547** | Tests + template validators for Soporte / Acerca de | https://github.com/diego-torres/nutriconsultas/issues/547 | **done** | ~~541–546~~ | MockMvc + registry + LogRedaction; feature PR coverage |
 | **548** | Plan + registry docs for support tickets track | https://github.com/diego-torres/nutriconsultas/issues/548 | **done** | 540 | `ISSUE-SUPPORT.md`, plan, workflow, AGENTS/README pointers |
 
 ---
@@ -66,12 +66,12 @@ Living index of GitHub issues for **in-app support tickets** and the topbar user
 
 ## Definition of done (track-level)
 
-- [ ] User menu: Perfil, Soporte, Acerca de, Salir
-- [ ] Nutritionists create and list only their tickets
-- [ ] Platform admins filter activos/cerrados; update and close; see user + subscription + title
-- [ ] Acerca de shows version; README documents bump for `main` releases
-- [ ] Liquibase + tests + template validators
-- [ ] This registry marked `done` for all children; epic #540 closed
+- [x] User menu: Perfil, Soporte, Acerca de, Salir
+- [x] Nutritionists create and list only their tickets
+- [x] Platform admins filter activos/cerrados; update and close; see user + subscription + title
+- [x] Acerca de shows version; README documents bump for `main` releases
+- [x] Liquibase + tests + template validators
+- [x] This registry marked `done` for all children; epic #540 closed
 
 ---
 

--- a/SUPPORT-WORKFLOW.md
+++ b/SUPPORT-WORKFLOW.md
@@ -10,7 +10,7 @@ How AI agents (and humans) ship the **`[Support]`** track on **`diego-torres/nut
 | [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md) | Product/tech plan, data model, version bump |
 | [`AGENT-WORKFLOW.md`](AGENT-WORKFLOW.md) | Mobile API workflow (orthogonal) |
 
-**Current next issue:** [#547](https://github.com/diego-torres/nutriconsultas/issues/547) — Remaining tests/validators (or close with feature coverage). ~~#546~~ platform admin Soporte **done**. ~~#545~~ ~~#542~~ ~~#544~~ ~~#541~~ ~~#543~~ ~~#548~~ done.
+**Current next issue:** None — `[Support]` track **complete** (#540–#548). ~~#547~~ tests/validators **done**.
 
 ---
 

--- a/src/test/java/com/nutriconsultas/support/SupportTicketTemplateValidatorRegistryTest.java
+++ b/src/test/java/com/nutriconsultas/support/SupportTicketTemplateValidatorRegistryTest.java
@@ -1,0 +1,31 @@
+package com.nutriconsultas.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.validation.template.TemplateValidator;
+import com.nutriconsultas.validation.template.TemplateValidatorRegistry;
+
+class SupportTicketTemplateValidatorRegistryTest {
+
+	private final TemplateValidatorRegistry registry = new TemplateValidatorRegistry();
+
+	@Test
+	void nutritionistSoporteTemplate_usesSupportTicketTemplateValidator() {
+		final TemplateValidator validator = registry.findValidator("sbadmin/soporte/listado");
+
+		assertThat(validator).isInstanceOf(SupportTicketTemplateValidator.class);
+		assertThat(validator.createMockModelVariables()).containsKeys("tickets", "form", "appVersion");
+	}
+
+	@Test
+	void adminSoporteTemplate_usesSupportTicketAdminTemplateValidator() {
+		final TemplateValidator validator = registry.findValidator("sbadmin/platform/soporte/listado");
+
+		assertThat(validator).isInstanceOf(SupportTicketAdminTemplateValidator.class);
+		assertThat(validator.createMockModelVariables()).containsKeys("adminTickets", "estado", "appVersion");
+		assertThat(validator.createMockModelVariables().get("platformAdmin")).isEqualTo(true);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/support/SupportTicketWebMvcTest.java
+++ b/src/test/java/com/nutriconsultas/support/SupportTicketWebMvcTest.java
@@ -1,0 +1,188 @@
+package com.nutriconsultas.support;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.nutriconsultas.subscription.PlanTier;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class SupportTicketWebMvcTest {
+
+	private static final String NUTRITIONIST_USER_ID = "auth0|nutritionist-support-test";
+
+	private static final String PLATFORM_ADMIN_USER_ID = "auth0|platform-admin-test";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private SupportTicketService supportTicketService;
+
+	@Test
+	void soporte_whenUnauthenticated_redirectsToLogin() throws Exception {
+		mockMvc.perform(get("/admin/soporte"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrlPattern("**/oauth2/authorization/**"));
+	}
+
+	@Test
+	void soporte_whenNutritionist_returnsOwnTicketsView() throws Exception {
+		final SupportTicket ticket = sampleTicket(1L, NUTRITIONIST_USER_ID, SupportTicketStatus.OPEN);
+		when(supportTicketService.findOwnTickets(NUTRITIONIST_USER_ID)).thenReturn(List.of(ticket));
+
+		mockMvc
+			.perform(get("/admin/soporte").with(oidcLogin().idToken(token -> token.subject(NUTRITIONIST_USER_ID)
+				.claim("name", "Nutrióloga Test")
+				.claim("email", "nutri@example.com"))))
+			.andExpect(status().isOk())
+			.andExpect(view().name("sbadmin/soporte/listado"))
+			.andExpect(model().attributeExists("tickets"))
+			.andExpect(model().attributeExists("form"))
+			.andExpect(model().attribute("activeMenu", "soporte"))
+			.andExpect(model().attributeExists("appVersion"));
+	}
+
+	@Test
+	void soporte_whenPlatformAdmin_redirectsToAdminInbox() throws Exception {
+		mockMvc
+			.perform(get("/admin/soporte").with(oidcLogin().idToken(token -> token.subject(PLATFORM_ADMIN_USER_ID)
+				.claim("name", "Admin Test")
+				.claim("email", "admin@example.com"))))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/platform/soporte"));
+	}
+
+	@Test
+	void createTicket_whenNutritionist_redirectsWithFlash() throws Exception {
+		final SupportTicket saved = sampleTicket(9L, NUTRITIONIST_USER_ID, SupportTicketStatus.OPEN);
+		when(supportTicketService.create(eq(NUTRITIONIST_USER_ID), eq("Falla al guardar"), eq("Detalle del error")))
+			.thenReturn(saved);
+
+		mockMvc
+			.perform(post("/admin/soporte")
+				.with(oidcLogin().idToken(token -> token.subject(NUTRITIONIST_USER_ID)
+					.claim("name", "Nutrióloga Test")
+					.claim("email", "nutri@example.com")))
+				.with(csrf())
+				.param("title", "Falla al guardar")
+				.param("description", "Detalle del error"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/soporte"))
+			.andExpect(flash().attribute("successMessage", "Ticket creado correctamente."));
+
+		verify(supportTicketService).create(NUTRITIONIST_USER_ID, "Falla al guardar", "Detalle del error");
+	}
+
+	@Test
+	void adminSoporte_whenNutritionist_forbidden() throws Exception {
+		mockMvc.perform(
+				get("/admin/platform/soporte").with(oidcLogin().idToken(token -> token.subject(NUTRITIONIST_USER_ID)
+					.claim("name", "Nutrióloga Test")
+					.claim("email", "nutri@example.com"))))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	void adminSoporte_whenPlatformAdmin_returnsInbox() throws Exception {
+		final SupportTicket ticket = sampleTicket(3L, NUTRITIONIST_USER_ID, SupportTicketStatus.OPEN);
+		final SupportTicketAdminView view = new SupportTicketAdminView(ticket, "Nutrióloga Test", PlanTier.PLUS,
+				"Plus");
+		when(supportTicketService.findByStatusForAdmin(SupportTicketStatus.OPEN)).thenReturn(List.of(view));
+
+		mockMvc
+			.perform(get("/admin/platform/soporte")
+				.with(oidcLogin().idToken(token -> token.subject(PLATFORM_ADMIN_USER_ID)
+					.claim("name", "Admin Test")
+					.claim("email", "admin@example.com"))))
+			.andExpect(status().isOk())
+			.andExpect(view().name("sbadmin/platform/soporte/listado"))
+			.andExpect(model().attributeExists("adminTickets"))
+			.andExpect(model().attribute("estado", "activos"))
+			.andExpect(model().attribute("activeMenu", "soporte-admin"))
+			.andExpect(model().attributeExists("appVersion"));
+	}
+
+	@Test
+	void adminClose_whenNutritionist_forbidden() throws Exception {
+		mockMvc.perform(post("/admin/platform/soporte/1/close")
+			.with(oidcLogin().idToken(token -> token.subject(NUTRITIONIST_USER_ID)
+				.claim("name", "Nutrióloga Test")
+				.claim("email", "nutri@example.com")))
+			.with(csrf())).andExpect(status().isForbidden());
+	}
+
+	@Test
+	void adminClose_whenPlatformAdmin_redirects() throws Exception {
+		when(supportTicketService.close(1L))
+			.thenReturn(sampleTicket(1L, NUTRITIONIST_USER_ID, SupportTicketStatus.CLOSED));
+
+		mockMvc
+			.perform(post("/admin/platform/soporte/1/close").param("estado", "activos")
+				.with(oidcLogin().idToken(token -> token.subject(PLATFORM_ADMIN_USER_ID)
+					.claim("name", "Admin Test")
+					.claim("email", "admin@example.com")))
+				.with(csrf()))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/platform/soporte?estado=activos"))
+			.andExpect(flash().attribute("successMessage", "Ticket cerrado correctamente."));
+
+		verify(supportTicketService).close(1L);
+	}
+
+	@Test
+	void adminUpdateNotes_whenPlatformAdmin_redirects() throws Exception {
+		when(supportTicketService.updateAdminNotes(eq(2L), anyString()))
+			.thenReturn(sampleTicket(2L, NUTRITIONIST_USER_ID, SupportTicketStatus.OPEN));
+
+		mockMvc
+			.perform(post("/admin/platform/soporte/2/notes").param("estado", "activos")
+				.param("adminNotes", "En revisión")
+				.with(oidcLogin().idToken(token -> token.subject(PLATFORM_ADMIN_USER_ID)
+					.claim("name", "Admin Test")
+					.claim("email", "admin@example.com")))
+				.with(csrf()))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/platform/soporte?estado=activos"))
+			.andExpect(flash().attribute("successMessage", "Notas actualizadas correctamente."));
+
+		verify(supportTicketService).updateAdminNotes(2L, "En revisión");
+	}
+
+	private static SupportTicket sampleTicket(final Long id, final String userId, final SupportTicketStatus status) {
+		final SupportTicket ticket = new SupportTicket();
+		ticket.setId(id);
+		ticket.setUserId(userId);
+		ticket.setTitle("Asunto de prueba");
+		ticket.setDescription("Descripción de prueba");
+		ticket.setStatus(status);
+		ticket.setCreatedAt(Instant.parse("2026-07-10T12:00:00Z"));
+		ticket.setUpdatedAt(Instant.parse("2026-07-10T12:00:00Z"));
+		return ticket;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/util/LogRedactionSupportTicketTest.java
+++ b/src/test/java/com/nutriconsultas/util/LogRedactionSupportTicketTest.java
@@ -1,0 +1,19 @@
+package com.nutriconsultas.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class LogRedactionSupportTicketTest {
+
+	@Test
+	void redactSupportTicket_includesIdOnly() {
+		assertThat(LogRedaction.redactSupportTicket(42L)).isEqualTo("SupportTicket[id=42]");
+	}
+
+	@Test
+	void redactSupportTicket_handlesNull() {
+		assertThat(LogRedaction.redactSupportTicket(null)).isEqualTo("SupportTicket[id=null]");
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `SupportTicketWebMvcTest` (auth redirect, nutritionist list/create, admin inbox/notes/close, non-admin 403, `appVersion` on model).
- Add template-validator registry assertions and `LogRedaction.redactSupportTicket` unit tests.
- Mark Support track complete in registry docs; epic #540 ready to close.

Fixes #547
Closes #540

## Test plan
- [x] `mvn -Dtest=SupportTicketWebMvcTest,SupportTicketTemplateValidatorRegistryTest,LogRedactionSupportTicketTest,SupportTicketControllerTest,SupportTicketAdminControllerTest,SupportTicketServiceTest,AppVersionModelAdviceTest,ThymeleafTemplateValidationTest test`
- [x] `mvn checkstyle:check pmd:check -Pci`
- [ ] CI green


Made with [Cursor](https://cursor.com)