### PR TITLE
Add auto-slash DOB mask for patient forms

### DIFF
--- a/scripts/test-date-of-birth-mask.cjs
+++ b/scripts/test-date-of-birth-mask.cjs
@@ -1,0 +1,24 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+
+const mask = require(path.join(
+  __dirname,
+  '..',
+  'src/main/resources/static/sbadmin/js/date-of-birth-mask.js'
+));
+
+assert.strictEqual(mask.format(''), '');
+assert.strictEqual(mask.format('1'), '1');
+assert.strictEqual(mask.format('15'), '15');
+assert.strictEqual(mask.format('150'), '15/0');
+assert.strictEqual(mask.format('1503'), '15/03');
+assert.strictEqual(mask.format('15031990'), '15/03/1990');
+assert.strictEqual(mask.format('15/03/1990'), '15/03/1990');
+assert.strictEqual(mask.format('15a03b1990'), '15/03/1990');
+assert.strictEqual(mask.format('150319901234'), '15/03/1990');
+assert.strictEqual(mask.format(null), '');
+assert.strictEqual(mask.format(undefined), '');
+
+process.stdout.write('ok\n');

--- a/src/main/resources/static/sbadmin/js/date-of-birth-mask.js
+++ b/src/main/resources/static/sbadmin/js/date-of-birth-mask.js
@@ -1,0 +1,108 @@
+'use strict';
+
+/**
+ * Auto-inserts slashes while typing a date of birth as dd/mm/yyyy.
+ * Keeps the numeric mobile keyboard usable (no manual "/").
+ */
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  }
+  else {
+    var api = factory();
+    root.DateOfBirthMask = api;
+    if (typeof document !== 'undefined') {
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () {
+          api.bindAll();
+        });
+      }
+      else {
+        api.bindAll();
+      }
+    }
+  }
+})(typeof self !== 'undefined' ? self : this, function () {
+  var MAX_DIGITS = 8;
+  var MAX_LENGTH = 10;
+
+  /**
+   * Formats raw input into dd/mm/yyyy with automatic slashes.
+   * @param {string} value
+   * @returns {string}
+   */
+  function format(value) {
+    var digits = String(value == null ? '' : value).replace(/\D/g, '').slice(0, MAX_DIGITS);
+    var length = digits.length;
+    var result = '';
+
+    if (length === 0) {
+      result = '';
+    }
+    else if (length <= 2) {
+      result = digits;
+    }
+    else if (length <= 4) {
+      result = digits.slice(0, 2) + '/' + digits.slice(2);
+    }
+    else {
+      result = digits.slice(0, 2) + '/' + digits.slice(2, 4) + '/' + digits.slice(4);
+    }
+
+    return result;
+  }
+
+  /**
+   * @param {HTMLInputElement} input
+   */
+  function bind(input) {
+    if (!input || input.getAttribute('data-dob-mask-bound') === 'true') {
+      return;
+    }
+
+    input.setAttribute('data-dob-mask-bound', 'true');
+    input.setAttribute('inputmode', 'numeric');
+    input.setAttribute('maxlength', String(MAX_LENGTH));
+    input.setAttribute('autocomplete', input.getAttribute('autocomplete') || 'bday');
+
+    if (!input.getAttribute('placeholder')) {
+      input.setAttribute('placeholder', 'dd/mm/aaaa');
+    }
+
+    input.addEventListener('input', function () {
+      var formatted = format(input.value);
+      if (input.value !== formatted) {
+        input.value = formatted;
+      }
+    });
+
+    input.addEventListener('blur', function () {
+      input.value = format(input.value);
+    });
+
+    if (input.value) {
+      input.value = format(input.value);
+    }
+  }
+
+  /**
+   * @param {ParentNode} [root]
+   */
+  function bindAll(root) {
+    var scope = root || document;
+    if (!scope || !scope.querySelectorAll) {
+      return;
+    }
+    var inputs = scope.querySelectorAll('input[data-dob-mask], input[name="dob"]');
+    for (var i = 0; i < inputs.length; i++) {
+      bind(inputs[i]);
+    }
+  }
+
+  return {
+    format: format,
+    bind: bind,
+    bindAll: bindAll,
+    MAX_LENGTH: MAX_LENGTH
+  };
+});

--- a/src/main/resources/templates/sbadmin/pacientes/afiliacion.html
+++ b/src/main/resources/templates/sbadmin/pacientes/afiliacion.html
@@ -63,8 +63,8 @@
                       <div class="form-group">
                         <label>Fecha Nac.</label>
                         <input type="text" th:field="*{dob}" class="form-control" placeholder="dd/mm/aaaa"
-                          inputmode="numeric" autocomplete="bday">
-                        <small class="form-text text-muted">Formato: dd/mm/aaaa</small>
+                          data-dob-mask inputmode="numeric" autocomplete="bday" maxlength="10">
+                        <small class="form-text text-muted">Formato: dd/mm/aaaa (las barras se insertan al escribir)</small>
                         <span th:if="${#fields.hasErrors('dob')}" th:errors="*{dob}"></span>
                       </div>
                       <div class="form-group">
@@ -212,6 +212,7 @@
 
     <!-- Custom scripts for all pages-->
     <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
