### PR TITLE
Add emoji picker to nutritionist patient chat

### DIFF
--- a/src/main/resources/static/sbadmin/css/patient-messages-widget.css
+++ b/src/main/resources/static/sbadmin/css/patient-messages-widget.css
@@ -183,11 +183,95 @@
 }
 
 #patientChatComposer {
+  position: relative;
   display: flex;
+  align-items: flex-end;
   gap: 0.5rem;
   padding: 0.75rem;
   border-top: 1px solid #e3e6f0;
   background: #fff;
+}
+
+#patientChatEmojiPicker {
+  position: absolute;
+  left: 0.5rem;
+  right: 0.5rem;
+  bottom: calc(100% + 0.25rem);
+  max-height: 11.5rem;
+  overflow-y: auto;
+  padding: 0.5rem 0.6rem 0.6rem;
+  background: #fff;
+  border: 1px solid #e3e6f0;
+  border-radius: 0.6rem;
+  box-shadow: 0 0.5rem 1.25rem rgba(0, 0, 0, 0.12);
+  z-index: 2;
+}
+
+#patientChatEmojiPicker[hidden] {
+  display: none;
+}
+
+.patient-chat-emoji-group {
+  margin-bottom: 0.45rem;
+}
+
+.patient-chat-emoji-group:last-child {
+  margin-bottom: 0;
+}
+
+.patient-chat-emoji-group-label {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #858796;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  margin-bottom: 0.25rem;
+}
+
+.patient-chat-emoji-grid {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 0.15rem;
+}
+
+.patient-chat-emoji-item {
+  border: none;
+  background: transparent;
+  border-radius: 0.35rem;
+  padding: 0.15rem 0;
+  font-size: 1.2rem;
+  line-height: 1.35;
+  cursor: pointer;
+}
+
+.patient-chat-emoji-item:hover,
+.patient-chat-emoji-item:focus {
+  background: #eaecf4;
+  outline: none;
+}
+
+#patientChatEmojiBtn {
+  border: 1px solid #d1d3e2;
+  border-radius: 0.5rem;
+  background: #fff;
+  color: #5a5c69;
+  min-width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  cursor: pointer;
+}
+
+#patientChatEmojiBtn:hover,
+#patientChatEmojiBtn[aria-expanded="true"] {
+  border-color: #4e73df;
+  color: #4e73df;
+  background: #f8f9fc;
+}
+
+#patientChatEmojiBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 #patientChatInput {
@@ -206,6 +290,8 @@
   border-radius: 0.5rem;
   background: #1cc88a;
   color: #fff;
+  min-width: 2.5rem;
+  height: 2.5rem;
   padding: 0 0.85rem;
   cursor: pointer;
 }

--- a/src/main/resources/static/sbadmin/js/patient-messages-widget.js
+++ b/src/main/resources/static/sbadmin/js/patient-messages-widget.js
@@ -4,6 +4,25 @@
   'use strict';
 
   var POLL_INTERVAL_MS = 60000;
+  var MAX_BODY_LENGTH = 2000;
+  var EMOJI_GROUPS = [
+    {
+      label: 'Reacciones',
+      emojis: ['😊', '🙂', '😄', '😁', '😍', '🤗', '😌', '😎', '🥳', '😇', '😉', '😅',
+        '😂', '🤩', '🥰', '😘', '🤔', '😮', '😴', '👍', '👎', '👏', '🙌', '💪',
+        '🙏', '❤️', '💚', '💙', '💛', '✨', '🌟', '🎉', '✅', '⚠️', '💯']
+    },
+    {
+      label: 'Alimentos',
+      emojis: ['🥗', '🍎', '🥦', '🥑', '🥕', '🍇', '🍊', '🍓', '🍌', '🍉', '🥝', '🍅',
+        '🥒', '🌽', '🥜', '🥚', '🥛', '🧀', '🐟', '🍗', '🥩', '🍞', '🍠', '🥣',
+        '🍽️', '💧', '☕', '🍵', '🥤']
+    },
+    {
+      label: 'Hábitos',
+      emojis: ['🏃', '🚶', '🧘', '🏋️', '🚴', '🛌', '☀️', '🌙', '⏰', '📝', '🚰', '💊']
+    }
+  ];
   var state = {
     open: false,
     unreadCount: 0,
@@ -12,7 +31,8 @@
     activePacienteId: null,
     activePacienteName: null,
     profileMode: false,
-    pollTimer: null
+    pollTimer: null,
+    emojiPickerOpen: false
   };
 
   function $(selector) {
@@ -129,7 +149,60 @@
     }
   }
 
