### PR TITLE
Persist Mina menu/plan drafts with nested schemas and preview links

### DIFF
--- a/src/main/java/com/nutriconsultas/ai/AiDraftCreationData.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftCreationData.java
@@ -3,5 +3,11 @@ package com.nutriconsultas.ai;
 /**
  * Common success payload for draft-creation tools.
  */
-public record AiDraftCreationData(long draftId, AiDraftType draftType, AiDraftStatus status, String summary) {
+public record AiDraftCreationData(long draftId, AiDraftType draftType, AiDraftStatus status, String summary,
+		String previewPath) {
+
+	public static String buildPreviewPath(final long threadId, final long draftId) {
+		return "/admin/ai?threadId=" + threadId + "&draftId=" + draftId;
+	}
+
 }

--- a/src/main/java/com/nutriconsultas/ai/AiDraftToolSchemaValidator.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftToolSchemaValidator.java
@@ -80,9 +80,18 @@ public final class AiDraftToolSchemaValidator {
 			return Optional.empty();
 		}
 		if (log.isWarnEnabled()) {
-			log.warn("AI draft tool schema validation failed violationCount={}", violations.size());
+			log.warn("AI draft tool schema validation failed violationCount={} samplePaths={}", violations.size(),
+					sampleViolationPaths(violations));
 		}
 		return Optional.of(toSpanishMessage(violations));
+	}
+
+	private static String sampleViolationPaths(final Set<ValidationMessage> violations) {
+		return violations.stream().limit(5).map(message -> {
+			final String path = formatPath(message.getInstanceLocation().toString());
+			final String location = path.isEmpty() ? "$" : path.trim();
+			return message.getType() + location;
+		}).reduce((left, right) -> left + "," + right).orElse("");
 	}
 
 	private static String toSpanishMessage(final Set<ValidationMessage> violations) {

--- a/src/main/java/com/nutriconsultas/ai/AiOpenAiToolCatalog.java
+++ b/src/main/java/com/nutriconsultas/ai/AiOpenAiToolCatalog.java
@@ -101,29 +101,39 @@ public final class AiOpenAiToolCatalog {
 		properties.put("warnings", stringArrayProperty());
 		return new OpenAiToolDefinition(CreateDishDraftToolService.TOOL_NAME,
 				secureDescription("Guarda un borrador de platillo/receta para revisión del nutriólogo. "
-						+ "No guarda en el catálogo final."),
+						+ "No guarda en el catálogo final. Tras éxito, responde solo con el previewPath."),
 				objectSchema(properties, List.of("name", "ingredients")));
 	}
 
 	private static OpenAiToolDefinition createMenuDraft() {
+		final Map<String, Object> properties = new LinkedHashMap<>();
+		properties.put("title", optionalStringProperty("Título del menú", 120));
+		properties.put("targetKcal", Map.of("type", "number"));
+		properties.put("ingestas", ingestaSlotArrayProperty(12));
+		properties.put("validationSummary", optionalStringProperty("Resumen de validación", 1000));
+		properties.put("assumptions", stringArrayProperty());
+		properties.put("warnings", stringArrayProperty());
 		return new OpenAiToolDefinition(CreateMenuDraftToolService.TOOL_NAME,
-				secureDescription("Guarda un borrador de menú de un día (varias ingestas). No asigna al paciente."),
-				objectSchema(Map.of("title", optionalStringProperty("Título del menú", 120), "targetKcal",
-						Map.of("type", "number"), "ingestas",
-						Map.of("type", "array", "minItems", 1, "maxItems", 12, "items", Map.of("type", "object")),
-						"validationSummary", optionalStringProperty("Resumen de validación", 1000), "assumptions",
-						stringArrayProperty(), "warnings", stringArrayProperty()), List.of("ingestas")));
+				secureDescription("Guarda un borrador de menú de un día (varias ingestas). No asigna al paciente. "
+						+ "Cada ingesta debe incluir items con type PLATILLO|ALIMENTO|RECIPE e IDs del catálogo. "
+						+ "Tras éxito, responde solo con el previewPath del borrador."),
+				objectSchema(properties, List.of("ingestas")));
 	}
 
 	private static OpenAiToolDefinition createDietPlanDraft() {
+		final Map<String, Object> properties = new LinkedHashMap<>();
+		properties.put("title", optionalStringProperty("Título del plan", 120));
+		properties.put("dayCount", Map.of("type", "integer", "minimum", 1, "maximum", 14));
+		properties.put("targetKcalPerDay", Map.of("type", "number"));
+		properties.put("days", dietPlanDayArrayProperty());
+		properties.put("validationSummary", optionalStringProperty("Resumen de validación", 2000));
+		properties.put("assumptions", stringArrayProperty());
+		properties.put("warnings", stringArrayProperty());
 		return new OpenAiToolDefinition(CreateDietPlanDraftToolService.TOOL_NAME,
-				secureDescription("Guarda un borrador de plan alimenticio multi-día. No asigna al paciente."),
-				objectSchema(Map.of("title", optionalStringProperty("Título del plan", 120), "dayCount",
-						Map.of("type", "integer", "minimum", 1, "maximum", 14), "targetKcalPerDay",
-						Map.of("type", "number"), "days",
-						Map.of("type", "array", "minItems", 1, "maxItems", 14, "items", Map.of("type", "object")),
-						"validationSummary", optionalStringProperty("Resumen de validación", 2000), "assumptions",
-						stringArrayProperty(), "warnings", stringArrayProperty()), List.of("days")));
+				secureDescription("Guarda un borrador de plan alimenticio multi-día. No asigna al paciente. "
+						+ "Cada día incluye ingestas con items tipados e IDs del catálogo. "
+						+ "Tras éxito, responde solo con el previewPath del borrador."),
+				objectSchema(properties, List.of("days")));
 	}
 
 	private static OpenAiToolDefinition getPatientAppointments() {
@@ -154,10 +164,52 @@ public final class AiOpenAiToolCatalog {
 	}
 
 	private static Map<String, Object> recipeIngredientArrayProperty() {
-		return Map.of("type", "array", "minItems", 1, "maxItems", 40, "items", Map.of("type", "object", "properties",
+		return Map.of("type", "array", "minItems", 1, "maxItems", 40, "items", recipeIngredientItemSchema());
+	}
+
+	private static Map<String, Object> recipeIngredientItemSchema() {
+		return Map.of("type", "object", "properties",
 				Map.of("alimentoId", Map.of("type", "integer"), "cantidad", Map.of("type", "string"), "pesoNetoG",
 						Map.of("type", "integer", "minimum", 1), "unidad", Map.of("type", "string", "maxLength", 40)),
-				"required", List.of("alimentoId", "cantidad"), "additionalProperties", false));
+				"required", List.of("alimentoId", "cantidad"), "additionalProperties", false);
+	}
+
+	private static Map<String, Object> ingestaSlotItemSchema() {
+		final Map<String, Object> properties = new LinkedHashMap<>();
+		properties.put("type", Map.of("type", "string", "enum", List.of("PLATILLO", "ALIMENTO", "RECIPE")));
+		properties.put("platilloId", Map.of("type", "integer"));
+		properties.put("alimentoId", Map.of("type", "integer"));
+		properties.put("portions", Map.of("type", "integer", "minimum", 1));
+		properties.put("ingredients",
+				Map.of("type", "array", "minItems", 1, "maxItems", 40, "items", recipeIngredientItemSchema()));
+		return Map.of("type", "object", "properties", properties, "required", List.of("type"), "additionalProperties",
+				false);
+	}
+
+	private static Map<String, Object> ingestaSlotSchema() {
+		final Map<String, Object> properties = new LinkedHashMap<>();
+		properties.put("nombre", Map.of("type", "string", "maxLength", 80));
+		properties.put("orden", Map.of("type", "integer"));
+		properties.put("items", Map.of("type", "array", "minItems", 1, "items", ingestaSlotItemSchema()));
+		return Map.of("type", "object", "properties", properties, "required", List.of("items"), "additionalProperties",
+				false);
+	}
+
+	private static Map<String, Object> ingestaSlotArrayProperty(final int maxItems) {
+		return Map.of("type", "array", "minItems", 1, "maxItems", maxItems, "items", ingestaSlotSchema());
+	}
+
+	private static Map<String, Object> dietPlanDaySchema() {
+		final Map<String, Object> properties = new LinkedHashMap<>();
+		properties.put("dayIndex", Map.of("type", "integer", "minimum", 1));
+		properties.put("label", Map.of("type", "string", "maxLength", 80));
+		properties.put("ingestas", ingestaSlotArrayProperty(12));
+		return Map.of("type", "object", "properties", properties, "required", List.of("dayIndex", "ingestas"),
+				"additionalProperties", false);
+	}
+
+	private static Map<String, Object> dietPlanDayArrayProperty() {
+		return Map.of("type", "array", "minItems", 1, "maxItems", 14, "items", dietPlanDaySchema());
 	}
 
 	private static Map<String, Object> stringArrayProperty() {

--- a/src/main/java/com/nutriconsultas/ai/CreateDietPlanDraftToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/CreateDietPlanDraftToolServiceImpl.java
@@ -82,7 +82,7 @@ public class CreateDietPlanDraftToolServiceImpl implements CreateDietPlanDraftTo
 					AiDraftType.DIET_PLAN, jsonPayload);
 			final String summary = DRAFT_LABEL + ": " + displayTitle;
 			final AiDraftCreationData data = new AiDraftCreationData(draft.getId(), AiDraftType.DIET_PLAN,
-					draft.getStatus(), summary);
+					draft.getStatus(), summary, AiDraftCreationData.buildPreviewPath(threadId, draft.getId()));
 			if (log.isInfoEnabled()) {
 				log.info("AI tool create_diet_plan_draft draftId={} threadId={} dayCount={}", draft.getId(), threadId,
 						input.days().size());

--- a/src/main/java/com/nutriconsultas/ai/CreateDishDraftToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/CreateDishDraftToolServiceImpl.java
@@ -77,7 +77,7 @@ public class CreateDishDraftToolServiceImpl implements CreateDishDraftToolServic
 					jsonPayload);
 			final String summary = DRAFT_LABEL + ": " + input.name().trim();
 			final AiDraftCreationData data = new AiDraftCreationData(draft.getId(), AiDraftType.DISH, draft.getStatus(),
-					summary);
+					summary, AiDraftCreationData.buildPreviewPath(threadId, draft.getId()));
 			if (log.isInfoEnabled()) {
 				log.info("AI tool create_dish_draft draftId={} threadId={}", draft.getId(), threadId);
 			}

