### PR TITLE
Allow assigning an empty food plan to a patient

### DIFF
--- a/src/main/java/com/nutriconsultas/dieta/DietaService.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaService.java
@@ -50,4 +50,6 @@ public interface DietaService {
 	Dieta copyDietaForPatientAssignment(@NonNull Long sourceDietaId, @NonNull Long pacienteId,
 			@NonNull String nutritionistUserId);
 
+	Dieta createEmptyDietaForPatient(@NonNull Long pacienteId, @NonNull String nutritionistUserId, String nombre);
+
 }

--- a/src/main/java/com/nutriconsultas/dieta/DietaServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaServiceImpl.java
@@ -22,6 +22,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DietaServiceImpl implements DietaService {
 
+	private static final String DEFAULT_EMPTY_PATIENT_DIET_NAME = "Plan alimentario";
+
+	private static final List<String> EMPTY_PLAN_INGESTA_NAMES = List.of("Desayuno", "Comida", "Cena");
+
 	@Autowired
 	private DietaRepository dietaRepository;
 
@@ -508,6 +512,40 @@ public class DietaServiceImpl implements DietaService {
 		final Dieta saved = dietaRepository.save(copy);
 		log.info("Created patient diet copy with id {} from source {}", saved.getId(), sourceDietaId);
 		return saved;
+	}
+
+	@Override
+	public Dieta createEmptyDietaForPatient(@NonNull final Long pacienteId, @NonNull final String nutritionistUserId,
+			final String nombre) {
+		log.info("Creating empty patient dieta for assignment");
+		final Dieta dieta = new Dieta();
+		dieta.setNombre(resolveEmptyDietaNombre(nombre));
+		dieta.setUserId(nutritionistUserId);
+		dieta.setPacienteId(pacienteId);
+		dieta.setEnergia(0);
+		dieta.setProteina(0.0);
+		dieta.setLipidos(0.0);
+		dieta.setHidratosDeCarbono(0.0);
+
+		final List<Ingesta> ingestas = new ArrayList<>();
+		for (int index = 0; index < EMPTY_PLAN_INGESTA_NAMES.size(); index++) {
+			final Ingesta ingesta = new Ingesta();
+			ingesta.setNombre(EMPTY_PLAN_INGESTA_NAMES.get(index));
+			ingesta.setOrden(index);
+			ingesta.setDieta(dieta);
+			ingesta.setEnergia(0);
+			ingesta.setProteina(0.0);
+			ingesta.setLipidos(0.0);
+			ingesta.setHidratosDeCarbono(0.0);
+			ingestas.add(ingesta);
+		}
+		dieta.setIngestas(ingestas);
+		return dietaRepository.save(dieta);
+	}
+
+	private static String resolveEmptyDietaNombre(final String nombre) {
+		final boolean hasCustomName = nombre != null && !nombre.isBlank();
+		return hasCustomName ? nombre.trim() : DEFAULT_EMPTY_PATIENT_DIET_NAME;
 	}
 
 	private Dieta buildDietaCopy(final Dieta originalDieta, final String nombre, final String userId,

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -881,7 +881,11 @@ public class PacienteController extends AbstractAuthorizedController {
 			hasErrors = true;
 		}
 
-		if (parsedType == PacienteDietaAssignmentType.DATE_RANGE) {
+		final boolean emptyPlan = PacienteDietaWeekdayRequestSupport.isEmptyPlanAssignment(assignmentType);
+		if (emptyPlan) {
+			pacienteDieta.setPaciente(paciente);
+		}
+		else if (parsedType == PacienteDietaAssignmentType.DATE_RANGE) {
 			if (dietaId == null) {
 				result.rejectValue("dieta", "NotNull", "La dieta es requerida");
 				hasErrors = true;
@@ -916,7 +920,11 @@ public class PacienteController extends AbstractAuthorizedController {
 		}
 
 		final PacienteDieta saved;
-		if (parsedType == PacienteDietaAssignmentType.WEEKLY) {
+		if (emptyPlan) {
+			saved = pacienteDietaService.assignEmptyDieta(id, pacienteDieta, userId,
+					request != null ? request.getParameter("emptyDietaNombre") : null);
+		}
+		else if (parsedType == PacienteDietaAssignmentType.WEEKLY) {
 			saved = pacienteDietaService.assignWeeklyDieta(id,
 					PacienteDietaWeekdayRequestSupport.parseWeekdayCatalogDietaIds(request), pacienteDieta, userId);
 		}

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaService.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaService.java
@@ -18,6 +18,9 @@ public interface PacienteDietaService {
 	PacienteDieta assignWeeklyDieta(@NonNull Long pacienteId, @NonNull Map<Integer, Long> weekdayCatalogDietaIds,
 			@NonNull PacienteDieta pacienteDieta, @NonNull String userId);
 
+	PacienteDieta assignEmptyDieta(@NonNull Long pacienteId, @NonNull PacienteDieta pacienteDieta,
+			@NonNull String userId, String nombre);
+
 	PacienteDieta updateAssignment(@NonNull Long id, @NonNull PacienteDieta pacienteDieta);
 
 	PacienteDieta updateWeeklyAssignment(@NonNull Long id, @NonNull Map<Integer, Long> weekdayCatalogDietaIds,

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaServiceImpl.java
@@ -89,6 +89,21 @@ public class PacienteDietaServiceImpl implements PacienteDietaService {
 	}
 
 	@Override
+	public PacienteDieta assignEmptyDieta(@NonNull final Long pacienteId, @NonNull final PacienteDieta pacienteDieta,
+			@NonNull final String userId, final String nombre) {
+		log.info("Assigning empty dieta to paciente {} for user {}", pacienteId, userId);
+		final Paciente paciente = pacienteRepository.findByIdAndUserId(pacienteId, userId)
+			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado paciente con id " + pacienteId));
+		final Dieta emptyDieta = dietaService.createEmptyDietaForPatient(pacienteId, userId, nombre);
+
+		final PacienteDieta newAssignment = buildAssignmentShell(paciente, pacienteDieta);
+		newAssignment.setAssignmentType(PacienteDietaAssignmentType.DATE_RANGE);
+		newAssignment.setDieta(emptyDieta);
+
+		return pacienteDietaRepository.save(newAssignment);
+	}
+
+	@Override
 	public PacienteDieta updateAssignment(@NonNull final Long id, @NonNull final PacienteDieta pacienteDieta) {
 		log.info("Updating dieta assignment {}", id);
 		final PacienteDieta existing = loadAssignment(id);

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaWeekdayRequestSupport.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaWeekdayRequestSupport.java
@@ -33,8 +33,12 @@ public final class PacienteDietaWeekdayRequestSupport {
 		return result;
 	}
 
+	public static boolean isEmptyPlanAssignment(final String raw) {
+		return "EMPTY_PLAN".equalsIgnoreCase(raw);
+	}
+
 	public static PacienteDietaAssignmentType parseAssignmentType(final String raw) {
-		if (raw == null || raw.isBlank()) {
+		if (raw == null || raw.isBlank() || isEmptyPlanAssignment(raw)) {
 			return PacienteDietaAssignmentType.DATE_RANGE;
 		}
 		try {

--- a/src/main/resources/templates/sbadmin/pacientes/asignar-dieta.html
+++ b/src/main/resources/templates/sbadmin/pacientes/asignar-dieta.html
@@ -136,6 +136,11 @@
                                  class="custom-control-input" value="WEEKLY">
                           <label class="custom-control-label" for="assignmentTypeWeekly">Plan semanal (lunes a domingo)</label>
                         </div>
+                        <div class="custom-control custom-radio">
+                          <input type="radio" id="assignmentTypeEmptyPlan" name="assignmentType"
+                                 class="custom-control-input" value="EMPTY_PLAN">
+                          <label class="custom-control-label" for="assignmentTypeEmptyPlan">Plan alimentario vacío (definir después)</label>
+                        </div>
                       </div>
 
                       <input type="hidden" name="dietaId" id="dietaIdInput" value="">
@@ -151,6 +156,19 @@
                             <strong>Seleccionada:</strong> <span id="dietaSelectedLabel">-</span>
                           </div>
                           <span th:if="${#fields.hasErrors('dieta')}" th:errors="*{dieta}"></span>
+                        </div>
+                      </div>
+
+                      <div id="emptyPlanSection" class="d-none">
+                        <div class="alert alert-light border py-2 mb-3" role="status">
+                          <i class="fas fa-clipboard"></i>
+                          Se creará un plan sin alimentos ni platillos, con ingestas de desayuno, comida y cena.
+                          Después podrá completar el menú desde el editor del plan alimentario.
+                        </div>
+                        <div class="form-group">
+                          <label for="emptyDietaNombre">Nombre del plan</label>
+                          <input type="text" class="form-control" id="emptyDietaNombre" name="emptyDietaNombre"
+                                 maxlength="255" placeholder="Plan alimentario" autocomplete="off">
                         </div>
                       </div>
 
@@ -305,8 +323,11 @@
         const form = document.getElementById('asignarDietaForm');
         const assignmentTypeDateRangeEl = document.getElementById('assignmentTypeDateRange');
         const assignmentTypeWeeklyEl = document.getElementById('assignmentTypeWeekly');
+        const assignmentTypeEmptyPlanEl = document.getElementById('assignmentTypeEmptyPlan');
         const dateRangeSection = document.getElementById('dateRangeSection');
+        const emptyPlanSection = document.getElementById('emptyPlanSection');
         const weeklySection = document.getElementById('weeklySection');
+        const dietaPickerSection = document.getElementById('dietaPickerSection');
         const weeklyPickerHint = document.getElementById('weeklyPickerHint');
         const weeklyActiveDayHint = document.getElementById('weeklyActiveDayHint');
         const weeklyActiveDayLabel = document.getElementById('weeklyActiveDayLabel');
@@ -617,6 +638,10 @@
 
         if (form) {
           form.addEventListener('submit', function(e) {
+            const isEmptyPlan = assignmentTypeEmptyPlanEl && assignmentTypeEmptyPlanEl.checked;
+            if (isEmptyPlan) {
+              return;
+            }
             const isWeekly = document.getElementById('assignmentTypeWeekly').checked;
             if (isWeekly) {
               const hasDay = Array.from(document.querySelectorAll('.weekday-dieta-input'))
@@ -644,11 +669,18 @@
 
         function toggleAssignmentSections() {
           const isWeekly = assignmentTypeWeeklyEl && assignmentTypeWeeklyEl.checked;
+          const isEmptyPlan = assignmentTypeEmptyPlanEl && assignmentTypeEmptyPlanEl.checked;
           if (dateRangeSection) {
-            dateRangeSection.classList.toggle('d-none', isWeekly);
+            dateRangeSection.classList.toggle('d-none', isWeekly || isEmptyPlan);
           }
           if (weeklySection) {
             weeklySection.classList.toggle('d-none', !isWeekly);
+          }
+          if (emptyPlanSection) {
+            emptyPlanSection.classList.toggle('d-none', !isEmptyPlan);
+          }
+          if (dietaPickerSection) {
+            dietaPickerSection.classList.toggle('d-none', isEmptyPlan);
           }
           if (dietaPickerSectionLabel) {
             dietaPickerSectionLabel.textContent = isWeekly
@@ -666,6 +698,9 @@
         }
         if (assignmentTypeWeeklyEl) {
           assignmentTypeWeeklyEl.addEventListener('change', toggleAssignmentSections);
+        }
+        if (assignmentTypeEmptyPlanEl) {
+          assignmentTypeEmptyPlanEl.addEventListener('change', toggleAssignmentSections);
         }
 
         document.querySelectorAll('.weekly-pick-btn').forEach(function(btn) {

--- a/src/test/java/com/nutriconsultas/dieta/DietaServiceTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaServiceTest.java
@@ -316,6 +316,40 @@ public class DietaServiceTest {
 	}
 
 	@Test
+	public void testCreateEmptyDietaForPatientUsesDefaultNameAndEmptyMeals() {
+		when(dietaRepository.save(any(Dieta.class))).thenAnswer(invocation -> {
+			final Dieta saved = invocation.getArgument(0);
+			saved.setId(50L);
+			return saved;
+		});
+
+		final Dieta created = dietaService.createEmptyDietaForPatient(7L, TEST_USER_ID, "  ");
+
+		assertThat(created.getId()).isEqualTo(50L);
+		assertThat(created.getNombre()).isEqualTo("Plan alimentario");
+		assertThat(created.getUserId()).isEqualTo(TEST_USER_ID);
+		assertThat(created.getPacienteId()).isEqualTo(7L);
+		assertThat(created.getEnergia()).isZero();
+		assertThat(created.getIngestas()).extracting(Ingesta::getNombre).containsExactly("Desayuno", "Comida", "Cena");
+		assertThat(created.getIngestas()).allSatisfy(ingesta -> {
+			assertThat(ingesta.getAlimentos()).isEmpty();
+			assertThat(ingesta.getPlatillos()).isEmpty();
+			assertThat(ingesta.getDieta()).isSameAs(created);
+		});
+		verify(dietaRepository).save(any(Dieta.class));
+	}
+
+	@Test
+	public void testCreateEmptyDietaForPatientUsesCustomName() {
+		when(dietaRepository.save(any(Dieta.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		final Dieta created = dietaService.createEmptyDietaForPatient(7L, TEST_USER_ID, "  Plan de Ana  ");
+
+		assertThat(created.getNombre()).isEqualTo("Plan de Ana");
+		assertThat(created.getPacienteId()).isEqualTo(7L);
+	}
+
+	@Test
 	public void testGetDietaByIdAndUserIdSuccess() {
 		log.info("Starting testGetDietaByIdAndUserIdSuccess");
 

--- a/src/test/java/com/nutriconsultas/paciente/AsignarDietaWeeklyUiIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/AsignarDietaWeeklyUiIntegrationTest.java
@@ -3,6 +3,8 @@ package com.nutriconsultas.paciente;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +19,9 @@ import org.springframework.test.web.servlet.MvcResult;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.List;
+
+import com.nutriconsultas.dieta.Dieta;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -30,6 +35,9 @@ class AsignarDietaWeeklyUiIntegrationTest {
 
 	@Autowired
 	private PacienteRepository pacienteRepository;
+
+	@Autowired
+	private PacienteDietaRepository pacienteDietaRepository;
 
 	private Paciente paciente;
 
@@ -58,7 +66,36 @@ class AsignarDietaWeeklyUiIntegrationTest {
 		assertThat(html).contains("id=\"dietaPickerList\"");
 		assertThat(html).contains("Seleccionar dieta");
 		assertThat(html).contains("No se requiere calcular GET/TEF");
+		assertThat(html).contains("id=\"assignmentTypeEmptyPlan\"");
+		assertThat(html).contains("id=\"emptyPlanSection\"");
+		assertThat(html).contains("Plan alimentario vacío");
+		assertThat(html).contains("name=\"emptyDietaNombre\"");
 		assertThat(html.indexOf("id=\"dietaPickerSection\"")).isGreaterThan(html.indexOf("id=\"dateRangeSection\""));
+	}
+
+	@Test
+	void assignEmptyPlan_createsPatientOwnedDietWithoutCatalogSelection() throws Exception {
+		mockMvc
+			.perform(post("/admin/pacientes/{id}/dietas/asignar", paciente.getId())
+				.with(oidcLogin().idToken(token -> token.subject(OWNER_SUB).claim("name", "Tester")))
+				.param("assignmentType", "EMPTY_PLAN")
+				.param("startDate", "2026-08-14")
+				.param("status", "ACTIVE")
+				.param("emptyDietaNombre", "Plan personalizado Ana"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/pacientes/" + paciente.getId() + "/dietas"));
+
+		final List<PacienteDieta> assignments = pacienteDietaRepository
+			.findByPacienteIdOrderByStartDateDesc(paciente.getId());
+		assertThat(assignments).hasSize(1);
+		final PacienteDieta assignment = assignments.get(0);
+		final Dieta assignedDieta = assignment.getDieta();
+		assertThat(assignedDieta).isNotNull();
+		assertThat(assignedDieta.getNombre()).isEqualTo("Plan personalizado Ana");
+		assertThat(assignedDieta.getPacienteId()).isEqualTo(paciente.getId());
+		assertThat(assignedDieta.getUserId()).isEqualTo(OWNER_SUB);
+		assertThat(assignment.getAssignmentType()).isEqualTo(PacienteDietaAssignmentType.DATE_RANGE);
+		assertThat(assignment.getStatus()).isEqualTo(PacienteDietaStatus.ACTIVE);
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
@@ -905,6 +905,47 @@ public class PacienteControllerTest {
 	}
 
 	@Test
+	public void testGuardarAsignacionEmptyPlan() {
+		final PacienteDieta pacienteDieta = new PacienteDieta();
+		pacienteDieta.setStartDate(new Date());
+		pacienteDieta.setStatus(PacienteDietaStatus.ACTIVE);
+
+		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
+		when(httpServletRequest.getParameter("emptyDietaNombre")).thenReturn("Plan personalizado");
+		when(pacienteDietaService.assignEmptyDieta(eq(1L), any(PacienteDieta.class), eq(TEST_USER_ID),
+				eq("Plan personalizado")))
+			.thenReturn(pacienteDieta);
+
+		final Model model = org.mockito.Mockito.mock(Model.class);
+
+		final String result = controller.guardarAsignacionDieta(1L, pacienteDieta, bindingResult, model, "EMPTY_PLAN",
+				null, httpServletRequest, principal);
+
+		assertThat(result).isEqualTo("redirect:/admin/pacientes/1/dietas");
+		verify(pacienteDietaService).assignEmptyDieta(eq(1L), any(PacienteDieta.class), eq(TEST_USER_ID),
+				eq("Plan personalizado"));
+		verify(pacienteDietaService, org.mockito.Mockito.never()).assignDieta(any(Long.class), any(Long.class),
+				any(PacienteDieta.class), any(String.class));
+		verify(dietaRepository, org.mockito.Mockito.never()).findById(any());
+	}
+
+	@Test
+	public void testGuardarAsignacionEmptyPlanWithValidationErrors() {
+		final PacienteDieta pacienteDieta = new PacienteDieta();
+		pacienteDieta.setStatus(null);
+		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
+		when(bindingResult.getAllErrors()).thenReturn(new ArrayList<>());
+		final Model model = org.mockito.Mockito.mock(Model.class);
+
+		final String result = controller.guardarAsignacionDieta(1L, pacienteDieta, bindingResult, model, "EMPTY_PLAN",
+				null, httpServletRequest, principal);
+
+		assertThat(result).isEqualTo("sbadmin/pacientes/asignar-dieta");
+		verify(bindingResult).rejectValue(eq("startDate"), eq("NotNull"), eq("La fecha de inicio es requerida"));
+		verify(pacienteDietaService, org.mockito.Mockito.never()).assignEmptyDieta(any(), any(), any(), any());
+	}
+
+	@Test
 	public void testEditarAsignacionDieta() {
 		log.info("starting testEditarAsignacionDieta");
 		// Arrange

--- a/src/test/java/com/nutriconsultas/paciente/PacienteDietaServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteDietaServiceTest.java
@@ -439,6 +439,45 @@ public class PacienteDietaServiceTest {
 	}
 
 	@Test
+	public void testAssignEmptyDieta() {
+		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(Optional.of(paciente));
+		when(dietaService.createEmptyDietaForPatient(1L, TEST_USER_ID, "Plan de Juan")).thenReturn(patientCopyDieta);
+		when(pacienteDietaRepository.save(any(PacienteDieta.class))).thenAnswer(invocation -> {
+			final PacienteDieta pd = invocation.getArgument(0);
+			pd.setId(11L);
+			return pd;
+		});
+
+		final PacienteDieta metadata = new PacienteDieta();
+		metadata.setStartDate(new Date());
+		metadata.setStatus(PacienteDietaStatus.ACTIVE);
+		metadata.setNotes("Definir menú después");
+
+		final PacienteDieta result = service.assignEmptyDieta(1L, metadata, TEST_USER_ID, "Plan de Juan");
+
+		assertThat(result.getId()).isEqualTo(11L);
+		assertThat(result.getPaciente()).isEqualTo(paciente);
+		assertThat(result.getDieta()).isEqualTo(patientCopyDieta);
+		assertThat(result.getAssignmentType()).isEqualTo(PacienteDietaAssignmentType.DATE_RANGE);
+		assertThat(result.getNotes()).isEqualTo("Definir menú después");
+		verify(dietaService).createEmptyDietaForPatient(1L, TEST_USER_ID, "Plan de Juan");
+		verify(dietaService, org.mockito.Mockito.never()).copyDietaForPatientAssignment(any(), any(), any());
+		verify(pacienteDietaRepository).save(any(PacienteDieta.class));
+	}
+
+	@Test
+	public void testAssignEmptyDietaThrowsExceptionWhenPacienteNotFound() {
+		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(Optional.empty());
+		final PacienteDieta metadata = new PacienteDieta();
+		metadata.setStartDate(new Date());
+
+		assertThatThrownBy(() -> service.assignEmptyDieta(1L, metadata, TEST_USER_ID, null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("No se ha encontrado paciente");
+		verify(dietaService, org.mockito.Mockito.never()).createEmptyDietaForPatient(any(), any(), any());
+	}
+
+	@Test
 	public void testFindByIdThrowsExceptionWhenNotFound() {
 		log.info("starting testFindByIdThrowsExceptionWhenNotFound");
 		// Arrange


### PR DESCRIPTION
## Summary
- Nutritionists can assign an empty food plan instead of copying a catalog diet, then fill meals later in the editor.
- The empty plan is patient-owned (desayuno, comida, cena with no foods) and stays out of the shared catalog.
- Assignment still uses the usual start/end dates, status, and optional name.

## Test plan
- [ ] Open Asignar Dieta for a patient and confirm the new option **Plan alimentario vacío (definir después)**.
- [ ] Assign an empty plan with a custom name; it should appear in the patient’s plan list and open in the diet editor.
- [ ] Confirm desayuno/comida/cena exist with no foods or dishes, then add items manually.
- [ ] Assign a catalog diet and a weekly plan to confirm those flows are unchanged.


Made with [Cursor](https://cursor.com)