### PR TITLE
Keep Mina drafts across conversations with delete on card

### DIFF
--- a/src/main/java/com/nutriconsultas/ai/AiChatDraftSummary.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatDraftSummary.java
@@ -5,6 +5,6 @@ import java.time.Instant;
 /**
  * Draft summary for chat REST responses (#384).
  */
-public record AiChatDraftSummary(long draftId, AiDraftType draftType, AiDraftStatus status, String summary,
-		Instant createdAt) {
+public record AiChatDraftSummary(long draftId, long threadId, AiDraftType draftType, AiDraftStatus status,
+		String summary, Instant createdAt) {
 }

--- a/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatRestController.java
@@ -241,6 +241,23 @@ public class AiChatRestController {
 		}
 	}
 
+	@GetMapping("/pending-drafts")
+	public ResponseEntity<Map<String, Object>> listPendingDrafts(@AuthenticationPrincipal final OidcUser principal) {
+		final String nutritionistId = nutritionistId(principal);
+		if (nutritionistId == null) {
+			return unauthorized();
+		}
+		try {
+			final List<AiChatDraftSummary> drafts = chatService.listPendingDrafts(nutritionistId);
+			final Map<String, Object> response = successBody();
+			response.put("drafts", toDraftMaps(drafts));
+			return ResponseEntity.ok(response);
+		}
+		catch (final AiChatException ex) {
+			return errorResponse(ex);
+		}
+	}
+
 	@GetMapping("/{threadId}/drafts")
 	public ResponseEntity<Map<String, Object>> listDrafts(@PathVariable @NonNull final Long threadId,
 			@AuthenticationPrincipal final OidcUser principal) {
@@ -343,6 +360,7 @@ public class AiChatRestController {
 		for (final AiChatDraftSummary draft : drafts) {
 			final Map<String, Object> map = new LinkedHashMap<>();
 			map.put("draftId", draft.draftId());
+			map.put("threadId", draft.threadId());
 			map.put("draftType", draft.draftType().name());
 			map.put("status", draft.status().name());
 			map.put("summary", draft.summary());

--- a/src/main/java/com/nutriconsultas/ai/AiChatService.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatService.java
@@ -1,5 +1,7 @@
 package com.nutriconsultas.ai;
 
+import java.util.List;
+
 import org.springframework.lang.Nullable;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -14,6 +16,11 @@ public interface AiChatService {
 	AiChatThreadDetail getThread(String nutritionistId, long threadId);
 
 	AiChatDraftList listDrafts(String nutritionistId, long threadId);
+
+	/**
+	 * Pending ({@link AiDraftStatus#DRAFT}) drafts owned by the nutritionist across all threads.
+	 */
+	List<AiChatDraftSummary> listPendingDrafts(String nutritionistId);
 
 	AiOrchestrationResult sendMessage(String nutritionistId, long threadId, String message,
 			AiChatPromptContext promptContext);

--- a/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/ai/AiChatServiceImpl.java
@@ -86,10 +86,21 @@ public class AiChatServiceImpl implements AiChatService {
 		loadOwnedThread(threadId, nutritionistId);
 		final List<AiChatDraftSummary> drafts = new ArrayList<>();
 		for (final AiGeneratedDraft draft : draftRepository.findByThreadIdOrderByCreatedAtDescIdDesc(threadId)) {
-			drafts.add(new AiChatDraftSummary(draft.getId(), draft.getDraftType(), draft.getStatus(),
-					AiDraftSummaryExtractor.summarize(draft), draft.getCreatedAt()));
+			drafts.add(toDraftSummary(draft, threadId));
 		}
 		return new AiChatDraftList(threadId, List.copyOf(drafts));
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<AiChatDraftSummary> listPendingDrafts(@NonNull final String nutritionistId) {
+		assertNutritionistAccess(nutritionistId);
+		final List<AiChatDraftSummary> drafts = new ArrayList<>();
+		for (final AiGeneratedDraft draft : draftRepository
+			.findByNutritionistIdAndStatusOrderByCreatedAtDescIdDesc(nutritionistId, AiDraftStatus.DRAFT)) {
+			drafts.add(toDraftSummary(draft, draft.getThread().getId()));
+		}
+		return List.copyOf(drafts);
 	}
 
 	@Override
@@ -308,6 +319,11 @@ public class AiChatServiceImpl implements AiChatService {
 		final AiChatPromptContext safeRequest = requestContext != null ? requestContext : AiChatPromptContext.empty();
 		final Long patientId = safeRequest.patientId() != null ? safeRequest.patientId() : threadPatientId;
 		return new AiChatPromptContext(patientId, safeRequest.dietaId(), safeRequest.platilloId());
+	}
+
+	private static AiChatDraftSummary toDraftSummary(final AiGeneratedDraft draft, final long threadId) {
+		return new AiChatDraftSummary(draft.getId(), threadId, draft.getDraftType(), draft.getStatus(),
+				AiDraftSummaryExtractor.summarize(draft), draft.getCreatedAt());
 	}
 
 	private AiChatThread loadOwnedThread(final long threadId, final String nutritionistId) {

--- a/src/main/java/com/nutriconsultas/ai/AiGeneratedDraftRepository.java
+++ b/src/main/java/com/nutriconsultas/ai/AiGeneratedDraftRepository.java
@@ -21,4 +21,9 @@ public interface AiGeneratedDraftRepository extends JpaRepository<AiGeneratedDra
 	List<AiGeneratedDraft> findByThreadIdAndStatusAndCreatedAtGreaterThanEqual(Long threadId, AiDraftStatus status,
 			Instant createdAt);
 
+	@Query("SELECT d FROM AiGeneratedDraft d JOIN FETCH d.thread t WHERE t.nutritionistId = :nutritionistId "
+			+ "AND d.status = :status ORDER BY d.createdAt DESC, d.id DESC")
+	List<AiGeneratedDraft> findByNutritionistIdAndStatusOrderByCreatedAtDescIdDesc(
+			@Param("nutritionistId") String nutritionistId, @Param("status") AiDraftStatus status);
+
 }

--- a/src/main/resources/static/sbadmin/css/ai-chat.css
+++ b/src/main/resources/static/sbadmin/css/ai-chat.css
@@ -162,14 +162,31 @@
 }
 
 .ai-chat-draft-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.35rem;
   width: 100%;
   text-align: left;
   border: 1px solid #e3e6f0;
   border-radius: 0.35rem;
   background: #f8f9fc;
-  padding: 0.55rem 0.65rem;
+  padding: 0.45rem 0.5rem;
   margin-bottom: 0.5rem;
+}
+
+.ai-chat-draft-card-select {
+  flex: 1 1 auto;
+  min-width: 0;
+  text-align: left;
+  border: 0;
+  background: transparent;
+  padding: 0.1rem 0.15rem;
   cursor: pointer;
+}
+
+.ai-chat-draft-card-delete {
+  flex: 0 0 auto;
+  margin-top: 0.1rem;
 }
 
 .ai-chat-draft-card:hover,

--- a/src/main/resources/static/sbadmin/js/ai-chat.js
+++ b/src/main/resources/static/sbadmin/js/ai-chat.js
@@ -228,27 +228,39 @@
     if (!container) {
       return;
     }
-    if (!state.threadId) {
-      container.innerHTML = '<p class="ai-chat-draft-empty">Inicia una conversación para ver borradores.</p>';
-      hideDraftPreview();
-      return;
-    }
     if (!state.drafts || state.drafts.length === 0) {
-      container.innerHTML = '<p class="ai-chat-draft-empty">Aún no hay borradores en esta conversación.</p>';
+      container.innerHTML = '<p class="ai-chat-draft-empty">Aún no hay borradores pendientes.</p>';
       hideDraftPreview();
       return;
     }
     container.innerHTML = state.drafts.map(function (draft) {
       var active = state.selectedDraftId === draft.draftId ? ' active' : '';
       var title = draft.summary || draftTypeLabel(draft.draftType);
-      return '<button type="button" class="ai-chat-draft-card' + active + '" data-draft-id="' + draft.draftId + '">' +
+      var canDelete = draft.status === 'DRAFT';
+      return '<div class="ai-chat-draft-card' + active + '" data-draft-id="' + draft.draftId + '">' +
+        '<button type="button" class="ai-chat-draft-card-select">' +
         '<p class="ai-chat-draft-card-title">' + escapeHtml(title) + '</p>' +
         '<p class="ai-chat-draft-card-meta">' + escapeHtml(draftTypeLabel(draft.draftType)) +
-        ' · ' + escapeHtml(draftStatusLabel(draft.status)) + '</p></button>';
+        ' · ' + escapeHtml(draftStatusLabel(draft.status)) + '</p></button>' +
+        (canDelete
+          ? '<button type="button" class="btn btn-outline-danger btn-sm ai-chat-draft-card-delete" ' +
+            'data-draft-delete-id="' + draft.draftId + '" aria-label="Eliminar borrador">Eliminar</button>'
+          : '') +
+        '</div>';
     }).join('');
-    container.querySelectorAll('[data-draft-id]').forEach(function (button) {
+    container.querySelectorAll('.ai-chat-draft-card-select').forEach(function (button) {
       button.addEventListener('click', function () {
-        selectDraft(Number(button.getAttribute('data-draft-id')));
+        var card = button.closest('[data-draft-id]');
+        if (card) {
+          selectDraft(Number(card.getAttribute('data-draft-id')));
+        }
+      });
+    });
+    container.querySelectorAll('[data-draft-delete-id]').forEach(function (button) {
+      button.addEventListener('click', function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        discardDraftById(Number(button.getAttribute('data-draft-delete-id')));
       });
     });
   }
@@ -351,14 +363,9 @@
     }
   }
 
-  function loadDrafts(threadId, options) {
+  function loadDrafts(options) {
     var opts = options || {};
-    if (!threadId) {
-      state.drafts = [];
-      renderDraftList();
-      return Promise.resolve();
-    }
-    return requestJson(API_BASE + '/' + threadId + '/drafts', { method: 'GET' })
+    return requestJson(API_BASE + '/pending-drafts', { method: 'GET' })
       .then(function (data) {
         state.drafts = data.drafts || [];
         if (state.selectedDraftId && !state.drafts.some(function (d) {
@@ -445,7 +452,7 @@
               timer: 3000
             });
           }
-          return loadDrafts(state.threadId);
+          return loadDrafts();
         })
         .catch(function (error) {
           showError(error.message, error.title);
@@ -460,24 +467,33 @@
     if (!state.selectedDraftId || !state.selectedPreview || state.selectedPreview.status !== 'DRAFT') {
       return;
     }
+    discardDraftById(state.selectedDraftId);
+  }
+
+  function discardDraftById(draftId) {
+    if (!draftId || state.busy) {
+      return;
+    }
     confirmDraftAction({
-      title: '¿Descartar borrador?',
+      title: '¿Eliminar borrador?',
       text: 'Esta acción no se puede deshacer.',
-      confirmText: 'Sí, descartar',
+      confirmText: 'Sí, eliminar',
       confirmColor: '#e74a3b'
     }, function () {
       setBusy(true);
-      requestJson(DRAFT_API + '/' + state.selectedDraftId + '/discard', { method: 'POST' })
+      requestJson(DRAFT_API + '/' + draftId + '/discard', { method: 'POST' })
         .then(function () {
           if (typeof swal === 'function') {
             swal({
-              title: 'Borrador descartado',
+              title: 'Borrador eliminado',
               type: 'success',
               timer: 2000
             });
           }
-          hideDraftPreview();
-          return loadDrafts(state.threadId);
+          if (state.selectedDraftId === draftId) {
+            hideDraftPreview();
+          }
+          return loadDrafts();
         })
         .catch(function (error) {
           showError(error.message, error.title);
@@ -631,7 +647,7 @@
     updateThreadTitle(data.title);
     state.messages = data.messages || [];
     renderMessages(false);
-    loadDrafts(data.threadId);
+    loadDrafts();
   }
 
   function loadThread(threadId) {
@@ -721,7 +737,7 @@
       }
       if (data && data.threadId) {
         persistThreadId(data.threadId);
-        loadDrafts(data.threadId, { selectNewest: true });
+        loadDrafts({ selectNewest: true });
       }
       renderMessages(false);
     }
@@ -849,10 +865,9 @@
   function resetConversation() {
     persistThreadId(null);
     state.messages = [];
-    state.drafts = [];
     cancelEditMessage();
     hideDraftPreview();
-    renderDraftList();
+    loadDrafts();
     updateThreadTitle(null);
     renderMessages(false);
     var textarea = $('#aiChatInput');
@@ -966,7 +981,7 @@
       loadThread(threadId);
     } else {
       renderMessages(false);
-      renderDraftList();
+      loadDrafts();
     }
   }
 

--- a/src/main/resources/templates/sbadmin/ai/chat.html
+++ b/src/main/resources/templates/sbadmin/ai/chat.html
@@ -127,7 +127,7 @@
                   <aside id="aiChatDraftsPanel" class="ai-chat-drafts-panel" aria-label="Borradores generados por IA">
                     <div class="ai-chat-drafts-header">
                       <h3 class="h6 font-weight-bold text-primary mb-0">Borradores IA</h3>
-                      <p class="ai-chat-drafts-subtitle mb-0">Borrador IA — revisión del nutriólogo requerida</p>
+                      <p class="ai-chat-drafts-subtitle mb-0">Pendientes de revisión (todas tus conversaciones)</p>
                     </div>
                     <div id="aiChatDraftList" class="ai-chat-draft-list"></div>
                     <div id="aiChatDraftPreview" class="ai-chat-draft-preview" hidden>

--- a/src/test/java/com/nutriconsultas/ai/AiChatRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatRestControllerTest.java
@@ -101,12 +101,28 @@ class AiChatRestControllerTest {
 	void listDraftsReturnsSummaries() {
 		final Instant now = Instant.parse("2026-06-30T12:00:00Z");
 		when(chatService.listDrafts(NUTRITIONIST_ID, 5L)).thenReturn(new AiChatDraftList(5L,
-				List.of(new AiChatDraftSummary(11L, AiDraftType.DISH, AiDraftStatus.DRAFT, "Borrador", now))));
+				List.of(new AiChatDraftSummary(11L, 5L, AiDraftType.DISH, AiDraftStatus.DRAFT, "Borrador", now))));
 
 		final ResponseEntity<Map<String, Object>> response = controller.listDrafts(5L, principal(NUTRITIONIST_ID));
 
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 		assertThat(response.getBody()).containsEntry("threadId", 5L).containsKey("drafts");
+	}
+
+	@Test
+	void listPendingDraftsReturnsSummaries() {
+		final Instant now = Instant.parse("2026-06-30T12:00:00Z");
+		when(chatService.listPendingDrafts(NUTRITIONIST_ID)).thenReturn(
+				List.of(new AiChatDraftSummary(11L, 5L, AiDraftType.DISH, AiDraftStatus.DRAFT, "Borrador", now)));
+
+		final ResponseEntity<Map<String, Object>> response = controller.listPendingDrafts(principal(NUTRITIONIST_ID));
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsKey("drafts");
+		@SuppressWarnings("unchecked")
+		final List<Map<String, Object>> drafts = (List<Map<String, Object>>) response.getBody().get("drafts");
+		assertThat(drafts).hasSize(1);
+		assertThat(drafts.get(0)).containsEntry("draftId", 11L).containsEntry("threadId", 5L);
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/AiChatServiceTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiChatServiceTest.java
@@ -173,6 +173,42 @@ class AiChatServiceTest {
 
 		assertThat(list.drafts()).hasSize(1);
 		assertThat(list.drafts().get(0).summary()).contains("Tacos");
+		assertThat(list.drafts().get(0).threadId()).isEqualTo(5L);
+	}
+
+	@Test
+	void listPendingDraftsReturnsOnlyOwnDrafts() {
+		final AiChatThread thread = sampleThread(5L, NUTRITIONIST_ID);
+		final AiGeneratedDraft draft = new AiGeneratedDraft();
+		draft.setId(11L);
+		draft.setThread(thread);
+		draft.setDraftType(AiDraftType.MENU);
+		draft.setStatus(AiDraftStatus.DRAFT);
+		draft.setJsonPayload(
+				"{\"name\":\"Menú semanal\",\"days\":[],\"label\":\"Borrador IA\"}");
+		draft.setCreatedAt(Instant.now());
+		when(draftRepository.findByNutritionistIdAndStatusOrderByCreatedAtDescIdDesc(NUTRITIONIST_ID,
+				AiDraftStatus.DRAFT))
+			.thenReturn(List.of(draft));
+
+		final List<AiChatDraftSummary> drafts = service.listPendingDrafts(NUTRITIONIST_ID);
+
+		assertThat(drafts).hasSize(1);
+		assertThat(drafts.get(0).draftId()).isEqualTo(11L);
+		assertThat(drafts.get(0).threadId()).isEqualTo(5L);
+		verify(draftRepository).findByNutritionistIdAndStatusOrderByCreatedAtDescIdDesc(NUTRITIONIST_ID,
+				AiDraftStatus.DRAFT);
+	}
+
+	@Test
+	void listPendingDraftsDoesNotQueryOtherNutritionist() {
+		when(draftRepository.findByNutritionistIdAndStatusOrderByCreatedAtDescIdDesc(NUTRITIONIST_ID,
+				AiDraftStatus.DRAFT))
+			.thenReturn(List.of());
+
+		assertThat(service.listPendingDrafts(NUTRITIONIST_ID)).isEmpty();
+		verify(draftRepository, never()).findByNutritionistIdAndStatusOrderByCreatedAtDescIdDesc(OTHER_NUTRITIONIST_ID,
+				AiDraftStatus.DRAFT);
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/ai/AiDraftFlowIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftFlowIntegrationTest.java
@@ -210,6 +210,9 @@ class AiDraftFlowIntegrationTest {
 
 		assertThat(threadRepository.findByIdAndNutritionistId(thread.getId(), NUTRITIONIST_B)).isEmpty();
 		assertThat(draftRepository.findByIdAndThreadNutritionistId(draftId, NUTRITIONIST_B)).isEmpty();
+		assertThat(chatService.listPendingDrafts(NUTRITIONIST_B)).isEmpty();
+		assertThat(chatService.listPendingDrafts(NUTRITIONIST_A)).extracting(AiChatDraftSummary::draftId)
+			.contains(draftId);
 
 		assertThatThrownBy(() -> chatService.getThread(NUTRITIONIST_B, thread.getId()))
 			.isInstanceOf(AiChatException.class);


### PR DESCRIPTION
## Summary
- Pending AI drafts stay visible after starting a new conversation (nutritionist-scoped list, not thread-only).
- Each draft card has an **Eliminar** action that discards via the existing ownership-checked discard API.
- Access remains limited to drafts owned by the authenticated nutritionist (`nutritionistId` on the thread).

## Test plan
- [ ] Open Mina, generate a draft, start **Nueva conversación** → draft still appears in the right panel
- [ ] Click **Eliminar** on a card → confirm → draft disappears from the list
- [ ] Preview/accept still works for a draft created in a previous conversation
- [ ] Another nutritionist cannot list/discard that draft (covered by integration test)


Made with [Cursor](https://cursor.com)