--- a/src/main/java/com/nutriconsultas/ai/CreateMenuDraftToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/CreateMenuDraftToolServiceImpl.java
@@ -73,7 +73,7 @@ public class CreateMenuDraftToolServiceImpl implements CreateMenuDraftToolServic
 					jsonPayload);
 			final String summary = DRAFT_LABEL + ": " + displayTitle;
 			final AiDraftCreationData data = new AiDraftCreationData(draft.getId(), AiDraftType.MENU, draft.getStatus(),
-					summary);
+					summary, AiDraftCreationData.buildPreviewPath(threadId, draft.getId()));
 			if (log.isInfoEnabled()) {
 				log.info("AI tool create_menu_draft draftId={} threadId={}", draft.getId(), threadId);
 			}

--- a/src/main/resources/ai/system-prompt-base.txt
+++ b/src/main/resources/ai/system-prompt-base.txt
@@ -12,9 +12,13 @@ HERRAMIENTAS Y CATÁLOGO
 
 BORRADORES (OBLIGATORIO)
 - Solo crea borradores; nunca guardes ni asignes planes finales a pacientes.
+- Si el nutriólogo pide un menú, plan alimenticio o platillo, debes llamar create_menu_draft, create_diet_plan_draft o create_dish_draft en el mismo turno con IDs reales del catálogo.
+- Prefiere pocas búsquedas amplias al catálogo; no agotes el cupo de herramientas solo con search_* sin crear el borrador.
+- Tras un create_*_draft exitoso, responde breve en español SIN detallar el menú/plan/platillo. Usa exactamente esta forma (con el previewPath del resultado de la herramienta):
+  «Se ha agregado el siguiente Borrador IA: [abrir borrador]({previewPath})»
+- El detalle del borrador se revisa en el panel de borradores / preview de Minutriporcion, no en el chat.
 - Etiqueta cada propuesta como: «Borrador IA — revisión del nutriólogo requerida».