+  function renderEmojiPicker() {
+    var picker = $('#patientChatEmojiPicker');
+    if (!picker || picker.dataset.ready === 'true') {
+      return;
+    }
+    picker.innerHTML = EMOJI_GROUPS.map(function (group) {
+      return '<div class="patient-chat-emoji-group">' +
+        '<span class="patient-chat-emoji-group-label">' + escapeHtml(group.label) + '</span>' +
+        '<div class="patient-chat-emoji-grid">' +
+        group.emojis.map(function (emoji) {
+          return '<button type="button" class="patient-chat-emoji-item" data-emoji="' + emoji +
+            '" aria-label="' + emoji + '">' + emoji + '</button>';
+        }).join('') +
+        '</div></div>';
+    }).join('');
+    picker.querySelectorAll('.patient-chat-emoji-item').forEach(function (button) {
+      button.addEventListener('click', function () {
+        insertEmoji(button.getAttribute('data-emoji'));
+      });
+    });
+    picker.dataset.ready = 'true';
+  }
+
+  function setEmojiPickerOpen(open) {
+    var picker = $('#patientChatEmojiPicker');
+    var button = $('#patientChatEmojiBtn');
+    state.emojiPickerOpen = !!open;
+    if (picker) {
+      picker.hidden = !state.emojiPickerOpen;
+    }
+    if (button) {
+      button.setAttribute('aria-expanded', state.emojiPickerOpen ? 'true' : 'false');
+    }
+  }
+
+  function insertEmoji(emoji) {
+    var input = $('#patientChatInput');
+    if (!input || input.disabled || !emoji) {
+      return;
+    }
+    var start = typeof input.selectionStart === 'number' ? input.selectionStart : input.value.length;
+    var end = typeof input.selectionEnd === 'number' ? input.selectionEnd : start;
+    var next = input.value.slice(0, start) + emoji + input.value.slice(end);
+    if (next.length > MAX_BODY_LENGTH) {
+      return;
+    }
+    input.value = next;
+    var caret = start + emoji.length;
+    input.focus();
+    input.setSelectionRange(caret, caret);
+  }
+
   function showGlobalView() {
+    setEmojiPickerOpen(false);
     $('#patientChatGlobalView').hidden = false;
     $('#patientChatThreadView').hidden = true;
     $('#patientChatBackBtn').hidden = true;
@@ -184,6 +257,11 @@
       return;
     }
     input.disabled = true;
+    var emojiBtn = $('#patientChatEmojiBtn');
+    if (emojiBtn) {
+      emojiBtn.disabled = true;
+    }
+    setEmojiPickerOpen(false);
     fetchJson('/rest/patient-messages/thread/' + state.activePacienteId, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -204,6 +282,9 @@
       }
     }).finally(function () {
       input.disabled = false;
+      if (emojiBtn) {
+        emojiBtn.disabled = false;
+      }
       input.focus();
     });
   }
@@ -222,6 +303,8 @@
         showGlobalView();
         loadUnread();
       }
+    } else {
+      setEmojiPickerOpen(false);
     }
   }
 
@@ -230,7 +313,9 @@
     var closeBtn = $('#patientChatClose');
     var backBtn = $('#patientChatBackBtn');
     var sendBtn = $('#patientChatSendBtn');
+    var emojiBtn = $('#patientChatEmojiBtn');
     var input = $('#patientChatInput');
