### PR TITLE
Fix clinical exam save failing on thyroid column names

### DIFF
--- a/src/main/java/com/nutriconsultas/clinical/exam/ThyroidPanel.java
+++ b/src/main/java/com/nutriconsultas/clinical/exam/ThyroidPanel.java
@@ -22,10 +22,10 @@ public class ThyroidPanel {
 	@Column(precision = 5)
 	private Double tsh;
 
-	@Column(precision = 5)
+	@Column(name = "t4_libre", precision = 5)
 	private Double t4Libre;
 
-	@Column(precision = 5)
+	@Column(name = "t3_libre", precision = 5)
 	private Double t3Libre;
 
 	@Column(precision = 5)

--- a/src/test/java/com/nutriconsultas/clinical/exam/ClinicalExamThyroidPanelTest.java
+++ b/src/test/java/com/nutriconsultas/clinical/exam/ClinicalExamThyroidPanelTest.java
@@ -2,6 +2,8 @@ package com.nutriconsultas.clinical.exam;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import jakarta.persistence.Column;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -22,6 +24,17 @@ class ClinicalExamThyroidPanelTest {
 		assertThat(exam.getT4Libre()).isEqualTo(1.2);
 		assertThat(exam.getT3Libre()).isEqualTo(3.1);
 		assertThat(exam.getAntiTpo()).isEqualTo(15.0);
+	}
+
+	@Test
+	void thyroidLibreFields_mapToSnakeCaseLiquibaseColumns() throws NoSuchFieldException {
+		final Column t4 = ThyroidPanel.class.getDeclaredField("t4Libre").getAnnotation(Column.class);
+		final Column t3 = ThyroidPanel.class.getDeclaredField("t3Libre").getAnnotation(Column.class);
+
+		assertThat(t4).isNotNull();
+		assertThat(t3).isNotNull();
+		assertThat(t4.name()).isEqualTo("t4_libre");
+		assertThat(t3.name()).isEqualTo("t3_libre");
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/clinical/exam/ThyroidPanelPersistenceTest.java
+++ b/src/test/java/com/nutriconsultas/clinical/exam/ThyroidPanelPersistenceTest.java
@@ -1,0 +1,67 @@
+package com.nutriconsultas.clinical.exam;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.nutriconsultas.paciente.Paciente;
+import com.nutriconsultas.paciente.PacienteRepository;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class ThyroidPanelPersistenceTest {
+
+	@Autowired
+	private ClinicalExamRepository clinicalExamRepository;
+
+	@Autowired
+	private PacienteRepository pacienteRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	void saveAndLoad_persistsThyroidLibreColumnsMatchingLiquibase() {
+		final Paciente paciente = pacienteRepository.saveAndFlush(samplePaciente());
+
+		final ClinicalExam exam = new ClinicalExam();
+		exam.setPaciente(paciente);
+		exam.setExamDateTime(new Date());
+		exam.setTitle("Examen Clínico");
+		exam.setTsh(2.5);
+		exam.setT4Libre(1.2);
+		exam.setT3Libre(3.1);
+		exam.setAntiTpo(15.0);
+
+		final ClinicalExam saved = clinicalExamRepository.saveAndFlush(exam);
+		entityManager.clear();
+
+		final ClinicalExam loaded = clinicalExamRepository.findById(saved.getId()).orElseThrow();
+
+		assertThat(loaded.getTsh()).isCloseTo(2.5, within(0.001));
+		assertThat(loaded.getT4Libre()).isCloseTo(1.2, within(0.001));
+		assertThat(loaded.getT3Libre()).isCloseTo(3.1, within(0.001));
+		assertThat(loaded.getAntiTpo()).isCloseTo(15.0, within(0.001));
+	}
+
+	private static Paciente samplePaciente() {
+		final Paciente paciente = new Paciente();
+		paciente.setName("Thyroid Persistence Test");
+		paciente.setUserId("nutritionist-thyroid");
+		final LocalDate dob = LocalDate.now().minusYears(30);
+		paciente.setDob(Date.from(dob.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		paciente.setGender("F");
+		return paciente;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Hibernate mapped `t3Libre`/`t4Libre` to `t3libre`/`t4libre`, but Liquibase created `t3_libre`/`t4_libre` on `thyroid_panel`.
- Production logs showed `PSQLException: column "t3libre" of relation "thyroid_panel" does not exist` on clinical exam create (`POST /admin/pacientes/{id}/clinicos`) and view.
- Explicit `@Column` names align the entity with changeset `032-thyroid-panel`.

## Test plan
- [x] `ClinicalExamThyroidPanelTest` asserts Liquibase column names
- [x] `ThyroidPanelPersistenceTest` round-trips TSH / T4 libre / T3 libre / Anti-TPO against H2 + Liquibase
- [ ] After deploy: nutritionist can create a clinical exam with thyroid fields and open the saved exam without a 500


Made with [Cursor](https://cursor.com)