### PR TITLE
Add nutritionist mobile-app patient preview

### DIFF
--- a/src/main/java/com/nutriconsultas/paciente/PacienteMobilePreviewRestController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteMobilePreviewRestController.java
@@ -1,0 +1,70 @@
+package com.nutriconsultas.paciente;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nutriconsultas.paciente.preview.PacienteMobilePreviewService;
+import com.nutriconsultas.paciente.preview.PatientMobilePreviewDto;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Nutritionist-session REST for patient mobile-app preview (phone-frame modal).
+ */
+@RestController
+@RequestMapping("/rest/pacientes/{pacienteId}/mobile-preview")
+@Slf4j
+public class PacienteMobilePreviewRestController {
+
+	private final PacienteMobilePreviewService pacienteMobilePreviewService;
+
+	public PacienteMobilePreviewRestController(final PacienteMobilePreviewService pacienteMobilePreviewService) {
+		this.pacienteMobilePreviewService = pacienteMobilePreviewService;
+	}
+
+	@GetMapping
+	public ResponseEntity<Map<String, Object>> getPreview(@PathVariable @NonNull final Long pacienteId,
+			@AuthenticationPrincipal final OidcUser principal) {
+		final String userId = requireUserId(principal);
+		try {
+			final PatientMobilePreviewDto preview = pacienteMobilePreviewService.buildPreview(pacienteId, userId);
+			final Map<String, Object> body = new LinkedHashMap<>();
+			body.put("success", true);
+			body.put("firstName", preview.firstName());
+			body.put("nutritionistDisplayName", preview.nutritionistDisplayName());
+			body.put("avatarUrl", preview.avatarUrl());
+			body.put("progress", preview.progress());
+			body.put("activePlan", preview.activePlan());
+			body.put("activePlanDetail", preview.activePlanDetail());
+			body.put("nextVisit", preview.nextVisit());
+			if (log.isDebugEnabled()) {
+				log.debug("Returning mobile preview for patient {}", LogRedaction.redactPaciente(pacienteId));
+			}
+			return ResponseEntity.ok(body);
+		}
+		catch (IllegalArgumentException ex) {
+			final String message = ex.getMessage() != null ? ex.getMessage() : "Paciente no encontrado";
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("success", false, "error", message));
+		}
+	}
+
+	private static String requireUserId(final OidcUser principal) {
+		if (principal == null || !StringUtils.hasText(principal.getSubject())) {
+			throw new IllegalStateException("Not authenticated");
+		}
+		return principal.getSubject();
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteRestController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteRestController.java
@@ -201,9 +201,11 @@ public class PacienteRestController extends AbstractGridController<PacienteListV
 			.getPatientAuthSub(), PatientMobileInvitationUiSupport.resolveRecipientEmailFromListRow(row))
 					? "<button type='button' class='btn action-btn btn-outline-success btn-sm paciente-mobile-invite-btn' "
 							+ "data-id='" + pacienteId
-							+ "' title='Invitar a la app'><i class='fas fa-mobile-alt'></i></button> "
+							+ "' title='Invitar a la app'><i class='fas fa-envelope'></i></button> "
 					: "";
-		return inviteButton
+		final String previewButton = "<button type='button' class='btn action-btn btn-outline-info btn-sm paciente-mobile-preview-btn' "
+				+ "data-id='" + pacienteId + "' title='Ver en app'><i class='fas fa-mobile-alt'></i></button> ";
+		return previewButton + inviteButton
 				+ "<button type='button' class='btn action-btn btn-outline-primary btn-sm paciente-export-btn' "
 				+ "data-id='" + pacienteId + "' title='Exportar registro'><i class='fas fa-download'></i></button> "
 				+ "<button type='button' class='btn action-btn btn-danger btn-sm paciente-delete-btn' data-id='"