+    <script th:src="@{/sbadmin/js/date-of-birth-mask.js}"></script>
     <script th:src="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.js}"></script>
     <script th:src="@{/sbadmin/js/paciente-mobile-invitation.js}"></script>
 

--- a/src/main/resources/templates/sbadmin/pacientes/nuevo.html
+++ b/src/main/resources/templates/sbadmin/pacientes/nuevo.html
@@ -64,8 +64,8 @@
                       <div class="form-group">
                         <label>Fecha Nac.<span style="color:red;">*</span></label>
                         <input type="text" th:field="*{dob}" class="form-control" placeholder="dd/mm/aaaa"
-                          inputmode="numeric" autocomplete="bday" required>
-                        <small class="form-text text-muted">Formato: dd/mm/aaaa</small>
+                          data-dob-mask inputmode="numeric" autocomplete="bday" maxlength="10" required>
+                        <small class="form-text text-muted">Formato: dd/mm/aaaa (las barras se insertan al escribir)</small>
                         <span th:if="${#fields.hasErrors('dob')}" th:errors="*{dob}"></span>
                       </div>
                       <div class="form-group">
@@ -130,6 +130,7 @@
 
     <!-- Custom scripts for all pages-->
     <script th:src="@{/sbadmin/js/sb-admin-2.min.js}"></script>
+    <script th:src="@{/sbadmin/js/date-of-birth-mask.js}"></script>
 
 </body>
 

--- a/src/test/java/com/nutriconsultas/paciente/DateOfBirthMaskScriptTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/DateOfBirthMaskScriptTest.java
@@ -1,0 +1,74 @@
+package com.nutriconsultas.paciente;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+/**
+ * Verifies the dd/mm/yyyy DOB input mask used on patient create/edit forms.
+ */
+class DateOfBirthMaskScriptTest {
+
+	static boolean isNodeAvailable() {
+		try {
+			final Process process = new ProcessBuilder("node", "--version").start();
+			return process.waitFor(5, TimeUnit.SECONDS) && process.exitValue() == 0;
+		}
+		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			return false;
+		}
+		catch (Exception ex) {
+			return false;
+		}
+	}
+
+	@Test
+	void maskScriptAndForms_includeAutoSlashSupport() throws Exception {
+		final Path maskScript = Path.of("src/main/resources/static/sbadmin/js/date-of-birth-mask.js");
+		final Path nuevo = Path.of("src/main/resources/templates/sbadmin/pacientes/nuevo.html");
+		final Path afiliacion = Path.of("src/main/resources/templates/sbadmin/pacientes/afiliacion.html");
+
+		assertThat(maskScript).exists();
+		assertThat(nuevo).exists();
+		assertThat(afiliacion).exists();
+
+		final String script = Files.readString(maskScript, StandardCharsets.UTF_8);
+		assertThat(script).contains("function format(");
+		assertThat(script).contains("data-dob-mask");
+		assertThat(script).contains("replace(/\\D/g");
+
+		final String nuevoHtml = Files.readString(nuevo, StandardCharsets.UTF_8);
+		assertThat(nuevoHtml).contains("data-dob-mask");
+		assertThat(nuevoHtml).contains("date-of-birth-mask.js");
+		assertThat(nuevoHtml).contains("maxlength=\"10\"");
+
+		final String afiliacionHtml = Files.readString(afiliacion, StandardCharsets.UTF_8);
+		assertThat(afiliacionHtml).contains("data-dob-mask");
+		assertThat(afiliacionHtml).contains("date-of-birth-mask.js");
+		assertThat(afiliacionHtml).contains("maxlength=\"10\"");
+	}
+
+	@Test
+	@EnabledIf("isNodeAvailable")
+	void format_insertsSlashesWhileTypingDigits() throws Exception {
+		final Path script = Path.of("scripts/test-date-of-birth-mask.cjs").toAbsolutePath();
+		final Process process = new ProcessBuilder("node", script.toString())
+			.directory(Path.of("").toAbsolutePath().toFile())
+			.redirectErrorStream(true)
+			.start();
+		final boolean finished = process.waitFor(30, TimeUnit.SECONDS);
+		final String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+
+		assertThat(finished).as("node mask script timed out").isTrue();
+		assertThat(process.exitValue()).as("node mask script failed: %s", output).isZero();
+		assertThat(output).isEqualTo("ok");
+	}
+
+}


### PR DESCRIPTION
## Summary
- Auto-inserts `/` while typing date of birth as `dd/mm/yyyy` on Nuevo Paciente and Afiliación
- Keeps `inputmode="numeric"` so mobile keyboards no longer need the slash key
- Adds Node + JUnit coverage for the mask formatter and form wiring

## Test plan
- [x] `./lint.sh` (includes checkstyle, spotbugs, PMD, Thymeleaf)
- [x] `mvn pmd:check`
- [x] `mvn test -Dtest=DateOfBirthMaskScriptTest`
- [ ] On `/admin/pacientes/nuevo`, type `15031990` and confirm field shows `15/03/1990`
- [ ] Submit a new patient and confirm DOB saves correctly


Made with [Cursor](https://cursor.com)