+    renderEmojiPicker();
 
     if (toggleBtn) {
       toggleBtn.addEventListener('click', function () {
@@ -254,6 +339,11 @@
     if (sendBtn) {
       sendBtn.addEventListener('click', sendMessage);
     }
+    if (emojiBtn) {
+      emojiBtn.addEventListener('click', function () {
+        setEmojiPickerOpen(!state.emojiPickerOpen);
+      });
+    }
     if (input) {
       input.addEventListener('keydown', function (event) {
         if (event.key === 'Enter' && !event.shiftKey) {
@@ -262,6 +352,21 @@
         }
       });
     }
+    document.addEventListener('click', function (event) {
+      if (!state.emojiPickerOpen) {
+        return;
+      }
+      var picker = $('#patientChatEmojiPicker');
+      if ((picker && picker.contains(event.target)) || (emojiBtn && emojiBtn.contains(event.target))) {
+        return;
+      }
+      setEmojiPickerOpen(false);
+    });
+    document.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape' && state.emojiPickerOpen) {
+        setEmojiPickerOpen(false);
+      }
+    });
   }
 
   function startPolling() {

--- a/src/main/resources/templates/sbadmin/fragments/patient-messages-widget.html
+++ b/src/main/resources/templates/sbadmin/fragments/patient-messages-widget.html
@@ -22,6 +22,11 @@
         <div id="patientChatThreadView" hidden>
           <div id="patientChatMessages"></div>
           <div id="patientChatComposer">
+            <div id="patientChatEmojiPicker" hidden role="dialog" aria-label="Elegir emoticon"></div>
+            <button type="button" id="patientChatEmojiBtn" title="Emoticones" aria-label="Emoticones"
+              aria-expanded="false" aria-controls="patientChatEmojiPicker">
+              <i class="fas fa-smile" aria-hidden="true"></i>
+            </button>
             <textarea id="patientChatInput" rows="2" maxlength="2000" placeholder="Escribe un mensaje…"></textarea>
             <button type="button" id="patientChatSendBtn" title="Enviar">
               <i class="fas fa-paper-plane"></i>

--- a/src/test/java/com/nutriconsultas/message/PatientChatEmojiMarkupTest.java
+++ b/src/test/java/com/nutriconsultas/message/PatientChatEmojiMarkupTest.java
@@ -1,0 +1,52 @@
+package com.nutriconsultas.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * Nutritionists can pick Unicode emoticons from the patient chat composer.
+ */
+class PatientChatEmojiMarkupTest {
+
+	@Test
+	void composerExposesEmojiPickerControls() throws IOException {
+		final String html = load("templates/sbadmin/fragments/patient-messages-widget.html");
+		assertThat(html).contains("id=\"patientChatEmojiBtn\"");
+		assertThat(html).contains("aria-label=\"Emoticones\"");
+		assertThat(html).contains("aria-controls=\"patientChatEmojiPicker\"");
+		assertThat(html).contains("id=\"patientChatEmojiPicker\"");
+		assertThat(html).contains("aria-label=\"Elegir emoticon\"");
+		assertThat(html).contains("fa-smile");
+	}
+
+	@Test
+	void widgetScriptDefinesNutritionEmojiCatalog() throws IOException {
+		final String js = load("static/sbadmin/js/patient-messages-widget.js");
+		assertThat(js).contains("EMOJI_GROUPS");
+		assertThat(js).contains("Reacciones");
+		assertThat(js).contains("Alimentos");
+		assertThat(js).contains("Hábitos");
+		assertThat(js).contains("insertEmoji");
+		assertThat(js).contains("🥗");
+		assertThat(js).contains("💪");
+		assertThat(js).contains("😊");
+	}
+
+	@Test
+	void widgetStylesPositionPickerAboveComposer() throws IOException {
+		final String css = load("static/sbadmin/css/patient-messages-widget.css");
+		assertThat(css).contains("#patientChatEmojiPicker");
+		assertThat(css).contains("#patientChatEmojiBtn");
+		assertThat(css).contains(".patient-chat-emoji-item");
+	}
+
+	private static String load(final String path) throws IOException {
+		return new ClassPathResource(path).getContentAsString(StandardCharsets.UTF_8);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/message/PatientMessageIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/message/PatientMessageIntegrationTest.java
@@ -102,6 +102,23 @@ class PatientMessageIntegrationTest {
 	}
 
 	@Test
+	void nutritionistReplyWithEmojiAppearsInMobileMessageThread() throws Exception {
+		mockMvc
+			.perform(post("/rest/patient-messages/thread/" + linkedPaciente.getId())
+				.with(oidcLogin().idToken(token -> token.subject(NUTRITIONIST_SUB).claim("name", "Nutritionist")))
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding("UTF-8")
+				.content("{\"body\":\"¡Sigue así! 🥗👍\"}"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.senderRole").value("NUTRITIONIST"))
+			.andExpect(jsonPath("$.body").value("¡Sigue así! 🥗👍"));
+
+		mockMvc.perform(get("/rest/mobile/patient/messages").with(mobileJwt(PATIENT_AUTH_SUB)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content[0].body").value("¡Sigue así! 🥗👍"));
+	}
+
+	@Test
 	void sendMessageForOtherNutritionistPatientReturnsNotFound() throws Exception {
 		final Paciente otherPatient = pacienteRepository.findByPatientAuthSub("auth0|114-other-patient")
 			.orElseGet(() -> pacienteRepository

--- a/src/test/java/com/nutriconsultas/message/PatientMessageServiceTest.java
+++ b/src/test/java/com/nutriconsultas/message/PatientMessageServiceTest.java
@@ -95,6 +95,26 @@ class PatientMessageServiceTest {
 	}
 
 	@Test
+	void sendAsNutritionist_persistsEmojiBody() {
+		final Paciente paciente = samplePaciente(1L);
+		when(pacienteRepository.findByIdAndUserId(1L, USER_ID)).thenReturn(Optional.of(paciente));
+		when(patientMessageRepository.save(any(PatientMessage.class))).thenAnswer(invocation -> {
+			final PatientMessage saved = invocation.getArgument(0);
+			saved.setId(100L);
+			saved.setSentAt(Instant.parse("2026-06-01T12:00:00Z"));
+			return saved;
+		});
+
+		final PatientMessageThreadItemDto sent = patientMessageService.sendAsNutritionist(1L, USER_ID,
+				"¡Excelente semana! 🥗💪");
+
+		assertThat(sent.body()).isEqualTo("¡Excelente semana! 🥗💪");
+		final ArgumentCaptor<PatientMessage> captor = ArgumentCaptor.forClass(PatientMessage.class);
+		verify(patientMessageRepository).save(captor.capture());
+		assertThat(captor.getValue().getBody()).isEqualTo("¡Excelente semana! 🥗💪");
+	}
+
+	@Test
 	void sendAsNutritionist_whenBodyBlank_doesNotNotifyPush() {
 		final Paciente paciente = samplePaciente(1L);
 		when(pacienteRepository.findByIdAndUserId(1L, USER_ID)).thenReturn(Optional.of(paciente));


### PR DESCRIPTION
## Summary
- Adds a Unicode emoji picker to the nutritionist patient-messages composer (reactions, foods, habits).
- Inserts emoticons into the message body so patients receive them on the mobile thread unchanged.
- Covers markup, persistence, and mobile-thread round-trip with tests.

## Test plan
- [ ] Open the patient chat widget as a nutritionist and confirm the smile button appears next to the composer.
- [ ] Pick emojis from Reacciones / Alimentos / Hábitos and send a mixed message (e.g. `¡Sigue así! 🥗👍`).
- [ ] Confirm the bubble shows the emojis and the patient mobile thread returns the same body.
- [ ] Close the picker with Escape, outside click, and after send.


Made with [Cursor](https://cursor.com)