### PR TITLE
Add store download links on patient invitation landing

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -125,8 +125,9 @@ nutriconsultas.patient.invitation.expiry-days=${PATIENT_INVITATION_EXPIRY_DAYS:1
 nutriconsultas.patient.invitation.human-code-prefix=NUTRI
 # TODO: move PATIENT_INVITATION_JWS_SECRET to GCP Secret Manager in production
 nutriconsultas.patient.invitation.jws-secret=${PATIENT_INVITATION_JWS_SECRET:}
-nutriconsultas.patient.invitation.ios-app-store-url=${PATIENT_INVITATION_IOS_APP_STORE_URL:}
-nutriconsultas.patient.invitation.android-play-store-url=${PATIENT_INVITATION_ANDROID_PLAY_STORE_URL:}
+# Store download links on invitation landing (/links/i/{token}) until official release pages stabilize
+nutriconsultas.patient.invitation.ios-app-store-url=${PATIENT_INVITATION_IOS_APP_STORE_URL:https://apps.apple.com/app/id6788892036}
+nutriconsultas.patient.invitation.android-play-store-url=${PATIENT_INVITATION_ANDROID_PLAY_STORE_URL:https://play.google.com/store/apps/details?id=com.minutriporcion.mobile}
 nutriconsultas.subscription.default-grace-period-days=${SUBSCRIPTION_GRACE_PERIOD_DAYS:7}
 nutriconsultas.subscription.expiry-reminder-days=7,3,1
 nutriconsultas.subscription.lifecycle-job-enabled=${SUBSCRIPTION_LIFECYCLE_JOB_ENABLED:true}


### PR DESCRIPTION
## Summary
- Sets default App Store (`id6788892036`) and Google Play (`com.minutriporcion.mobile`) URLs for patient invitation landing download buttons.
- URLs remain overridable via `PATIENT_INVITATION_IOS_APP_STORE_URL` / `PATIENT_INVITATION_ANDROID_PLAY_STORE_URL`.
- No secrets in the change — only public store listing URLs.

## Test plan
- [ ] Open a patient invitation landing page (`/links/i/{token}`) and confirm App Store / Google Play buttons appear for the relevant platform.
- [ ] Confirm env overrides still replace the defaults when set.
- [ ] Confirm App Store link resolves once the listing is live (Apple ID `6788892036`).


Made with [Cursor](https://cursor.com)