-- Incluye supuestos explícitos y advertencias cuando falten datos, haya contradicciones o nutrientes incompletos en la base de datos.
-- Devuelve borradores estructurados (ingredientes, ingestas, totales calóricos) listos para revisión.
+- Incluye supuestos explícitos y advertencias cuando falten datos, haya contradicciones o nutrientes incompletos en la base de datos (en el payload del tool, no como menú largo en el chat).
 
 PREGUNTAS CLARIFICADORAS
 - Pregunta antes de generar borradores extensos si faltan: objetivo calórico, número de ingestas, restricciones no conocidas o porciones.

--- a/src/main/resources/static/sbadmin/js/ai-chat.js
+++ b/src/main/resources/static/sbadmin/js/ai-chat.js
@@ -256,6 +256,7 @@
   function hideDraftPreview() {
     state.selectedDraftId = null;
     state.selectedPreview = null;
+    persistDraftId(null);
     var panel = $('#aiChatDraftPreview');
     if (panel) {
       panel.hidden = true;
@@ -334,7 +335,8 @@
     }
   }
 
-  function loadDrafts(threadId) {
+  function loadDrafts(threadId, options) {
+    var opts = options || {};
     if (!threadId) {
       state.drafts = [];
       renderDraftList();
@@ -347,6 +349,9 @@
           return d.draftId === state.selectedDraftId;
         })) {
           hideDraftPreview();
+        }
+        if (!state.selectedDraftId && opts.selectNewest && state.drafts.length > 0) {
+          state.selectedDraftId = state.drafts[0].draftId;
         }
         renderDraftList();
         if (state.selectedDraftId) {
@@ -364,6 +369,7 @@
       .then(function (preview) {
         state.selectedDraftId = draftId;
         state.selectedPreview = preview;
+        persistDraftId(draftId);
         renderDraftList();
         renderDraftPreview(preview);
       })
@@ -533,12 +539,27 @@
       }
     } else {
       sessionStorage.removeItem(STORAGE_KEY);
+      state.selectedDraftId = null;
       if (window.history && window.history.replaceState) {
         var cleanUrl = new URL(window.location.href);
         cleanUrl.searchParams.delete('threadId');
+        cleanUrl.searchParams.delete('draftId');
         window.history.replaceState({}, '', cleanUrl.pathname + cleanUrl.search);
       }
     }
