### PR TITLE
Assign Mina menu drafts to patient for 1 month

### DIFF
--- a/src/main/java/com/nutriconsultas/ai/AiDraftAcceptanceResult.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftAcceptanceResult.java
@@ -4,5 +4,7 @@ package com.nutriconsultas.ai;
  * Result of accepting an AI draft and materializing it into catalog data.
  */
 public record AiDraftAcceptanceResult(long draftId, AiDraftType draftType, AiDraftStatus status,
-		AiDraftCreatedEntityType createdEntityType, long createdEntityId, String summary) {
+		AiDraftCreatedEntityType createdEntityType, long createdEntityId, String createdEntityName,
+		String createdEntityPath, String summary, Long pacienteId, Long pacienteDietaAssignmentId,
+		String pacienteAssignmentPath) {
 }

--- a/src/main/java/com/nutriconsultas/ai/AiDraftAcceptanceServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftAcceptanceServiceImpl.java
@@ -128,8 +128,8 @@ public class AiDraftAcceptanceServiceImpl implements AiDraftAcceptanceService {
 			return new PatientAssignment(pacienteId, saved.getId(), patientAssignmentPath(pacienteId));
 		}
 		catch (IllegalArgumentException ex) {
-			throw new AiDraftLifecycleException(ex.getMessage() != null ? ex.getMessage()
-					: "No se pudo asignar la dieta al paciente.");
+			throw new AiDraftLifecycleException(
+					ex.getMessage() != null ? ex.getMessage() : "No se pudo asignar la dieta al paciente.", ex);
 		}
 	}
 

--- a/src/main/java/com/nutriconsultas/ai/AiDraftAcceptanceServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftAcceptanceServiceImpl.java
@@ -1,16 +1,25 @@
 package com.nutriconsultas.ai;
 
+import java.sql.Date;
+import java.time.LocalDate;
+
 import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.paciente.PacienteDieta;
