### PR TITLE
Show patient age on profile page

### DIFF
--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -288,6 +288,7 @@ public class PacienteController extends AbstractAuthorizedController {
 		addLatestCompositionMetricsToModel(id, model);
 		// Calculate age and check if patient is under 18 for growth table display
 		final Integer age = calculateAge(paciente.getDob());
+		model.addAttribute("patientAge", age);
 		final boolean isUnder18 = age != null && age < 18;
 		model.addAttribute("isUnder18", isUnder18);
 		// Fetch anthropometric measurements for growth table (only if under 18)

--- a/src/main/resources/templates/sbadmin/pacientes/perfil.html
+++ b/src/main/resources/templates/sbadmin/pacientes/perfil.html
@@ -75,6 +75,9 @@
                     </form>
                   </div>
                   <h5 class="my-3">[[(${paciente != null ? paciente.name : ''})]]</h5>
+                  <p class="text-muted mb-1" th:if="${patientAge != null}">
+                    <i class="fas fa-birthday-cake"></i> [[(${patientAge})]] años
+                  </p>
                   <p class="text-muted mb-1"><i class="fas fa-envelope"></i> [[(${paciente != null ? paciente.email : ''})]]</p>
                   <p class="text-muted mb-4"><i class="fas fa-phone"></i> [[(${paciente != null ? paciente.phone : ''})]]</p>
                   <div class="d-flex justify-content-center flex-wrap" th:if="${paciente != null}">
@@ -186,6 +189,16 @@
                     </div>
                     <div class="col-sm-9">
                       <p class="text-muted mb-0">[[(${paciente.name})]]</p>
+                    </div>
+                  </div>
+                  <hr>
+                  <div class="row">
+                    <div class="col-sm-3">
+                      <p class="mb-0">Edad</p>
+                    </div>
+                    <div class="col-sm-9">
+                      <p class="text-muted mb-0" th:if="${patientAge != null}">[[(${patientAge})]] años</p>
+                      <p class="text-muted mb-0" th:if="${patientAge == null}">N/A</p>
                     </div>
                   </div>
                   <hr>

--- a/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
@@ -545,6 +545,7 @@ public class PacienteControllerTest {
 		assertThat(result).isEqualTo("sbadmin/pacientes/perfil");
 		verify(model).addAttribute("activeMenu", "perfil");
 		verify(model).addAttribute("paciente", paciente);
+		verify(model).addAttribute("patientAge", 30);
 		// Dietas were moved to separate page, so they should not be in perfil anymore
 		verify(model, org.mockito.Mockito.never()).addAttribute(eq("dietasAsignadas"), any());
 		verify(model, org.mockito.Mockito.never()).addAttribute(eq("dietasActivas"), any());
@@ -600,6 +601,7 @@ public class PacienteControllerTest {
 
 		// Assert
 		assertThat(result).isEqualTo("sbadmin/pacientes/perfil");
+		verify(model).addAttribute("patientAge", 10);
 		verify(model).addAttribute("isUnder18", true);
 		verify(model).addAttribute(eq("growthMeasurements"), any(List.class));
 		log.info("finished testPerfilPacienteUnder18WithMeasurements");
@@ -629,6 +631,7 @@ public class PacienteControllerTest {
 
 		// Assert
 		assertThat(result).isEqualTo("sbadmin/pacientes/perfil");
+		verify(model).addAttribute("patientAge", 5);
 		verify(model).addAttribute("isUnder18", true);
 		verify(model).addAttribute(eq("growthMeasurements"), any(List.class));
 		log.info("finished testPerfilPacienteUnder18WithoutMeasurements");
@@ -649,6 +652,7 @@ public class PacienteControllerTest {
 
 		// Assert
 		assertThat(result).isEqualTo("sbadmin/pacientes/perfil");
+		verify(model).addAttribute("patientAge", 30);
 		verify(model).addAttribute("isUnder18", false);
 		verify(anthropometricMeasurementService).findByPacienteId(1L);
 		verify(model, org.mockito.Mockito.never()).addAttribute(eq("growthMeasurements"), any(List.class));
@@ -680,6 +684,7 @@ public class PacienteControllerTest {
 		// Assert
 		assertThat(result).isEqualTo("sbadmin/pacientes/perfil");
 		// Patient exactly 18 should not show growth table (age < 18, not <= 18)
+		verify(model).addAttribute("patientAge", 18);
 		verify(model).addAttribute("isUnder18", false);
 		verify(anthropometricMeasurementService).findByPacienteId(4L);
 		verify(model, org.mockito.Mockito.never()).addAttribute(eq("growthMeasurements"), any(List.class));


### PR DESCRIPTION
## Summary
- Expose calculated `patientAge` on the patient perfil model.
- Display age under the name and as an Edad row in profile details.

## Test plan
- [x] PacienteControllerTest asserts `patientAge` for adult/under-18/exactly-18 cases
- [ ] Manual: open a patient perfil and confirm age appears beside contact info


Made with [Cursor](https://cursor.com)