+  }
+
+  function persistDraftId(draftId) {
+    if (!(window.history && window.history.replaceState)) {
+      return;
+    }
+    var url = new URL(window.location.href);
+    if (draftId) {
+      url.searchParams.set('draftId', String(draftId));
+    } else {
+      url.searchParams.delete('draftId');
+    }
+    window.history.replaceState({}, '', url.toString());
   }
 
   function updateThreadTitle(title) {
@@ -682,7 +703,7 @@
       }
       if (data && data.threadId) {
         persistThreadId(data.threadId);
-        loadDrafts(data.threadId);
+        loadDrafts(data.threadId, { selectNewest: true });
       }
       renderMessages(false);
     }
@@ -827,11 +848,26 @@
     if (config.initialThreadId) {
       return Number(config.initialThreadId);
     }
+    var params = new URLSearchParams(window.location.search);
+    var fromQuery = params.get('threadId');
+    if (fromQuery) {
+      return Number(fromQuery);
+    }
     var stored = sessionStorage.getItem(STORAGE_KEY);
     if (stored) {
       return Number(stored);
     }
     return null;
+  }
+
+  function resolveInitialDraftId() {
+    var params = new URLSearchParams(window.location.search);
+    var fromQuery = params.get('draftId');
+    if (!fromQuery) {
+      return null;
+    }
+    var draftId = Number(fromQuery);
+    return Number.isFinite(draftId) && draftId > 0 ? draftId : null;
   }
 
   function bindEvents() {
@@ -903,6 +939,10 @@
 
   function init() {
     bindEvents();
+    var initialDraftId = resolveInitialDraftId();
+    if (initialDraftId) {
+      state.selectedDraftId = initialDraftId;
+    }
     var threadId = resolveInitialThreadId();
     if (threadId) {
       loadThread(threadId);

--- a/src/test/java/com/nutriconsultas/ai/AiOpenAiToolCatalogTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiOpenAiToolCatalogTest.java
@@ -2,6 +2,7 @@ package com.nutriconsultas.ai;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,39 @@ class AiOpenAiToolCatalogTest {
 				null, Map.of(), null, null, null, null, null);
 		assertThat(catalog.definitionsForSession(patient).stream().map(OpenAiToolDefinition::name))
 			.contains(GetPatientAppointmentsToolService.TOOL_NAME);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void menuAndDietPlanDraftSchemasIncludeNestedIngestaItems() {
+		final OpenAiToolDefinition menu = catalog.definitions()
+			.stream()
+			.filter(definition -> CreateMenuDraftToolService.TOOL_NAME.equals(definition.name()))
+			.findFirst()
+			.orElseThrow();
+		final Map<String, Object> menuProps = (Map<String, Object>) menu.parameters().get("properties");
+		final Map<String, Object> ingestas = (Map<String, Object>) menuProps.get("ingestas");
+		final Map<String, Object> slot = (Map<String, Object>) ingestas.get("items");
+		final Map<String, Object> slotProps = (Map<String, Object>) slot.get("properties");
+		final Map<String, Object> items = (Map<String, Object>) slotProps.get("items");
+		final Map<String, Object> itemSchema = (Map<String, Object>) items.get("items");
+		final Map<String, Object> itemProps = (Map<String, Object>) itemSchema.get("properties");
+		assertThat(slot.get("required")).isEqualTo(List.of("items"));
+		assertThat(itemProps.get("type")).isInstanceOf(Map.class);
+		assertThat(((Map<String, Object>) itemProps.get("type")).get("enum"))
+			.isEqualTo(List.of("PLATILLO", "ALIMENTO", "RECIPE"));
+
+		final OpenAiToolDefinition plan = catalog.definitions()
+			.stream()
+			.filter(definition -> CreateDietPlanDraftToolService.TOOL_NAME.equals(definition.name()))
+			.findFirst()
+			.orElseThrow();
+		final Map<String, Object> planProps = (Map<String, Object>) plan.parameters().get("properties");
+		final Map<String, Object> days = (Map<String, Object>) planProps.get("days");
+		final Map<String, Object> day = (Map<String, Object>) days.get("items");
+		final Map<String, Object> dayProps = (Map<String, Object>) day.get("properties");
+		assertThat(day.get("required")).isEqualTo(List.of("dayIndex", "ingestas"));
+		assertThat(dayProps).containsKey("ingestas");
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcherTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcherTest.java
@@ -125,8 +125,8 @@ class AiOrchestrationToolDispatcherTest {
 				new AiDraftToolSchemaValidator());
 		when(createDishDraftToolService.createDraft(org.mockito.ArgumentMatchers.eq(NUTRITIONIST_ID),
 				org.mockito.ArgumentMatchers.eq(THREAD_ID), org.mockito.ArgumentMatchers.any()))
-			.thenReturn(AiToolResult
-				.success(new AiDraftCreationData(1L, AiDraftType.DISH, AiDraftStatus.DRAFT, "Borrador IA — Tacos")));
+			.thenReturn(AiToolResult.success(new AiDraftCreationData(1L, AiDraftType.DISH, AiDraftStatus.DRAFT,
+					"Borrador IA — Tacos", "/admin/ai?threadId=10&draftId=1")));
 
 		final String json = realSchemaDispatcher.dispatch(context(), CreateDishDraftToolService.TOOL_NAME, """
 				{

--- a/src/test/java/com/nutriconsultas/ai/AiSystemPromptServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiSystemPromptServiceTest.java
@@ -42,6 +42,11 @@ class AiSystemPromptServiceTest {
 		assertThat(prompt).contains("Puedo ayudarte con 1 borrador de ejemplo que revises y apruebes");
 		assertThat(prompt).contains("todos tus pacientes en un solo turno");
 		assertThat(prompt).contains("<mensaje_nutriologo>");
+		assertThat(prompt).contains("create_menu_draft");
+		assertThat(prompt).contains("create_diet_plan_draft");
+		assertThat(prompt).contains("create_dish_draft");
+		assertThat(prompt).contains("Se ha agregado el siguiente Borrador IA");
+		assertThat(prompt).contains("previewPath");
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/CreateDietPlanDraftToolServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/CreateDietPlanDraftToolServiceTest.java
@@ -54,6 +54,7 @@ class CreateDietPlanDraftToolServiceTest {
 		assertThat(result.data().draftType()).isEqualTo(AiDraftType.DIET_PLAN);
 		assertThat(result.data().status()).isEqualTo(AiDraftStatus.DRAFT);
 		assertThat(result.data().summary()).contains("Plan semanal");
+		assertThat(result.data().previewPath()).isEqualTo("/admin/ai?threadId=42&draftId=77");
 		verify(draftLifecycleService).createDraft(eq(THREAD_ID), eq(NUTRITIONIST_ID), eq(AiDraftType.DIET_PLAN), any());
 		verify(ingestaNutrientCalculator, times(2)).computeIngestas(eq(NUTRITIONIST_ID), any());
 	}

--- a/src/test/java/com/nutriconsultas/ai/CreateDishDraftToolServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/CreateDishDraftToolServiceTest.java
@@ -54,6 +54,7 @@ class CreateDishDraftToolServiceTest {
 		assertThat(result.data().draftType()).isEqualTo(AiDraftType.DISH);
 		assertThat(result.data().status()).isEqualTo(AiDraftStatus.DRAFT);
 		assertThat(result.data().summary()).contains("Tacos de pollo");
+		assertThat(result.data().previewPath()).isEqualTo("/admin/ai?threadId=42&draftId=99");
 		verify(draftLifecycleService).createDraft(eq(THREAD_ID), eq(NUTRITIONIST_ID), eq(AiDraftType.DISH), any());
 	}
 

--- a/src/test/java/com/nutriconsultas/ai/CreateMenuDraftToolServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/CreateMenuDraftToolServiceTest.java
@@ -54,6 +54,7 @@ class CreateMenuDraftToolServiceTest {
 		assertThat(result.data().draftType()).isEqualTo(AiDraftType.MENU);
 		assertThat(result.data().status()).isEqualTo(AiDraftStatus.DRAFT);
 		assertThat(result.data().summary()).contains("Menú balanceado");
+		assertThat(result.data().previewPath()).isEqualTo("/admin/ai?threadId=42&draftId=88");
 		verify(draftLifecycleService).createDraft(eq(THREAD_ID), eq(NUTRITIONIST_ID), eq(AiDraftType.MENU), any());
 	}
 


### PR DESCRIPTION
## Summary
- Completes OpenAI tool schemas for `create_menu_draft` / `create_diet_plan_draft` with nested `IngestaSlot.items` so drafts actually persist.
- Returns `previewPath` (`/admin/ai?threadId=&draftId=`) from draft tools; system prompt asks Mina to reply with that link only.
- Chat UI deep-links `?draftId=` and auto-selects the newest draft after a successful turn.

## Test plan
- [ ] `mvn -Dtest=AiOpenAiToolCatalogTest,AiSystemPromptServiceTest,CreateMenuDraftToolServiceTest,CreateDishDraftToolServiceTest,CreateDietPlanDraftToolServiceTest,AiOrchestrationToolDispatcherTest,AiDraftFlowIntegrationTest test`
- [ ] Ask Mina for a 1-day menu and confirm an `ai_generated_draft` row is created
- [ ] Confirm chat reply is the short “Se ha agregado el siguiente Borrador IA” link and the panel opens the draft


Made with [Cursor](https://cursor.com)