+import com.nutriconsultas.paciente.PacienteDietaService;
+import com.nutriconsultas.paciente.PacienteDietaStatus;
 import com.nutriconsultas.platillos.Platillo;
 
 @Service
 public class AiDraftAcceptanceServiceImpl implements AiDraftAcceptanceService {
+
+	static final int PATIENT_ASSIGNMENT_MONTHS = 1;
 
 	private final AiGeneratedDraftRepository draftRepository;
 
@@ -22,15 +31,18 @@ public class AiDraftAcceptanceServiceImpl implements AiDraftAcceptanceService {
 
 	private final AiAuditLogger auditLogger;
 
+	private final PacienteDietaService pacienteDietaService;
+
 	public AiDraftAcceptanceServiceImpl(final AiGeneratedDraftRepository draftRepository,
 			final AiDraftMaterializationService materializationService,
 			final AiDraftLifecycleService draftLifecycleService, final AiEntitlementGuard aiEntitlementGuard,
-			final AiAuditLogger auditLogger) {
+			final AiAuditLogger auditLogger, final PacienteDietaService pacienteDietaService) {
 		this.draftRepository = draftRepository;
 		this.materializationService = materializationService;
 		this.draftLifecycleService = draftLifecycleService;
 		this.aiEntitlementGuard = aiEntitlementGuard;
 		this.auditLogger = auditLogger;
+		this.pacienteDietaService = pacienteDietaService;
 	}
 
 	@Override
@@ -43,12 +55,16 @@ public class AiDraftAcceptanceServiceImpl implements AiDraftAcceptanceService {
 		aiEntitlementGuard.assertCanUseAiAssistant(nutritionistId);
 		final AiGeneratedDraft draft = loadMutableDraft(draftId, nutritionistId);
 		final MaterializedEntity entity = materialize(draft, nutritionistId, principal);
-		final AiGeneratedDraft accepted = draftLifecycleService.acceptDraft(draftId, nutritionistId);
-		final String summary = buildSummary(draft.getDraftType(), entity);
+		final PatientAssignment assignment = assignToPatientIfNeeded(draft, entity, nutritionistId);
+		final AiGeneratedDraft accepted = draftLifecycleService.acceptDraft(draftId, nutritionistId,
+				entity.entityType(), entity.entityId(), entity.entityName());
+		final String createdEntityPath = AiDraftCreatedEntityLinks.path(entity.entityType(), entity.entityId());
+		final String summary = buildSummary(draft.getDraftType(), entity, assignment);
 		auditLogger.logDraftMaterialized(accepted.getId(), accepted.getThread().getId(), entity.entityType(),
 				entity.entityId());
 		return new AiDraftAcceptanceResult(accepted.getId(), accepted.getDraftType(), accepted.getStatus(),
-				entity.entityType(), entity.entityId(), summary);
+				entity.entityType(), entity.entityId(), entity.entityName(), createdEntityPath, summary,
+				assignment.pacienteId(), assignment.assignmentId(), assignment.assignmentPath());
 	}
 
 	private AiGeneratedDraft loadMutableDraft(final Long draftId, final String nutritionistId) {
@@ -73,32 +89,95 @@ public class AiDraftAcceptanceServiceImpl implements AiDraftAcceptanceService {
 			final OidcUser principal) {
 		final DishDraftPayload payload = AiDraftPayloadDeserializer.dish(draft.getJsonPayload());
 		final Platillo platillo = materializationService.materializeDish(payload, nutritionistId, principal);
-		return new MaterializedEntity(AiDraftCreatedEntityType.PLATILLO, platillo.getId());
+		return new MaterializedEntity(AiDraftCreatedEntityType.PLATILLO, platillo.getId(),
+				resolveName(platillo.getName(), "Platillo", platillo.getId()));
 	}
 
 	private MaterializedEntity materializeMenu(final AiGeneratedDraft draft, final String nutritionistId,
 			final OidcUser principal) {
 		final MenuDraftPayload payload = AiDraftPayloadDeserializer.menu(draft.getJsonPayload());
 		final Dieta dieta = materializationService.materializeMenu(payload, nutritionistId, principal);
-		return new MaterializedEntity(AiDraftCreatedEntityType.DIETA, dieta.getId());
+		return new MaterializedEntity(AiDraftCreatedEntityType.DIETA, dieta.getId(),
+				resolveName(dieta.getNombre(), "Dieta", dieta.getId()));
 	}
 
 	private MaterializedEntity materializeDietPlan(final AiGeneratedDraft draft, final String nutritionistId,
 			final OidcUser principal) {
 		final DietPlanDraftPayload payload = AiDraftPayloadDeserializer.dietPlan(draft.getJsonPayload());
 		final Dieta dieta = materializationService.materializeDietPlan(payload, nutritionistId, principal);
-		return new MaterializedEntity(AiDraftCreatedEntityType.DIETA, dieta.getId());
+		return new MaterializedEntity(AiDraftCreatedEntityType.DIETA, dieta.getId(),
+				resolveName(dieta.getNombre(), "Plan alimenticio", dieta.getId()));
 	}
 
-	private static String buildSummary(final AiDraftType draftType, final MaterializedEntity entity) {
-		return switch (draftType) {
-			case DISH -> "Platillo creado en catálogo (id=" + entity.entityId() + ").";
-			case MENU -> "Menú guardado como dieta en catálogo (id=" + entity.entityId() + ").";
-			case DIET_PLAN -> "Plan alimenticio guardado en catálogo (id=" + entity.entityId() + ").";
+	private PatientAssignment assignToPatientIfNeeded(final AiGeneratedDraft draft, final MaterializedEntity entity,
+			final String nutritionistId) {
+		final Long pacienteId = resolvePacienteId(draft);
+		if (pacienteId == null || entity.entityType() != AiDraftCreatedEntityType.DIETA) {
+			return PatientAssignment.none();
+		}
+		final PacienteDieta shell = new PacienteDieta();
+		final LocalDate start = LocalDate.now();
+		shell.setStartDate(Date.valueOf(start));
+		shell.setEndDate(Date.valueOf(start.plusMonths(PATIENT_ASSIGNMENT_MONTHS)));
+		shell.setStatus(PacienteDietaStatus.ACTIVE);
+		shell.setNotes("Asignación automática al aceptar borrador IA (vigencia "
+				+ PATIENT_ASSIGNMENT_MONTHS + " mes).");
+		try {
+			final PacienteDieta saved = pacienteDietaService.assignDieta(pacienteId, entity.entityId(), shell,
+					nutritionistId);
+			return new PatientAssignment(pacienteId, saved.getId(), patientAssignmentPath(pacienteId));
+		}
+		catch (IllegalArgumentException ex) {
+			throw new AiDraftLifecycleException(ex.getMessage() != null ? ex.getMessage()
+					: "No se pudo asignar la dieta al paciente.");
+		}
+	}
+
+	@Nullable
+	private static Long resolvePacienteId(final AiGeneratedDraft draft) {
+		if (draft.getPacienteId() != null) {
+			return draft.getPacienteId();
+		}
+		if (draft.getThread() != null && draft.getThread().getPatient() != null) {
+			return draft.getThread().getPatient().getId();
+		}
+		return null;
+	}
+
+	private static String patientAssignmentPath(final long pacienteId) {
+		return "/admin/pacientes/" + pacienteId + "/dietas";
+	}
+
+	private static String resolveName(final String name, final String fallbackLabel, final long entityId) {
+		if (StringUtils.hasText(name)) {
+			return name.trim();
+		}
+		return fallbackLabel + " #" + entityId;
+	}
+
+	private static String buildSummary(final AiDraftType draftType, final MaterializedEntity entity,
+			final PatientAssignment assignment) {
+		final String catalogSummary = switch (draftType) {
+			case DISH -> "Se creó el platillo «" + entity.entityName() + "» en tu catálogo.";
+			case MENU -> "Se creó la dieta «" + entity.entityName() + "» en tu catálogo.";
+			case DIET_PLAN -> "Se creó el plan «" + entity.entityName() + "» en tu catálogo.";
 		};
+		if (assignment.pacienteId() == null) {
+			return catalogSummary;
+		}
+		return catalogSummary + " Se asignó al paciente por " + PATIENT_ASSIGNMENT_MONTHS + " mes.";
 	}
 
-	private record MaterializedEntity(AiDraftCreatedEntityType entityType, long entityId) {
+	private record MaterializedEntity(AiDraftCreatedEntityType entityType, long entityId, String entityName) {
+	}
+
+	private record PatientAssignment(@Nullable Long pacienteId, @Nullable Long assignmentId,
+			@Nullable String assignmentPath) {
+
+		private static PatientAssignment none() {
+			return new PatientAssignment(null, null, null);
+		}
+
 	}
 
 }

--- a/src/main/java/com/nutriconsultas/ai/AiDraftCreatedEntityLinks.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftCreatedEntityLinks.java
@@ -1,0 +1,18 @@
+package com.nutriconsultas.ai;
+
+/**
+ * Admin catalog paths for entities created from accepted AI drafts.
+ */
+public final class AiDraftCreatedEntityLinks {
+
+	private AiDraftCreatedEntityLinks() {
+	}
+
+	public static String path(final AiDraftCreatedEntityType entityType, final long entityId) {
+		return switch (entityType) {
+			case PLATILLO -> "/admin/platillos/" + entityId;
+			case DIETA -> "/admin/dietas/" + entityId;
+		};
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/ai/AiDraftCreationData.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftCreationData.java
@@ -4,7 +4,7 @@ package com.nutriconsultas.ai;
  * Common success payload for draft-creation tools.
  */
 public record AiDraftCreationData(long draftId, AiDraftType draftType, AiDraftStatus status, String summary,
-		String previewPath) {
+		String previewPath, Long pacienteId) {
 
 	public static String buildPreviewPath(final long threadId, final long draftId) {
 		return "/admin/ai?threadId=" + threadId + "&draftId=" + draftId;

--- a/src/main/java/com/nutriconsultas/ai/AiDraftLifecycleService.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftLifecycleService.java
@@ -7,7 +7,8 @@ public interface AiDraftLifecycleService {
 
 	AiGeneratedDraft createDraft(Long threadId, String nutritionistId, AiDraftType draftType, String jsonPayload);
 
-	AiGeneratedDraft acceptDraft(Long draftId, String nutritionistId);
+	AiGeneratedDraft acceptDraft(Long draftId, String nutritionistId, AiDraftCreatedEntityType createdEntityType,
+			long createdEntityId, String createdEntityName);
 
 	AiGeneratedDraft discardDraft(Long draftId, String nutritionistId);
 

--- a/src/main/java/com/nutriconsultas/ai/AiDraftLifecycleServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftLifecycleServiceImpl.java
@@ -40,6 +40,9 @@ public class AiDraftLifecycleServiceImpl implements AiDraftLifecycleService {
 		draft.setDraftType(draftType);
 		draft.setJsonPayload(jsonPayload.trim());
 		draft.setStatus(AiDraftStatus.DRAFT);
+		if (thread.getPatient() != null) {
+			draft.setPacienteId(thread.getPatient().getId());
+		}
 		final AiGeneratedDraft saved = draftRepository.save(draft);
 		auditLogger.logDraftCreated(saved.getId(), threadId, draftType);
 		return saved;
@@ -47,11 +50,16 @@ public class AiDraftLifecycleServiceImpl implements AiDraftLifecycleService {
 
 	@Override
 	@Transactional
-	public AiGeneratedDraft acceptDraft(@NonNull final Long draftId, @NonNull final String nutritionistId) {
+	public AiGeneratedDraft acceptDraft(@NonNull final Long draftId, @NonNull final String nutritionistId,
+			@NonNull final AiDraftCreatedEntityType createdEntityType, final long createdEntityId,
+			@NonNull final String createdEntityName) {
 		aiEntitlementGuard.assertCanUseAiAssistant(nutritionistId);
 		final AiGeneratedDraft draft = loadMutableDraft(draftId, nutritionistId);
 		draft.setStatus(AiDraftStatus.ACCEPTED);
 		draft.setAcceptedAt(Instant.now());
+		draft.setCreatedEntityType(createdEntityType);
+		draft.setCreatedEntityId(createdEntityId);
+		draft.setCreatedEntityName(createdEntityName.trim());
 		final AiGeneratedDraft saved = draftRepository.save(draft);
 		auditLogger.logDraftAccepted(saved.getId(), saved.getThread().getId(), saved.getStatus());
 		return saved;

--- a/src/main/java/com/nutriconsultas/ai/AiDraftPreviewServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftPreviewServiceImpl.java
@@ -49,7 +49,8 @@ public class AiDraftPreviewServiceImpl implements AiDraftPreviewService {
 				"Platillo (receta)", reviewLabel, payload.name(), summary, payload.portions(), null,
 				payload.nutrientsPerPortion(), toIngredientLines(payload.ingredients()), List.of(),
 				safeList(payload.preparationSteps()), safeList(payload.assumptions()), safeList(payload.warnings()),
-				null);
+				null, draft.getCreatedEntityType(), draft.getCreatedEntityId(), draft.getCreatedEntityName(),
+				createdEntityPath(draft), draft.getPacienteId(), assignsToPatientOnAccept(draft));
 	}
 
 	private AiDraftPreviewView fromMenu(final AiGeneratedDraft draft, final String summary) {
@@ -59,7 +60,9 @@ public class AiDraftPreviewServiceImpl implements AiDraftPreviewService {
 		return new AiDraftPreviewView(draft.getId(), draft.getThread().getId(), draft.getDraftType(), draft.getStatus(),
 				"Menú", reviewLabel, payload.title(), summary, null, null, payload.nutrientsTotal(), List.of(),
 				toMealSlots(payload.ingestas()), List.of(), safeList(payload.assumptions()),
-				safeList(payload.warnings()), payload.validationSummary());
+				safeList(payload.warnings()), payload.validationSummary(), draft.getCreatedEntityType(),
+				draft.getCreatedEntityId(), draft.getCreatedEntityName(), createdEntityPath(draft),
+				draft.getPacienteId(), assignsToPatientOnAccept(draft));
 	}
 
 	private AiDraftPreviewView fromDietPlan(final AiGeneratedDraft draft, final String summary) {
@@ -80,7 +83,21 @@ public class AiDraftPreviewServiceImpl implements AiDraftPreviewService {
 		return new AiDraftPreviewView(draft.getId(), draft.getThread().getId(), draft.getDraftType(), draft.getStatus(),
 				"Plan alimentario", reviewLabel, payload.title(), summary, null, payload.dayCount(),
 				payload.weeklyAverageNutrients(), List.of(), mealSlots, List.of(), safeList(payload.assumptions()),
-				safeList(payload.warnings()), payload.validationSummary());
+				safeList(payload.warnings()), payload.validationSummary(), draft.getCreatedEntityType(),
+				draft.getCreatedEntityId(), draft.getCreatedEntityName(), createdEntityPath(draft),
+				draft.getPacienteId(), assignsToPatientOnAccept(draft));
+	}
+
+	private static boolean assignsToPatientOnAccept(final AiGeneratedDraft draft) {
+		return draft.getPacienteId() != null
+				&& (draft.getDraftType() == AiDraftType.MENU || draft.getDraftType() == AiDraftType.DIET_PLAN);
+	}
+
+	private static String createdEntityPath(final AiGeneratedDraft draft) {
+		if (draft.getCreatedEntityType() == null || draft.getCreatedEntityId() == null) {
+			return null;
+		}
+		return AiDraftCreatedEntityLinks.path(draft.getCreatedEntityType(), draft.getCreatedEntityId());
 	}
 
 	private static List<Map<String, String>> toIngredientLines(final List<RecipeIngredientInput> ingredients) {

--- a/src/main/java/com/nutriconsultas/ai/AiDraftPreviewView.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftPreviewView.java
@@ -12,5 +12,8 @@ public record AiDraftPreviewView(long draftId, long threadId, AiDraftType draftT
 		String draftTypeLabel, String reviewLabel, @Nullable String title, String summary, @Nullable Integer portions,
 		@Nullable Integer dayCount, @Nullable NutrientSummary nutrients, List<Map<String, String>> ingredients,
 		List<Map<String, Object>> mealSlots, List<String> preparationSteps, List<String> assumptions,
-		List<String> warnings, @Nullable String validationSummary) {
+		List<String> warnings, @Nullable String validationSummary,
+		@Nullable AiDraftCreatedEntityType createdEntityType, @Nullable Long createdEntityId,
+		@Nullable String createdEntityName, @Nullable String createdEntityPath, @Nullable Long pacienteId,
+		boolean assignsToPatientOnAccept) {
 }

--- a/src/main/java/com/nutriconsultas/ai/AiDraftRestController.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftRestController.java
@@ -61,6 +61,14 @@ public class AiDraftRestController {
 			body.put("assumptions", preview.assumptions());
 			body.put("warnings", preview.warnings());
 			body.put("validationSummary", preview.validationSummary());
+			if (preview.createdEntityType() != null) {
+				body.put("createdEntityType", preview.createdEntityType().name());
+			}
+			body.put("createdEntityId", preview.createdEntityId());
+			body.put("createdEntityName", preview.createdEntityName());
+			body.put("createdEntityPath", preview.createdEntityPath());
+			body.put("pacienteId", preview.pacienteId());
+			body.put("assignsToPatientOnAccept", preview.assignsToPatientOnAccept());
 			return ResponseEntity.ok(body);
 		}
 		catch (AiDraftLifecycleException ex) {
@@ -84,7 +92,12 @@ public class AiDraftRestController {
 			body.put("status", result.status().name());
 			body.put("createdEntityType", result.createdEntityType().name());
 			body.put("createdEntityId", result.createdEntityId());
+			body.put("createdEntityName", result.createdEntityName());
+			body.put("createdEntityPath", result.createdEntityPath());
 			body.put("summary", result.summary());
+			body.put("pacienteId", result.pacienteId());
+			body.put("pacienteDietaAssignmentId", result.pacienteDietaAssignmentId());
+			body.put("pacienteAssignmentPath", result.pacienteAssignmentPath());
 			return ResponseEntity.ok(body);
 		}
 		catch (AiDraftLifecycleException ex) {

--- a/src/main/java/com/nutriconsultas/ai/AiGeneratedDraft.java
+++ b/src/main/java/com/nutriconsultas/ai/AiGeneratedDraft.java
@@ -57,6 +57,19 @@ public class AiGeneratedDraft {
 	@Column(name = "accepted_at")
 	private Instant acceptedAt;
 
+	@Enumerated(EnumType.STRING)
+	@Column(name = "created_entity_type", length = 20)
+	private AiDraftCreatedEntityType createdEntityType;
+
+	@Column(name = "created_entity_id")
+	private Long createdEntityId;
+
+	@Column(name = "created_entity_name", length = 255)
+	private String createdEntityName;
+
+	@Column(name = "paciente_id")
+	private Long pacienteId;
+
 	@PrePersist
 	void onCreate() {
 		if (createdAt == null) {

--- a/src/main/java/com/nutriconsultas/ai/AiPatientPromptContext.java
+++ b/src/main/java/com/nutriconsultas/ai/AiPatientPromptContext.java
@@ -3,13 +3,13 @@ package com.nutriconsultas.ai;
 import java.util.Map;
 
 /**
- * Redacted patient constraints merged into the AI system prompt (#367). Mirrors
- * {@code AiPatientContext} from {@code DATA-ACCESS-RULES.md} — no name, email, or phone.
+ * Patient constraints merged into the AI system prompt (#367). Includes display name for
+ * nutritionist confirmation only; do not log this record.
  */
 public record AiPatientPromptContext(Long patientId, Double requerimientoKcal, Double finalTotalKcal,
 		Boolean physiologicalStressActive, String gender, Boolean pregnancy, String nivelPeso, Double imc,
 		Map<String, Boolean> pathologyFlags, String alergias, String activityLevel, String nextAppointmentAtIso,
-		String nextAppointmentTitle, Integer nextAppointmentDurationMinutes) {
+		String nextAppointmentTitle, Integer nextAppointmentDurationMinutes, String displayName) {
 
 	public AiPatientPromptContext {
 		pathologyFlags = pathologyFlags == null ? Map.of() : Map.copyOf(pathologyFlags);

--- a/src/main/java/com/nutriconsultas/ai/AiPatientPromptContextResolverImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiPatientPromptContextResolverImpl.java
@@ -51,7 +51,19 @@ public class AiPatientPromptContextResolverImpl implements AiPatientPromptContex
 				paciente.getFinalTotalKcal(), paciente.getPhysiologicalStressActive(), paciente.getGender(),
 				paciente.getPregnancy(), nivelPesoLabel(paciente), paciente.getImc(), pathologyFlags(history),
 				sanitizeAlergias(history != null ? history.getAlergias() : null), activityLevel,
-				nextAppointment.atIso(), nextAppointment.title(), nextAppointment.durationMinutes());
+				nextAppointment.atIso(), nextAppointment.title(), nextAppointment.durationMinutes(),
+				sanitizeDisplayName(paciente.getDisplayName()));
+	}
+
+	private static String sanitizeDisplayName(final String displayName) {
+		if (!StringUtils.hasText(displayName)) {
+			return null;
+		}
+		final String trimmed = displayName.replaceAll("\\p{Cntrl}", " ").trim();
+		if (trimmed.isEmpty()) {
+			return null;
+		}
+		return trimmed.length() <= 120 ? trimmed : trimmed.substring(0, 120);
 	}
 
 	private NextAppointmentSummary resolveNextAppointment(final long patientId) {

--- a/src/main/java/com/nutriconsultas/ai/AiSystemPromptServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiSystemPromptServiceImpl.java
@@ -65,7 +65,7 @@ public class AiSystemPromptServiceImpl implements AiSystemPromptService {
 		if (patient == null) {
 			return "";
 		}
-		final StringBuilder section = new StringBuilder(512);
+		final StringBuilder section = new StringBuilder(1024);
 		section.append("CONTEXTO DEL PACIENTE VINCULADO A ESTA CONVERSACIÓN\n");
 		if (StringUtils.hasText(patient.displayName())) {
 			section.append("- Nombre en expediente: ").append(patient.displayName().trim()).append('\n');
@@ -74,9 +74,8 @@ public class AiSystemPromptServiceImpl implements AiSystemPromptService {
 			section.append("- patientId interno: ").append(patient.patientId()).append('\n');
 		}
 		section.append(
-				"- Al aceptar un borrador de menú o plan, el sistema asignará la dieta a este paciente por 1 mes.\n");
-		section.append(
-				"- Confirma al nutriólogo, de forma breve, que encontraste a este paciente antes de generar el borrador.\n");
+				"- Al aceptar un borrador de menú o plan, el sistema asignará la dieta a este paciente por 1 mes.\n"
+						+ "- Confirma al nutriólogo, de forma breve, que encontraste a este paciente antes de generar el borrador.\n");
 		if (patient.requerimientoKcal() != null) {
 			section.append("- Objetivo calórico (requerimientoKcal): ")
 				.append(formatNumber(patient.requerimientoKcal()))

--- a/src/main/java/com/nutriconsultas/ai/AiSystemPromptServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiSystemPromptServiceImpl.java
@@ -19,7 +19,7 @@ public class AiSystemPromptServiceImpl implements AiSystemPromptService {
 
 	static final String SAFETY_MARKER_DRAFT_LABEL = "Borrador IA — revisión del nutriólogo requerida";
 
-	static final String SAFETY_MARKER_NO_ASSIGN = "no asignes dietas al paciente";
+	static final String SAFETY_MARKER_NO_ASSIGN = "no asignes dietas por tu cuenta";
 
 	static final String SAFETY_MARKER_CATALOG_TOOLS = "herramientas del backend";
 
@@ -66,10 +66,17 @@ public class AiSystemPromptServiceImpl implements AiSystemPromptService {
 			return "";
 		}
 		final StringBuilder section = new StringBuilder(512);
-		section.append("CONTEXTO DEL PACIENTE (SIN DATOS IDENTIFICABLES)\n");
+		section.append("CONTEXTO DEL PACIENTE VINCULADO A ESTA CONVERSACIÓN\n");
+		if (StringUtils.hasText(patient.displayName())) {
+			section.append("- Nombre en expediente: ").append(patient.displayName().trim()).append('\n');
+		}
 		if (patient.patientId() != null) {
 			section.append("- patientId interno: ").append(patient.patientId()).append('\n');
 		}
+		section.append(
+				"- Al aceptar un borrador de menú o plan, el sistema asignará la dieta a este paciente por 1 mes.\n");
+		section.append(
+				"- Confirma al nutriólogo, de forma breve, que encontraste a este paciente antes de generar el borrador.\n");
 		if (patient.requerimientoKcal() != null) {
 			section.append("- Objetivo calórico (requerimientoKcal): ")
 				.append(formatNumber(patient.requerimientoKcal()))

--- a/src/main/java/com/nutriconsultas/ai/CreateDietPlanDraftToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/CreateDietPlanDraftToolServiceImpl.java
@@ -82,7 +82,8 @@ public class CreateDietPlanDraftToolServiceImpl implements CreateDietPlanDraftTo
 					AiDraftType.DIET_PLAN, jsonPayload);
 			final String summary = DRAFT_LABEL + ": " + displayTitle;
 			final AiDraftCreationData data = new AiDraftCreationData(draft.getId(), AiDraftType.DIET_PLAN,
-					draft.getStatus(), summary, AiDraftCreationData.buildPreviewPath(threadId, draft.getId()));
+					draft.getStatus(), summary, AiDraftCreationData.buildPreviewPath(threadId, draft.getId()),
+					draft.getPacienteId());
 			if (log.isInfoEnabled()) {
 				log.info("AI tool create_diet_plan_draft draftId={} threadId={} dayCount={}", draft.getId(), threadId,
 						input.days().size());

--- a/src/main/java/com/nutriconsultas/ai/CreateDishDraftToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/CreateDishDraftToolServiceImpl.java
@@ -77,7 +77,7 @@ public class CreateDishDraftToolServiceImpl implements CreateDishDraftToolServic
 					jsonPayload);
 			final String summary = DRAFT_LABEL + ": " + input.name().trim();
 			final AiDraftCreationData data = new AiDraftCreationData(draft.getId(), AiDraftType.DISH, draft.getStatus(),
-					summary, AiDraftCreationData.buildPreviewPath(threadId, draft.getId()));
+					summary, AiDraftCreationData.buildPreviewPath(threadId, draft.getId()), draft.getPacienteId());
 			if (log.isInfoEnabled()) {
 				log.info("AI tool create_dish_draft draftId={} threadId={}", draft.getId(), threadId);
 			}

--- a/src/main/java/com/nutriconsultas/ai/CreateMenuDraftToolServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/CreateMenuDraftToolServiceImpl.java
@@ -73,7 +73,7 @@ public class CreateMenuDraftToolServiceImpl implements CreateMenuDraftToolServic
 					jsonPayload);
 			final String summary = DRAFT_LABEL + ": " + displayTitle;
 			final AiDraftCreationData data = new AiDraftCreationData(draft.getId(), AiDraftType.MENU, draft.getStatus(),
-					summary, AiDraftCreationData.buildPreviewPath(threadId, draft.getId()));
+					summary, AiDraftCreationData.buildPreviewPath(threadId, draft.getId()), draft.getPacienteId());
 			if (log.isInfoEnabled()) {
 				log.info("AI tool create_menu_draft draftId={} threadId={}", draft.getId(), threadId);
 			}

--- a/src/main/resources/ai/system-prompt-base.txt
+++ b/src/main/resources/ai/system-prompt-base.txt
@@ -18,7 +18,7 @@ HERRAMIENTAS Y CATÁLOGO
 - Si falta un alimento, indícalo y sugiere agregarlo manualmente al catálogo o elegir un sustituto del catálogo.
 
 BORRADORES (OBLIGATORIO)
-- Solo crea borradores; nunca guardes ni asignes planes finales a pacientes.
+- Solo crea borradores; no guardes en catálogo ni asignes planes por tu cuenta (eso ocurre cuando el nutriólogo acepta el borrador).
 - Si el nutriólogo pide un menú, plan alimenticio o platillo, debes llamar create_menu_draft, create_diet_plan_draft o create_dish_draft en el mismo turno con IDs reales del catálogo.
 - Prefiere pocas búsquedas amplias al catálogo; no agotes el cupo de herramientas solo con search_* sin crear el borrador.
 - Tras un create_*_draft exitoso, responde en UNA sola línea (sin detallar el menú/plan/platillo). Usa exactamente esta forma Markdown con el previewPath del resultado de la herramienta:
@@ -27,6 +27,11 @@ BORRADORES (OBLIGATORIO)
 - El detalle del borrador se revisa en el panel de borradores / preview de Minutriporcion, no en el chat.
 - Etiqueta cada propuesta como: «Borrador IA — revisión del nutriólogo requerida».
 - Incluye supuestos explícitos y advertencias cuando falten datos, haya contradicciones o nutrientes incompletos en la base de datos (en el payload del tool, no como menú largo en el chat).
+
+PACIENTE VINCULADO VS PLAN GENERAL
+- Si hay CONTEXTO DEL PACIENTE en esta conversación: confirma brevemente que encontraste a ese paciente (usa el nombre en expediente si está) y que, al aceptar el borrador de menú/plan, se asignará a su plan alimentario por 1 mes. Luego genera el borrador.
+- Si NO hay contexto de paciente: genera borradores de catálogo generales; no digas que se asignarán a un paciente.
+- Los platillos (create_dish_draft) solo van al catálogo; no se asignan al paciente al aceptar.
 
 PREGUNTAS CLARIFICADORAS
 - Pregunta solo lo imprescindible antes de generar borradores extensos (días, restricción extra no conocida).
@@ -47,7 +52,7 @@ SEGURIDAD CLÍNICA
 - No diagnostiques enfermedades ni prescribas medicamentos o tratamiento médico.
 - No afirmes que un plan es clínicamente apropiado, seguro o definitivo; siempre requiere revisión profesional del nutriólogo.
 - Ante emergencias médicas, indica buscar atención profesional inmediata.
-- No asignes dietas al paciente; el nutriólogo lo hace en la interfaz de Minutriporcion después de revisar el borrador.
+- No asignes dietas por tu cuenta vía herramientas; la asignación de menú/plan al paciente ocurre solo cuando el nutriólogo acepta el borrador (si la conversación tiene paciente vinculado).
 
 AGENDA DEL PACIENTE
 - Cuando hay contexto de paciente vinculado, puedes consultar citas con get_patient_appointments (programadas o pasadas).

--- a/src/main/resources/db/changelog/changes/038-ai-draft-created-entity.yaml
+++ b/src/main/resources/db/changelog/changes/038-ai-draft-created-entity.yaml
@@ -1,0 +1,31 @@
+databaseChangeLog:
+  - changeSet:
+      id: 038-ai-draft-created-entity
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - tableExists:
+            tableName: ai_generated_draft
+        - not:
+            columnExists:
+              tableName: ai_generated_draft
+              columnName: created_entity_id
+      changes:
+        - addColumn:
+            tableName: ai_generated_draft
+            columns:
+              - column:
+                  name: created_entity_type
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_entity_id
+                  type: BIGINT
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_entity_name
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: true

--- a/src/main/resources/db/changelog/changes/039-ai-draft-paciente.yaml
+++ b/src/main/resources/db/changelog/changes/039-ai-draft-paciente.yaml
@@ -1,0 +1,34 @@
+databaseChangeLog:
+  - changeSet:
+      id: 039-ai-draft-paciente
+      author: nutriconsultas
+      preConditions:
+        - onFail: MARK_RAN
+        - tableExists:
+            tableName: ai_generated_draft
+        - not:
+            columnExists:
+              tableName: ai_generated_draft
+              columnName: paciente_id
+      changes:
+        - addColumn:
+            tableName: ai_generated_draft
+            columns:
+              - column:
+                  name: paciente_id
+                  type: BIGINT
+                  constraints:
+                    nullable: true
+        - addForeignKeyConstraint:
+            baseTableName: ai_generated_draft
+            baseColumnNames: paciente_id
+            referencedTableName: paciente
+            referencedColumnNames: id
+            constraintName: fk_ai_generated_draft_paciente
+            onDelete: SET NULL
+        - createIndex:
+            indexName: idx_ai_generated_draft_paciente_id
+            tableName: ai_generated_draft
+            columns:
+              - column:
+                  name: paciente_id

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -110,3 +110,9 @@ databaseChangeLog:
   - include:
       file: changes/037-appointment-question.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/038-ai-draft-created-entity.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: changes/039-ai-draft-paciente.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-test-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-test-master.yaml
@@ -101,3 +101,9 @@ databaseChangeLog:
   - include:
       file: changes/037-appointment-question.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/038-ai-draft-created-entity.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: changes/039-ai-draft-paciente.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/static/sbadmin/css/ai-chat.css
+++ b/src/main/resources/static/sbadmin/css/ai-chat.css
@@ -216,6 +216,17 @@
   margin-bottom: 0.25rem;
 }
 
+.ai-chat-draft-created-link a {
+  color: #4e73df;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.ai-chat-draft-created-link a:hover,
+.ai-chat-draft-created-link a:focus {
+  color: #2e59d9;
+}
+
 .ai-chat-draft-section ul {
   margin: 0;
   padding-left: 1.1rem;

--- a/src/main/resources/static/sbadmin/js/ai-chat.js
+++ b/src/main/resources/static/sbadmin/js/ai-chat.js
@@ -286,6 +286,22 @@
     }
 
     var html = '';
+    if (preview.assignsToPatientOnAccept && preview.pacienteId && preview.status === 'DRAFT') {
+      html += '<section class="ai-chat-draft-section"><h5>Asignación al paciente</h5><p>' +
+        'Al aceptar, se asignará al paciente #' + escapeHtml(String(preview.pacienteId)) +
+        ' por 1 mes.</p></section>';
+    }
+    if (preview.status === 'ACCEPTED' && preview.createdEntityPath) {
+      var linkLabel = preview.createdEntityName || 'Ver registro en catálogo';
+      html += '<section class="ai-chat-draft-section ai-chat-draft-created-link">' +
+        '<h5>Registro creado</h5><p><a href="' + escapeHtml(preview.createdEntityPath) + '">' +
+        escapeHtml(linkLabel) + '</a></p></section>';
+    }
+    if (preview.status === 'ACCEPTED' && preview.pacienteId) {
+      html += '<section class="ai-chat-draft-section ai-chat-draft-created-link">' +
+        '<h5>Plan del paciente</h5><p><a href="/admin/pacientes/' +
+        encodeURIComponent(String(preview.pacienteId)) + '/dietas">Ver dietas del paciente</a></p></section>';
+    }
     if (preview.portions != null) {
       html += '<section class="ai-chat-draft-section"><h5>Porciones</h5><p>' +
         escapeHtml(String(preview.portions)) + '</p></section>';
@@ -412,7 +428,9 @@
     }
     confirmDraftAction({
       title: '¿Aceptar borrador?',
-      text: 'Se creará un registro en tu catálogo a partir de este borrador. Revisa que los datos sean correctos.',
+      text: (state.selectedPreview.assignsToPatientOnAccept
+        ? 'Se creará en tu catálogo y se asignará al paciente por 1 mes. Revisa que los datos sean correctos.'
+        : 'Se creará un registro en tu catálogo a partir de este borrador. Revisa que los datos sean correctos.'),
       confirmText: 'Sí, aceptar',
       confirmColor: '#1cc88a'
     }, function () {
@@ -422,9 +440,9 @@
           if (typeof swal === 'function') {
             swal({
               title: 'Borrador aceptado',
-              text: data.summary || 'El borrador se guardó en tu catálogo.',
+              text: data.summary || ('Se creó «' + (data.createdEntityName || 'el registro') + '» en tu catálogo.'),
               type: 'success',
-              timer: 2500
+              timer: 3000
             });
           }
           return loadDrafts(state.threadId);

--- a/src/test/java/com/nutriconsultas/ai/AiDraftAcceptanceServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftAcceptanceServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,6 +14,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,6 +23,8 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 
 import com.nutriconsultas.dieta.Dieta;
+import com.nutriconsultas.paciente.PacienteDieta;
+import com.nutriconsultas.paciente.PacienteDietaService;
 import com.nutriconsultas.platillos.Platillo;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,6 +50,9 @@ class AiDraftAcceptanceServiceTest {
 	@Mock
 	private AiAuditLogger auditLogger;
 
+	@Mock
+	private PacienteDietaService pacienteDietaService;
+
 	@org.junit.jupiter.api.BeforeEach
 	void stubEntitlement() {
 		org.mockito.Mockito.lenient()
@@ -60,19 +67,28 @@ class AiDraftAcceptanceServiceTest {
 		when(draftRepository.findByIdAndThreadNutritionistId(55L, NUTRITIONIST_ID)).thenReturn(Optional.of(draft));
 		final Platillo platillo = new Platillo();
 		platillo.setId(200L);
+		platillo.setName("Tacos");
 		when(materializationService.materializeDish(any(), eq(NUTRITIONIST_ID), any())).thenReturn(platillo);
 		final AiGeneratedDraft accepted = dishDraft();
 		accepted.setStatus(AiDraftStatus.ACCEPTED);
 		accepted.setThread(draft.getThread());
-		when(draftLifecycleService.acceptDraft(55L, NUTRITIONIST_ID)).thenReturn(accepted);
+		when(draftLifecycleService.acceptDraft(eq(55L), eq(NUTRITIONIST_ID), eq(AiDraftCreatedEntityType.PLATILLO),
+				eq(200L), eq("Tacos")))
+			.thenReturn(accepted);
 
 		final AiDraftAcceptanceResult result = service.accept(55L, NUTRITIONIST_ID, principal());
 
 		assertThat(result.createdEntityType()).isEqualTo(AiDraftCreatedEntityType.PLATILLO);
 		assertThat(result.createdEntityId()).isEqualTo(200L);
+		assertThat(result.createdEntityName()).isEqualTo("Tacos");
+		assertThat(result.createdEntityPath()).isEqualTo("/admin/platillos/200");
+		assertThat(result.summary()).contains("Tacos").doesNotContain("id=");
+		assertThat(result.pacienteId()).isNull();
 		assertThat(result.status()).isEqualTo(AiDraftStatus.ACCEPTED);
 		verify(materializationService).materializeDish(any(), eq(NUTRITIONIST_ID), any());
-		verify(draftLifecycleService).acceptDraft(55L, NUTRITIONIST_ID);
+		verify(pacienteDietaService, never()).assignDieta(any(), any(), any(), any());
+		verify(draftLifecycleService).acceptDraft(55L, NUTRITIONIST_ID, AiDraftCreatedEntityType.PLATILLO, 200L,
+				"Tacos");
 	}
 
 	@Test
@@ -85,21 +101,62 @@ class AiDraftAcceptanceServiceTest {
 	}
 
 	@Test
-	void acceptMaterializesMenuDraftAsDieta() {
+	void acceptMaterializesMenuDraftAsDietaWithoutPatient() {
 		final AiGeneratedDraft draft = menuDraft();
 		when(draftRepository.findByIdAndThreadNutritionistId(56L, NUTRITIONIST_ID)).thenReturn(Optional.of(draft));
 		final Dieta dieta = new Dieta();
 		dieta.setId(300L);
+		dieta.setNombre("Menú del día");
 		when(materializationService.materializeMenu(any(), eq(NUTRITIONIST_ID), any())).thenReturn(dieta);
 		final AiGeneratedDraft accepted = menuDraft();
 		accepted.setStatus(AiDraftStatus.ACCEPTED);
 		accepted.setThread(draft.getThread());
-		when(draftLifecycleService.acceptDraft(56L, NUTRITIONIST_ID)).thenReturn(accepted);
+		when(draftLifecycleService.acceptDraft(eq(56L), eq(NUTRITIONIST_ID), eq(AiDraftCreatedEntityType.DIETA),
+				eq(300L), eq("Menú del día")))
+			.thenReturn(accepted);
 
 		final AiDraftAcceptanceResult result = service.accept(56L, NUTRITIONIST_ID, principal());
 
 		assertThat(result.createdEntityType()).isEqualTo(AiDraftCreatedEntityType.DIETA);
 		assertThat(result.createdEntityId()).isEqualTo(300L);
+		assertThat(result.createdEntityName()).isEqualTo("Menú del día");
+		assertThat(result.createdEntityPath()).isEqualTo("/admin/dietas/300");
+		assertThat(result.summary()).contains("Menú del día").doesNotContain("id=");
+		assertThat(result.pacienteId()).isNull();
+		verify(pacienteDietaService, never()).assignDieta(any(), any(), any(), any());
+	}
+
+	@Test
+	void acceptMenuDraftWithPacienteAssignsDietForOneMonth() {
+		final AiGeneratedDraft draft = menuDraft();
+		draft.setPacienteId(77L);
+		when(draftRepository.findByIdAndThreadNutritionistId(56L, NUTRITIONIST_ID)).thenReturn(Optional.of(draft));
+		final Dieta dieta = new Dieta();
+		dieta.setId(300L);
+		dieta.setNombre("Menú del día");
+		when(materializationService.materializeMenu(any(), eq(NUTRITIONIST_ID), any())).thenReturn(dieta);
+		final PacienteDieta assignment = new PacienteDieta();
+		assignment.setId(901L);
+		when(pacienteDietaService.assignDieta(eq(77L), eq(300L), any(PacienteDieta.class), eq(NUTRITIONIST_ID)))
+			.thenReturn(assignment);
+		final AiGeneratedDraft accepted = menuDraft();
+		accepted.setStatus(AiDraftStatus.ACCEPTED);
+		accepted.setPacienteId(77L);
+		accepted.setThread(draft.getThread());
+		when(draftLifecycleService.acceptDraft(eq(56L), eq(NUTRITIONIST_ID), eq(AiDraftCreatedEntityType.DIETA),
+				eq(300L), eq("Menú del día")))
+			.thenReturn(accepted);
+
+		final AiDraftAcceptanceResult result = service.accept(56L, NUTRITIONIST_ID, principal());
+
+		assertThat(result.pacienteId()).isEqualTo(77L);
+		assertThat(result.pacienteDietaAssignmentId()).isEqualTo(901L);
+		assertThat(result.pacienteAssignmentPath()).isEqualTo("/admin/pacientes/77/dietas");
+		assertThat(result.summary()).contains("asignó al paciente por 1 mes");
+		final ArgumentCaptor<PacienteDieta> shellCaptor = ArgumentCaptor.forClass(PacienteDieta.class);
+		verify(pacienteDietaService).assignDieta(eq(77L), eq(300L), shellCaptor.capture(), eq(NUTRITIONIST_ID));
+		assertThat(shellCaptor.getValue().getStartDate()).isNotNull();
+		assertThat(shellCaptor.getValue().getEndDate()).isNotNull();
 	}
 
 	private static AiGeneratedDraft dishDraft() {

--- a/src/test/java/com/nutriconsultas/ai/AiDraftCreatedEntityLinksTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftCreatedEntityLinksTest.java
@@ -1,0 +1,16 @@
+package com.nutriconsultas.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AiDraftCreatedEntityLinksTest {
+
+	@Test
+	void pathForPlatilloAndDieta() {
+		assertThat(AiDraftCreatedEntityLinks.path(AiDraftCreatedEntityType.PLATILLO, 9L))
+			.isEqualTo("/admin/platillos/9");
+		assertThat(AiDraftCreatedEntityLinks.path(AiDraftCreatedEntityType.DIETA, 12L)).isEqualTo("/admin/dietas/12");
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/ai/AiDraftFlowIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftFlowIntegrationTest.java
@@ -188,8 +188,14 @@ class AiDraftFlowIntegrationTest {
 		assertThat(accepted.status()).isEqualTo(AiDraftStatus.ACCEPTED);
 		assertThat(accepted.createdEntityType()).isEqualTo(AiDraftCreatedEntityType.PLATILLO);
 		assertThat(accepted.createdEntityId()).isNotNull();
+		assertThat(accepted.createdEntityName()).isNotBlank();
+		assertThat(accepted.createdEntityPath()).isEqualTo("/admin/platillos/" + accepted.createdEntityId());
+		assertThat(accepted.summary()).contains(accepted.createdEntityName()).doesNotContain("id=");
 		assertThat(platilloRepository.count()).isEqualTo(platillosBefore + 1);
 		assertThat(platilloRepository.findByIdAndUserId(accepted.createdEntityId(), NUTRITIONIST_A)).isPresent();
+		final AiGeneratedDraft savedDraft = draftRepository.findById(draftId).orElseThrow();
+		assertThat(savedDraft.getCreatedEntityName()).isEqualTo(accepted.createdEntityName());
+		assertThat(savedDraft.getCreatedEntityId()).isEqualTo(accepted.createdEntityId());
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/AiDraftLifecycleServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftLifecycleServiceTest.java
@@ -73,6 +73,28 @@ class AiDraftLifecycleServiceTest {
 		assertThat(created.getStatus()).isEqualTo(AiDraftStatus.DRAFT);
 		assertThat(created.getDraftType()).isEqualTo(AiDraftType.MENU);
 		assertThat(created.getAcceptedAt()).isNull();
+		assertThat(created.getPacienteId()).isNull();
+	}
+
+	@Test
+	void createDraftCopiesPacienteIdFromThreadPatient() {
+		final com.nutriconsultas.paciente.Paciente paciente = new com.nutriconsultas.paciente.Paciente();
+		paciente.setId(77L);
+		thread.setPatient(paciente);
+		when(threadRepository.findByIdAndNutritionistId(10L, NUTRITIONIST_A)).thenReturn(Optional.of(thread));
+		when(draftRepository.save(any(AiGeneratedDraft.class))).thenAnswer(invocation -> {
+			final AiGeneratedDraft draft = invocation.getArgument(0);
+			draft.setId(100L);
+			return draft;
+		});
+
+		final AiGeneratedDraft created = service.createDraft(10L, NUTRITIONIST_A, AiDraftType.MENU,
+				"{\"title\":\"Menú lunes\"}");
+
+		assertThat(created.getPacienteId()).isEqualTo(77L);
+		final ArgumentCaptor<AiGeneratedDraft> captor = ArgumentCaptor.forClass(AiGeneratedDraft.class);
+		verify(draftRepository).save(captor.capture());
+		assertThat(captor.getValue().getPacienteId()).isEqualTo(77L);
 	}
 
 	@Test
@@ -92,10 +114,14 @@ class AiDraftLifecycleServiceTest {
 		when(draftRepository.findByIdAndThreadNutritionistId(99L, NUTRITIONIST_A)).thenReturn(Optional.of(draft));
 		when(draftRepository.save(draft)).thenReturn(draft);
 
-		final AiGeneratedDraft accepted = service.acceptDraft(99L, NUTRITIONIST_A);
+		final AiGeneratedDraft accepted = service.acceptDraft(99L, NUTRITIONIST_A, AiDraftCreatedEntityType.PLATILLO,
+				42L, "Tacos");
 
 		assertThat(accepted.getStatus()).isEqualTo(AiDraftStatus.ACCEPTED);
 		assertThat(accepted.getAcceptedAt()).isNotNull();
+		assertThat(accepted.getCreatedEntityType()).isEqualTo(AiDraftCreatedEntityType.PLATILLO);
+		assertThat(accepted.getCreatedEntityId()).isEqualTo(42L);
+		assertThat(accepted.getCreatedEntityName()).isEqualTo("Tacos");
 	}
 
 	@Test
@@ -114,7 +140,8 @@ class AiDraftLifecycleServiceTest {
 	void acceptDraftBlocksCrossTenantAccess() {
 		when(draftRepository.findByIdAndThreadNutritionistId(99L, NUTRITIONIST_B)).thenReturn(Optional.empty());
 
-		assertThatThrownBy(() -> service.acceptDraft(99L, NUTRITIONIST_B)).isInstanceOf(AiDraftLifecycleException.class)
+		assertThatThrownBy(() -> service.acceptDraft(99L, NUTRITIONIST_B, AiDraftCreatedEntityType.PLATILLO, 1L, "X"))
+			.isInstanceOf(AiDraftLifecycleException.class)
 			.hasMessageContaining("Borrador no encontrado");
 
 		verify(draftRepository, never()).save(any());
@@ -125,7 +152,8 @@ class AiDraftLifecycleServiceTest {
 		final AiGeneratedDraft draft = sampleDraft(AiDraftStatus.ACCEPTED);
 		when(draftRepository.findByIdAndThreadNutritionistId(99L, NUTRITIONIST_A)).thenReturn(Optional.of(draft));
 
-		assertThatThrownBy(() -> service.acceptDraft(99L, NUTRITIONIST_A)).isInstanceOf(AiDraftLifecycleException.class)
+		assertThatThrownBy(() -> service.acceptDraft(99L, NUTRITIONIST_A, AiDraftCreatedEntityType.DIETA, 1L, "X"))
+			.isInstanceOf(AiDraftLifecycleException.class)
 			.hasMessageContaining("ya no se puede modificar");
 
 		verify(draftRepository, never()).save(any());

--- a/src/test/java/com/nutriconsultas/ai/AiDraftPreviewServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftPreviewServiceTest.java
@@ -55,6 +55,24 @@ class AiDraftPreviewServiceTest {
 		assertThat(preview.warnings()).containsExactly("Revisar sodio");
 		assertThat(preview.portions()).isEqualTo(2);
 		assertThat(preview.nutrients().energiaKcal()).isEqualTo(250);
+		assertThat(preview.createdEntityPath()).isNull();
+	}
+
+	@Test
+	void getPreviewIncludesCreatedEntityLinkWhenAccepted() throws Exception {
+		final AiGeneratedDraft draft = dishDraft();
+		draft.setStatus(AiDraftStatus.ACCEPTED);
+		draft.setCreatedEntityType(AiDraftCreatedEntityType.PLATILLO);
+		draft.setCreatedEntityId(77L);
+		draft.setCreatedEntityName("Tacos de pollo");
+		when(draftRepository.findByIdAndThreadNutritionistId(10L, NUTRITIONIST_ID)).thenReturn(Optional.of(draft));
+
+		final AiDraftPreviewView preview = service.getPreview(10L, NUTRITIONIST_ID);
+
+		assertThat(preview.createdEntityType()).isEqualTo(AiDraftCreatedEntityType.PLATILLO);
+		assertThat(preview.createdEntityId()).isEqualTo(77L);
+		assertThat(preview.createdEntityName()).isEqualTo("Tacos de pollo");
+		assertThat(preview.createdEntityPath()).isEqualTo("/admin/platillos/77");
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/AiDraftRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftRestControllerTest.java
@@ -42,7 +42,7 @@ class AiDraftRestControllerTest {
 		final AiDraftPreviewView preview = new AiDraftPreviewView(10L, 5L, AiDraftType.DISH, AiDraftStatus.DRAFT,
 				"Platillo (receta)", AiDraftSummaryExtractor.REVIEW_LABEL, "Tacos", "Resumen", 2, null,
 				new NutrientSummary(250, 20.0, 8.0, 30.0, null, null, null), List.of(), List.of(), List.of("Paso 1"),
-				List.of("Supuesto"), List.of("Advertencia"), null);
+				List.of("Supuesto"), List.of("Advertencia"), null, null, null, null, null, null, false);
 		when(draftPreviewService.getPreview(10L, NUTRITIONIST_ID)).thenReturn(preview);
 
 		final ResponseEntity<Map<String, Object>> response = controller.getDraftPreview(10L, principal());
@@ -59,14 +59,18 @@ class AiDraftRestControllerTest {
 	void acceptDraftReturnsCreatedEntity() {
 		when(draftAcceptanceService.accept(eq(10L), eq(NUTRITIONIST_ID), any()))
 			.thenReturn(new AiDraftAcceptanceResult(10L, AiDraftType.DISH, AiDraftStatus.ACCEPTED,
-					AiDraftCreatedEntityType.PLATILLO, 42L, "Platillo creado en catálogo (id=42)."));
+					AiDraftCreatedEntityType.PLATILLO, 42L, "Tacos", "/admin/platillos/42",
+					"Se creó el platillo «Tacos» en tu catálogo.", null, null, null));
 
 		final ResponseEntity<Map<String, Object>> response = controller.acceptDraft(10L, principal());
 
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 		assertThat(response.getBody()).containsEntry("success", true)
 			.containsEntry("createdEntityType", "PLATILLO")
-			.containsEntry("createdEntityId", 42L);
+			.containsEntry("createdEntityId", 42L)
+			.containsEntry("createdEntityName", "Tacos")
+			.containsEntry("createdEntityPath", "/admin/platillos/42")
+			.containsEntry("summary", "Se creó el platillo «Tacos» en tu catálogo.");
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/AiNutritionGoldenPromptTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiNutritionGoldenPromptTest.java
@@ -263,7 +263,7 @@ class AiNutritionGoldenPromptTest {
 			return new AiOrchestrationContext(NUTRITIONIST_ID, THREAD_ID, null, null, null);
 		}
 		final AiPatientPromptContext patient = new AiPatientPromptContext(42L, 1800.0, null, false, "F", false,
-				"NORMAL", 23.5, Map.of(), "Huevo", "MODERATE", null, null, null);
+				"NORMAL", 23.5, Map.of(), "Huevo", "MODERATE", null, null, null, null);
 		return new AiOrchestrationContext(NUTRITIONIST_ID, THREAD_ID, patient, null, null);
 	}
 

--- a/src/test/java/com/nutriconsultas/ai/AiOpenAiToolCatalogTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiOpenAiToolCatalogTest.java
@@ -44,7 +44,7 @@ class AiOpenAiToolCatalogTest {
 		assertThat(catalog.definitionsForSession(null)).hasSize(catalog.definitions().size() - 1);
 
 		final AiPatientPromptContext patient = new AiPatientPromptContext(5L, 1800.0, null, false, "M", false, null,
-				null, Map.of(), null, null, null, null, null);
+				null, Map.of(), null, null, null, null, null, null);
 		assertThat(catalog.definitionsForSession(patient).stream().map(OpenAiToolDefinition::name))
 			.contains(GetPatientAppointmentsToolService.TOOL_NAME);
 	}

--- a/src/test/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcherTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiOrchestrationToolDispatcherTest.java
@@ -93,7 +93,7 @@ class AiOrchestrationToolDispatcherTest {
 	@Test
 	void dispatchGetPatientAppointmentsUsesLinkedPatientContext() {
 		final AiPatientPromptContext patient = new AiPatientPromptContext(5L, 2795.0, null, false, "M", false, null,
-				null, Map.of(), null, null, null, null, null);
+				null, Map.of(), null, null, null, null, null, null);
 		final PatientAppointmentsData data = new PatientAppointmentsData(List.of(), List.of(), 0);
 		when(getPatientAppointmentsToolService.getAppointments(eq(NUTRITIONIST_ID), eq(5L),
 				eq(PatientAppointmentScope.UPCOMING), eq(3)))
@@ -126,7 +126,7 @@ class AiOrchestrationToolDispatcherTest {
 		when(createDishDraftToolService.createDraft(org.mockito.ArgumentMatchers.eq(NUTRITIONIST_ID),
 				org.mockito.ArgumentMatchers.eq(THREAD_ID), org.mockito.ArgumentMatchers.any()))
 			.thenReturn(AiToolResult.success(new AiDraftCreationData(1L, AiDraftType.DISH, AiDraftStatus.DRAFT,
-					"Borrador IA — Tacos", "/admin/ai?threadId=10&draftId=1")));
+					"Borrador IA — Tacos", "/admin/ai?threadId=10&draftId=1", null)));
 
 		final String json = realSchemaDispatcher.dispatch(context(), CreateDishDraftToolService.TOOL_NAME, """
 				{

--- a/src/test/java/com/nutriconsultas/ai/AiPlanConstraintEvaluatorTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiPlanConstraintEvaluatorTest.java
@@ -58,7 +58,7 @@ class AiPlanConstraintEvaluatorTest {
 		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.MENU, null, null,
 				null, null, null, null, null, null, null, 50.0);
 		final AiPatientPromptContext patientContext = new AiPatientPromptContext(1L, 2000.0, 2200.0, true, "F", false,
-				null, null, Map.of(), null, null, null, null, null);
+				null, null, Map.of(), null, null, null, null, null, null);
 
 		final List<PlanConstraintWarning> warnings = AiPlanConstraintEvaluator.evaluate(computed, request,
 				patientContext, Set.of(), mock(AlimentosRepository.class));
@@ -77,7 +77,7 @@ class AiPlanConstraintEvaluatorTest {
 		when(repository.findById(5L)).thenReturn(java.util.Optional.of(mani));
 
 		final AiPatientPromptContext patientContext = new AiPatientPromptContext(1L, 2000.0, null, false, "F", false,
-				null, null, Map.of(), "cacahuate, mariscos", null, null, null, null);
+				null, null, Map.of(), "cacahuate, mariscos", null, null, null, null, null);
 		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.DISH, null, null,
 				null, null, null, null, null, null, null, null);
 
@@ -92,7 +92,7 @@ class AiPlanConstraintEvaluatorTest {
 	@Test
 	void evaluateAddsPathologyInfoNote() {
 		final AiPatientPromptContext patientContext = new AiPatientPromptContext(1L, 2000.0, null, false, "F", false,
-				null, null, Map.of("diabetes", true), null, null, null, null, null);
+				null, null, Map.of("diabetes", true), null, null, null, null, null, null);
 		final ValidatePlanConstraintsRequest request = new ValidatePlanConstraintsRequest(AiPlanType.MENU, null, null,
 				null, null, null, null, null, null, null, null);
 

--- a/src/test/java/com/nutriconsultas/ai/AiSystemPromptServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiSystemPromptServiceTest.java
@@ -45,6 +45,7 @@ class AiSystemPromptServiceTest {
 		assertThat(prompt).contains("create_menu_draft");
 		assertThat(prompt).contains("create_diet_plan_draft");
 		assertThat(prompt).contains("create_dish_draft");
+		assertThat(prompt).contains("PACIENTE VINCULADO VS PLAN GENERAL");
 		assertThat(prompt).contains("Se ha agregado el siguiente Borrador IA");
 		assertThat(prompt).contains("previewPath");
 		assertThat(prompt).contains("[abrir borrador]({previewPath})");
@@ -66,13 +67,15 @@ class AiSystemPromptServiceTest {
 	void promptIncludesPatientConstraintsWithoutReaskInstruction() {
 		final AiPatientPromptContext patient = new AiPatientPromptContext(42L, 1800.0, 2000.0, true, "F", false,
 				"NORMAL", 23.5, Map.of("hipertension", true, "diabetes", false), "Mariscos", "MODERATE",
-				"2026-07-12T16:00:00Z", "Consulta de seguimiento", 60);
+				"2026-07-12T16:00:00Z", "Consulta de seguimiento", 60, "Ana Demo");
 		final String prompt = service
 			.buildSystemPrompt(new AiSystemPromptContext(Locale.forLanguageTag("es-MX"), null, patient, null, null));
 
-		assertThat(prompt).contains("CONTEXTO DEL PACIENTE");
+		assertThat(prompt).contains("CONTEXTO DEL PACIENTE VINCULADO");
 		assertThat(prompt).contains(AiPromptDelimiters.PATIENT_CONTEXT_OPEN);
 		assertThat(prompt).contains(AiPromptDelimiters.PATIENT_CONTEXT_CLOSE);
+		assertThat(prompt).contains("Ana Demo");
+		assertThat(prompt).contains("patientId interno: 42");
 		assertThat(prompt).contains("1800.0 kcal");
 		assertThat(prompt).contains("2000.0 kcal");
 		assertThat(prompt).contains("Mariscos");
@@ -80,6 +83,7 @@ class AiSystemPromptServiceTest {
 		assertThat(prompt).contains("No preguntes de nuevo el objetivo calórico ni las alergias");
 		assertThat(prompt).contains("Próxima cita programada");
 		assertThat(prompt).contains("Consulta de seguimiento");
+		assertThat(prompt).contains("asignará la dieta a este paciente por 1 mes");
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/CreateMenuDraftToolServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/CreateMenuDraftToolServiceTest.java
@@ -55,6 +55,7 @@ class CreateMenuDraftToolServiceTest {
 		assertThat(result.data().status()).isEqualTo(AiDraftStatus.DRAFT);
 		assertThat(result.data().summary()).contains("Menú balanceado");
 		assertThat(result.data().previewPath()).isEqualTo("/admin/ai?threadId=42&draftId=88");
+		assertThat(result.data().pacienteId()).isNull();
 		verify(draftLifecycleService).createDraft(eq(THREAD_ID), eq(NUTRITIONIST_ID), eq(AiDraftType.MENU), any());
 	}
 


### PR DESCRIPTION
## Summary
- Persist `paciente_id` on AI drafts when the chat thread is linked to a patient; general drafts remain catalog-only.
- On accept of menu/diet-plan drafts with a patient: create the catalog dieta and assign it via `PacienteDieta` for **1 month**.
- After accept, success copy uses the **record name** (not id) and the draft preview shows links to the created catalog item and patient diets.
- Mina prompt: confirm the linked patient (display name) before generating; do not claim assignment for general (no-patient) chats.
- Liquibase `038` (created entity fields) + `039` (`paciente_id`).

## Test plan
- [ ] From patient widget: ask Mina for a menú; she confirms the patient; create draft; accept → dieta in catalog + assignment with ~1 month end date.
- [ ] From `/admin/ai` without patient: accept menu → catalog only, no patient assignment.
- [ ] Accept dish draft → platillo in catalog only; success popup shows name + clickable link.
- [ ] Re-open accepted patient draft → links to catalog dieta and `/admin/pacientes/{id}/dietas`.


Made with [Cursor](https://cursor.com)