### PR TITLE
Emit patient push on nutritionist reply (#576)

### DIFF
--- a/docs/mobile-api/PUSH-SETUP.md
+++ b/docs/mobile-api/PUSH-SETUP.md
@@ -16,7 +16,7 @@ Server-side push gateway for **killed/background** patient message alerts. Our A
 | Soft disable | `PUSH_ENABLED=false` or missing creds → sender no-ops (local/dev safe) |
 | Invalid tokens | APNs `BadDeviceToken`/`Unregistered` and FCM `UNREGISTERED` delete the `patient_device` row |
 
-Device register/deregister: `POST`/`DELETE` `/rest/mobile/patient/devices` (#574). Emit-on-reply is [#576](https://github.com/diego-torres/nutriconsultas/issues/576).
+Device register/deregister: `POST`/`DELETE` `/rest/mobile/patient/devices` (#574). Emit-on-reply: nutritionist `POST` message thread calls `PatientPushSender` after commit (#576).
 
 ---
 

--- a/src/main/java/com/nutriconsultas/config/AsyncConfig.java
+++ b/src/main/java/com/nutriconsultas/config/AsyncConfig.java
@@ -1,0 +1,28 @@
+package com.nutriconsultas.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * Async execution for best-effort side effects such as patient push (#576).
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+	@Bean(name = "patientPushExecutor")
+	public Executor patientPushExecutor() {
+		final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(2);
+		executor.setMaxPoolSize(8);
+		executor.setQueueCapacity(200);
+		executor.setThreadNamePrefix("patient-push-");
+		executor.initialize();
+		return executor;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/message/PatientMessagePushNotifier.java
+++ b/src/main/java/com/nutriconsultas/message/PatientMessagePushNotifier.java
@@ -1,0 +1,37 @@
+package com.nutriconsultas.message;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import com.nutriconsultas.device.PatientPushSender;
+import com.nutriconsultas.device.PushEvent;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Async bridge from nutritionist message save to patient push (#576).
+ */
+@Service
+@Slf4j
+public class PatientMessagePushNotifier {
+
+	private final PatientPushSender patientPushSender;
+
+	public PatientMessagePushNotifier(final PatientPushSender patientPushSender) {
+		this.patientPushSender = patientPushSender;
+	}
+
+	@Async("patientPushExecutor")
+	public void notifyNewNutritionistMessage(final Long pacienteId, final Long messageId) {
+		if (pacienteId == null || messageId == null) {
+			return;
+		}
+		if (log.isDebugEnabled()) {
+			log.debug("Notifying patient push for patient {} message {}", LogRedaction.redactPaciente(pacienteId),
+					LogRedaction.redactPatientMessage(messageId));
+		}
+		patientPushSender.send(pacienteId, PushEvent.newMessage(messageId));
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/message/PatientMessageService.java
+++ b/src/main/java/com/nutriconsultas/message/PatientMessageService.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -29,10 +31,13 @@ public class PatientMessageService {
 
 	private final PacienteRepository pacienteRepository;
 
+	private final PatientMessagePushNotifier patientMessagePushNotifier;
+
 	public PatientMessageService(final PatientMessageRepository patientMessageRepository,
-			final PacienteRepository pacienteRepository) {
+			final PacienteRepository pacienteRepository, final PatientMessagePushNotifier patientMessagePushNotifier) {
 		this.patientMessageRepository = patientMessageRepository;
 		this.pacienteRepository = pacienteRepository;
+		this.patientMessagePushNotifier = patientMessagePushNotifier;
 	}
 
 	@Transactional(readOnly = true)
@@ -81,6 +86,7 @@ public class PatientMessageService {
 		message.setReadByNutritionist(true);
 		final PatientMessage saved = patientMessageRepository.save(message);
 		log.info("Nutritionist sent patient message: {}", LogRedaction.redactPatientMessage(saved.getId()));
+		schedulePushAfterCommit(paciente.getId(), saved.getId());
 		return PatientMessageThreadItemDto.fromEntity(saved);
 	}
 
@@ -92,6 +98,19 @@ public class PatientMessageService {
 			log.info("Marked {} patient messages read for patient {}", updated,
 					LogRedaction.redactPaciente(pacienteId));
 		}
+	}
+
+	private void schedulePushAfterCommit(final Long pacienteId, final Long messageId) {
+		if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+			patientMessagePushNotifier.notifyNewNutritionistMessage(pacienteId, messageId);
+			return;
+		}
+		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+			@Override
+			public void afterCommit() {
+				patientMessagePushNotifier.notifyNewNutritionistMessage(pacienteId, messageId);
+			}
+		});
 	}
 
 	private Paciente requireOwnedPaciente(final Long pacienteId, final String userId) {

--- a/src/test/java/com/nutriconsultas/message/PatientMessagePushNotifierTest.java
+++ b/src/test/java/com/nutriconsultas/message/PatientMessagePushNotifierTest.java
@@ -1,0 +1,39 @@
+package com.nutriconsultas.message;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.device.PatientPushSender;
+import com.nutriconsultas.device.PushEvent;
+
+@ExtendWith(MockitoExtension.class)
+class PatientMessagePushNotifierTest {
+
+	@InjectMocks
+	private PatientMessagePushNotifier notifier;
+
+	@Mock
+	private PatientPushSender patientPushSender;
+
+	@Test
+	void notifyNewNutritionistMessage_delegatesToPushSender() {
+		notifier.notifyNewNutritionistMessage(5L, 99L);
+
+		verify(patientPushSender).send(5L, PushEvent.newMessage(99L));
+	}
+
+	@Test
+	void notifyNewNutritionistMessage_whenIdsNull_isNoOp() {
+		notifier.notifyNewNutritionistMessage(null, 99L);
+		notifier.notifyNewNutritionistMessage(5L, null);
+
+		verifyNoInteractions(patientPushSender);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/message/PatientMessageServiceTest.java
+++ b/src/test/java/com/nutriconsultas/message/PatientMessageServiceTest.java
@@ -39,6 +39,9 @@ class PatientMessageServiceTest {
 	@Mock
 	private PacienteRepository pacienteRepository;
 
+	@Mock
+	private PatientMessagePushNotifier patientMessagePushNotifier;
+
 	@Test
 	void listThread_returnsAscendingMessages() {
 		final Paciente paciente = samplePaciente(1L);
@@ -88,10 +91,11 @@ class PatientMessageServiceTest {
 		assertThat(captor.getValue().getBody()).isEqualTo("Respuesta");
 		assertThat(captor.getValue().isReadByNutritionist()).isTrue();
 		assertThat(captor.getValue().isReadByPatient()).isFalse();
+		verify(patientMessagePushNotifier).notifyNewNutritionistMessage(1L, 99L);
 	}
 
 	@Test
-	void sendAsNutritionist_whenBodyBlank_throwsBadRequest() {
+	void sendAsNutritionist_whenBodyBlank_doesNotNotifyPush() {
 		final Paciente paciente = samplePaciente(1L);
 		when(pacienteRepository.findByIdAndUserId(1L, USER_ID)).thenReturn(Optional.of(paciente));
 
@@ -101,6 +105,7 @@ class PatientMessageServiceTest {
 			.isEqualTo(HttpStatus.BAD_REQUEST);
 
 		verify(patientMessageRepository, never()).save(any(PatientMessage.class));
+		verify(patientMessagePushNotifier, never()).notifyNewNutritionistMessage(any(), any());
 	}
 
 	@Test
@@ -113,6 +118,7 @@ class PatientMessageServiceTest {
 			.isEqualTo(HttpStatus.NOT_FOUND);
 
 		verify(patientMessageRepository, never()).save(any(PatientMessage.class));
+		verify(patientMessagePushNotifier, never()).notifyNewNutritionistMessage(any(), any());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- After a nutritionist saves a patient thread reply, schedule `PatientPushSender` with `{ type: NEW_MESSAGE, messageId }` **after commit**
- Run the send on `patientPushExecutor` so APNs/FCM latency does not block the HTTP response
- Patient-sent mobile messages and read-flag updates do not trigger push

Closes #576  
Depends on #575 / PR #579 (and #574 / PR #578)  
Part of epic #573 (mobile #26)

## Test plan
- [x] `PatientMessageServiceTest` — notifier called once with patient/message ids; blank/not-owned never notify
- [x] `PatientMessagePushNotifierTest` — delegates to `PatientPushSender`
- [x] `PatientMessageIntegrationTest` / mobile message tests still green (async no-op with push disabled)
- [ ] Manual E2E with registered device + staging APNs/FCM after #574–#575 secrets are set


Made with [Cursor](https://cursor.com)