--- a/src/main/java/com/nutriconsultas/paciente/preview/PacienteMobilePreviewService.java
+++ b/src/main/java/com/nutriconsultas/paciente/preview/PacienteMobilePreviewService.java
@@ -1,0 +1,132 @@
+package com.nutriconsultas.paciente.preview;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.nutriconsultas.calendar.EventStatus;
+import com.nutriconsultas.mobile.MobilePatientDietPlanService;
+import com.nutriconsultas.mobile.MobilePatientProgressService;
+import com.nutriconsultas.mobile.MobilePatientVisitService;
+import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
+import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
+import com.nutriconsultas.mobile.dto.PagedResponse;
+import com.nutriconsultas.mobile.dto.PatientProgressSnapshotDto;
+import com.nutriconsultas.mobile.dto.VisitSummaryDto;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacientePictureSupport;
+import com.nutriconsultas.paciente.PacienteService;
+import com.nutriconsultas.profile.NutritionistBrandingHelper;
+import com.nutriconsultas.profile.NutritionistProfileRepository;
+import com.nutriconsultas.util.LogRedaction;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Builds a read-only mobile-app preview for a nutritionist's patient.
+ */
+@Service
+@Slf4j
+public class PacienteMobilePreviewService {
+
+	private static final int NEXT_VISIT_CANDIDATES = 20;
+
+	private final PacienteService pacienteService;
+
+	private final MobilePatientProgressService mobilePatientProgressService;
+
+	private final MobilePatientDietPlanService mobilePatientDietPlanService;
+
+	private final MobilePatientVisitService mobilePatientVisitService;
+
+	private final NutritionistProfileRepository nutritionistProfileRepository;
+
+	public PacienteMobilePreviewService(final PacienteService pacienteService,
+			final MobilePatientProgressService mobilePatientProgressService,
+			final MobilePatientDietPlanService mobilePatientDietPlanService,
+			final MobilePatientVisitService mobilePatientVisitService,
+			final NutritionistProfileRepository nutritionistProfileRepository) {
+		this.pacienteService = pacienteService;
+		this.mobilePatientProgressService = mobilePatientProgressService;
+		this.mobilePatientDietPlanService = mobilePatientDietPlanService;
+		this.mobilePatientVisitService = mobilePatientVisitService;
+		this.nutritionistProfileRepository = nutritionistProfileRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public PatientMobilePreviewDto buildPreview(final Long pacienteId, final String nutritionistUserId) {
+		final Paciente paciente = pacienteService.findByIdAndUserId(pacienteId, nutritionistUserId);
+		if (paciente == null) {
+			throw new IllegalArgumentException("Paciente no encontrado");
+		}
+
+		final PatientProgressSnapshotDto progress = mobilePatientProgressService.getSnapshot(pacienteId);
+		final DietPlanSummaryDto activePlan = resolveActivePlan(pacienteId);
+		final DietPlanDetailDto activePlanDetail = activePlan != null
+				? mobilePatientDietPlanService.getDietPlanDetail(pacienteId, activePlan.assignmentId()) : null;
+		final VisitSummaryDto nextVisit = resolveNextVisit(pacienteId);
+		final String nutritionistDisplayName = resolveNutritionistDisplayName(nutritionistUserId);
+		final String firstName = resolveFirstName(paciente);
+		final String avatarUrl = PacientePictureSupport.resolveDisplayUrlForAdmin(paciente);
+
+		if (log.isDebugEnabled()) {
+			log.debug("Built mobile preview for patient {} nutritionist {}", LogRedaction.redactPaciente(pacienteId),
+					nutritionistUserId);
+		}
+
+		return new PatientMobilePreviewDto(firstName, nutritionistDisplayName, avatarUrl, progress, activePlan,
+				activePlanDetail, nextVisit);
+	}
+
+	private DietPlanSummaryDto resolveActivePlan(final Long pacienteId) {
+		final PagedResponse<DietPlanSummaryDto> page = mobilePatientDietPlanService.listDietPlans(pacienteId, 0, 1,
+				true);
+		if (page == null || page.content() == null || page.content().isEmpty()) {
+			return null;
+		}
+		return page.content().get(0);
+	}
+
+	private VisitSummaryDto resolveNextVisit(final Long pacienteId) {
+		final Instant now = Instant.now();
+		final PagedResponse<VisitSummaryDto> page = mobilePatientVisitService.listVisits(pacienteId, 0,
+				NEXT_VISIT_CANDIDATES, EventStatus.SCHEDULED, now, null);
+		if (page == null || page.content() == null || page.content().isEmpty()) {
+			return null;
+		}
+		return pickSoonestUpcomingVisit(page.content(), now);
+	}
+
+	static VisitSummaryDto pickSoonestUpcomingVisit(final List<VisitSummaryDto> visits, final Instant now) {
+		return visits.stream()
+			.filter(visit -> visit != null && visit.status() == EventStatus.SCHEDULED)
+			.filter(visit -> visit.eventDateTime() != null && !visit.eventDateTime().isBefore(now))
+			.min(Comparator.comparing(VisitSummaryDto::eventDateTime))
+			.orElse(null);
+	}
+
+	private String resolveNutritionistDisplayName(final String nutritionistUserId) {
+		if (!StringUtils.hasText(nutritionistUserId)) {
+			return null;
+		}
+		return nutritionistProfileRepository.findByUserId(nutritionistUserId)
+			.map(profile -> NutritionistBrandingHelper.resolveDisplayName(profile, null))
+			.orElse(null);
+	}
+
+	static String resolveFirstName(final Paciente paciente) {
+		final String source = StringUtils.hasText(paciente.getDisplayName()) ? paciente.getDisplayName()
+				: paciente.getName();
+		if (!StringUtils.hasText(source)) {
+			return "Paciente";
+		}
+		final String trimmed = source.trim();
+		final int space = trimmed.indexOf(' ');
+		return space > 0 ? trimmed.substring(0, space) : trimmed;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/paciente/preview/PatientMobilePreviewDto.java
+++ b/src/main/java/com/nutriconsultas/paciente/preview/PatientMobilePreviewDto.java
@@ -1,0 +1,16 @@
+package com.nutriconsultas.paciente.preview;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
+import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
+import com.nutriconsultas.mobile.dto.PatientProgressSnapshotDto;
+import com.nutriconsultas.mobile.dto.VisitSummaryDto;
+
+/**
+ * Aggregated patient mobile-app preview for nutritionist web.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record PatientMobilePreviewDto(String firstName, String nutritionistDisplayName, String avatarUrl,
+		PatientProgressSnapshotDto progress, DietPlanSummaryDto activePlan, DietPlanDetailDto activePlanDetail,
+		VisitSummaryDto nextVisit) {
+}

--- a/src/main/resources/static/sbadmin/css/paciente-mobile-preview.css
+++ b/src/main/resources/static/sbadmin/css/paciente-mobile-preview.css
@@ -1,0 +1,385 @@
+/* Patient mobile-app preview phone frame (nutritionist web). */
+
+.mnp-preview-modal .modal-dialog {
+  max-width: 420px;
+}
+
+.mnp-preview-modal .modal-content {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+.mnp-preview-modal .modal-header {
+  border: none;
+  padding: 0 0 0.75rem;
+  color: #fff;
+}
+
+.mnp-preview-modal .modal-header .close {
+  color: #fff;
+  opacity: 0.9;
+  text-shadow: none;
+}
+
+.mnp-preview-modal .modal-body {
+  padding: 0;
+  display: flex;
+  justify-content: center;
+}
+
+.mnp-phone {
+  --mnp-bone: #f4f1ea;
+  --mnp-surf: #fbfaf6;
+  --mnp-ink: #1e241f;
+  --mnp-forest: #1f4d3c;
+  --mnp-mint: #2ecc8d;
+  --mnp-sage: #e7ece2;
+  --mnp-muted: #8a938b;
+  --mnp-sand: #c99a6a;
+  --mnp-line: rgba(30, 36, 31, 0.12);
+  width: 320px;
+  height: 640px;
+  background: #111;
+  border-radius: 36px;
+  padding: 12px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.35);
+  position: relative;
+}
+
+.mnp-phone::before {
+  content: '';
+  position: absolute;
+  top: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 96px;
+  height: 8px;
+  background: #222;
+  border-radius: 8px;
+  z-index: 2;
+}
+
+.mnp-phone-screen {
+  width: 100%;
+  height: 100%;
+  background: var(--mnp-bone);
+  border-radius: 28px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  color: var(--mnp-ink);
+  font-family: 'Nunito', 'Segoe UI', sans-serif;
+}
+
+.mnp-phone-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem 0.9rem 0.75rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+.mnp-loading,
+.mnp-error {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--mnp-muted);
+  font-size: 0.9rem;
+}
+
+.mnp-error {
+  color: #b4533a;
+}
+
+.mnp-greeting-date {
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--mnp-muted);
+  margin-bottom: 0.25rem;
+}
+
+.mnp-greeting-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.mnp-greeting-text {
+  font-size: 1.55rem;
+  line-height: 1.15;
+  font-weight: 700;
+  color: var(--mnp-ink);
+}
+
+.mnp-greeting-text span {
+  display: block;
+  font-weight: 400;
+  font-size: 1rem;
+  color: var(--mnp-muted);
+  margin-bottom: 0.15rem;
+}
+
+.mnp-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--mnp-sage);
+  flex-shrink: 0;
+}
+
+.mnp-avatar-fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--mnp-forest);
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.mnp-card {
+  background: var(--mnp-surf);
+  border: 1px solid var(--mnp-line);
+  border-radius: 16px;
+  padding: 0.85rem 0.9rem;
+  margin-bottom: 0.75rem;
+}
+
+.mnp-card-sage {
+  background: var(--mnp-sage);
+}
+
+.mnp-card-forest {
+  background: var(--mnp-forest);
+  color: #fff;
+  border-color: transparent;
+}
+
+.mnp-card-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.mnp-card-title .mnp-link {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--mnp-forest);
+}
+
+.mnp-card-forest .mnp-card-title .mnp-link {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.mnp-muted {
+  color: var(--mnp-muted);
+  font-size: 0.78rem;
+}
+
+.mnp-imc-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  margin-bottom: 0.35rem;
+}
+
+.mnp-imc-value {
+  font-size: 1.45rem;
+  font-weight: 700;
+}
+
+.mnp-imc-label {
+  font-size: 0.8rem;
+  color: var(--mnp-muted);
+}
+
+.mnp-delta {
+  margin-left: auto;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.mnp-delta-up {
+  color: #b4533a;
+}
+
+.mnp-delta-down {
+  color: var(--mnp-mint);
+}
+
+.mnp-gauge {
+  height: 8px;
+  border-radius: 8px;
+  background: linear-gradient(90deg, #7ec8e3 0%, #2ecc8d 35%, #f0c36a 65%, #e07a5f 100%);
+  position: relative;
+  margin: 0.5rem 0 0.75rem;
+}
+
+.mnp-gauge-marker {
+  position: absolute;
+  top: -3px;
+  width: 4px;
+  height: 14px;
+  background: var(--mnp-ink);
+  border-radius: 2px;
+  transform: translateX(-50%);
+}
+
+.mnp-weight {
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.mnp-chip {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: var(--mnp-sage);
+  color: var(--mnp-forest);
+}
+
+.mnp-chip-active {
+  background: rgba(46, 204, 141, 0.2);
+  color: var(--mnp-forest);
+}
+
+.mnp-plan-name {
+  font-weight: 700;
+  font-size: 0.95rem;
+  margin-bottom: 0.2rem;
+}
+
+.mnp-plan-kcal {
+  font-size: 0.85rem;
+  color: var(--mnp-muted);
+}
+
+.mnp-visit-eyebrow {
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.85;
+  margin-bottom: 0.25rem;
+}
+
+.mnp-visit-title {
+  font-weight: 700;
+  font-size: 1rem;
+  margin-bottom: 0.2rem;
+}
+
+.mnp-visit-meta {
+  font-size: 0.8rem;
+  opacity: 0.9;
+}
+
+.mnp-ingesta {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.65rem 0;
+  border-bottom: 1px solid var(--mnp-line);
+}
+
+.mnp-ingesta:last-child {
+  border-bottom: none;
+}
+
+.mnp-ingesta-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: var(--mnp-sage);
+  color: var(--mnp-forest);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.mnp-ingesta-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.mnp-ingesta-tipo {
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.mnp-ingesta-meta {
+  font-size: 0.75rem;
+  color: var(--mnp-muted);
+}
+
+.mnp-tabbar {
+  display: flex;
+  border-top: 1px solid var(--mnp-line);
+  background: var(--mnp-surf);
+  padding: 0.35rem 0.25rem 0.55rem;
+}
+
+.mnp-tab {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--mnp-muted);
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 0.35rem 0.15rem;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+}
+
+.mnp-tab i {
+  font-size: 0.95rem;
+}
+
+.mnp-tab.active {
+  color: var(--mnp-forest);
+}
+
+.mnp-tab:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.mnp-panel[hidden] {
+  display: none !important;
+}
+
+.mnp-empty {
+  color: var(--mnp-muted);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.mnp-preview-content {
+  display: none;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+}
+
+.mnp-preview-content.is-visible {
+  display: flex;
+}
+
+@media (max-width: 480px) {
+  .mnp-phone {
+    width: 290px;
+    height: 580px;
+  }
+}

--- a/src/main/resources/static/sbadmin/js/paciente-mobile-preview.js
+++ b/src/main/resources/static/sbadmin/js/paciente-mobile-preview.js
@@ -1,0 +1,378 @@
+'use strict';
+
+/**
+ * Patient mobile-app preview (phone-frame modal) for nutritionist web.
+ */
+(function (window, $) {
+  if (!$) {
+    return;
+  }
+
+  var MONTHS_SHORT = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
+  var WEEKDAYS = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
+  var WEEKDAYS_SHORT = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
+
+  function previewUrl(pacienteId) {
+    return '/rest/pacientes/' + pacienteId + '/mobile-preview';
+  }
+
+  function escapeHtml(value) {
+    if (value == null) {
+      return '';
+    }
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function greetingForHour(hour) {
+    if (hour < 12) {
+      return 'Buenos días';
+    }
+    if (hour < 19) {
+      return 'Buenas tardes';
+    }
+    return 'Buenas noches';
+  }
+
+  function formatDateEyebrow(date) {
+    return (WEEKDAYS[date.getDay()] + ', ' + MONTHS_SHORT[date.getMonth()] + ' ' + date.getDate()).toUpperCase();
+  }
+
+  function formatShortDate(iso) {
+    if (!iso) {
+      return null;
+    }
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) {
+      return null;
+    }
+    return WEEKDAYS_SHORT[d.getDay()] + ' ' + d.getDate() + ', ' + d.getFullYear();
+  }
+
+  function formatLocalDate(isoDate) {
+    if (!isoDate) {
+      return null;
+    }
+    var parts = String(isoDate).split('-');
+    if (parts.length !== 3) {
+      return isoDate;
+    }
+    var monthIndex = parseInt(parts[1], 10) - 1;
+    var day = parseInt(parts[2], 10);
+    if (monthIndex < 0 || monthIndex > 11) {
+      return isoDate;
+    }
+    return day + ' ' + MONTHS_SHORT[monthIndex] + ' ' + parts[0];
+  }
+
+  function formatDateTime(iso) {
+    if (!iso) {
+      return '';
+    }
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) {
+      return '';
+    }
+    var hours = d.getHours();
+    var minutes = d.getMinutes();
+    var hh = hours < 10 ? '0' + hours : String(hours);
+    var mm = minutes < 10 ? '0' + minutes : String(minutes);
+    return formatLocalDate(d.getFullYear() + '-' + pad2(d.getMonth() + 1) + '-' + pad2(d.getDate()))
+      + ' · ' + hh + ':' + mm;
+  }
+
+  function pad2(n) {
+    return n < 10 ? '0' + n : String(n);
+  }
+
+  function formatNumber(value, digits) {
+    if (value == null || value === '' || isNaN(Number(value))) {
+      return '—';
+    }
+    return Number(value).toFixed(digits == null ? 1 : digits);
+  }
+
+  function formatDelta(value, suffix) {
+    if (value == null || isNaN(Number(value))) {
+      return '';
+    }
+    var n = Number(value);
+    var sign = n > 0 ? '+' : '';
+    var cls = n > 0 ? 'mnp-delta-up' : (n < 0 ? 'mnp-delta-down' : '');
+    return '<span class="mnp-delta ' + cls + '">' + sign + formatNumber(n, 1) + (suffix || '') + '</span>';
+  }
+
+  function imcGaugePercent(bmi) {
+    if (bmi == null || isNaN(Number(bmi))) {
+      return 50;
+    }
+    var v = Number(bmi);
+    // Map ~15–40 IMC onto 0–100 for a simple marker.
+    var pct = ((v - 15) / 25) * 100;
+    if (pct < 2) {
+      return 2;
+    }
+    if (pct > 98) {
+      return 98;
+    }
+    return pct;
+  }
+
+  function itemCount(ingesta) {
+    var platillos = (ingesta && ingesta.platillos) ? ingesta.platillos.length : 0;
+    var alimentos = (ingesta && ingesta.alimentos) ? ingesta.alimentos.length : 0;
+    return platillos + alimentos;
+  }
+
+  function statusLabel(status) {
+    if (status === 'ACTIVE') {
+      return 'Activo';
+    }
+    if (status === 'SCHEDULED') {
+      return 'Programada';
+    }
+    return status || '';
+  }
+
+  function renderAvatar(avatarUrl, firstName) {
+    var initial = (firstName && firstName.charAt(0)) ? firstName.charAt(0).toUpperCase() : 'P';
+    if (avatarUrl) {
+      return '<img class="mnp-avatar" src="' + escapeHtml(avatarUrl) + '" alt="">';
+    }
+    return '<div class="mnp-avatar mnp-avatar-fallback" aria-hidden="true">' + escapeHtml(initial) + '</div>';
+  }
+
+  function renderHome(data) {
+    var now = new Date();
+    var progress = data.progress || {};
+    var circ = progress.circumferences || {};
+    var plan = data.activePlan;
+    var visit = data.nextVisit;
+    var lastVisit = formatShortDate(progress.latestMeasurementAt);
+    var html = '';
+
+    html += '<div class="mnp-greeting-date">' + escapeHtml(formatDateEyebrow(now)) + '</div>';
+    html += '<div class="mnp-greeting-row">';
+    html += '<div class="mnp-greeting-text"><span>' + escapeHtml(greetingForHour(now.getHours())) + ',</span>'
+      + escapeHtml(data.firstName || 'Paciente') + '.</div>';
+    html += renderAvatar(data.avatarUrl, data.firstName);
+    html += '</div>';
+
+    html += '<div class="mnp-card">';
+    html += '<div class="mnp-card-title">Tu progreso<span class="mnp-link">Gráfica</span></div>';
+    if (lastVisit) {
+      html += '<div class="mnp-muted mb-2">Última visita: ' + escapeHtml(lastVisit) + '</div>';
+    }
+    html += '<div class="mnp-imc-row">';
+    html += '<span class="mnp-muted">IMC</span>';
+    html += '<span class="mnp-imc-value">' + escapeHtml(formatNumber(progress.bmi, 1)) + '</span>';
+    if (progress.imcLabel) {
+      html += '<span class="mnp-imc-label">' + escapeHtml(progress.imcLabel) + '</span>';
+    }
+    html += formatDelta(progress.deltaImc, '');
+    html += '</div>';
+    html += '<div class="mnp-gauge"><div class="mnp-gauge-marker" style="left:'
+      + imcGaugePercent(progress.bmi) + '%"></div></div>';
+    html += '<div class="mnp-muted">Peso</div>';
+    html += '<div class="d-flex align-items-baseline">';
+    html += '<div class="mnp-weight">' + escapeHtml(formatNumber(progress.weightKg, 1)) + ' kg</div>';
+    html += formatDelta(progress.deltaPeso, ' kg');
+    html += '</div>';
+    if (circ.waistCm != null || circ.hipCm != null) {
+      html += '<div class="mnp-muted mt-2">';
+      if (circ.waistCm != null) {
+        html += 'Cintura ' + escapeHtml(formatNumber(circ.waistCm, 0)) + ' cm';
+      }
+      if (circ.waistCm != null && circ.hipCm != null) {
+        html += ' · ';
+      }
+      if (circ.hipCm != null) {
+        html += 'Cadera ' + escapeHtml(formatNumber(circ.hipCm, 0)) + ' cm';
+      }
+      html += '</div>';
+    }
+    html += '</div>';
+
+    html += '<div class="mnp-card-title">Tu plan alimenticio</div>';
+    if (plan) {
+      html += '<div class="mnp-card">';
+      html += '<div class="d-flex justify-content-between align-items-start">';
+      html += '<div class="mnp-plan-name">' + escapeHtml(plan.dietaName || 'Plan alimentario') + '</div>';
+      html += '<span class="mnp-chip mnp-chip-active">' + escapeHtml(statusLabel(plan.status)) + '</span>';
+      html += '</div>';
+      if (plan.startDate) {
+        html += '<div class="mnp-muted">Desde ' + escapeHtml(formatLocalDate(plan.startDate)) + '</div>';
+      }
+      if (plan.totalKcal != null) {
+        html += '<div class="mnp-plan-kcal mt-1">' + escapeHtml(String(plan.totalKcal)) + ' kcal/día</div>';
+      }
+      html += '</div>';
+    } else {
+      html += '<div class="mnp-card mnp-card-sage"><div class="mnp-empty">'
+        + 'Tu nutriólogo está trabajando en construir tu plan alimentario.</div></div>';
+    }
+
+    if (visit) {
+      html += '<div class="mnp-card-title">Tu próxima visita<span class="mnp-link">Abrir agenda</span></div>';
+      html += '<div class="mnp-card mnp-card-forest">';
+      html += '<div class="mnp-visit-eyebrow">Tu cita</div>';
+      html += '<div class="mnp-visit-title">' + escapeHtml(visit.title || 'Consulta') + '</div>';
+      if (data.nutritionistDisplayName) {
+        html += '<div class="mnp-visit-meta">' + escapeHtml(data.nutritionistDisplayName) + '</div>';
+      }
+      html += '<div class="mnp-visit-meta">' + escapeHtml(formatDateTime(visit.eventDateTime)) + '</div>';
+      html += '<div class="mnp-visit-meta mt-1">';
+      if (visit.durationMinutes != null) {
+        html += escapeHtml(String(visit.durationMinutes)) + ' min · ';
+      }
+      html += escapeHtml(statusLabel(visit.status));
+      html += '</div></div>';
+    } else if (data.nutritionistDisplayName) {
+      html += '<div class="mnp-card-title">Tu nutriólogo</div>';
+      html += '<div class="mnp-card"><div class="mnp-plan-name">'
+        + escapeHtml(data.nutritionistDisplayName) + '</div>';
+      html += '<div class="mnp-empty mt-1">Los detalles de tu próxima visita aparecerán aquí.</div></div>';
+    }
+
+    return html;
+  }
+
+  function renderDiet(data) {
+    var plan = data.activePlan;
+    var detail = data.activePlanDetail;
+    var html = '';
+
+    html += '<div class="mnp-card-title mb-2" style="font-size:1.1rem">Planes de dieta</div>';
+
+    if (!plan) {
+      html += '<div class="mnp-card mnp-card-sage"><div class="mnp-empty">No hay plan activo.</div></div>';
+      return html;
+    }
+
+    html += '<div class="mnp-card">';
+    html += '<div class="d-flex justify-content-between align-items-start">';
+    html += '<div class="mnp-plan-name">' + escapeHtml(plan.dietaName || 'Plan alimentario') + '</div>';
+    html += '<span class="mnp-chip mnp-chip-active">' + escapeHtml(statusLabel(plan.status)) + '</span>';
+    html += '</div>';
+    if (plan.totalKcal != null) {
+      html += '<div class="mnp-plan-kcal">' + escapeHtml(String(plan.totalKcal)) + ' kcal/día</div>';
+    }
+    if (plan.startDate) {
+      html += '<div class="mnp-muted mt-1">Desde ' + escapeHtml(formatLocalDate(plan.startDate)) + '</div>';
+    }
+    html += '</div>';
+
+    html += '<div class="mnp-card-title">Ingestas del día</div>';
+    html += '<div class="mnp-card">';
+    var ingestas = (detail && detail.ingestas) ? detail.ingestas : [];
+    if (!ingestas.length) {
+      html += '<div class="mnp-empty">Este plan aún no tiene ingestas.</div>';
+    } else {
+      ingestas.forEach(function (ingesta) {
+        var count = itemCount(ingesta);
+        var kcal = ingesta.totalKcal != null ? ingesta.totalKcal : '—';
+        html += '<div class="mnp-ingesta">';
+        html += '<div class="mnp-ingesta-icon"><i class="fas fa-utensils"></i></div>';
+        html += '<div class="mnp-ingesta-body">';
+        html += '<div class="mnp-ingesta-tipo">' + escapeHtml(ingesta.tipo || 'Ingesta') + '</div>';
+        html += '<div class="mnp-ingesta-meta">' + escapeHtml(String(count)) + ' elementos · '
+          + escapeHtml(String(kcal)) + ' kcal</div>';
+        html += '</div></div>';
+      });
+    }
+    html += '</div>';
+
+    return html;
+  }
+
+  function showError(message) {
+    $('#mnpPreviewLoading').hide();
+    $('#mnpPreviewContent').removeClass('is-visible');
+    $('#mnpPreviewError').text(message || 'No se pudo cargar el preview.').show();
+  }
+
+  function showLoading() {
+    $('#mnpPreviewError').hide().text('');
+    $('#mnpPreviewContent').removeClass('is-visible');
+    $('#mnpPreviewLoading').show();
+  }
+
+  function showContent(data) {
+    $('#mnpPreviewLoading').hide();
+    $('#mnpPreviewError').hide();
+    $('#mnpHomePanel').html(renderHome(data));
+    $('#mnpDietPanel').html(renderDiet(data));
+    activateTab('home');
+    $('#mnpPreviewContent').addClass('is-visible');
+  }
+
+  function activateTab(tab) {
+    $('.mnp-tab').removeClass('active');
+    $('.mnp-panel').attr('hidden', true);
+    if (tab === 'diet') {
+      $('#mnpTabDiet').addClass('active');
+      $('#mnpDietPanel').removeAttr('hidden');
+    } else {
+      $('#mnpTabHome').addClass('active');
+      $('#mnpHomePanel').removeAttr('hidden');
+    }
+  }
+
+  function openPreview(pacienteId) {
+    var $modal = $('#pacienteMobilePreviewModal');
+    showLoading();
+    $modal.modal('show');
+
+    $.ajax({
+      url: previewUrl(pacienteId),
+      method: 'GET',
+      dataType: 'json'
+    }).done(function (data) {
+      if (!data || data.success === false) {
+        showError((data && data.error) || 'No se pudo cargar el preview.');
+        return;
+      }
+      showContent(data);
+    }).fail(function (xhr) {
+      var msg = 'No se pudo cargar el preview.';
+      if (xhr.responseJSON) {
+        msg = xhr.responseJSON.message || xhr.responseJSON.error || msg;
+      }
+      showError(msg);
+    });
+  }
+
+  function bind() {
+    $(document).on('click', '.paciente-mobile-preview-btn', function (e) {
+      e.preventDefault();
+      var pacienteId = $(this).data('id');
+      if (pacienteId == null) {
+        return;
+      }
+      openPreview(pacienteId);
+    });
+
+    $(document).on('click', '#mnpTabHome', function (e) {
+      e.preventDefault();
+      activateTab('home');
+    });
+
+    $(document).on('click', '#mnpTabDiet', function (e) {
+      e.preventDefault();
+      activateTab('diet');
+    });
+  }
+
+  window.PacienteMobilePreview = {
+    bind: bind,
+    open: openPreview
+  };
+
+  $(function () {
+    bind();
+  });
+})(window, window.jQuery);

--- a/src/main/resources/templates/sbadmin/pacientes/listado.html
+++ b/src/main/resources/templates/sbadmin/pacientes/listado.html
@@ -24,6 +24,7 @@
   <!-- Custom styles for this template-->
   <link th:href="@{/sbadmin/css/sb-admin-2.min.css}" rel="stylesheet">
   <link th:href="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.css}" rel="stylesheet">
+  <link th:href="@{/sbadmin/css/paciente-mobile-preview.css}" rel="stylesheet">
 </head>
 
 <body id="page-top">
@@ -112,6 +113,49 @@
     </div>
     <!-- End of Page Wrapper -->
 
+    <!-- Mobile app preview modal -->
+    <div class="modal fade mnp-preview-modal" id="pacienteMobilePreviewModal" tabindex="-1" role="dialog"
+      aria-labelledby="pacienteMobilePreviewTitle" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="pacienteMobilePreviewTitle">Vista previa de la app</h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Cerrar">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <div class="mnp-phone" aria-live="polite">
+              <div class="mnp-phone-screen">
+                <div id="mnpPreviewLoading" class="mnp-loading">Cargando vista previa…</div>
+                <div id="mnpPreviewError" class="mnp-error" style="display:none"></div>
+                <div id="mnpPreviewContent" class="mnp-preview-content">
+                  <div class="mnp-phone-body">
+                    <div id="mnpHomePanel" class="mnp-panel"></div>
+                    <div id="mnpDietPanel" class="mnp-panel" hidden></div>
+                  </div>
+                  <nav class="mnp-tabbar" aria-label="Navegación de preview">
+                    <button type="button" class="mnp-tab active" id="mnpTabHome">
+                      <i class="fas fa-home"></i> Inicio
+                    </button>
+                    <button type="button" class="mnp-tab" id="mnpTabDiet">
+                      <i class="fas fa-utensils"></i> Planes
+                    </button>
+                    <button type="button" class="mnp-tab" disabled title="Solo lectura">
+                      <i class="fas fa-calendar-alt"></i> Visitas
+                    </button>
+                    <button type="button" class="mnp-tab" disabled title="Solo lectura">
+                      <i class="fas fa-user"></i> Perfil
+                    </button>
+                  </nav>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Bootstrap core JavaScript-->
     <script th:src="@{/sbadmin/vendor/jquery/jquery.min.js}"></script>
     <script th:src="@{/sbadmin/vendor/bootstrap/js/bootstrap.bundle.min.js}"></script>
@@ -127,6 +171,7 @@
     <script th:src="@{/sbadmin/vendor/bootstrap-sweetalert/sweetalert.js}"></script>
     <script th:src="@{/sbadmin/js/paciente-mpx-actions.js}"></script>
     <script th:src="@{/sbadmin/js/paciente-mobile-invitation.js}"></script>
+    <script th:src="@{/sbadmin/js/paciente-mobile-preview.js}"></script>
     <script lang="javascript">
       'use strict';
       (function ($) {

--- a/src/test/java/com/nutriconsultas/paciente/PacienteMobilePreviewRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteMobilePreviewRestControllerTest.java
@@ -1,0 +1,69 @@
+package com.nutriconsultas.paciente;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import com.nutriconsultas.paciente.preview.PacienteMobilePreviewService;
+import com.nutriconsultas.paciente.preview.PatientMobilePreviewDto;
+
+@ExtendWith(MockitoExtension.class)
+class PacienteMobilePreviewRestControllerTest {
+
+	private static final String NUTRITIONIST_SUB = "auth0|nutritionist-preview";
+
+	@InjectMocks
+	private PacienteMobilePreviewRestController controller;
+
+	@Mock
+	private PacienteMobilePreviewService pacienteMobilePreviewService;
+
+	@Test
+	void getPreview_returnsSuccessPayload() {
+		final PatientMobilePreviewDto preview = new PatientMobilePreviewDto("María", "Lic. Ana", null, null, null, null,
+				null);
+		when(pacienteMobilePreviewService.buildPreview(eq(1L), eq(NUTRITIONIST_SUB))).thenReturn(preview);
+
+		final ResponseEntity<Map<String, Object>> response = controller.getPreview(1L, principal());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("success", true)
+			.containsEntry("firstName", "María")
+			.containsEntry("nutritionistDisplayName", "Lic. Ana");
+		verify(pacienteMobilePreviewService).buildPreview(1L, NUTRITIONIST_SUB);
+	}
+
+	@Test
+	void getPreview_returnsNotFoundWhenPatientMissing() {
+		when(pacienteMobilePreviewService.buildPreview(eq(2L), eq(NUTRITIONIST_SUB)))
+			.thenThrow(new IllegalArgumentException("Paciente no encontrado"));
+
+		final ResponseEntity<Map<String, Object>> response = controller.getPreview(2L, principal());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(response.getBody()).containsEntry("success", false).containsEntry("error", "Paciente no encontrado");
+	}
+
+	private static OidcUser principal() {
+		final Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject(NUTRITIONIST_SUB).build();
+		final OidcIdToken idToken = new OidcIdToken("token", jwt.getIssuedAt(), jwt.getExpiresAt(),
+				Map.of("sub", NUTRITIONIST_SUB));
+		return new DefaultOidcUser(null, idToken);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/paciente/PacienteRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteRestControllerTest.java
@@ -267,6 +267,7 @@ public class PacienteRestControllerTest {
 		assertThat(result.get(4)).isEqualTo("M");
 		assertThat(result.get(5)).isEqualTo("Maria Perez");
 		assertThat(result.get(6)).contains("badge");
+		assertThat(result.get(7)).contains("paciente-mobile-preview-btn");
 		assertThat(result.get(7)).contains("paciente-export-btn");
 		assertThat(result.get(7)).contains("paciente-delete-btn");
 		log.info("finished testToStringList");

--- a/src/test/java/com/nutriconsultas/paciente/preview/PacienteMobilePreviewServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/preview/PacienteMobilePreviewServiceTest.java
@@ -1,0 +1,169 @@
+package com.nutriconsultas.paciente.preview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nutriconsultas.calendar.EventStatus;
+import com.nutriconsultas.mobile.MobilePatientDietPlanService;
+import com.nutriconsultas.mobile.MobilePatientProgressService;
+import com.nutriconsultas.mobile.MobilePatientVisitService;
+import com.nutriconsultas.mobile.dto.DietIngestaDto;
+import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
+import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
+import com.nutriconsultas.mobile.dto.PagedResponse;
+import com.nutriconsultas.mobile.dto.PatientProgressSnapshotDto;
+import com.nutriconsultas.mobile.dto.VisitSummaryDto;
+import com.nutriconsultas.paciente.NivelPeso;
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteDietaStatus;
+import com.nutriconsultas.paciente.PacienteService;
+import com.nutriconsultas.profile.NutritionistProfile;
+import com.nutriconsultas.profile.NutritionistProfileRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PacienteMobilePreviewServiceTest {
+
+	private static final String USER_ID = "auth0|nutritionist-preview";
+
+	@InjectMocks
+	private PacienteMobilePreviewService service;
+
+	@Mock
+	private PacienteService pacienteService;
+
+	@Mock
+	private MobilePatientProgressService mobilePatientProgressService;
+
+	@Mock
+	private MobilePatientDietPlanService mobilePatientDietPlanService;
+
+	@Mock
+	private MobilePatientVisitService mobilePatientVisitService;
+
+	@Mock
+	private NutritionistProfileRepository nutritionistProfileRepository;
+
+	@Test
+	void buildPreview_returnsAggregatedPayload() {
+		final Paciente paciente = paciente(10L, "María López", "María");
+		when(pacienteService.findByIdAndUserId(10L, USER_ID)).thenReturn(paciente);
+
+		final PatientProgressSnapshotDto progress = new PatientProgressSnapshotDto(Instant.now(), null, 72.5, 1.68,
+				25.7, NivelPeso.ALTO, "Sobrepeso", 1450.0, null, -0.8, -0.3, null, "avatar_1", null);
+		when(mobilePatientProgressService.getSnapshot(10L)).thenReturn(progress);
+
+		final DietPlanSummaryDto summary = new DietPlanSummaryDto(55L, PacienteDietaStatus.ACTIVE,
+				LocalDate.of(2026, 3, 16), null, null, "Plan hipocalórico", 1800, 90.0, 55.0, 200.0);
+		when(mobilePatientDietPlanService.listDietPlans(eq(10L), eq(0), eq(1), eq(true)))
+			.thenReturn(new PagedResponse<>(List.of(summary), 0, 1, 1, 1, true));
+
+		final DietPlanDetailDto detail = new DietPlanDetailDto(55L, PacienteDietaStatus.ACTIVE,
+				LocalDate.of(2026, 3, 16), null, null, "Plan hipocalórico", 1800, 90.0, 55.0, 200.0,
+				List.of(new DietIngestaDto("Desayuno", 450, 20.0, 10.0, 50.0, List.of(), List.of())));
+		when(mobilePatientDietPlanService.getDietPlanDetail(10L, 55L)).thenReturn(detail);
+
+		final Instant soon = Instant.now().plus(2, ChronoUnit.DAYS);
+		final VisitSummaryDto visit = new VisitSummaryDto(7L, soon, "Consulta seguimiento", EventStatus.SCHEDULED, 60,
+				null);
+		when(mobilePatientVisitService.listVisits(eq(10L), eq(0), eq(20), eq(EventStatus.SCHEDULED), any(Instant.class),
+				isNull()))
+			.thenReturn(new PagedResponse<>(List.of(visit), 0, 20, 1, 1, true));
+
+		final NutritionistProfile profile = new NutritionistProfile();
+		profile.setDisplayName("Lic. Ana López");
+		when(nutritionistProfileRepository.findByUserId(USER_ID)).thenReturn(Optional.of(profile));
+
+		final PatientMobilePreviewDto preview = service.buildPreview(10L, USER_ID);
+
+		assertThat(preview.firstName()).isEqualTo("María");
+		assertThat(preview.nutritionistDisplayName()).isEqualTo("Lic. Ana López");
+		assertThat(preview.progress()).isEqualTo(progress);
+		assertThat(preview.activePlan()).isEqualTo(summary);
+		assertThat(preview.activePlanDetail()).isEqualTo(detail);
+		assertThat(preview.nextVisit()).isEqualTo(visit);
+		assertThat(preview.activePlanDetail().ingestas()).hasSize(1);
+	}
+
+	@Test
+	void buildPreview_withoutDietOrVisit_returnsNullSections() {
+		final Paciente paciente = paciente(11L, "Juan Perez", null);
+		when(pacienteService.findByIdAndUserId(11L, USER_ID)).thenReturn(paciente);
+		when(mobilePatientProgressService.getSnapshot(11L)).thenReturn(new PatientProgressSnapshotDto(null, null, null,
+				null, null, null, null, null, null, null, null, null, null, null));
+		when(mobilePatientDietPlanService.listDietPlans(eq(11L), eq(0), eq(1), eq(true)))
+			.thenReturn(new PagedResponse<>(List.of(), 0, 1, 0, 0, true));
+		when(mobilePatientVisitService.listVisits(eq(11L), eq(0), eq(20), eq(EventStatus.SCHEDULED), any(Instant.class),
+				isNull()))
+			.thenReturn(new PagedResponse<>(List.of(), 0, 20, 0, 0, true));
+		when(nutritionistProfileRepository.findByUserId(USER_ID)).thenReturn(Optional.empty());
+
+		final PatientMobilePreviewDto preview = service.buildPreview(11L, USER_ID);
+
+		assertThat(preview.firstName()).isEqualTo("Juan");
+		assertThat(preview.activePlan()).isNull();
+		assertThat(preview.activePlanDetail()).isNull();
+		assertThat(preview.nextVisit()).isNull();
+		assertThat(preview.nutritionistDisplayName()).isNull();
+		verify(mobilePatientDietPlanService, never()).getDietPlanDetail(any(), any());
+	}
+
+	@Test
+	void buildPreview_throwsWhenPatientNotOwned() {
+		when(pacienteService.findByIdAndUserId(99L, USER_ID)).thenReturn(null);
+
+		assertThatThrownBy(() -> service.buildPreview(99L, USER_ID)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Paciente no encontrado");
+		verify(mobilePatientProgressService, never()).getSnapshot(any());
+		verify(mobilePatientDietPlanService, never()).listDietPlans(any(), anyInt(), anyInt(), anyBoolean());
+	}
+
+	@Test
+	void resolveFirstName_fallsBackToPaciente() {
+		final Paciente paciente = paciente(1L, null, null);
+		assertThat(PacienteMobilePreviewService.resolveFirstName(paciente)).isEqualTo("Paciente");
+	}
+
+	@Test
+	void pickSoonestUpcomingVisit_selectsEarliestFuture() {
+		final Instant now = Instant.parse("2026-08-11T12:00:00Z");
+		final VisitSummaryDto later = new VisitSummaryDto(2L, now.plus(5, ChronoUnit.DAYS), "Later",
+				EventStatus.SCHEDULED, 30, null);
+		final VisitSummaryDto sooner = new VisitSummaryDto(1L, now.plus(1, ChronoUnit.DAYS), "Sooner",
+				EventStatus.SCHEDULED, 30, null);
+		final VisitSummaryDto past = new VisitSummaryDto(3L, now.minus(1, ChronoUnit.DAYS), "Past",
+				EventStatus.SCHEDULED, 30, null);
+
+		assertThat(PacienteMobilePreviewService.pickSoonestUpcomingVisit(List.of(later, sooner, past), now))
+			.isEqualTo(sooner);
+	}
+
+	private static Paciente paciente(final Long id, final String name, final String displayName) {
+		final Paciente paciente = new Paciente();
+		paciente.setId(id);
+		paciente.setName(name);
+		paciente.setDisplayName(displayName);
+		paciente.setUserId(USER_ID);
+		return paciente;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds a **Ver en app** action on the patient grid that opens a phone-frame modal (Home + Planes) with real patient data.
- New session endpoint `GET /rest/pacientes/{id}/mobile-preview` reuses mobile progress/diet/visit services with nutritionist ownership checks.
- Invitation icon → envelope; preview icon → cellphone.

## Test plan
- [x] Unit tests for preview service/controller + grid action assertion
- [x] Thymeleaf validation (listado modal)
- [ ] Manual: open Pacientes → Ver en app on a patient with active diet; confirm Home/Planes and empty states
- [ ] After deploy: verify icons and modal on production


Made with [Cursor](https://cursor.com)