### PR TITLE
Fix Mina catalog search and gpt-5-mini OpenAI params

### DIFF
--- a/src/main/java/com/nutriconsultas/ai/AiRequestScopeClassifierImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiRequestScopeClassifierImpl.java
@@ -77,7 +77,7 @@ public class AiRequestScopeClassifierImpl implements AiRequestScopeClassifier {
 		}
 		catch (final RuntimeException ex) {
 			if (log.isWarnEnabled()) {
-				log.warn("AI scope classifier failed, allowing request");
+				log.warn("AI scope classifier failed, allowing request: {}", ex.getMessage());
 			}
 			return Optional.empty();
 		}

--- a/src/main/java/com/nutriconsultas/ai/OpenAiClientErrorMapper.java
+++ b/src/main/java/com/nutriconsultas/ai/OpenAiClientErrorMapper.java
@@ -16,29 +16,30 @@ final class OpenAiClientErrorMapper {
 	static OpenAiClientException mapResponseException(final RestClientResponseException ex) {
 		final int status = ex.getStatusCode().value();
 		final String providerMessage = extractProviderMessage(ex.getResponseBodyAsString());
+		final String providerHint = StringUtils.hasText(providerMessage) ? " providerMessage=" + providerMessage : "";
 		if (status == HttpStatus.UNAUTHORIZED.value() || status == HttpStatus.FORBIDDEN.value()) {
 			return new OpenAiClientException(OpenAiClientException.ErrorKind.AUTH, HttpStatus.BAD_GATEWAY,
-					AiErrorMessages.OPENAI_AUTH, "OpenAI auth failure status=" + status, ex);
+					AiErrorMessages.OPENAI_AUTH, "OpenAI auth failure status=" + status + providerHint, ex);
 		}
 		if (status == HttpStatus.TOO_MANY_REQUESTS.value()) {
 			return new OpenAiClientException(OpenAiClientException.ErrorKind.RATE_LIMIT, HttpStatus.TOO_MANY_REQUESTS,
-					AiErrorMessages.OPENAI_RATE_LIMIT, "OpenAI rate limit status=429", ex);
+					AiErrorMessages.OPENAI_RATE_LIMIT, "OpenAI rate limit status=429" + providerHint, ex);
 		}
 		if (status == HttpStatus.NOT_FOUND.value() && isModelError(providerMessage)) {
 			return new OpenAiClientException(OpenAiClientException.ErrorKind.MODEL_NOT_FOUND, HttpStatus.BAD_GATEWAY,
-					AiErrorMessages.OPENAI_MODEL_NOT_FOUND, "OpenAI model not found status=404", ex);
+					AiErrorMessages.OPENAI_MODEL_NOT_FOUND, "OpenAI model not found status=404" + providerHint, ex);
 		}
 		if (status == HttpStatus.BAD_REQUEST.value()) {
 			return new OpenAiClientException(OpenAiClientException.ErrorKind.INVALID_REQUEST, HttpStatus.BAD_GATEWAY,
-					AiErrorMessages.OPENAI_INVALID_REQUEST, "OpenAI invalid request status=400", ex);
+					AiErrorMessages.OPENAI_INVALID_REQUEST, "OpenAI invalid request status=400" + providerHint, ex);
 		}
 		if (status == HttpStatus.BAD_GATEWAY.value() || status == HttpStatus.SERVICE_UNAVAILABLE.value()
 				|| status == HttpStatus.GATEWAY_TIMEOUT.value()) {
 			return new OpenAiClientException(OpenAiClientException.ErrorKind.UNAVAILABLE, HttpStatus.BAD_GATEWAY,
-					AiErrorMessages.OPENAI_UNAVAILABLE, "OpenAI unavailable status=" + status, ex);
+					AiErrorMessages.OPENAI_UNAVAILABLE, "OpenAI unavailable status=" + status + providerHint, ex);
 		}
 		return new OpenAiClientException(OpenAiClientException.ErrorKind.UNKNOWN, HttpStatus.BAD_GATEWAY,
-				AiErrorMessages.OPENAI_UNKNOWN, "OpenAI error status=" + status, ex);
+				AiErrorMessages.OPENAI_UNKNOWN, "OpenAI error status=" + status + providerHint, ex);
 	}
 
 	static OpenAiClientException timeout(final Exception ex) {

--- a/src/main/java/com/nutriconsultas/ai/OpenAiClientServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/OpenAiClientServiceImpl.java
@@ -93,9 +93,12 @@ public class OpenAiClientServiceImpl implements OpenAiClientService {
 			function.put("parameters", tool.parameters());
 			tools.add(new OpenAiApiTool("function", function));
 		}
-		return new OpenAiApiRequest(properties.getOpenai().getModel(), messages, tools.isEmpty() ? null : tools,
-				properties.getOpenai().isStore(), request.parameters().temperature(), request.parameters().maxTokens(),
-				responseFormat(request.parameters().responseFormatType()));
+		final String model = properties.getOpenai().getModel();
+		final boolean reasoningStyle = OpenAiModelCapabilities.isReasoningStyleModel(model);
+		final Integer maxTokens = request.parameters().maxTokens();
+		return new OpenAiApiRequest(model, messages, tools.isEmpty() ? null : tools, properties.getOpenai().isStore(),
+				reasoningStyle ? null : request.parameters().temperature(), reasoningStyle ? null : maxTokens,
+				reasoningStyle ? maxTokens : null, responseFormat(request.parameters().responseFormatType()));
 	}
 
 	private static Map<String, String> responseFormat(final String type) {
@@ -139,6 +142,7 @@ public class OpenAiClientServiceImpl implements OpenAiClientService {
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private record OpenAiApiRequest(String model, List<OpenAiApiMessage> messages, List<OpenAiApiTool> tools,
 			boolean store, Double temperature, @JsonProperty("max_tokens") Integer maxTokens,
+			@JsonProperty("max_completion_tokens") Integer maxCompletionTokens,
 			@JsonProperty("response_format") Map<String, String> responseFormat) {
 	}
 

--- a/src/main/java/com/nutriconsultas/ai/OpenAiModelCapabilities.java
+++ b/src/main/java/com/nutriconsultas/ai/OpenAiModelCapabilities.java
@@ -1,0 +1,29 @@
+package com.nutriconsultas.ai;
+
+import java.util.Locale;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Detects OpenAI chat-completion parameter quirks for reasoning-style models (GPT-5 /
+ * o-series): {@code max_completion_tokens} instead of {@code max_tokens}, and no custom
+ * {@code temperature}.
+ */
+public final class OpenAiModelCapabilities {
+
+	private OpenAiModelCapabilities() {
+	}
+
+	/**
+	 * @return {@code true} when the model id requires reasoning-style request params.
+	 */
+	public static boolean isReasoningStyleModel(final String model) {
+		if (!StringUtils.hasText(model)) {
+			return false;
+		}
+		final String normalized = model.trim().toLowerCase(Locale.ROOT);
+		return normalized.startsWith("gpt-5") || normalized.startsWith("o1") || normalized.startsWith("o3")
+				|| normalized.startsWith("o4");
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/SearchDishCatalogToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/SearchDishCatalogToolServiceImpl.java
@@ -65,10 +65,18 @@ public class SearchDishCatalogToolServiceImpl implements SearchDishCatalogToolSe
 				nutritionistId.trim());
 		final String searchPattern = "%" + trimmedQuery + "%";
 		final String ingestasFilter = buildIngestasFilter(ingestasSugeridas);
-		final List<Platillo> platillos = platilloRepository
-			.findForAuthorizedCatalogSearch(authorizedUserIds, searchPattern, ingestasFilter,
-					PageRequest.of(0, effectiveLimit))
-			.getContent();
+		final PageRequest pageRequest = PageRequest.of(0, effectiveLimit);
+		final List<Platillo> platillos;
+		if (ingestasFilter == null) {
+			// Avoid JPQL null string params on PostgreSQL (lower(bytea) does not exist).
+			platillos = platilloRepository.findForAuthorizedCatalogSearch(authorizedUserIds, searchPattern, pageRequest)
+				.getContent();
+		}
+		else {
+			platillos = platilloRepository
+				.findForAuthorizedCatalogSearchByIngestas(authorizedUserIds, searchPattern, ingestasFilter, pageRequest)
+				.getContent();
+		}
 		final List<DishCatalogSearchItem> items = platillos.stream()
 			.map(platillo -> toItem(platillo, nutritionistId.trim()))
 			.toList();

--- a/src/main/java/com/nutriconsultas/ai/SearchFoodCatalogToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/SearchFoodCatalogToolServiceImpl.java
@@ -61,10 +61,19 @@ public class SearchFoodCatalogToolServiceImpl implements SearchFoodCatalogToolSe
 
 		final String searchPattern = "%" + trimmedQuery + "%";
 		final String clasificacionFilter = buildClasificacionFilter(clasificacion);
-		final long totalMatches = alimentosRepository.countForCatalogSearch(searchPattern, clasificacionFilter);
-		final List<Alimento> alimentos = alimentosRepository
-			.findForCatalogSearch(searchPattern, clasificacionFilter, PageRequest.of(0, effectiveLimit))
-			.getContent();
+		final PageRequest pageRequest = PageRequest.of(0, effectiveLimit);
+		final long totalMatches;
+		final List<Alimento> alimentos;
+		if (clasificacionFilter == null) {
+			// Avoid JPQL null string params on PostgreSQL (lower(bytea) does not exist).
+			totalMatches = alimentosRepository.countBySearchTerm(searchPattern);
+			alimentos = alimentosRepository.findBySearchTerm(searchPattern, pageRequest).getContent();
+		}
+		else {
+			totalMatches = alimentosRepository.countForCatalogSearch(searchPattern, clasificacionFilter);
+			alimentos = alimentosRepository.findForCatalogSearch(searchPattern, clasificacionFilter, pageRequest)
+				.getContent();
+		}
 		final List<FoodCatalogSearchItem> items = alimentos.stream().map(this::toItem).toList();
 		final boolean truncated = totalMatches > items.size();
 		final FoodCatalogSearchData data = new FoodCatalogSearchData(items, items.size(), truncated);

--- a/src/main/java/com/nutriconsultas/alimentos/AlimentosRepository.java
+++ b/src/main/java/com/nutriconsultas/alimentos/AlimentosRepository.java
@@ -25,15 +25,23 @@ public interface AlimentosRepository extends JpaRepository<Alimento, Long> {
 			+ "(LOWER(a.nombreAlimento) LIKE LOWER(:searchTerm) OR LOWER(a.clasificacion) LIKE LOWER(:searchTerm))")
 	long countBySearchTerm(@Param("searchTerm") String searchTerm);
 
+	/**
+	 * Catalog search with a required clasificación filter. Callers must not pass
+	 * {@code null} for {@code clasificacionFilter} — PostgreSQL + Hibernate bind null
+	 * string params as {@code bytea}, which breaks {@code LOWER(:param)}.
+	 */
 	@Query("SELECT a FROM Alimento a WHERE "
 			+ "(LOWER(a.nombreAlimento) LIKE LOWER(:searchTerm) OR LOWER(a.clasificacion) LIKE LOWER(:searchTerm)) "
-			+ "AND (:clasificacionFilter IS NULL OR LOWER(a.clasificacion) LIKE LOWER(:clasificacionFilter))")
+			+ "AND LOWER(a.clasificacion) LIKE LOWER(:clasificacionFilter)")
 	Page<Alimento> findForCatalogSearch(@Param("searchTerm") String searchTerm,
 			@Param("clasificacionFilter") String clasificacionFilter, Pageable pageable);
 
+	/**
+	 * @see #findForCatalogSearch(String, String, Pageable)
+	 */
 	@Query("SELECT COUNT(a) FROM Alimento a WHERE "
 			+ "(LOWER(a.nombreAlimento) LIKE LOWER(:searchTerm) OR LOWER(a.clasificacion) LIKE LOWER(:searchTerm)) "
-			+ "AND (:clasificacionFilter IS NULL OR LOWER(a.clasificacion) LIKE LOWER(:clasificacionFilter))")
+			+ "AND LOWER(a.clasificacion) LIKE LOWER(:clasificacionFilter)")
 	long countForCatalogSearch(@Param("searchTerm") String searchTerm,
 			@Param("clasificacionFilter") String clasificacionFilter);
 

--- a/src/main/java/com/nutriconsultas/platillos/PlatilloRepository.java
+++ b/src/main/java/com/nutriconsultas/platillos/PlatilloRepository.java
@@ -41,10 +41,19 @@ public interface PlatilloRepository extends JpaRepository<Platillo, Long> {
 	long countBySearchTerm(@Param("searchTerm") String searchTerm);
 
 	@Query("SELECT p FROM Platillo p WHERE p.userId IN :userIds AND " + "(LOWER(p.name) LIKE LOWER(:searchTerm) OR "
-			+ "(p.ingestasSugeridas IS NOT NULL AND LOWER(p.ingestasSugeridas) LIKE LOWER(:searchTerm))) "
-			+ "AND (:ingestasFilter IS NULL OR (p.ingestasSugeridas IS NOT NULL "
-			+ "AND LOWER(p.ingestasSugeridas) LIKE LOWER(:ingestasFilter)))")
+			+ "(p.ingestasSugeridas IS NOT NULL AND LOWER(p.ingestasSugeridas) LIKE LOWER(:searchTerm)))")
 	Page<Platillo> findForAuthorizedCatalogSearch(@Param("userIds") Collection<String> userIds,
+			@Param("searchTerm") String searchTerm, Pageable pageable);
+
+	/**
+	 * Authorized catalog search with a required ingestas filter. Do not pass {@code null}
+	 * for {@code ingestasFilter} (PostgreSQL binds null strings as {@code bytea} and
+	 * {@code LOWER(:param)} fails).
+	 */
+	@Query("SELECT p FROM Platillo p WHERE p.userId IN :userIds AND " + "(LOWER(p.name) LIKE LOWER(:searchTerm) OR "
+			+ "(p.ingestasSugeridas IS NOT NULL AND LOWER(p.ingestasSugeridas) LIKE LOWER(:searchTerm))) "
+			+ "AND p.ingestasSugeridas IS NOT NULL AND LOWER(p.ingestasSugeridas) LIKE LOWER(:ingestasFilter)")
+	Page<Platillo> findForAuthorizedCatalogSearchByIngestas(@Param("userIds") Collection<String> userIds,
 			@Param("searchTerm") String searchTerm, @Param("ingestasFilter") String ingestasFilter, Pageable pageable);
 
 }

