### PR TITLE
Document mobile push contract + gitleaks pre-commit (#577)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,10 +1,28 @@
-# Red Hat PwnedAlert / rh-pre-commit allowlist (top-level [allowlist] only).
+# Secret scanning config for nutriconsultas.
+# Used by:
+#   - git-hooks/pre-commit → `gitleaks protect --staged`
+#   - Red Hat PwnedAlert / rh-pre-commit (top-level [allowlist] regexes)
+#
 # Google reCAPTCHA v2 public test keys — not production secrets.
 # https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
-[allowlist]
-  description = "Google reCAPTCHA v2 public test keys (dev/CI only)"
 
-  regexes = [
-    '''6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe''',
-    '''6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI''',
-  ]
+title = "nutriconsultas"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Documented placeholders, fixtures, and public test keys"
+paths = [
+  '''(^|/)\.env\.example$''',
+  '''(^|/)application-test\.properties$''',
+  '''(^|/)application-h2-schema-export\.properties$''',
+  '''(^|/)docs/''',
+  '''(^|/)\.gitleaks\.toml$''',
+  '''(^|/)git-hooks/''',
+  '''(^|/)src/test/''',
+]
+regexes = [
+  '''6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe''',
+  '''6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI''',
+]

--- a/README.md
+++ b/README.md
@@ -451,12 +451,13 @@ The workflow uses the `ci` Maven profile which enables strict linting (fails on 
 
 ### Git Pre-commit Hook
 
-A pre-commit hook is installed to validate code quality before each commit. The hook:
+A pre-commit hook is installed to block common mistakes before each commit. The hook:
 
-1. Checks if any Java files are staged
-2. Runs checkstyle validation to ensure code quality standards
-3. Blocks the commit if checkstyle violations are found
-4. Allows the commit to proceed if all checks pass
+1. Runs **gitleaks** on the **staged** diff (secret protection — always)
+2. When Java files are staged: runs **checkstyle** and the logging security script
+3. Blocks the commit if any check fails
+
+Requires [`gitleaks`](https://github.com/gitleaks/gitleaks) on your `PATH` (e.g. `brew install gitleaks`). Config: [`.gitleaks.toml`](.gitleaks.toml).
 
 #### Installation
 
@@ -477,7 +478,7 @@ The hook will run automatically on every commit.
 
 #### Usage
 
-**To bypass the hook** (not recommended):
+**To bypass the hook** (not recommended — especially not for secret findings):
 
 ```bash
 git commit --no-verify
@@ -489,4 +490,8 @@ git commit --no-verify
 .git/hooks/pre-commit
 ```
 
-**Note:** The hook formats all Java files in the project (Spring Java Format doesn't support formatting only specific files). If you have uncommitted changes, they will be formatted as well. It's recommended to commit or stash changes before committing.
+**To scan the whole working tree:**
+
+```bash
+gitleaks detect --source . --config .gitleaks.toml --no-banner
+```

--- a/docs/mobile-api/ALIGNMENT-SPEC.md
+++ b/docs/mobile-api/ALIGNMENT-SPEC.md
@@ -63,7 +63,7 @@ flutter_pdfview, connectivity_plus, envied (env config). (notification deps alre
 | FL-6 Progress + chart          | #16 Progress snapshot, #20 Progress chart(fl_chart), #8 progress models, #15 ProgressRepository | #98, #99 | fl_chart dep |
 | FL-7 Messaging                 | #19 Messages feature, #6 message model, #14 MessagesRepository | #96, #97 | |
 | FL-8 PDF download/open         | part of #18 | #95 | flutter_pdfview/share |
-| FL-9 Push (FCM)                | (none — GAP; notification_service exists) | #96 | NEW issue |
+| FL-9 Push (FCM)                | Backend epic #573 (#574–#577): devices + APNs/FCM HTTP v1 + emit on nutritionist reply; contract [`PUSH-CONTRACT.md`](PUSH-CONTRACT.md) | mobile #26 | **Backend shipped (PRs stacked); mobile killed-state E2E remaining** |
 | infra                          | #2 deps, #4 routes, #11 DI bootstrap, #21 component lib | Phase 0 | |
 
 ## BACKEND ENDPOINT ↔ MOBILE CONSUMER cross-reference (for two-way linking)

--- a/docs/mobile-api/PUSH-CONTRACT.md
+++ b/docs/mobile-api/PUSH-CONTRACT.md
@@ -1,0 +1,197 @@
+# Mobile push contract — devices + killed-state alerts (#577)
+
+**Epic:** [#573](https://github.com/diego-torres/nutriconsultas/issues/573)  
+**Issues:** [#574](https://github.com/diego-torres/nutriconsultas/issues/574) devices · [#575](https://github.com/diego-torres/nutriconsultas/issues/575) sender · [#576](https://github.com/diego-torres/nutriconsultas/issues/576) emit · [#577](https://github.com/diego-torres/nutriconsultas/issues/577) this doc  
+**Mobile:** [Escanor4323/nutriconsultas-mobile#26](https://github.com/Escanor4323/nutriconsultas-mobile/issues/26)
+
+Stable contract for Dio models + register/deregister on login/logout, and for handling killed-state pushes. Machine-readable twin: [`../api/openapi-mobile.yaml`](../api/openapi-mobile.yaml) (`/rest/mobile/patient/devices`). Ops/secrets: [`PUSH-SETUP.md`](PUSH-SETUP.md).
+
+---
+
+## Product rules (read first)
+
+| Rule | Detail |
+|------|--------|
+| Backend owns messaging | Device tokens register with **our** API; sends go through **our** APNs + FCM HTTP v1 clients |
+| No Firebase BaaS | Do **not** use Firebase Auth/Firestore/etc. Android may use a **minimal** Firebase Messaging client **only** to obtain an FCM registration token and display notification messages |
+| No PHI in push | Notification title/body are generic Spanish; data payload is type + optional `messageId` only — never message text |
+| Auth | Same patient JWT as other `/rest/mobile/patient/**` (`sub` → `Paciente.patientAuthSub`) |
+
+---
+
+## AuthZ / error codes
+
+Applies to both device endpoints (and matches other patient mobile routes).
+
+| HTTP | When |
+|------|------|
+| **401** | Missing or invalid JWT |
+| **403** | Patient not linked / onboarding gate (`PatientLinkageFilter`) — e.g. complete registration required |
+| **400** | Validation failed (blank token, missing `platform`, oversized fields) |
+| **429** | Write rate limit envelope may appear in OpenAPI shared annotations; devices are not currently rate-limited like messages — treat as optional |
+
+Envelope for JSON error bodies: same mobile `ApiResponse` / localized `message` + `timestamp` as other patient endpoints.
+
+---
+
+## `POST /rest/mobile/patient/devices` — register / upsert
+
+**Auth:** patient JWT  
+**Success:** **200** + `ApiResponse<PatientDeviceDto>`
+
+### Request
+
+```json
+{
+  "platform": "IOS",
+  "token": "<apns-or-fcm-registration-token>",
+  "appVersion": "1.2.3"
+}
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `platform` | enum | yes | `IOS` \| `ANDROID` |
+| `token` | string | yes | max 512; APNs device token or FCM registration token |
+| `appVersion` | string | no | max 50 |
+
+### Response `data`
+
+```json
+{
+  "id": 123,
+  "platform": "IOS",
+  "updatedAt": "2026-08-11T17:00:00Z"
+}
+```
+
+### Semantics
+
+- Upsert by **token** (globally unique).
+- Same token re-POSTed refreshes `appVersion` / `lastSeenAt` / `updatedAt`.
+- If the token was registered to another patient, it is **reassigned** to the current patient (device switched accounts).
+- Call on login / when the OS grants a new token; refresh whenever the token rotates.
+
+### Example (curl)
+
+```bash
+curl -sS -X POST "$API/rest/mobile/patient/devices" \
+  -H "Authorization: Bearer $PATIENT_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"platform":"ANDROID","token":"fcm-reg-token","appVersion":"1.2.3"}'
+```
+
+---
+
+## `DELETE /rest/mobile/patient/devices` — deregister
+
+**Auth:** patient JWT  
+**Success:** **204** No Content (idempotent — already gone still 204)  
+**Body required:**
+
+```json
+{
+  "token": "<same token>"
+}
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `token` | string | yes | max 512 |
+
+### Semantics
+
+- Deletes only if the token belongs to the **current** patient.
+- Token owned by another patient → still **204** (no leak); row unchanged.
+- Call on logout / uninstall / before clearing local credentials.
+
+### Example (curl)
+
+```bash
+curl -sS -X DELETE "$API/rest/mobile/patient/devices" \
+  -H "Authorization: Bearer $PATIENT_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"token":"fcm-reg-token"}'
+```
+
+---
+
+## Push event (killed / background)
+
+Triggered when a **nutritionist** saves a reply on the web thread (`senderRole = NUTRITIONIST`).  
+**Not** triggered for patient-sent messages (`POST /rest/mobile/patient/messages`) or read-flag updates.
+
+### Data payload (custom / FCM `data` / APNs custom keys)
+
+```json
+{
+  "type": "NEW_MESSAGE",
+  "messageId": "12345"
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `type` | string | Currently only `NEW_MESSAGE` |
+| `messageId` | string (FCM) / number (APNs custom) | Optional correlation; use to open Messages / fetch thread. **Never** treat as body text |
+
+FCM requires **string** data values; mobile should parse `messageId` as string then to int if needed.
+
+### Visible notification copy (OS tray)
+
+Fixed Spanish — **do not** expect message PHI from the server:
+
+| | Value |
+|--|-------|
+| Title | `Nuevo mensaje` |
+| Body | `Nuevo mensaje de tu nutriólogo` |
+
+### Suggested mobile handling
+
+1. Permission + obtain platform token (APNs / FCM).
+2. `POST /devices` after successful patient linkage.
+3. On push / local tap: route to Messages; optionally refresh thread using `messageId`.
+4. `DELETE /devices` on logout.
+5. Foreground: existing Phase B poll + local notify remains valid; this contract unlocks **killed-state** delivery.
+
+---
+
+## Android / Firebase clarification
+
+| Allowed | Not allowed |
+|---------|-------------|
+| Firebase Messaging SDK for **token + displaying** FCM notification messages | Firebase as product BaaS (Auth, Firestore, RTDB, etc.) |
+| Register token with Minutriporcion `/devices` | Sending pushes from the mobile app or a Firebase console campaign as the primary path |
+
+iOS uses native APNs token acquisition (no Firebase required for iOS token).
+
+---
+
+## Staging / secrets checklist (pointer)
+
+Deploy enablement and key rotation live in [`PUSH-SETUP.md`](PUSH-SETUP.md):
+
+- `PUSH_ENABLED`, `APNS_*`, `FCM_PROJECT_ID`, `FCM_SERVICE_ACCOUNT_JSON`
+- Soft no-op when disabled or misconfigured
+- Never commit `.p8` / service-account JSON — use Secrets Manager / SSM / env
+
+Local template placeholders: [`.env.example`](../../.env.example).
+
+---
+
+## Mobile doc cross-links (consumer repo)
+
+Please add reciprocal links in the mobile repo (separate PR is fine):
+
+- [`docs/api-contract.md`](https://github.com/Escanor4323/nutriconsultas-mobile/blob/main/docs/api-contract.md) → this file + OpenAPI devices paths
+- [`docs/plans/cross-repo-backend-mobile-map.md`](https://github.com/Escanor4323/nutriconsultas-mobile/blob/main/docs/plans/cross-repo-backend-mobile-map.md) → epic #573 / backend #574–#577
+
+---
+
+## OpenAPI regen
+
+```bash
+./scripts/export-openapi-mobile.sh
+```
+
+Writes [`docs/api/openapi-mobile.yaml`](../api/openapi-mobile.yaml).

--- a/docs/mobile-api/PUSH-SETUP.md
+++ b/docs/mobile-api/PUSH-SETUP.md
@@ -42,8 +42,8 @@ Spring maps these under `nutriconsultas.push.*` in `application.properties`.
 ## Local / staging checklist
 
 1. Keep `PUSH_ENABLED=false` until APNs and/or FCM creds are present.
-2. Register a device via the mobile app (or curl) against `#574` endpoints.
-3. Call `PatientPushSender.send(pacienteId, PushEvent.newMessage(messageId))` from a temporary admin/test path, or wait for #576.
+2. Register a device via the mobile app (or curl) against `/rest/mobile/patient/devices` — see [`PUSH-CONTRACT.md`](PUSH-CONTRACT.md).
+3. Have a nutritionist send a thread reply (web) — after commit the API emits `NEW_MESSAGE` via `PatientPushSender` (#576).
 4. Confirm startup log: `Patient push enabled (apnsConfigured=..., fcmConfigured=...)` — never logs key material or tokens.
 
 ---

--- a/docs/mobile-api/README.md
+++ b/docs/mobile-api/README.md
@@ -14,6 +14,9 @@ Canonical cross-repo contracts for the `[Mobile API]` track. Indexed from [`../.
 | [`../auth0/PATIENT-POST-LOGIN-GATE.md`](../auth0/PATIENT-POST-LOGIN-GATE.md) | Auth0 Post-Login invitation gate (#140) — Action script + deployment |
 | [`../api/openapi-mobile.yaml`](../api/openapi-mobile.yaml) | OpenAPI 3.1 export (#112, PR #164); regen: `scripts/export-openapi-mobile.sh` |
 | [`PUSH-SETUP.md`](PUSH-SETUP.md) | APNs + FCM HTTP v1 credentials, local enable, key rotation (#575) |
+| [`PUSH-CONTRACT.md`](PUSH-CONTRACT.md) | Devices API + push payload contract for mobile (#577); OpenAPI twin |
+
+**Status (2026-08-11):** Epic [#573](https://github.com/diego-torres/nutriconsultas/issues/573) mobile push — ~~#574~~–~~#577~~ backend contract/docs. (Older grocery status below retained.)
 
 **Status (2026-06-30):** ~~#353~~ **in-progress** — grocery list endpoint. ~~#354~~ ~~#352~~ **done** (PR [#357](https://github.com/diego-torres/nutriconsultas/pull/357)). ~~#349~~ **done** (PR [#356](https://github.com/diego-torres/nutriconsultas/pull/356)).
 

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# Pre-commit hook to validate code quality
-# This hook runs checkstyle to ensure code quality standards are met
-# Note: Automatic formatting has been disabled to prevent conflicts with checkstyle rules
+# Pre-commit hook: secret scan (always) + Java quality checks when Java is staged.
+# Install: ./setup-git-hooks.sh
+
+set -euo pipefail
 
 # Colors for output
 RED='\033[0;31m'
@@ -10,69 +11,78 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-echo -e "${YELLOW}Running pre-commit code quality checks...${NC}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 
-# Get list of staged Java files
+echo -e "${YELLOW}Running pre-commit checks...${NC}"
+
+# --- Secret protection (always; staged diff only) ---
+echo -e "${YELLOW}Running gitleaks on staged changes...${NC}"
+if ! command -v gitleaks >/dev/null 2>&1; then
+	echo -e "${RED}✗ gitleaks is not installed or not in PATH${NC}"
+	echo -e "${YELLOW}Install: brew install gitleaks  (or see https://github.com/gitleaks/gitleaks)${NC}"
+	echo -e "${YELLOW}Then re-run the commit. Secret scanning is required.${NC}"
+	exit 1
+fi
+
+GITLEAKS_ARGS=(protect --staged --no-banner --redact --source "$REPO_ROOT")
+if [ -f "$REPO_ROOT/.gitleaks.toml" ]; then
+	GITLEAKS_ARGS+=(--config "$REPO_ROOT/.gitleaks.toml")
+fi
+
+if ! gitleaks "${GITLEAKS_ARGS[@]}"; then
+	echo -e "${RED}✗ Potential secrets detected in staged changes${NC}"
+	echo -e "${YELLOW}Remove secrets from the commit (use env / Secrets Manager).${NC}"
+	echo -e "${YELLOW}Placeholders belong in .env.example only — never real keys.${NC}"
+	exit 1
+fi
+echo -e "${GREEN}✓ Secret scan passed${NC}"
+
+# --- Java quality (only when Java files are staged) ---
 STAGED_JAVA_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.java$' || true)
 
 if [ -z "$STAGED_JAVA_FILES" ]; then
-    echo -e "${GREEN}✓ No Java files to check${NC}"
-    exit 0
+	echo -e "${GREEN}✓ No Java files to check${NC}"
+	echo -e "${GREEN}✓ Pre-commit checks passed${NC}"
+	exit 0
 fi
 
 echo -e "${YELLOW}Found $(echo "$STAGED_JAVA_FILES" | wc -l | tr -d ' ') staged Java file(s)${NC}"
 
-# Check if Maven is available
-if ! command -v mvn &> /dev/null; then
-    echo -e "${RED}✗ Error: Maven is not installed or not in PATH${NC}"
-    exit 1
+if ! command -v mvn >/dev/null 2>&1; then
+	echo -e "${RED}✗ Error: Maven is not installed or not in PATH${NC}"
+	exit 1
 fi
 
-# Change to project root
-cd "$(git rev-parse --show-toplevel)"
-
-# Run checkstyle check
 echo -e "${YELLOW}Running checkstyle validation...${NC}"
-if mvn checkstyle:check -q 2>&1 | grep -q "violations"; then
-    echo -e "${RED}✗ Checkstyle violations found${NC}"
-    echo -e "${YELLOW}Please fix the violations before committing.${NC}"
-    echo -e "${YELLOW}Run 'mvn checkstyle:check' to see details.${NC}"
-    exit 1
-fi
-
-# Check if checkstyle actually found violations (exit code check)
 mvn checkstyle:check > /tmp/checkstyle-output.txt 2>&1
 CHECKSTYLE_EXIT=$?
 
 if [ $CHECKSTYLE_EXIT -ne 0 ]; then
-    # Check if there are actual violations (not just warnings)
-    if grep -q "violations" /tmp/checkstyle-output.txt; then
-        echo -e "${RED}✗ Checkstyle violations found${NC}"
-        cat /tmp/checkstyle-output.txt | grep -E "(WARN|ERROR)" | head -20
-        echo ""
-        echo -e "${YELLOW}Please fix the violations before committing.${NC}"
-        echo -e "${YELLOW}Run 'mvn checkstyle:check' to see full details.${NC}"
-        rm -f /tmp/checkstyle-output.txt
-        exit 1
-    fi
+	if grep -q "violations" /tmp/checkstyle-output.txt; then
+		echo -e "${RED}✗ Checkstyle violations found${NC}"
+		grep -E "(WARN|ERROR)" /tmp/checkstyle-output.txt | head -20 || true
+		echo ""
+		echo -e "${YELLOW}Please fix the violations before committing.${NC}"
+		echo -e "${YELLOW}Run 'mvn checkstyle:check' to see full details.${NC}"
+		rm -f /tmp/checkstyle-output.txt
+		exit 1
+	fi
 fi
 
 rm -f /tmp/checkstyle-output.txt
 
-# Run logging security check
 echo -e "${YELLOW}Running logging security check...${NC}"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-if [ -f "$SCRIPT_DIR/scripts/check-logging-security.sh" ]; then
-    if ! bash "$SCRIPT_DIR/scripts/check-logging-security.sh"; then
-        echo -e "${RED}✗ Logging security check failed${NC}"
-        echo -e "${YELLOW}Please fix unsafe logging patterns before committing.${NC}"
-        exit 1
-    fi
-    echo -e "${GREEN}✓ Logging security check passed${NC}"
+if [ -f "$REPO_ROOT/scripts/check-logging-security.sh" ]; then
+	if ! bash "$REPO_ROOT/scripts/check-logging-security.sh"; then
+		echo -e "${RED}✗ Logging security check failed${NC}"
+		echo -e "${YELLOW}Please fix unsafe logging patterns before committing.${NC}"
+		exit 1
+	fi
+	echo -e "${GREEN}✓ Logging security check passed${NC}"
 else
-    echo -e "${YELLOW}⚠ Logging security check script not found, skipping...${NC}"
+	echo -e "${YELLOW}⚠ Logging security check script not found, skipping...${NC}"
 fi
 
-echo -e "${GREEN}✓ Code quality checks passed${NC}"
+echo -e "${GREEN}✓ Pre-commit checks passed${NC}"
 exit 0
-

--- a/setup-git-hooks.sh
+++ b/setup-git-hooks.sh
@@ -1,50 +1,40 @@
 #!/bin/bash
 
-# Script to install git hooks for the project
-# This copies the pre-commit hook to .git/hooks/
+# Install git hooks for the project (copies templates from git-hooks/ into .git/hooks/).
 
-set -e
+set -euo pipefail
 
-# Colors for output
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOKS_DIR="$SCRIPT_DIR/.git/hooks"
+HOOK_TEMPLATE="$SCRIPT_DIR/git-hooks/pre-commit"
 HOOK_FILE="$HOOKS_DIR/pre-commit"
 
-# Check if we're in a git repository
 if [ ! -d "$SCRIPT_DIR/.git" ]; then
-    echo -e "${RED}✗ Error: Not a git repository${NC}"
-    exit 1
+	echo -e "${RED}✗ Error: Not a git repository${NC}"
+	exit 1
 fi
 
-# Create hooks directory if it doesn't exist
 mkdir -p "$HOOKS_DIR"
 
-# Check if hook template exists (for new installations)
-HOOK_TEMPLATE="$SCRIPT_DIR/git-hooks/pre-commit"
-if [ -f "$HOOK_TEMPLATE" ]; then
-    echo -e "${YELLOW}Installing pre-commit hook from template...${NC}"
-    cp "$HOOK_TEMPLATE" "$HOOK_FILE"
-    chmod +x "$HOOK_FILE"
-    echo -e "${GREEN}✓ Pre-commit hook installed successfully${NC}"
-elif [ -f "$HOOK_FILE" ]; then
-    echo -e "${GREEN}✓ Pre-commit hook already exists${NC}"
-    echo -e "${YELLOW}To reinstall, remove .git/hooks/pre-commit and run this script again${NC}"
-else
-    echo -e "${YELLOW}⚠ No hook template found. Creating default pre-commit hook...${NC}"
-    # Create a basic hook if template doesn't exist
-    cat > "$HOOK_FILE" << 'EOF'
-#!/bin/bash
-# Pre-commit hook for formatting validation
-# This is a placeholder. Run: mvn spring-javaformat:apply before committing.
-exit 0
-EOF
-    chmod +x "$HOOK_FILE"
-    echo -e "${GREEN}✓ Basic pre-commit hook created${NC}"
-    echo -e "${YELLOW}Note: For full functionality, ensure the pre-commit hook is properly configured${NC}"
+if [ ! -f "$HOOK_TEMPLATE" ]; then
+	echo -e "${RED}✗ Missing template: git-hooks/pre-commit${NC}"
+	exit 1
 fi
 
+cp "$HOOK_TEMPLATE" "$HOOK_FILE"
+chmod +x "$HOOK_FILE"
+echo -e "${GREEN}✓ Pre-commit hook installed from git-hooks/pre-commit${NC}"
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+	echo -e "${YELLOW}⚠ gitleaks not found on PATH — pre-commit will fail until it is installed${NC}"
+	echo -e "${YELLOW}  brew install gitleaks${NC}"
+else
+	echo -e "${GREEN}✓ gitleaks available: $(gitleaks version 2>/dev/null | head -1)${NC}"
+fi
+
+echo -e "${YELLOW}Tip: commits always run a staged secret scan; Java commits also run checkstyle.${NC}"


### PR DESCRIPTION
## Summary
- Add [`docs/mobile-api/PUSH-CONTRACT.md`](docs/mobile-api/PUSH-CONTRACT.md): `POST`/`DELETE /devices`, error codes, push payload (no PHI), Android FCM vs no-BaaS rule, staging secrets pointer, mobile cross-link notes
- Index in mobile-api README / ALIGNMENT-SPEC FL-9 / PUSH-SETUP checklist
- Pre-commit always runs **gitleaks** on staged diffs (`.gitleaks.toml`); `./setup-git-hooks.sh` installs the updated hook

Closes #577  
Depends on #576 / PR #580 (stack: #574→#575→#576→#577)  
Part of epic #573 (mobile #26)

## Test plan
- [x] Docs alone sufficient for Dio register/deregister + tap routing fields
- [x] `gitleaks detect --config .gitleaks.toml` clean on tree
- [x] `./setup-git-hooks.sh` + staged PEM smoke test blocks; docs commit passes
- [ ] Mobile repo: add reciprocal links in `api-contract.md` / cross-repo map (separate mobile PR)


Made with [Cursor](https://cursor.com)