### PR TITLE
Add patient device registry for mobile push (#574)

### DIFF
--- a/docs/api/openapi-mobile.yaml
+++ b/docs/api/openapi-mobile.yaml
@@ -15,9 +15,76 @@ security:
 tags:
 - name: Mobile
   description: Patient mobile API
+- name: Mobile Auth
+  description: Backend-brokered patient database signup and login
 - name: Mobile Invitations
   description: Nutritionist-initiated patient onboarding
 paths:
+  /rest/mobile/patient/profile/photo:
+    get:
+      tags:
+      - Mobile
+      summary: Get patient profile photo
+      description: Returns custom photo bytes or redirects to catalog avatar when
+        no custom photo is set.
+      operationId: getPhoto
+      responses:
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+    put:
+      tags:
+      - Mobile
+      summary: Upload patient profile photo
+      description: Stores a custom profile photo in S3.
+      operationId: uploadPhoto
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                photoFile:
+                  type: string
+                  format: binary
+              required:
+              - photoFile
+      responses:
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseMobilePatientPhotoResponse"
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseMobilePatientPhotoResponse"
+        "400":
+          description: Validation failed
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseMobilePatientPhotoResponse"
+        "429":
+          description: "Rate limit exceeded (Retry-After: 60)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseMobilePatientPhotoResponse"
   /rest/mobile/patient/messages:
     get:
       tags:
@@ -102,6 +169,75 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/ApiResponsePatientMessageSummaryDto"
+  /rest/mobile/patient/devices:
+    post:
+      tags:
+      - Mobile
+      summary: Register device
+      description: Upserts an APNs or FCM registration token for the authenticated
+        patient.
+      operationId: registerDevice
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterPatientDeviceRequest"
+        required: true
+      responses:
+        "200":
+          description: Registered device summary
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientDeviceDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientDeviceDto"
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientDeviceDto"
+        "400":
+          description: Validation failed
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientDeviceDto"
+        "429":
+          description: "Rate limit exceeded (Retry-After: 60)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientDeviceDto"
+    delete:
+      tags:
+      - Mobile
+      summary: Deregister device
+      description: Removes a push token for the authenticated patient. Idempotent
+        when already gone.
+      operationId: deregisterDevice
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeregisterPatientDeviceRequest"
+        required: true
+      responses:
+        "204":
+          description: Token removed or already absent
+        "401":
+          description: Missing or invalid JWT
+        "403":
+          description: Patient account not linked to Auth0 sub
+        "400":
+          description: Validation failed
+        "429":
+          description: "Rate limit exceeded (Retry-After: 60)"
   /rest/mobile/invitations:
     post:
       tags:
@@ -232,6 +368,199 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/ApiResponseRevokedPatientInvitationDto"
+  /rest/mobile/invitations/reconcile:
+    post:
+      tags:
+      - Mobile Invitations
+      summary: Reconcile patient invitation linkage
+      description: Patient JWT links Auth0 sub to a pending invitation when redeem
+        did not run (e.g. returning user). Matches JWT email to INVITED Paciente or
+        optional credential in body.
+      operationId: reconcileInvitation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PatientInvitationReconcileRequest"
+      responses:
+        "200":
+          description: Patient linked or already linked
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+        "400":
+          description: Malformed invitation token
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+        "404":
+          description: Invalid or expired invitation
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+        "409":
+          description: Invitation already redeemed by another account
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+        "422":
+          description: Patient not in INVITED status
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+        "429":
+          description: "Rate limit exceeded (Retry-After: 60)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+  /rest/mobile/invitations/by-code/{code}/redeem:
+    post:
+      tags:
+      - Mobile Invitations
+      summary: Redeem patient invitation by human code
+      description: Patient JWT binds Auth0 sub using human-readable code (e.g. NUTRI-ABCD-EFGH).
+      operationId: redeemInvitationByHumanCode
+      parameters:
+      - name: code
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Invitation redeemed or idempotent retry by same sub
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+        "401":
+          description: Missing or invalid JWT
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+        "400":
+          description: Malformed invitation token
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+        "404":
+          description: Invalid or expired invitation
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+        "409":
+          description: Invitation already redeemed by another account
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+        "422":
+          description: Patient not in INVITED status
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+        "429":
+          description: "Rate limit exceeded (Retry-After: 60)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseRedeemedPatientInvitationDto"
+  /rest/mobile/auth/signup:
+    post:
+      tags:
+      - Mobile Auth
+      summary: Register patient Auth0 account
+      description: "Public, rate-limited. Validates pending invitation, creates Auth0\
+        \ database user server-side, returns OIDC tokens."
+      operationId: signUp
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PatientSignupRequest"
+        required: true
+      responses:
+        "201":
+          description: Auth0 account created and session tokens issued
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientAuthTokensDto"
+        "400":
+          description: Malformed invitation token
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientAuthTokensDto"
+        "404":
+          description: Invalid or expired invitation
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientAuthTokensDto"
+        "429":
+          description: "Rate limit exceeded (Retry-After: 60)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientAuthTokensDto"
+      security: []
+  /rest/mobile/auth/login:
+    post:
+      tags:
+      - Mobile Auth
+      summary: Patient database login
+      description: "Public, rate-limited. Authenticates via Auth0 server-side broker\
+        \ and returns OIDC tokens."
+      operationId: login
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PatientLoginRequest"
+        required: true
+      responses:
+        "200":
+          description: Session tokens issued
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientAuthTokensDto"
+        "400":
+          description: Malformed invitation token
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientAuthTokensDto"
+        "404":
+          description: Invalid or expired invitation
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientAuthTokensDto"
+        "429":
+          description: "Rate limit exceeded (Retry-After: 60)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePatientAuthTokensDto"
+      security: []
   /rest/mobile/patient/me:
     get:
       tags:
@@ -303,61 +632,6 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/ApiResponsePatientOnboardingProfileDto"
-  /rest/mobile/patient/profile/photo:
-    get:
-      tags:
-      - Mobile
-      summary: Get patient profile photo
-      description: Returns custom photo bytes or redirects to catalog avatar when no custom photo is set.
-      operationId: getProfilePhoto
-      responses:
-        "200":
-          description: Custom profile photo bytes
-          content:
-            image/*:
-              schema:
-                type: string
-                format: binary
-        "302":
-          description: Redirect to catalog avatar when no custom photo is stored
-        "401":
-          description: Missing or invalid JWT
-        "403":
-          description: Patient account not linked to Auth0 sub
-        "404":
-          description: Patient not found
-    put:
-      tags:
-      - Mobile
-      summary: Upload patient profile photo
-      description: Stores a custom profile photo in S3 for the authenticated patient.
-      operationId: uploadProfilePhoto
-      requestBody:
-        required: true
-        content:
-          multipart/form-data:
-            schema:
-              type: object
-              required:
-              - photoFile
-              properties:
-                photoFile:
-                  type: string
-                  format: binary
-                  description: Image file (JPG, PNG, GIF, or WebP)
-      responses:
-        "200":
-          description: Upload succeeded
-          content:
-            '*/*':
-              schema:
-                $ref: "#/components/schemas/ApiResponseMobilePatientPhotoResponse"
-        "400":
-          description: Empty or unreadable file
-        "401":
-          description: Missing or invalid JWT
-        "403":
-          description: Patient account not linked to Auth0 sub
   /rest/mobile/patient/visits:
     get:
       tags:
@@ -640,8 +914,8 @@ paths:
       tags:
       - Mobile
       summary: Get platillo detail
-      description: Returns ingredients, preparation, and nutrition for a platillo in
-        the patient's assignment.
+      description: "Returns ingredients, preparation, and nutrition for a platillo\
+        \ in the patient's assignment."
       operationId: getPlatilloDetail
       parameters:
       - name: assignmentId
@@ -683,6 +957,47 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/ApiResponseDietPlatilloDetailDto"
+  /rest/mobile/patient/diet-plans/{assignmentId}/pdf:
+    get:
+      tags:
+      - Mobile
+      summary: Download diet plan PDF
+      description: Returns a printable PDF for an assignment owned by the patient.
+      operationId: getDietPlanPdf
+      parameters:
+      - name: assignmentId
+        in: path
+        description: PacienteDieta assignment identifier
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: PDF bytes
+          content:
+            application/pdf: {}
+        "401":
+          description: Missing or invalid JWT
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: byte
+        "403":
+          description: Patient account not linked to Auth0 sub
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: byte
+        "404":
+          description: Resource not found or not owned by patient
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: byte
   /rest/mobile/patient/diet-plans/{assignmentId}/grocery-list:
     get:
       tags:
@@ -731,47 +1046,6 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/ApiResponseDietGroceryListDto"
-  /rest/mobile/patient/diet-plans/{assignmentId}/pdf:
-    get:
-      tags:
-      - Mobile
-      summary: Download diet plan PDF
-      description: Returns a printable PDF for an assignment owned by the patient.
-      operationId: getDietPlanPdf
-      parameters:
-      - name: assignmentId
-        in: path
-        description: PacienteDieta assignment identifier
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        "200":
-          description: PDF bytes
-          content:
-            application/pdf: {}
-        "401":
-          description: Missing or invalid JWT
-          content:
-            application/pdf:
-              schema:
-                type: string
-                format: byte
-        "403":
-          description: Patient account not linked to Auth0 sub
-          content:
-            application/pdf:
-              schema:
-                type: string
-                format: byte
-        "404":
-          description: Resource not found or not owned by patient
-          content:
-            application/pdf:
-              schema:
-                type: string
-                format: byte
   /rest/mobile/invitations/{token}/preview:
     get:
       tags:
@@ -854,6 +1128,23 @@ paths:
       security: []
 components:
   schemas:
+    ApiResponseMobilePatientPhotoResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/MobilePatientPhotoResponse"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    MobilePatientPhotoResponse:
+      type: object
+      properties:
+        photoUrl:
+          type: string
+        photoExtension:
+          type: string
     SendPatientMessageRequest:
       type: object
       properties:
@@ -894,6 +1185,52 @@ components:
           type: boolean
         senderDisplayName:
           type: string
+    RegisterPatientDeviceRequest:
+      type: object
+      properties:
+        platform:
+          type: string
+          description: Device push platform
+          enum:
+          - IOS
+          - ANDROID
+        token:
+          type: string
+          description: APNs or FCM registration token
+          maxLength: 512
+          minLength: 0
+        appVersion:
+          type: string
+          description: Optional mobile app version
+          maxLength: 50
+          minLength: 0
+      required:
+      - platform
+      - token
+    ApiResponsePatientDeviceDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/PatientDeviceDto"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    PatientDeviceDto:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        platform:
+          type: string
+          enum:
+          - IOS
+          - ANDROID
+        updatedAt:
+          type: string
+          format: date-time
     CreatePatientInvitationRequest:
       type: object
       description: Create patient + invitation
@@ -1053,6 +1390,91 @@ components:
           - EXPIRED
           - REVOKED
           example: REVOKED
+    PatientInvitationReconcileRequest:
+      type: object
+      description: Optional invitation credential for reconcile
+      properties:
+        token:
+          type: string
+          description: Raw invite URL token
+        humanCode:
+          type: string
+          description: Human-readable invitation code
+    PatientSignupRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          description: Patient email
+        password:
+          type: string
+          description: Account password
+          maxLength: 128
+          minLength: 8
+        displayName:
+          type: string
+          description: Display name stored in Auth0 user metadata
+          maxLength: 120
+          minLength: 0
+        token:
+          type: string
+          description: Raw invite URL token
+        humanCode:
+          type: string
+          description: Human-readable invitation code
+      required:
+      - email
+      - password
+    ApiResponsePatientAuthTokensDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/PatientAuthTokensDto"
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    PatientAuthTokensDto:
+      type: object
+      description: Auth0 OIDC tokens brokered for the mobile app
+      properties:
+        accessToken:
+          type: string
+          description: Access token for /rest/mobile/**
+        idToken:
+          type: string
+          description: OpenID Connect ID token
+        refreshToken:
+          type: string
+          description: Refresh token when offline_access is granted
+        expiresIn:
+          type: integer
+          format: int64
+          description: Access token lifetime in seconds
+        tokenType:
+          type: string
+          description: "Token type, typically Bearer"
+    PatientLoginRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          description: Patient email
+        password:
+          type: string
+          description: Account password
+          maxLength: 128
+          minLength: 1
+        token:
+          type: string
+          description: Optional invite URL token for first-login gate
+        humanCode:
+          type: string
+          description: Optional human invitation code for first-login gate
+      required:
+      - email
+      - password
     PatchPatientOnboardingProfileRequest:
       type: object
       description: Patch patient onboarding profile
@@ -1194,27 +1616,6 @@ components:
         assignedDietPlan:
           $ref: "#/components/schemas/AssignedDietPlanReferenceDto"
           description: "Primary active diet assignment, when present"
-    ApiResponseMobilePatientPhotoResponse:
-      type: object
-      properties:
-        data:
-          $ref: "#/components/schemas/MobilePatientPhotoResponse"
-        message:
-          type: string
-        timestamp:
-          type: string
-          format: date-time
-    MobilePatientPhotoResponse:
-      type: object
-      properties:
-        photoUrl:
-          type: string
-          description: Resolver URL for the profile picture
-          example: /rest/mobile/patient/profile/photo
-        photoExtension:
-          type: string
-          description: Stored file extension when a custom photo exists
-          example: png
     ApiResponsePagedResponseVisitSummaryDto:
       type: object
       properties:
@@ -1632,7 +2033,6 @@ components:
         id:
           type: integer
           format: int64
-          description: PlatilloIngesta id for detail deep links (#354)
         nombre:
           type: string
         porciones:
@@ -1654,7 +2054,7 @@ components:
           type: string
         imageUrl:
           type: string
-          description: Relative URL; defaults to `/sbadmin/img/plato-vacio.jpg` when unset (#355)
+    ApiResponseDietPlatilloDetailDto:
       type: object
       properties:
         data:
@@ -1677,10 +2077,8 @@ components:
           format: int32
         imageUrl:
           type: string
-          description: Relative URL; defaults to `/sbadmin/img/plato-vacio.jpg` when unset (#355)
         description:
           type: string
-          description: Preparation instructions (from PlatilloIngesta.recommendations)
         videoUrl:
           type: string
         pdfUrl:
@@ -1791,6 +2189,16 @@ components:
           type: string
           description: Masked email for optional pre-fill (never the full address)
           example: p***@example.com
+    DeregisterPatientDeviceRequest:
+      type: object
+      properties:
+        token:
+          type: string
+          description: APNs or FCM registration token to remove
+          maxLength: 512
+          minLength: 0
+      required:
+      - token
   securitySchemes:
     bearer-jwt:
       type: http

--- a/docs/db/LIQUIBASE.md
+++ b/docs/db/LIQUIBASE.md
@@ -17,6 +17,7 @@ Nutriconsultas uses [Liquibase](https://www.liquibase.org/) for schema and catal
 | `changes/023-patient-invitation-human-code.yaml` | `human_code` on `patient_invitation` (#336) |
 | `changes/024-ai-chat-schema.yaml` | AI chat thread, message, and draft tables (#369) |
 | `changes/034-support-ticket.yaml` | In-app support ticket table (#543) |
+| `changes/035-patient-device.yaml` | Patient push device registry (#574) |
 | `changes/008-platillo-ingesta-source-platillo-id.yaml` | `source_platillo_id` on `platillo_ingesta` + catalog backfill (#250) |
 | `data/alimentos-seed.sql` | SMAE alimentos catalog (from `alimentos.sql`) |
 | `data/platillos-seed.sql` | Catalog `platillo` + `ingrediente` rows |

--- a/src/main/java/com/nutriconsultas/device/PatientDevice.java
+++ b/src/main/java/com/nutriconsultas/device/PatientDevice.java
@@ -1,0 +1,76 @@
+package com.nutriconsultas.device;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import com.nutriconsultas.paciente.Paciente;
+
+@Entity
+@Table(name = "patient_device")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PatientDevice {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "paciente_id", nullable = false)
+	private Paciente paciente;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private PatientDevicePlatform platform;
+
+	@Column(nullable = false, length = 512, unique = true)
+	private String token;
+
+	@Column(name = "app_version", length = 50)
+	private String appVersion;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private Instant createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private Instant updatedAt;
+
+	@Column(name = "last_seen_at", nullable = false)
+	private Instant lastSeenAt;
+
+	@PrePersist
+	void onCreate() {
+		final Instant now = Instant.now();
+		if (createdAt == null) {
+			createdAt = now;
+		}
+		if (updatedAt == null) {
+			updatedAt = now;
+		}
+		if (lastSeenAt == null) {
+			lastSeenAt = now;
+		}
+	}
+
+	@PreUpdate
+	void onUpdate() {
+		updatedAt = Instant.now();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/device/PatientDevicePlatform.java
+++ b/src/main/java/com/nutriconsultas/device/PatientDevicePlatform.java
@@ -1,0 +1,10 @@
+package com.nutriconsultas.device;
+
+/**
+ * Mobile push platform for a registered patient device (#574).
+ */
+public enum PatientDevicePlatform {
+
+	IOS, ANDROID
+
+}

--- a/src/main/java/com/nutriconsultas/device/PatientDeviceRepository.java
+++ b/src/main/java/com/nutriconsultas/device/PatientDeviceRepository.java
@@ -1,0 +1,18 @@
+package com.nutriconsultas.device;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PatientDeviceRepository extends JpaRepository<PatientDevice, Long> {
+
+	Optional<PatientDevice> findByToken(String token);
+
+	List<PatientDevice> findByPacienteId(Long pacienteId);
+
+	long deleteByPacienteIdAndToken(Long pacienteId, String token);
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDeviceController.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDeviceController.java
@@ -1,0 +1,76 @@
+package com.nutriconsultas.mobile;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nutriconsultas.mobile.config.MobileOpenApiResponses;
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.DeregisterPatientDeviceRequest;
+import com.nutriconsultas.mobile.dto.PatientDeviceDto;
+import com.nutriconsultas.mobile.dto.RegisterPatientDeviceRequest;
+import com.nutriconsultas.util.LogRedaction;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/rest/mobile/patient/devices")
+@Tag(name = "Mobile", description = "Patient mobile API")
+@Slf4j
+public class MobilePatientDeviceController extends AbstractMobilePatientController {
+
+	private final MobilePatientDeviceService mobilePatientDeviceService;
+
+	public MobilePatientDeviceController(final PatientAuthService patientAuthService,
+			final MobilePatientDeviceService mobilePatientDeviceService) {
+		super(patientAuthService);
+		this.mobilePatientDeviceService = mobilePatientDeviceService;
+	}
+
+	@PostMapping
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(summary = "Register device",
+			description = "Upserts an APNs or FCM registration token for the authenticated patient.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	@MobileOpenApiResponses.WriteEndpoint
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+			description = "Registered device summary")
+	public ApiResponse<PatientDeviceDto> registerDevice(@AuthenticationPrincipal final Jwt jwt,
+			@Valid @RequestBody final RegisterPatientDeviceRequest request) {
+		final Long pacienteId = getAuthenticatedPacienteId(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile device register request for patient {} platform={}",
+					LogRedaction.redactPaciente(pacienteId), request.platform());
+		}
+		final PatientDeviceDto device = mobilePatientDeviceService.upsertDevice(pacienteId, request.platform(),
+				request.token(), request.appVersion());
+		return ApiResponse.ok(device);
+	}
+
+	@DeleteMapping
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@Operation(summary = "Deregister device",
+			description = "Removes a push token for the authenticated patient. Idempotent when already gone.")
+	@MobileOpenApiResponses.AuthenticatedPatient
+	@MobileOpenApiResponses.WriteEndpoint
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204",
+			description = "Token removed or already absent")
+	public void deregisterDevice(@AuthenticationPrincipal final Jwt jwt,
+			@Valid @RequestBody final DeregisterPatientDeviceRequest request) {
+		final Long pacienteId = getAuthenticatedPacienteId(jwt);
+		if (log.isDebugEnabled()) {
+			log.debug("Mobile device deregister request for patient {}", LogRedaction.redactPaciente(pacienteId));
+		}
+		mobilePatientDeviceService.deregisterDevice(pacienteId, request.token());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/MobilePatientDeviceService.java
+++ b/src/main/java/com/nutriconsultas/mobile/MobilePatientDeviceService.java
@@ -1,0 +1,63 @@
+package com.nutriconsultas.mobile;
+
+import java.time.Instant;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.device.PatientDevice;
+import com.nutriconsultas.device.PatientDevicePlatform;
+import com.nutriconsultas.device.PatientDeviceRepository;
+import com.nutriconsultas.mobile.dto.PatientDeviceDto;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class MobilePatientDeviceService {
+
+	private final PatientDeviceRepository patientDeviceRepository;
+
+	private final PacienteRepository pacienteRepository;
+
+	public MobilePatientDeviceService(final PatientDeviceRepository patientDeviceRepository,
+			final PacienteRepository pacienteRepository) {
+		this.patientDeviceRepository = patientDeviceRepository;
+		this.pacienteRepository = pacienteRepository;
+	}
+
+	@Transactional
+	public PatientDeviceDto upsertDevice(final Long pacienteId, final PatientDevicePlatform platform,
+			final String token, final String appVersion) {
+		final Instant now = Instant.now();
+		final PatientDevice device = patientDeviceRepository.findByToken(token).orElseGet(PatientDevice::new);
+		final boolean isNew = device.getId() == null;
+		final Paciente pacienteRef = pacienteRepository.getReferenceById(pacienteId);
+		device.setPaciente(pacienteRef);
+		device.setPlatform(platform);
+		device.setToken(token);
+		device.setAppVersion(StringUtils.hasText(appVersion) ? appVersion.trim() : null);
+		device.setLastSeenAt(now);
+		device.setUpdatedAt(now);
+		final PatientDevice saved = patientDeviceRepository.save(device);
+		if (log.isInfoEnabled()) {
+			log.info("Patient device {} for patient {} platform={} token={}", isNew ? "registered" : "refreshed",
+					LogRedaction.redactPaciente(pacienteId), platform, LogRedaction.redactDeviceToken(token));
+		}
+		return PatientDeviceDto.fromEntity(saved);
+	}
+
+	@Transactional
+	public void deregisterDevice(final Long pacienteId, final String token) {
+		final long removed = patientDeviceRepository.deleteByPacienteIdAndToken(pacienteId, token);
+		if (log.isInfoEnabled()) {
+			log.info("Patient device deregister removed={} for patient {} token={}", removed,
+					LogRedaction.redactPaciente(pacienteId), LogRedaction.redactDeviceToken(token));
+		}
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/DeregisterPatientDeviceRequest.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DeregisterPatientDeviceRequest.java
@@ -1,0 +1,9 @@
+package com.nutriconsultas.mobile.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record DeregisterPatientDeviceRequest(@NotBlank @Size(max = 512) @Schema(minLength = 1, maxLength = 512,
+		description = "APNs or FCM registration token to remove") String token) {
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/PatientDeviceDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/PatientDeviceDto.java
@@ -1,0 +1,14 @@
+package com.nutriconsultas.mobile.dto;
+
+import java.time.Instant;
+
+import com.nutriconsultas.device.PatientDevice;
+import com.nutriconsultas.device.PatientDevicePlatform;
+
+public record PatientDeviceDto(Long id, PatientDevicePlatform platform, Instant updatedAt) {
+
+	public static PatientDeviceDto fromEntity(final PatientDevice device) {
+		return new PatientDeviceDto(device.getId(), device.getPlatform(), device.getUpdatedAt());
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/mobile/dto/RegisterPatientDeviceRequest.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/RegisterPatientDeviceRequest.java
@@ -1,0 +1,15 @@
+package com.nutriconsultas.mobile.dto;
+
+import com.nutriconsultas.device.PatientDevicePlatform;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record RegisterPatientDeviceRequest(@NotNull @Schema(description = "Device push platform", allowableValues = {
+		"IOS", "ANDROID" }) PatientDevicePlatform platform,
+		@NotBlank @Size(max = 512) @Schema(minLength = 1, maxLength = 512,
+				description = "APNs or FCM registration token") String token,
+		@Size(max = 50) @Schema(maxLength = 50, description = "Optional mobile app version") String appVersion) {
+}

--- a/src/main/java/com/nutriconsultas/util/LogRedaction.java
+++ b/src/main/java/com/nutriconsultas/util/LogRedaction.java
@@ -269,4 +269,18 @@ public final class LogRedaction {
 		return "email[" + email.charAt(0) + "***@" + email.substring(atIndex + 1) + "]";
 	}
 
+	/**
+	 * Redacts a push device token for logging. Shows only a short prefix so ops can
+	 * correlate without exposing the full token.
+	 * @param token the APNs or FCM registration token
+	 * @return a safe truncated representation (e.g., "deviceToken[abc123...REDACTED]")
+	 */
+	public static String redactDeviceToken(final String token) {
+		if (token == null || token.isEmpty()) {
+			return "deviceToken[null]";
+		}
+		final String prefix = token.length() > 6 ? token.substring(0, 6) : token;
+		return "deviceToken[" + prefix + "...REDACTED]";
+	}
+
 }

--- a/src/main/resources/db/changelog/changes/035-patient-device.yaml
+++ b/src/main/resources/db/changelog/changes/035-patient-device.yaml
@@ -1,0 +1,74 @@
+databaseChangeLog:
+  - changeSet:
+      id: 035-patient-device
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            tableExists:
+              tableName: patient_device
+      changes:
+        - createTable:
+            tableName: patient_device
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: paciente_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: platform
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: token
+                  type: VARCHAR(512)
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
+                  name: app_version
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_seen_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: patient_device
+            baseColumnNames: paciente_id
+            referencedTableName: paciente
+            referencedColumnNames: id
+            constraintName: fk_patient_device_paciente
+        - createIndex:
+            indexName: idx_patient_device_paciente_id
+            tableName: patient_device
+            columns:
+              - column:
+                  name: paciente_id
+        - createIndex:
+            indexName: idx_patient_device_token
+            tableName: patient_device
+            columns:
+              - column:
+                  name: token

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -101,3 +101,6 @@ databaseChangeLog:
   - include:
       file: changes/034-support-ticket.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/035-patient-device.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -92,3 +92,6 @@ databaseChangeLog:
   - include:
       file: changes/034-support-ticket.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/035-patient-device.yaml
+      relativeToChangelogFile: true

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDeviceControllerTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDeviceControllerTest.java
@@ -1,0 +1,77 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.nutriconsultas.device.PatientDevicePlatform;
+import com.nutriconsultas.mobile.dto.ApiResponse;
+import com.nutriconsultas.mobile.dto.DeregisterPatientDeviceRequest;
+import com.nutriconsultas.mobile.dto.PatientDeviceDto;
+import com.nutriconsultas.mobile.dto.RegisterPatientDeviceRequest;
+import com.nutriconsultas.paciente.projection.PacienteAuthView;
+
+@ExtendWith(MockitoExtension.class)
+class MobilePatientDeviceControllerTest {
+
+	private static final String PATIENT_SUB = "auth0|mobile-device-patient";
+
+	@InjectMocks
+	private MobilePatientDeviceController controller;
+
+	@Mock
+	private PatientAuthService patientAuthService;
+
+	@Mock
+	private MobilePatientDeviceService mobilePatientDeviceService;
+
+	@Test
+	void registerDevice_returnsApiResponseEnvelope() {
+		final PatientDeviceDto device = new PatientDeviceDto(12L, PatientDevicePlatform.IOS,
+				Instant.parse("2026-08-11T16:00:00Z"));
+		final Jwt jwt = jwtWithSub(PATIENT_SUB);
+		final RegisterPatientDeviceRequest request = new RegisterPatientDeviceRequest(PatientDevicePlatform.IOS,
+				"apns-token-abc", "1.2.3");
+
+		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(authView(5L));
+		when(mobilePatientDeviceService.upsertDevice(eq(5L), eq(PatientDevicePlatform.IOS), eq("apns-token-abc"),
+				eq("1.2.3")))
+			.thenReturn(device);
+
+		final ApiResponse<PatientDeviceDto> response = controller.registerDevice(jwt, request);
+
+		assertThat(response.data().id()).isEqualTo(12L);
+		assertThat(response.data().platform()).isEqualTo(PatientDevicePlatform.IOS);
+		assertThat(response.timestamp()).isNotNull();
+		verify(mobilePatientDeviceService).upsertDevice(5L, PatientDevicePlatform.IOS, "apns-token-abc", "1.2.3");
+	}
+
+	@Test
+	void deregisterDevice_delegatesToService() {
+		final Jwt jwt = jwtWithSub(PATIENT_SUB);
+		when(patientAuthService.requireAuthViewByJwt(jwt)).thenReturn(authView(5L));
+
+		controller.deregisterDevice(jwt, new DeregisterPatientDeviceRequest("apns-token-abc"));
+
+		verify(mobilePatientDeviceService).deregisterDevice(5L, "apns-token-abc");
+	}
+
+	private static Jwt jwtWithSub(final String subject) {
+		return Jwt.withTokenValue("token").header("alg", "none").subject(subject).build();
+	}
+
+	private static PacienteAuthView authView(final Long id) {
+		return MobileTestPacienteAuthViews.authView(id, PATIENT_SUB, "auth0|nutritionist-owner");
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDeviceIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDeviceIntegrationTest.java
@@ -1,0 +1,191 @@
+package com.nutriconsultas.mobile;
+
+import static com.nutriconsultas.mobile.MobileIntegrationTestJwt.mobileJwt;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.nutriconsultas.device.PatientDevice;
+import com.nutriconsultas.device.PatientDeviceRepository;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MobilePatientDeviceIntegrationTest {
+
+	private static final String LINKED_SUB = "auth0|mobile-device-integration";
+
+	private static final String OTHER_SUB = "auth0|mobile-device-other";
+
+	private static final String TOKEN = "fcm-or-apns-token-integration-001";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@Autowired
+	private PatientDeviceRepository patientDeviceRepository;
+
+	private Paciente linkedPaciente;
+
+	private Paciente otherPaciente;
+
+	@BeforeEach
+	void seedData() {
+		linkedPaciente = pacienteRepository.findByPatientAuthSub(LINKED_SUB)
+			.orElseGet(() -> pacienteRepository.saveAndFlush(samplePaciente(LINKED_SUB, "Paciente devices")));
+		otherPaciente = pacienteRepository.findByPatientAuthSub(OTHER_SUB)
+			.orElseGet(() -> pacienteRepository.saveAndFlush(samplePaciente(OTHER_SUB, "Otro paciente devices")));
+		patientDeviceRepository.findByPacienteId(linkedPaciente.getId()).forEach(patientDeviceRepository::delete);
+		patientDeviceRepository.findByPacienteId(otherPaciente.getId()).forEach(patientDeviceRepository::delete);
+		patientDeviceRepository.findByToken(TOKEN).ifPresent(patientDeviceRepository::delete);
+		patientDeviceRepository.flush();
+	}
+
+	@Test
+	void registerDeviceWithLinkedJwtUpsertsAndReturnsSummary() throws Exception {
+		mockMvc
+			.perform(post("/rest/mobile/patient/devices").with(mobileJwt(LINKED_SUB))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"platform":"IOS","token":"%s","appVersion":"1.2.3"}
+						""".formatted(TOKEN)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.id").isNumber())
+			.andExpect(jsonPath("$.data.platform").value("IOS"))
+			.andExpect(jsonPath("$.data.updatedAt").exists())
+			.andExpect(jsonPath("$.timestamp").exists());
+
+		assertThat(patientDeviceRepository.findByToken(TOKEN)).isPresent();
+		assertThat(patientDeviceRepository.findByToken(TOKEN).get().getAppVersion()).isEqualTo("1.2.3");
+	}
+
+	@Test
+	void registerDeviceAgainRefreshesSameRow() throws Exception {
+		registerDevice(LINKED_SUB, TOKEN, "1.0.0");
+		final Long firstId = patientDeviceRepository.findByToken(TOKEN).orElseThrow().getId();
+
+		mockMvc
+			.perform(post("/rest/mobile/patient/devices").with(mobileJwt(LINKED_SUB))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"platform":"IOS","token":"%s","appVersion":"1.2.4"}
+						""".formatted(TOKEN)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.id").value(firstId))
+			.andExpect(jsonPath("$.data.platform").value("IOS"));
+
+		assertThat(patientDeviceRepository.findByToken(TOKEN).orElseThrow().getAppVersion()).isEqualTo("1.2.4");
+	}
+
+	@Test
+	void registerDeviceReassignsTokenWhenPatientChanges() throws Exception {
+		registerDevice(OTHER_SUB, TOKEN, "1.0.0");
+		assertThat(patientDeviceRepository.findByToken(TOKEN).orElseThrow().getPaciente().getId())
+			.isEqualTo(otherPaciente.getId());
+
+		registerDevice(LINKED_SUB, TOKEN, "2.0.0");
+
+		final PatientDevice device = patientDeviceRepository.findByToken(TOKEN).orElseThrow();
+		assertThat(device.getPaciente().getId()).isEqualTo(linkedPaciente.getId());
+		assertThat(device.getAppVersion()).isEqualTo("2.0.0");
+		assertThat(patientDeviceRepository.findByPacienteId(otherPaciente.getId())).isEmpty();
+	}
+
+	@Test
+	void deregisterDeviceReturnsNoContentAndIsIdempotent() throws Exception {
+		registerDevice(LINKED_SUB, TOKEN, "1.0.0");
+
+		mockMvc
+			.perform(delete("/rest/mobile/patient/devices").with(mobileJwt(LINKED_SUB))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"token":"%s"}
+						""".formatted(TOKEN)))
+			.andExpect(status().isNoContent());
+		assertThat(patientDeviceRepository.findByToken(TOKEN)).isEmpty();
+
+		mockMvc
+			.perform(delete("/rest/mobile/patient/devices").with(mobileJwt(LINKED_SUB))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"token":"%s"}
+						""".formatted(TOKEN)))
+			.andExpect(status().isNoContent());
+	}
+
+	@Test
+	void deregisterDeviceDoesNotRemoveOtherPatientsToken() throws Exception {
+		registerDevice(OTHER_SUB, TOKEN, "1.0.0");
+
+		mockMvc
+			.perform(delete("/rest/mobile/patient/devices").with(mobileJwt(LINKED_SUB))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"token":"%s"}
+						""".formatted(TOKEN)))
+			.andExpect(status().isNoContent());
+
+		assertThat(patientDeviceRepository.findByToken(TOKEN)).isPresent();
+		assertThat(patientDeviceRepository.findByToken(TOKEN).orElseThrow().getPaciente().getId())
+			.isEqualTo(otherPaciente.getId());
+	}
+
+	@Test
+	void registerDeviceForUnlinkedJwtReturnsForbidden() throws Exception {
+		mockMvc
+			.perform(post("/rest/mobile/patient/devices").with(mobileJwt("auth0|mobile-device-unlinked"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"platform":"ANDROID","token":"unlinked-token","appVersion":"1.0.0"}
+						"""))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	void registerDeviceWithBlankTokenReturnsBadRequest() throws Exception {
+		mockMvc
+			.perform(post("/rest/mobile/patient/devices").with(mobileJwt(LINKED_SUB))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"platform":"IOS","token":"   "}
+						"""))
+			.andExpect(status().isBadRequest());
+	}
+
+	private void registerDevice(final String sub, final String token, final String appVersion) throws Exception {
+		mockMvc
+			.perform(post("/rest/mobile/patient/devices").with(mobileJwt(sub))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"platform":"ANDROID","token":"%s","appVersion":"%s"}
+						""".formatted(token, appVersion)))
+			.andExpect(status().isOk());
+	}
+
+	private static Paciente samplePaciente(final String patientAuthSub, final String name) {
+		final Paciente paciente = new Paciente();
+		paciente.setName(name);
+		paciente.setUserId("auth0|nutritionist-owner");
+		paciente.setPatientAuthSub(patientAuthSub);
+		paciente.setDob(new java.util.Date());
+		paciente.setGender("F");
+		return paciente;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDeviceServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDeviceServiceTest.java
@@ -1,0 +1,102 @@
+package com.nutriconsultas.mobile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.device.PatientDevice;
+import com.nutriconsultas.device.PatientDevicePlatform;
+import com.nutriconsultas.device.PatientDeviceRepository;
+import com.nutriconsultas.mobile.dto.PatientDeviceDto;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MobilePatientDeviceServiceTest {
+
+	@InjectMocks
+	private MobilePatientDeviceService service;
+
+	@Mock
+	private PatientDeviceRepository patientDeviceRepository;
+
+	@Mock
+	private PacienteRepository pacienteRepository;
+
+	@Test
+	void upsertDevice_createsNewDevice() {
+		final Paciente paciente = paciente(5L);
+		when(patientDeviceRepository.findByToken("token-new")).thenReturn(Optional.empty());
+		when(pacienteRepository.getReferenceById(5L)).thenReturn(paciente);
+		when(patientDeviceRepository.save(any(PatientDevice.class))).thenAnswer(invocation -> {
+			final PatientDevice device = invocation.getArgument(0);
+			device.setId(99L);
+			return device;
+		});
+
+		final PatientDeviceDto dto = service.upsertDevice(5L, PatientDevicePlatform.ANDROID, "token-new", "2.0.0");
+
+		assertThat(dto.id()).isEqualTo(99L);
+		assertThat(dto.platform()).isEqualTo(PatientDevicePlatform.ANDROID);
+		final ArgumentCaptor<PatientDevice> captor = ArgumentCaptor.forClass(PatientDevice.class);
+		verify(patientDeviceRepository).save(captor.capture());
+		assertThat(captor.getValue().getToken()).isEqualTo("token-new");
+		assertThat(captor.getValue().getAppVersion()).isEqualTo("2.0.0");
+		assertThat(captor.getValue().getPaciente().getId()).isEqualTo(5L);
+		assertThat(captor.getValue().getLastSeenAt()).isNotNull();
+	}
+
+	@Test
+	void upsertDevice_reassignsExistingTokenToNewPatient() {
+		final Paciente previousOwner = paciente(1L);
+		final Paciente newOwner = paciente(5L);
+		final PatientDevice existing = new PatientDevice();
+		existing.setId(40L);
+		existing.setPaciente(previousOwner);
+		existing.setPlatform(PatientDevicePlatform.IOS);
+		existing.setToken("shared-token");
+		existing.setCreatedAt(Instant.parse("2026-01-01T00:00:00Z"));
+		existing.setUpdatedAt(Instant.parse("2026-01-01T00:00:00Z"));
+		existing.setLastSeenAt(Instant.parse("2026-01-01T00:00:00Z"));
+
+		when(patientDeviceRepository.findByToken("shared-token")).thenReturn(Optional.of(existing));
+		when(pacienteRepository.getReferenceById(5L)).thenReturn(newOwner);
+		when(patientDeviceRepository.save(any(PatientDevice.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		final PatientDeviceDto dto = service.upsertDevice(5L, PatientDevicePlatform.IOS, "shared-token", "1.2.3");
+
+		assertThat(dto.id()).isEqualTo(40L);
+		assertThat(existing.getPaciente().getId()).isEqualTo(5L);
+		assertThat(existing.getAppVersion()).isEqualTo("1.2.3");
+	}
+
+	@Test
+	void deregisterDevice_deletesByPatientAndToken() {
+		when(patientDeviceRepository.deleteByPacienteIdAndToken(5L, "token-x")).thenReturn(1L);
+
+		service.deregisterDevice(5L, "token-x");
+
+		verify(patientDeviceRepository).deleteByPacienteIdAndToken(5L, "token-x");
+		verify(patientDeviceRepository, never()).delete(any());
+	}
+
+	private static Paciente paciente(final Long id) {
+		final Paciente paciente = new Paciente();
+		paciente.setId(id);
+		return paciente;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/util/LogRedactionDeviceTokenTest.java
+++ b/src/test/java/com/nutriconsultas/util/LogRedactionDeviceTokenTest.java
@@ -1,0 +1,21 @@
+package com.nutriconsultas.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class LogRedactionDeviceTokenTest {
+
+	@Test
+	void redactDeviceToken_masksAllButPrefix() {
+		assertThat(LogRedaction.redactDeviceToken("abcdef1234567890")).isEqualTo("deviceToken[abcdef...REDACTED]");
+	}
+
+	@Test
+	void redactDeviceToken_handlesNullAndShortValues() {
+		assertThat(LogRedaction.redactDeviceToken(null)).isEqualTo("deviceToken[null]");
+		assertThat(LogRedaction.redactDeviceToken("")).isEqualTo("deviceToken[null]");
+		assertThat(LogRedaction.redactDeviceToken("abc")).isEqualTo("deviceToken[abc...REDACTED]");
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `patient_device` Liquibase schema + entity/repo for APNs/FCM registration tokens
- Expose `POST`/`DELETE` `/rest/mobile/patient/devices` (JWT `sub` → `patientAuthSub`) with upsert, account reassignment, and idempotent deregister
- Regenerate mobile OpenAPI; redact device tokens in logs

Closes #574  
Part of epic #573 (mobile #26 killed-state push)

## Test plan
- [x] `MobilePatientDeviceControllerTest` / `MobilePatientDeviceServiceTest`
- [x] `MobilePatientDeviceIntegrationTest` (upsert, refresh, reassign, delete idempotent, unlinked 403)
- [x] `scripts/export-openapi-mobile.sh`
- [ ] Manual: register/deregister from mobile build against staging once deployed


Made with [Cursor](https://cursor.com)