### PR TITLE
Add Mobile Social Reconcile track registry (#560–#569)

### DIFF
--- a/AGENT-WORKFLOW.md
+++ b/AGENT-WORKFLOW.md
@@ -55,11 +55,17 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | [`SUPPORT-WORKFLOW.md`](SUPPORT-WORKFLOW.md) | Agent workflow for Soporte / Acerca de |
 | [`docs/support/SUPPORT-TICKETS-PLAN.md`](docs/support/SUPPORT-TICKETS-PLAN.md) | Menu, roles, data model, version bump |
 
+**Parallel track (mobile social reconcile — Auth0/SES + invite reconcile; do not mix into unrelated PRs):**
+
+| File | Purpose |
+|------|---------|
+| [`ISSUE-MOBILE-SOCIAL-RECONCILE.md`](ISSUE-MOBILE-SOCIAL-RECONCILE.md) | `[Mobile Social Reconcile]` epic #560–#569 (planning #558 / mobile #124) |
+
 **Current next issue (public booking):** None — epic ~~#245~~ **done**; ~~#246~~, ~~#247~~, ~~#248~~, ~~#297~~, ~~#300~~, ~~#302~~ done. Deferred follow-ups need new issues. See [`ISSUE-PUBLIC-BOOKING.md`](ISSUE-PUBLIC-BOOKING.md).
 
 **Current next issue (mobile):** [#353 — Grocery list for patient diet plan](https://github.com/diego-torres/nutriconsultas/issues/353) (`in-progress`). ~~#354~~ ~~#352~~ **done** (PR [#357](https://github.com/diego-torres/nutriconsultas/pull/357)).
 
-**Planning in parallel (mobile):** [#558 — Auth0 social login reconcile alignment](https://github.com/diego-torres/nutriconsultas/issues/558) — **PLANNING**, cross-repo counterpart to mobile [#124](https://github.com/Escanor4323/nutriconsultas-mobile/issues/124). Implementation gated on product sign-off of #124's revised social-first flow — do not start code until that lands. See [Planning — #558](#planning--558-auth0-social-login-reconcile-alignment) below for insertion points.
+**Current next issue (mobile social reconcile):** [#569](https://github.com/diego-torres/nutriconsultas/issues/569) track docs (or ops [#561](https://github.com/diego-torres/nutriconsultas/issues/561)–[#563](https://github.com/diego-torres/nutriconsultas/issues/563) in parallel). Epic [#560](https://github.com/diego-torres/nutriconsultas/issues/560). Planning source [#558](https://github.com/diego-torres/nutriconsultas/issues/558) / mobile [#124](https://github.com/Escanor4323/nutriconsultas-mobile/issues/124). See [`ISSUE-MOBILE-SOCIAL-RECONCILE.md`](ISSUE-MOBILE-SOCIAL-RECONCILE.md) and [Planning — #558](#planning--558-auth0-social-login-reconcile-alignment).
 
 **Current next issue (subscription):** Registered track **complete** (~~#244~~ ✓ on `subscription/244-contact-form-prefill`). Triage open `[Subscription]` GitHub issues. See [`ISSUE-SUBSCRIPTION.md`](ISSUE-SUBSCRIPTION.md).
 
@@ -79,7 +85,7 @@ How AI agents (and humans pairing with them) ship the **patient mobile API** on 
 | **API surface** | All mobile endpoints live under `/rest/mobile/patient/` as plain JSON (not DataTables-shaped like the admin `*RestController`s). |
 | **Identity (security-critical)** | JWT `sub` → **`Paciente.patientAuthSub`** (#107 ✓ PR #117). **Never `Paciente.userId`** — that is the NUTRITIONIST's Auth0 sub / tenant owner (ALIGNMENT-SPEC §F2). `PatientLinkageFilter` returns **403** if no linked `Paciente`. |
 | **Ownership / IDOR** | Return only the authenticated patient's rows. On an ownership miss prefer **404** (not 403) so existence isn't leaked (esp. #92). Never return cross-tenant data. |
-| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **Cross-cutting done** (#111–#116). **#156**, **#46**, **#132–#141** done. **Phase 2 invitation onboarding complete.** Next mobile work requires new issues. Requires `AUTH_AUDIENCE` env var. **#558 (Auth0 social login reconcile alignment) is PLANNING** — reconcile-by-code already works (#136/PR #345) but needs a security-review sign-off + contract docs before further changes; do not implement until product signs off on mobile #124. |
+| **Backend state** | **Phase 0 done** (#107, #109, #110). **All endpoints #91–#99 done** on `main`. **Cross-cutting done** (#111–#116). **#156**, **#46**, **#132–#141** done. **Phase 2 invitation onboarding complete.** Requires `AUTH_AUDIENCE` env var. **#558 planning → implementation track [#560](https://github.com/diego-torres/nutriconsultas/issues/560)–#569** ([`ISSUE-MOBILE-SOCIAL-RECONCILE.md`](ISSUE-MOBILE-SOCIAL-RECONCILE.md)): Auth0/SES ops, verified-email fallback, PATCH email-lock, reconcile contract docs. |
 | **Auth0UserLookup correction** | `Auth0UserLookupImpl` (Management API `users-by-email`) is **fully implemented**, not a deferred stub — only `AUTH0_MGMT_*` env wiring remains (surfaced during #558 audit; corrects an assumption in mobile's `docs/plans/issue-99-invite-auth-routing.md`). |
 | **DTO envelope** | `ApiResponse<T>`; lists in `PagedResponse<T>` or `CursorPagedResponse<T>` (messages); ISO-8601 date strings. See #110. |
 | **Schema ground truth** | ALIGNMENT-SPEC §F8 field-name map (`nombre→dietaName`, `energia→totalKcal`, `lipidos→totalGrasas`, `hidratosDeCarbono→totalCarbohidratos`, `Ingesta.nombre→tipo`); enums `EventStatus`/`PacienteDietaStatus` (no INACTIVE)/`NivelPeso`. Serialization aliases only — **no DB schema changes** for field renames. |
@@ -374,9 +380,9 @@ Precise list of what changed. For each technical term, add a one-line plain-Engl
 
 ## Planning — #558 Auth0 social login reconcile alignment
 
-**Status: PLANNING.** Cross-repo counterpart to mobile [#124](https://github.com/Escanor4323/nutriconsultas-mobile/issues/124). **Do not implement until product signs off on #124's revised social-first flow.** Full resolved-decisions record lives in [`ISSUE.md`](ISSUE.md#558-resolved-decisions) — read it before touching any file below. This section exists so a future implementation agent can start without re-exploring the codebase.
+**Status: TRACK OPEN.** Planning issue [#558](https://github.com/diego-torres/nutriconsultas/issues/558); implementation epic [#560](https://github.com/diego-torres/nutriconsultas/issues/560)–[#569](https://github.com/diego-torres/nutriconsultas/issues/569) in [`ISSUE-MOBILE-SOCIAL-RECONCILE.md`](ISSUE-MOBILE-SOCIAL-RECONCILE.md). Cross-repo counterpart to mobile [#124](https://github.com/Escanor4323/nutriconsultas-mobile/issues/124). Full resolved-decisions record lives in [`ISSUE.md`](ISSUE.md#558-resolved-decisions) — read it before touching any file below.
 
-**Relationship to #108 (Auth0 tenant, still open):** #558's audit surfaced three *new* tenant items that belong on #108, not in backend Java:
+**Relationship to #108 (Auth0 tenant, still open):** #558's audit surfaced tenant items now owned by the social-reconcile track (#561–#563), with a cross-link on #108 for audience/scopes:
 - Auth0 custom email provider → Amazon SES (Dashboard → Branding → Email Provider) — carries verification mail for the fill-by-hand (db-connection) signup path. SES is already the transport for invitation email (`SesPatientInvitationEmailSender`, `application.properties:106-113`); this is tenant config, not new code.
 - `email_verified` claim mapping into the **access token** (Auth0 Action/claim rule) — the resource-server JWT does not carry this claim today; without the mapping, none of the backend insertion points below have anything to read.
 - SPF/DKIM domain authentication on the sending domain — shared prerequisite with Apple private-relay outbound mail (see `ISSUE.md` §1c).
@@ -470,8 +476,8 @@ gh pr create ...
 | Gate | Issues | When |
 |------|--------|------|
 | Phase 0 foundation | ~~#107~~ ✓, ~~#109~~ ✓, ~~#110~~ ✓ | **Done** |
-| Auth linkage (tenant) | #108 (tenant config; prod audience deployed #118; new items from #558: SES email provider, `email_verified` claim mapping, SPF/DKIM domain auth) | Before full Auth0 tenant hardening |
-| Social login reconcile alignment | **#558** (planning — reconcile-by-code security review, contract docs, `patient/me` alignment) | Gated on product sign-off of mobile [#124](https://github.com/Escanor4323/nutriconsultas-mobile/issues/124) |
+| Auth linkage (tenant) | #108 (audience/scopes); SES/`email_verified`/relay ops → [#561](https://github.com/diego-torres/nutriconsultas/issues/561)–[#563](https://github.com/diego-torres/nutriconsultas/issues/563) | Before full Auth0 tenant hardening |
+| Social login reconcile alignment | **#560–#569** ([`ISSUE-MOBILE-SOCIAL-RECONCILE.md`](ISSUE-MOBILE-SOCIAL-RECONCILE.md); planning #558 / mobile [#124](https://github.com/Escanor4323/nutriconsultas-mobile/issues/124)) | **NEXT** #569 or ops #561–#563 |
 | Endpoints | ~~#91–#99~~ ✓ | **Done** (PR #153) |
 | Cross-cutting | ~~#111~~ ✓, ~~#112~~ ✓ (OpenAPI), ~~#115~~ ✓ (PHI audit) | **Done** |
 | Hardening / additive | ~~#113~~ ✓, ~~#116~~ ✓ (`senderDisplayName`), ~~#114~~ ✓ (nutritionist reply) | **Done** |
@@ -481,7 +487,7 @@ gh pr create ...
 
 **Patient mobile API on `main`:** Phase 0 + endpoints **#91–#99** done; cross-cutting **#111–#116** done. Phase 2 invitation onboarding **#132–#141 complete** (PRs #214, #229, #319, #324–#333).
 
-**Next (mobile):** Phase 2 invitation onboarding **complete** (~~#141~~). **Planning in parallel:** #558 (Auth0 social login reconcile alignment) — see [Planning — #558](#planning--558-auth0-social-login-reconcile-alignment); gated on product sign-off of mobile #124.
+**Next (mobile):** Phase 2 invitation onboarding **complete** (~~#141~~). **Social reconcile track:** epic [#560](https://github.com/diego-torres/nutriconsultas/issues/560)–#569 — see [`ISSUE-MOBILE-SOCIAL-RECONCILE.md`](ISSUE-MOBILE-SOCIAL-RECONCILE.md) and [Planning — #558](#planning--558-auth0-social-login-reconcile-alignment).
 
 **Schema track:** ~~#46~~ Liquibase baseline (PR #196). Changesets **003–007** on `main` (subscription, patient invitation). All new edits → forward changesets only.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -628,6 +628,12 @@ Issue registry: [`ISSUE-SUPPORT.md`](ISSUE-SUPPORT.md). Plan: [`docs/support/SUP
 
 **Epic #540–#548** (2026-07-13): Topbar **Perfil / Soporte / Acerca de / Salir**; nutritionist own tickets + create form; platform-admin triage (user, subscription, title; update/close; activos/cerrados filter); Acerca de app version + README bump process. **Track complete** — ~~#540–#548~~ **done**. Orthogonal to public `ContactInquiry`.
 
+## Mobile social reconcile (tracking)
+
+Issue registry: [`ISSUE-MOBILE-SOCIAL-RECONCILE.md`](ISSUE-MOBILE-SOCIAL-RECONCILE.md). Planning: [#558](https://github.com/diego-torres/nutriconsultas/issues/558). Mobile: [Escanor4323/nutriconsultas-mobile#124](https://github.com/Escanor4323/nutriconsultas-mobile/issues/124).
+
+**Epic #560–#569** (2026-07-18): Auth0 social invite reconcile (credential-first), `email_verified` fallback, PATCH email-lock, contract docs, plus **Auth0 → Amazon SES** verification mail and domain/Apple private relay ops. **NEXT:** [#569](https://github.com/diego-torres/nutriconsultas/issues/569) (or ops [#561](https://github.com/diego-torres/nutriconsultas/issues/561)–[#563](https://github.com/diego-torres/nutriconsultas/issues/563) in parallel).
+
 ## Resources
 
 - [Spring Boot Documentation](https://spring.io/projects/spring-boot)

--- a/ISSUE-MOBILE-SOCIAL-RECONCILE.md
+++ b/ISSUE-MOBILE-SOCIAL-RECONCILE.md
@@ -1,0 +1,98 @@
+# Issue Registry — `[Mobile Social Reconcile]` track
+
+Living index of GitHub issues that close planning [#558](https://github.com/diego-torres/nutriconsultas/issues/558) / mobile [Escanor4323/nutriconsultas-mobile#124](https://github.com/Escanor4323/nutriconsultas-mobile/issues/124): Auth0 social invite reconcile, verified-email fallback, and Auth0→Amazon SES verification mail.
+
+**Repo:** [diego-torres/nutriconsultas](https://github.com/diego-torres/nutriconsultas)  
+**Planning:** [#558](https://github.com/diego-torres/nutriconsultas/issues/558)  
+**Epic:** [#560](https://github.com/diego-torres/nutriconsultas/issues/560)  
+**Mobile consumer:** [Escanor4323/nutriconsultas-mobile#124](https://github.com/Escanor4323/nutriconsultas-mobile/issues/124)  
+**Last updated:** 2026-07-18 — track issues created (#560–#569). **NEXT:** [#569](https://github.com/diego-torres/nutriconsultas/issues/569) registry/workflow (or ops #561–#563 in parallel).
+
+> **Scope.** Harden `POST /rest/mobile/invitations/reconcile` for social login (credential-first, email hint-only), require `email_verified` on empty-body email fallback, lock PATCH `/patient/me` email vs JWT, document the reconcile matrix, and configure **Auth0 + Amazon SES** (verification mail, domain auth, Apple private relay). Does **not** replace Auth0 or invent a separate social onboarding API. Broader Auth0 API audience/scopes remain [#108](https://github.com/diego-torres/nutriconsultas/issues/108).
+
+---
+
+## Legend
+
+| State | Meaning |
+|-------|---------|
+| `NEXT` | Active — pick this up now (if unblocked) |
+| `open` | Not started |
+| `in-progress` | Branch / PR open |
+| `done` | Merged to `main` |
+| `deferred` | Paused |
+
+---
+
+## Epic — Social invite reconcile + email verification
+
+| Requirement | Issues |
+|-------------|--------|
+| Epic umbrella | #560 |
+| Auth0 → Amazon SES email provider | #561 |
+| SES SPF/DKIM + Apple private relay | #562 |
+| Auth0 `email_verified` claim + Post-Login Action | #563 |
+| Backend verified-email fallback + audit log | #564 |
+| Reconcile-by-code rate limits | #565 |
+| PATCH `/patient/me` email-lock | #566 |
+| Reconcile matrix contract docs | #567 |
+| Tests | #568 |
+| Track registry / plan / workflow | #569 |
+
+**Suggested order:** #569 → (#561 ∥ #562 ∥ #563) → #564 → (#565 ∥ #566) → #567 → #568.
+
+| # | Title | URL | State | Depends on | Notes |
+|---|-------|-----|-------|------------|-------|
+| **560** | Epic — Auth0 social invite reconcile + email verification | https://github.com/diego-torres/nutriconsultas/issues/560 | open | #558 (planning) | Close #558 when epic done |
+| **561** | Configure Auth0 custom email provider → Amazon SES | https://github.com/diego-torres/nutriconsultas/issues/561 | open | 560 | Tenant + AWS; no Spring code |
+| **562** | SES domain SPF/DKIM + Apple private email relay registration | https://github.com/diego-torres/nutriconsultas/issues/562 | open | 560 | Complements #209 SES infra |
+| **563** | Auth0 — map `email_verified` into access tokens + Post-Login Action | https://github.com/diego-torres/nutriconsultas/issues/563 | open | 560 | Prerequisite for #564 claim read |
+| **564** | Enforce `email_verified` on reconcile email-fallback + audit log | https://github.com/diego-torres/nutriconsultas/issues/564 | open | 563 | Credential paths stay email-agnostic |
+| **565** | Confirm/harden rate limits for authenticated reconcile-by-code | https://github.com/diego-torres/nutriconsultas/issues/565 | open | 560 | Existing per-sub limiter may suffice |
+| **566** | PATCH `/patient/me` — lock email to JWT claim | https://github.com/diego-torres/nutriconsultas/issues/566 | open | 560 | Ignore or reject mismatch |
+| **567** | Document reconcile matrix (ALIGNMENT-SPEC, gate, OpenAPI) | https://github.com/diego-torres/nutriconsultas/issues/567 | open | 564, 566 | Agent context-handoff blocker |
+| **568** | Tests — social onboarding, REVOKED, verified-email fallback | https://github.com/diego-torres/nutriconsultas/issues/568 | open | 564–566 | Residual quality gate OK |
+| **569** | Track registry + plan + workflow docs | https://github.com/diego-torres/nutriconsultas/issues/569 | **NEXT** | 560 | This file + AGENTS/AGENT-WORKFLOW pointers |
+
+---
+
+## Product decisions (authoritative)
+
+| Decision | Policy |
+|----------|--------|
+| Nutritionist invite email | **Hint-only** |
+| Apple private relay / social email mismatch | **Allow with code reconcile** |
+| Empty-body email fallback | Requires `email_verified == true` |
+| Connection-type branching | **None** in link logic (audit only) |
+| Unverified db-auth + valid invite code | **Proceed** (do not block credential reconcile) |
+
+---
+
+## Cross-track links
+
+| Track / issue | Interaction |
+|---------------|-------------|
+| [#558](https://github.com/diego-torres/nutriconsultas/issues/558) | Planning / security review source |
+| [#108](https://github.com/diego-torres/nutriconsultas/issues/108) | Auth0 API audience/scopes (orthogonal; cross-link claim docs) |
+| [#209](https://github.com/diego-torres/nutriconsultas/issues/209) | Invitation SES infra already shipped |
+| [`ISSUE-APPLE-SIGNIN.md`](ISSUE-APPLE-SIGNIN.md) | Apple social + private relay lifecycle |
+| [`ISSUE.md`](ISSUE.md) | Mobile API invitation onboarding (#132–#141) |
+| [`docs/subscription/INVITATION-EMAIL.md`](docs/subscription/INVITATION-EMAIL.md) | SES runbook to extend for Auth0 provider |
+
+---
+
+## Definition of done (track-level)
+
+- [ ] Auth0 verification mail via SES on verified domain
+- [ ] SPF/DKIM + Apple relay sources configured
+- [ ] Access tokens carry `email_verified`; fallback enforces it
+- [ ] Credential reconcile remains connection-blind and email-agnostic
+- [ ] Reconcile matrix in ALIGNMENT-SPEC + gate diagram + OpenAPI
+- [ ] PATCH email-lock enforced
+- [ ] Tests green; #558 and #560 closed
+
+---
+
+**How to update this file**
+
+Same convention as [`ISSUE.md`](ISSUE.md): mark `in-progress` when a PR opens, `done` when merged. Keep **NEXT** on the unblocked issue agents should pick up.


### PR DESCRIPTION
## Summary
- Add [`ISSUE-MOBILE-SOCIAL-RECONCILE.md`](ISSUE-MOBILE-SOCIAL-RECONCILE.md) for epic [#560](https://github.com/diego-torres/nutriconsultas/issues/560)–[#569](https://github.com/diego-torres/nutriconsultas/issues/569) (planning [#558](https://github.com/diego-torres/nutriconsultas/issues/558) / mobile #124).
- Wire pointers in `AGENTS.md` and `AGENT-WORKFLOW.md`, including Auth0→SES ops issues and rebase resolution against the #558 planning section.

## Test plan
- [ ] Confirm registry links resolve to #560–#569
- [ ] Skim `AGENT-WORKFLOW.md` for leftover conflict markers / contradictory “do not implement” wording vs open track


Made with [Cursor](https://cursor.com)