--- a/src/test/java/com/nutriconsultas/ai/OpenAiClientServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/OpenAiClientServiceTest.java
@@ -213,7 +213,7 @@ class OpenAiClientServiceTest {
 	}
 
 	@Test
-	void chatCompletionSerializesOptionalParameters() {
+	void chatCompletionSerializesOptionalParametersForClassicModels() {
 		mockServer.expect(requestTo("https://api.openai.com/v1/chat/completions")).andExpect(content().json("""
 				{
 				  "model": "gpt-test",
@@ -226,6 +226,33 @@ class OpenAiClientServiceTest {
 				""", false)).andRespond(withSuccess("""
 				{
 				  "id": "chatcmpl-json",
+				  "choices": [{
+				    "message": {"role":"assistant","content":"{\\"decision\\":\\"ALLOW\\"}"},
+				    "finish_reason": "stop"
+				  }]
+				}
+				""", MediaType.APPLICATION_JSON));
+
+		service.chatCompletion(new OpenAiChatCompletionRequest(List.of(OpenAiChatMessage.user("Clasifica")), List.of(),
+				OpenAiCompletionParameters.scopeClassifier(200)));
+
+		mockServer.verify();
+	}
+
+	@Test
+	void chatCompletionUsesMaxCompletionTokensWithoutTemperatureForGpt5() {
+		properties.getOpenai().setModel("gpt-5-mini");
+		mockServer.expect(requestTo("https://api.openai.com/v1/chat/completions")).andExpect(content().json("""
+				{
+				  "model": "gpt-5-mini",
+				  "messages": [{"role":"user","content":"Clasifica"}],
+				  "store": false,
+				  "max_completion_tokens": 200,
+				  "response_format": {"type":"json_object"}
+				}
+				""", true)).andRespond(withSuccess("""
+				{
+				  "id": "chatcmpl-json-gpt5",
 				  "choices": [{
 				    "message": {"role":"assistant","content":"{\\"decision\\":\\"ALLOW\\"}"},
 				    "finish_reason": "stop"

--- a/src/test/java/com/nutriconsultas/ai/OpenAiModelCapabilitiesTest.java
+++ b/src/test/java/com/nutriconsultas/ai/OpenAiModelCapabilitiesTest.java
@@ -1,0 +1,37 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class OpenAiModelCapabilitiesTest {
+
+	@Test
+	void detectsGpt5FamilyAsReasoningStyle() {
+		assertThat(OpenAiModelCapabilities.isReasoningStyleModel("gpt-5-mini")).isTrue();
+		assertThat(OpenAiModelCapabilities.isReasoningStyleModel("GPT-5")).isTrue();
+		assertThat(OpenAiModelCapabilities.isReasoningStyleModel("gpt-5.2-chat")).isTrue();
+	}
+
+	@Test
+	void detectsOSeriesAsReasoningStyle() {
+		assertThat(OpenAiModelCapabilities.isReasoningStyleModel("o1")).isTrue();
+		assertThat(OpenAiModelCapabilities.isReasoningStyleModel("o3-mini")).isTrue();
+		assertThat(OpenAiModelCapabilities.isReasoningStyleModel("o4-mini")).isTrue();
+	}
+
+	@Test
+	void leavesClassicChatModelsAsNonReasoning() {
+		assertThat(OpenAiModelCapabilities.isReasoningStyleModel("gpt-4o")).isFalse();
+		assertThat(OpenAiModelCapabilities.isReasoningStyleModel("gpt-4.1-mini")).isFalse();
+		assertThat(OpenAiModelCapabilities.isReasoningStyleModel("gpt-test")).isFalse();
+	}
+
+	@Test
+	void blankModelIsNotReasoningStyle() {
+		assertThat(OpenAiModelCapabilities.isReasoningStyleModel(null)).isFalse();
+		assertThat(OpenAiModelCapabilities.isReasoningStyleModel("")).isFalse();
+		assertThat(OpenAiModelCapabilities.isReasoningStyleModel("   ")).isFalse();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/SearchDishCatalogToolServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/SearchDishCatalogToolServiceTest.java
@@ -38,7 +38,7 @@ class SearchDishCatalogToolServiceTest {
 	void searchReturnsMappedItemsWithDefaultLimit() {
 		final Platillo systemDish = samplePlatillo(1L, "Ensalada verde",
 				PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID, "Comida", 120, 4.0);
-		when(platilloRepository.findForAuthorizedCatalogSearch(any(), eq("%ensalada%"), eq(null), any(Pageable.class)))
+		when(platilloRepository.findForAuthorizedCatalogSearch(any(), eq("%ensalada%"), any(Pageable.class)))
 			.thenReturn(new PageImpl<>(List.of(systemDish)));
 
 		final AiToolResult<DishCatalogSearchData> result = service.search(NUTRITIONIST_A, "ensalada", null, null);
@@ -55,21 +55,20 @@ class SearchDishCatalogToolServiceTest {
 		assertThat(result.data().totalReturned()).isEqualTo(1);
 
 		final ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-		verify(platilloRepository).findForAuthorizedCatalogSearch(any(), eq("%ensalada%"), eq(null),
-				pageableCaptor.capture());
+		verify(platilloRepository).findForAuthorizedCatalogSearch(any(), eq("%ensalada%"), pageableCaptor.capture());
 		assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(SearchDishCatalogToolServiceImpl.DEFAULT_LIMIT);
 	}
 
 	@Test
 	void searchScopesToSystemCatalogAndAuthenticatedNutritionist() {
-		when(platilloRepository.findForAuthorizedCatalogSearch(any(), any(), any(), any(Pageable.class)))
+		when(platilloRepository.findForAuthorizedCatalogSearch(any(), any(), any(Pageable.class)))
 			.thenReturn(new PageImpl<>(List.of()));
 
 		service.search(NUTRITIONIST_A, "tacos", null, 5);
 
 		@SuppressWarnings("unchecked")
 		final ArgumentCaptor<List<String>> userIdsCaptor = ArgumentCaptor.forClass(List.class);
-		verify(platilloRepository).findForAuthorizedCatalogSearch(userIdsCaptor.capture(), eq("%tacos%"), eq(null),
+		verify(platilloRepository).findForAuthorizedCatalogSearch(userIdsCaptor.capture(), eq("%tacos%"),
 				any(Pageable.class));
 		assertThat(userIdsCaptor.getValue()).containsExactly(PlatilloCatalogConstants.SYSTEM_CATALOG_USER_ID,
 				NUTRITIONIST_A);
@@ -79,7 +78,7 @@ class SearchDishCatalogToolServiceTest {
 	@Test
 	void searchMarksOwnedNutritionistPlatillos() {
 		final Platillo ownedDish = samplePlatillo(2L, "Tacos de pollo", NUTRITIONIST_A, "Cena", 300, 18.0);
-		when(platilloRepository.findForAuthorizedCatalogSearch(any(), eq("%tacos%"), eq(null), any(Pageable.class)))
+		when(platilloRepository.findForAuthorizedCatalogSearch(any(), eq("%tacos%"), any(Pageable.class)))
 			.thenReturn(new PageImpl<>(List.of(ownedDish)));
 
 		final AiToolResult<DishCatalogSearchData> result = service.search(NUTRITIONIST_A, "tacos", null, null);
@@ -91,14 +90,14 @@ class SearchDishCatalogToolServiceTest {
 
 	@Test
 	void searchAppliesIngestasFilter() {
-		when(platilloRepository.findForAuthorizedCatalogSearch(any(), eq("%avena%"), eq("%desayuno%"),
+		when(platilloRepository.findForAuthorizedCatalogSearchByIngestas(any(), eq("%avena%"), eq("%desayuno%"),
 				any(Pageable.class)))
 			.thenReturn(new PageImpl<>(List.of()));
 
 		final AiToolResult<DishCatalogSearchData> result = service.search(NUTRITIONIST_A, "avena", "desayuno", 10);
 
 		assertThat(result.success()).isTrue();
-		verify(platilloRepository).findForAuthorizedCatalogSearch(any(), eq("%avena%"), eq("%desayuno%"),
+		verify(platilloRepository).findForAuthorizedCatalogSearchByIngestas(any(), eq("%avena%"), eq("%desayuno%"),
 				any(Pageable.class));
 	}
 
@@ -128,7 +127,7 @@ class SearchDishCatalogToolServiceTest {
 
 	@Test
 	void searchReturnsEmptyListWhenNoMatches() {
-		when(platilloRepository.findForAuthorizedCatalogSearch(any(), eq("%xyzq%"), eq(null), any(Pageable.class)))
+		when(platilloRepository.findForAuthorizedCatalogSearch(any(), eq("%xyzq%"), any(Pageable.class)))
 			.thenReturn(new PageImpl<>(List.of()));
 
 		final AiToolResult<DishCatalogSearchData> result = service.search(NUTRITIONIST_A, "xyzq", null, null);
@@ -138,13 +137,13 @@ class SearchDishCatalogToolServiceTest {
 		assertThat(result.data().totalReturned()).isZero();
 	}
 
-	private static Platillo samplePlatillo(final long id, final String name, final String userId,
-			final String ingestasSugeridas, final int energia, final double proteina) {
+	private static Platillo samplePlatillo(final long id, final String name, final String userId, final String ingestas,
+			final int energia, final double proteina) {
 		final Platillo platillo = new Platillo();
 		platillo.setId(id);
 		platillo.setName(name);
 		platillo.setUserId(userId);
-		platillo.setIngestasSugeridas(ingestasSugeridas);
+		platillo.setIngestasSugeridas(ingestas);
 		platillo.setEnergia(energia);
 		platillo.setProteina(proteina);
 		return platillo;

--- a/src/test/java/com/nutriconsultas/ai/SearchFoodCatalogToolServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/SearchFoodCatalogToolServiceTest.java
@@ -35,8 +35,8 @@ class SearchFoodCatalogToolServiceTest {
 	@Test
 	void searchReturnsMappedItemsWithDefaultLimit() {
 		final Alimento avena = sampleAlimento(1L, "Avena", "Cereales", "taza", 0.5, 150);
-		when(alimentosRepository.countForCatalogSearch("%avena%", null)).thenReturn(1L);
-		when(alimentosRepository.findForCatalogSearch(eq("%avena%"), eq(null), any(Pageable.class)))
+		when(alimentosRepository.countBySearchTerm("%avena%")).thenReturn(1L);
+		when(alimentosRepository.findBySearchTerm(eq("%avena%"), any(Pageable.class)))
 			.thenReturn(new PageImpl<>(List.of(avena)));
 
 		final AiToolResult<FoodCatalogSearchData> result = service.search(NUTRITIONIST_ID, "avena", null, null);
@@ -53,7 +53,7 @@ class SearchFoodCatalogToolServiceTest {
 		assertThat(result.data().truncated()).isFalse();
 
 		final ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-		verify(alimentosRepository).findForCatalogSearch(eq("%avena%"), eq(null), pageableCaptor.capture());
+		verify(alimentosRepository).findBySearchTerm(eq("%avena%"), pageableCaptor.capture());
 		assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(SearchFoodCatalogToolServiceImpl.DEFAULT_LIMIT);
 	}
 
@@ -72,8 +72,8 @@ class SearchFoodCatalogToolServiceTest {
 
 	@Test
 	void searchMarksTruncatedWhenMoreMatchesExist() {
-		when(alimentosRepository.countForCatalogSearch("%arroz%", null)).thenReturn(40L);
-		when(alimentosRepository.findForCatalogSearch(eq("%arroz%"), eq(null), any(Pageable.class)))
+		when(alimentosRepository.countBySearchTerm("%arroz%")).thenReturn(40L);
+		when(alimentosRepository.findBySearchTerm(eq("%arroz%"), any(Pageable.class)))
 			.thenReturn(new PageImpl<>(List.of(sampleAlimento(3L, "Arroz", "Cereales", "taza", 1.0, 200))));
 
 		final AiToolResult<FoodCatalogSearchData> result = service.search(NUTRITIONIST_ID, "arroz", null, 10);
@@ -119,9 +119,8 @@ class SearchFoodCatalogToolServiceTest {
 
 	@Test
 	void searchReturnsEmptyListWhenNoMatches() {
-		when(alimentosRepository.countForCatalogSearch("%xyzq%", null)).thenReturn(0L);
-		when(alimentosRepository.findForCatalogSearch(eq("%xyzq%"), eq(null), any(Pageable.class)))
-			.thenReturn(Page.empty());
+		when(alimentosRepository.countBySearchTerm("%xyzq%")).thenReturn(0L);
+		when(alimentosRepository.findBySearchTerm(eq("%xyzq%"), any(Pageable.class))).thenReturn(Page.empty());
 
 		final AiToolResult<FoodCatalogSearchData> result = service.search(NUTRITIONIST_ID, "xyzq", null, null);
 

--- a/src/test/java/com/nutriconsultas/alimentos/AlimentosRepositoryCatalogSearchTest.java
+++ b/src/test/java/com/nutriconsultas/alimentos/AlimentosRepositoryCatalogSearchTest.java
@@ -1,0 +1,54 @@
+package com.nutriconsultas.alimentos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+
+/**
+ * Ensures catalog search JPQL works without optional null string filters (PostgreSQL
+ * {@code lower(bytea)} regression for Mina food search).
+ */
+@DataJpaTest
+class AlimentosRepositoryCatalogSearchTest {
+
+	@Autowired
+	private AlimentosRepository alimentosRepository;
+
+	@Test
+	void searchWithoutClasificacionFilterUsesSearchTermQueries() {
+		alimentosRepository.save(buildMinimalAlimento("Avena cocida", "Cereales"));
+		alimentosRepository.save(buildMinimalAlimento("Leche descremada", "Lácteos"));
+		alimentosRepository.flush();
+
+		assertThat(alimentosRepository.countBySearchTerm("%avena%")).isEqualTo(1L);
+		assertThat(alimentosRepository.findBySearchTerm("%avena%", PageRequest.of(0, 10)).getContent())
+			.extracting(Alimento::getNombreAlimento)
+			.containsExactly("Avena cocida");
+	}
+
+	@Test
+	void searchWithClasificacionFilterRequiresNonNullPattern() {
+		alimentosRepository.save(buildMinimalAlimento("Avena cocida", "Cereales"));
+		alimentosRepository.save(buildMinimalAlimento("Avena con leche", "Lácteos"));
+		alimentosRepository.flush();
+
+		assertThat(alimentosRepository.countForCatalogSearch("%avena%", "%cereales%")).isEqualTo(1L);
+		assertThat(
+				alimentosRepository.findForCatalogSearch("%avena%", "%cereales%", PageRequest.of(0, 10)).getContent())
+			.extracting(Alimento::getNombreAlimento)
+			.containsExactly("Avena cocida");
+	}
+
+	private static Alimento buildMinimalAlimento(final String nombre, final String clasificacion) {
+		final Alimento alimento = new Alimento();
+		alimento.setNombreAlimento(nombre);
+		alimento.setClasificacion(clasificacion);
+		alimento.setUnidad("g");
+		alimento.setCantSugerida(1.0);
+		return alimento;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Avoid PostgreSQL `lower(bytea)` failures when Mina searches alimentos/platillos without optional filters (root cause of “Servicio no disponible” with patient context).
- Send `max_completion_tokens` and omit custom `temperature` for GPT-5 / o-series models so the scope classifier stops getting OpenAI 400s.
- Include OpenAI provider error text in diagnostics for faster production triage.

## Test plan
- [x] Unit/integration tests for catalog search branching and OpenAI serialization (`OpenAiClientServiceTest`, `AlimentosRepositoryCatalogSearchTest`, dish/food tool tests)
- [ ] After deploy: from admin, open Mina with patient Daniel and ask a prompt that triggers food catalog search; confirm a normal assistant reply instead of “Servicio no disponible”
- [ ] Confirm startup log still shows `AI assistant enabled (model=gpt-5-mini, ...)` and no repeated scope-classifier INVALID_REQUEST for the same request pattern


Made with [Cursor](https://cursor.com)