### PR TITLE
Fix Mina chat history LOB OID corruption on PostgreSQL

### DIFF
--- a/src/main/java/com/nutriconsultas/ai/AiAuditLogger.java
+++ b/src/main/java/com/nutriconsultas/ai/AiAuditLogger.java
@@ -132,13 +132,24 @@ public final class AiAuditLogger {
 	}
 
 	public void logOpenAiError(@Nullable final Long threadId, final String errorKind, final int httpStatus) {
+		logOpenAiError(threadId, errorKind, httpStatus, null);
+	}
+
+	public void logOpenAiError(@Nullable final Long threadId, final String errorKind, final int httpStatus,
+			@Nullable final String detail) {
 		usageMetrics.recordOpenAiError(errorKind);
 		if (OpenAiClientException.ErrorKind.RATE_LIMIT.name().equals(errorKind)) {
 			usageMetrics.recordOpenAiRateLimited();
 		}
 		if (log.isWarnEnabled()) {
-			log.warn("AI audit event=openai_error threadId={} errorKind={} httpStatus={}", threadId, errorKind,
-					httpStatus);
+			if (StringUtils.hasText(detail)) {
+				log.warn("AI audit event=openai_error threadId={} errorKind={} httpStatus={} detail={}", threadId,
+						errorKind, httpStatus, AiAuditRedaction.redactSecrets(detail));
+			}
+			else {
+				log.warn("AI audit event=openai_error threadId={} errorKind={} httpStatus={}", threadId, errorKind,
+						httpStatus);
+			}
 		}
 	}
 

--- a/src/main/java/com/nutriconsultas/ai/AiChatMessage.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatMessage.java
@@ -13,7 +13,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
@@ -45,8 +44,7 @@ public class AiChatMessage {
 	@Column(nullable = false, length = 20)
 	private AiChatMessageRole role;
 
-	@Lob
-	@Column(nullable = false)
+	@Column(nullable = false, columnDefinition = "TEXT")
 	private String content;
 
 	@Column(name = "tool_name", length = 120)

--- a/src/main/java/com/nutriconsultas/ai/AiGeneratedDraft.java
+++ b/src/main/java/com/nutriconsultas/ai/AiGeneratedDraft.java
@@ -13,7 +13,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
@@ -49,8 +48,7 @@ public class AiGeneratedDraft {
 	@Column(nullable = false, length = 20)
 	private AiDraftStatus status = AiDraftStatus.DRAFT;
 
-	@Lob
-	@Column(name = "json_payload", nullable = false)
+	@Column(name = "json_payload", nullable = false, columnDefinition = "TEXT")
 	private String jsonPayload;
 
 	@Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/nutriconsultas/ai/OpenAiClientServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/OpenAiClientServiceImpl.java
@@ -56,7 +56,8 @@ public class OpenAiClientServiceImpl implements OpenAiClientService {
 		}
 		catch (final RestClientResponseException ex) {
 			final OpenAiClientException mapped = OpenAiClientErrorMapper.mapResponseException(ex);
-			auditLogger.logOpenAiError(null, mapped.getKind().name(), mapped.getHttpStatus().value());
+			auditLogger.logOpenAiError(null, mapped.getKind().name(), mapped.getHttpStatus().value(),
+					mapped.getMessage());
 			throw mapped;
 		}
 		catch (final ResourceAccessException ex) {

--- a/src/main/resources/db/changelog/changes/036-ai-chat-materialize-lob-oids.yaml
+++ b/src/main/resources/db/changelog/changes/036-ai-chat-materialize-lob-oids.yaml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: 036-ai-chat-materialize-lob-oids
+      author: nutriconsultas
+      comment: >
+        Hibernate @Lob on PostgreSQL stored pg_largeobject OIDs in TEXT columns.
+        Materialize message/draft payloads with lo_get so Mina history is real text again.
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: postgresql
+        - tableExists:
+            tableName: ai_chat_message
+      changes:
+        - sql:
+            sql: >
+              UPDATE ai_chat_message
+              SET content = convert_from(lo_get(content::oid), 'UTF8')
+              WHERE content ~ '^[0-9]+$'
+                AND content::bigint IN (SELECT oid FROM pg_largeobject_metadata);
+        - sql:
+            sql: >
+              UPDATE ai_generated_draft
+              SET json_payload = convert_from(lo_get(json_payload::oid), 'UTF8')
+              WHERE json_payload ~ '^[0-9]+$'
+                AND json_payload::bigint IN (SELECT oid FROM pg_largeobject_metadata);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -104,3 +104,6 @@ databaseChangeLog:
   - include:
       file: changes/035-patient-device.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/036-ai-chat-materialize-lob-oids.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -95,3 +95,6 @@ databaseChangeLog:
   - include:
       file: changes/035-patient-device.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/036-ai-chat-materialize-lob-oids.yaml
+      relativeToChangelogFile: true

--- a/src/test/java/com/nutriconsultas/ai/AiChatPersistenceRepositoryTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatPersistenceRepositoryTest.java
@@ -61,10 +61,15 @@ class AiChatPersistenceRepositoryTest {
 		assertThat(loaded.getTitle()).isEqualTo("Menú semanal");
 		assertThat(loaded.getCreatedAt()).isNotNull();
 		assertThat(loaded.getUpdatedAt()).isNotNull();
-		assertThat(messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(thread.getId())).hasSize(1);
-		assertThat(
-				draftRepository.findByThreadIdAndStatusOrderByCreatedAtDescIdDesc(thread.getId(), AiDraftStatus.DRAFT))
-			.hasSize(1);
+		final List<AiChatMessage> messages = messageRepository.findByThreadIdOrderByCreatedAtAscIdAsc(thread.getId());
+		assertThat(messages).hasSize(1);
+		assertThat(messages.get(0).getContent()).isEqualTo("Genera un menú de 1800 kcal");
+		assertThat(messages.get(0).getContent()).doesNotMatch("^[0-9]+$");
+		final List<AiGeneratedDraft> drafts = draftRepository
+			.findByThreadIdAndStatusOrderByCreatedAtDescIdDesc(thread.getId(), AiDraftStatus.DRAFT);
+		assertThat(drafts).hasSize(1);
+		assertThat(drafts.get(0).getJsonPayload()).isEqualTo("{\"title\":\"Menú lunes\"}");
+		assertThat(drafts.get(0).getJsonPayload()).doesNotMatch("^[0-9]+$");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Root cause of “No se pudo procesar… reformular”: Hibernate `@Lob` on PostgreSQL stored `pg_largeobject` OIDs in `ai_chat_message.content`, so Mina sent numeric OIDs (e.g. `17460`) as conversation history and OpenAI returned `INVALID_REQUEST`.
- Persist message/draft JSON as plain `TEXT` (no `@Lob`).
- Liquibase `#036` materializes existing OIDs via `lo_get`.
- OpenAI error audits now include provider `detail` (redacted).

## Test plan
- [x] `AiChatPersistenceRepositoryTest` asserts content round-trips as real text (not digits-only)
- [ ] After deploy: confirm `ai_chat_message.content` no longer looks like `^[0-9]+$`
- [ ] New Mina thread with patient Daniel; ask for a menu/prompt and confirm a normal reply
- [ ] If a prior thread fails, start a fresh thread (history recovered where LOBs existed)


Made with [Cursor](https://cursor.com)