### PR TITLE
Let nutritionists open diet plans in the patient app preview

### DIFF
--- a/src/main/java/com/nutriconsultas/paciente/PacienteMobilePreviewRestController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteMobilePreviewRestController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
 import com.nutriconsultas.paciente.preview.PacienteMobilePreviewService;
 import com.nutriconsultas.paciente.preview.PatientMobilePreviewDto;
 import com.nutriconsultas.util.LogRedaction;
@@ -48,6 +49,7 @@ public class PacienteMobilePreviewRestController {
 			body.put("progress", preview.progress());
 			body.put("activePlan", preview.activePlan());
 			body.put("activePlanDetail", preview.activePlanDetail());
+			body.put("plans", preview.plans());
 			body.put("nextVisit", preview.nextVisit());
 			if (log.isDebugEnabled()) {
 				log.debug("Returning mobile preview for patient {}", LogRedaction.redactPaciente(pacienteId));
@@ -56,6 +58,27 @@ public class PacienteMobilePreviewRestController {
 		}
 		catch (IllegalArgumentException ex) {
 			final String message = ex.getMessage() != null ? ex.getMessage() : "Paciente no encontrado";
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("success", false, "error", message));
+		}
+	}
+
+	@GetMapping("/diet-plans/{assignmentId}")
+	public ResponseEntity<Map<String, Object>> getDietPlanDetail(@PathVariable @NonNull final Long pacienteId,
+			@PathVariable @NonNull final Long assignmentId, @AuthenticationPrincipal final OidcUser principal) {
+		final String userId = requireUserId(principal);
+		try {
+			final DietPlanDetailDto plan = pacienteMobilePreviewService.getPlanDetail(pacienteId, userId, assignmentId);
+			final Map<String, Object> body = new LinkedHashMap<>();
+			body.put("success", true);
+			body.put("plan", plan);
+			if (log.isDebugEnabled()) {
+				log.debug("Returning mobile preview diet plan {} for patient {}",
+						LogRedaction.redactPacienteDieta(assignmentId), LogRedaction.redactPaciente(pacienteId));
+			}
+			return ResponseEntity.ok(body);
+		}
+		catch (IllegalArgumentException ex) {
+			final String message = ex.getMessage() != null ? ex.getMessage() : "Plan alimentario no encontrado";
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("success", false, "error", message));
 		}
 	}

--- a/src/main/java/com/nutriconsultas/paciente/preview/PacienteMobilePreviewService.java
+++ b/src/main/java/com/nutriconsultas/paciente/preview/PacienteMobilePreviewService.java
@@ -4,9 +4,11 @@ import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.nutriconsultas.calendar.EventStatus;
 import com.nutriconsultas.mobile.MobilePatientDietPlanService;
@@ -34,6 +36,8 @@ import lombok.extern.slf4j.Slf4j;
 public class PacienteMobilePreviewService {
 
 	private static final int NEXT_VISIT_CANDIDATES = 20;
+
+	private static final int PLAN_LIST_SIZE = 50;
 
 	private final PacienteService pacienteService;
 
@@ -65,6 +69,7 @@ public class PacienteMobilePreviewService {
 		}
 
 		final PatientProgressSnapshotDto progress = mobilePatientProgressService.getSnapshot(pacienteId);
+		final List<DietPlanSummaryDto> plans = resolvePlans(pacienteId);
 		final DietPlanSummaryDto activePlan = resolveActivePlan(pacienteId);
 		final DietPlanDetailDto activePlanDetail = activePlan != null
 				? mobilePatientDietPlanService.getDietPlanDetail(pacienteId, activePlan.assignmentId()) : null;
@@ -79,7 +84,42 @@ public class PacienteMobilePreviewService {
 		}
 
 		return new PatientMobilePreviewDto(firstName, nutritionistDisplayName, avatarUrl, progress, activePlan,
-				activePlanDetail, nextVisit);
+				activePlanDetail, plans, nextVisit);
+	}
+
+	@Transactional(readOnly = true)
+	public DietPlanDetailDto getPlanDetail(final Long pacienteId, final String nutritionistUserId,
+			final Long assignmentId) {
+		final Paciente paciente = pacienteService.findByIdAndUserId(pacienteId, nutritionistUserId);
+		if (paciente == null) {
+			throw new IllegalArgumentException("Paciente no encontrado");
+		}
+		return loadPlanDetail(pacienteId, assignmentId);
+	}
+
+	private DietPlanDetailDto loadPlanDetail(final Long pacienteId, final Long assignmentId) {
+		DietPlanDetailDto detail = null;
+		try {
+			detail = mobilePatientDietPlanService.getDietPlanDetail(pacienteId, assignmentId);
+		}
+		catch (ResponseStatusException ex) {
+			if (ex.getStatusCode() != HttpStatus.NOT_FOUND) {
+				throw new IllegalStateException("No se pudo cargar el plan alimentario", ex);
+			}
+		}
+		if (detail == null) {
+			throw new IllegalArgumentException("Plan alimentario no encontrado");
+		}
+		return detail;
+	}
+
+	private List<DietPlanSummaryDto> resolvePlans(final Long pacienteId) {
+		final PagedResponse<DietPlanSummaryDto> page = mobilePatientDietPlanService.listDietPlans(pacienteId, 0,
+				PLAN_LIST_SIZE, false);
+		if (page == null || page.content() == null) {
+			return List.of();
+		}
+		return page.content();
 	}
 
 	private DietPlanSummaryDto resolveActivePlan(final Long pacienteId) {

--- a/src/main/java/com/nutriconsultas/paciente/preview/PatientMobilePreviewDto.java
+++ b/src/main/java/com/nutriconsultas/paciente/preview/PatientMobilePreviewDto.java
@@ -1,5 +1,7 @@
 package com.nutriconsultas.paciente.preview;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
 import com.nutriconsultas.mobile.dto.DietPlanSummaryDto;
@@ -12,5 +14,5 @@ import com.nutriconsultas.mobile.dto.VisitSummaryDto;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record PatientMobilePreviewDto(String firstName, String nutritionistDisplayName, String avatarUrl,
 		PatientProgressSnapshotDto progress, DietPlanSummaryDto activePlan, DietPlanDetailDto activePlanDetail,
-		VisitSummaryDto nextVisit) {
+		List<DietPlanSummaryDto> plans, VisitSummaryDto nextVisit) {
 }

--- a/src/main/resources/static/sbadmin/css/paciente-mobile-preview.css
+++ b/src/main/resources/static/sbadmin/css/paciente-mobile-preview.css
@@ -355,6 +355,123 @@
   cursor: default;
 }
 
+.mnp-preview-content.is-stacked .mnp-tabbar {
+  display: none;
+}
+
+.mnp-tappable {
+  cursor: pointer;
+}
+
+.mnp-tappable:hover,
+.mnp-tappable:focus {
+  outline: none;
+  border-color: rgba(31, 77, 60, 0.35);
+}
+
+.mnp-plan-card-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.45rem;
+}
+
+.mnp-plan-card-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.mnp-plan-dates {
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--mnp-muted);
+  margin: 0.15rem 0 0.2rem;
+}
+
+.mnp-chevron {
+  color: var(--mnp-muted);
+  font-size: 0.75rem;
+  margin-top: 0.4rem;
+  flex-shrink: 0;
+}
+
+.mnp-chip-completed {
+  background: rgba(46, 204, 141, 0.18);
+  color: var(--mnp-forest);
+}
+
+.mnp-chip-cancelled {
+  background: rgba(138, 147, 139, 0.2);
+  color: var(--mnp-muted);
+}
+
+.mnp-back {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: none;
+  background: transparent;
+  color: var(--mnp-forest);
+  font-weight: 700;
+  font-size: 1.05rem;
+  padding: 0 0 0.85rem;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+}
+
+.mnp-back i {
+  font-size: 0.85rem;
+}
+
+.mnp-screen-title {
+  font-size: 1.35rem;
+  font-weight: 700;
+  line-height: 1.2;
+  margin-bottom: 0.25rem;
+}
+
+.mnp-filter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  background: var(--mnp-surf);
+  border: 1px solid var(--mnp-line);
+  border-radius: 12px;
+  padding: 0.65rem 0.85rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.mnp-thumb {
+  width: 48px;
+  height: 48px;
+  border-radius: 10px;
+  object-fit: cover;
+  background: var(--mnp-sage);
+  flex-shrink: 0;
+}
+
+.mnp-food-tile {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.mnp-food-kcal {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--mnp-forest);
+  white-space: nowrap;
+}
+
+.mnp-ingesta-card .mnp-ingesta {
+  padding: 0;
+  border: none;
+}
+
 .mnp-panel[hidden] {
   display: none !important;
 }

--- a/src/main/resources/static/sbadmin/js/paciente-mobile-preview.js
+++ b/src/main/resources/static/sbadmin/js/paciente-mobile-preview.js
@@ -128,6 +128,16 @@
     return platillos + alimentos;
   }
 
+  var WEEKLY_PLAN_NAME = 'Plan semanal';
+
+  var state = {
+    pacienteId: null,
+    data: null,
+    activeOnly: false,
+    detailCache: {},
+    stack: []
+  };
+
   function statusLabel(status) {
     if (status === 'ACTIVE') {
       return 'Activo';
@@ -135,7 +145,76 @@
     if (status === 'SCHEDULED') {
       return 'Programada';
     }
+    if (status === 'COMPLETED') {
+      return 'Completada';
+    }
+    if (status === 'CANCELLED') {
+      return 'Cancelada';
+    }
     return status || '';
+  }
+
+  function chipClass(status) {
+    if (status === 'ACTIVE') {
+      return 'mnp-chip-active';
+    }
+    if (status === 'COMPLETED') {
+      return 'mnp-chip-completed';
+    }
+    if (status === 'CANCELLED') {
+      return 'mnp-chip-cancelled';
+    }
+    return '';
+  }
+
+  function isWeeklyPlan(plan) {
+    return !!(plan && plan.dietaName === WEEKLY_PLAN_NAME);
+  }
+
+  function planDisplayName(plan) {
+    if (isWeeklyPlan(plan)) {
+      return WEEKLY_PLAN_NAME;
+    }
+    return (plan && plan.dietaName) ? plan.dietaName : 'Plan alimentario';
+  }
+
+  function formatPlanDates(plan) {
+    if (!plan) {
+      return '';
+    }
+    var start = formatLocalDate(plan.startDate);
+    if (!start) {
+      return '';
+    }
+    if (!plan.endDate) {
+      return 'Desde ' + start;
+    }
+    var end = formatLocalDate(plan.endDate);
+    return start + (end ? ' – ' + end : '');
+  }
+
+  function firstPlatilloImage(ingesta) {
+    var platillos = (ingesta && ingesta.platillos) ? ingesta.platillos : [];
+    var i;
+    for (i = 0; i < platillos.length; i++) {
+      if (platillos[i] && platillos[i].imageUrl) {
+        return platillos[i].imageUrl;
+      }
+    }
+    return null;
+  }
+
+  function portionLabel(count, unit) {
+    if (unit) {
+      return String(count != null ? count : 1) + ' ' + unit;
+    }
+    return String(count != null ? count : 1) + ' porción(es)';
+  }
+
+  function cachePlanDetail(detail) {
+    if (detail && detail.assignmentId != null) {
+      state.detailCache[String(detail.assignmentId)] = detail;
+    }
   }
 
   function renderAvatar(avatarUrl, firstName) {
@@ -199,18 +278,7 @@
 
     html += '<div class="mnp-card-title">Tu plan alimenticio</div>';
     if (plan) {
-      html += '<div class="mnp-card">';
-      html += '<div class="d-flex justify-content-between align-items-start">';
-      html += '<div class="mnp-plan-name">' + escapeHtml(plan.dietaName || 'Plan alimentario') + '</div>';
-      html += '<span class="mnp-chip mnp-chip-active">' + escapeHtml(statusLabel(plan.status)) + '</span>';
-      html += '</div>';
-      if (plan.startDate) {
-        html += '<div class="mnp-muted">Desde ' + escapeHtml(formatLocalDate(plan.startDate)) + '</div>';
-      }
-      if (plan.totalKcal != null) {
-        html += '<div class="mnp-plan-kcal mt-1">' + escapeHtml(String(plan.totalKcal)) + ' kcal/día</div>';
-      }
-      html += '</div>';
+      html += renderPlanCard(plan, true);
     } else {
       html += '<div class="mnp-card mnp-card-sage"><div class="mnp-empty">'
         + 'Tu nutriólogo está trabajando en construir tu plan alimentario.</div></div>';
@@ -241,52 +309,279 @@
     return html;
   }
 
-  function renderDiet(data) {
-    var plan = data.activePlan;
-    var detail = data.activePlanDetail;
-    var html = '';
-
-    html += '<div class="mnp-card-title mb-2" style="font-size:1.1rem">Planes de dieta</div>';
-
-    if (!plan) {
-      html += '<div class="mnp-card mnp-card-sage"><div class="mnp-empty">No hay plan activo.</div></div>';
-      return html;
+  function renderPlanCard(plan, tappable) {
+    var html = '<div class="mnp-card';
+    if (tappable && plan.assignmentId != null) {
+      html += ' mnp-tappable" data-mnp-open-plan="' + escapeHtml(String(plan.assignmentId))
+        + '" role="button" tabindex="0">';
+    } else {
+      html += '">';
     }
-
-    html += '<div class="mnp-card">';
-    html += '<div class="d-flex justify-content-between align-items-start">';
-    html += '<div class="mnp-plan-name">' + escapeHtml(plan.dietaName || 'Plan alimentario') + '</div>';
-    html += '<span class="mnp-chip mnp-chip-active">' + escapeHtml(statusLabel(plan.status)) + '</span>';
-    html += '</div>';
+    html += '<div class="mnp-plan-card-row">';
+    html += '<div class="mnp-plan-card-body">';
+    html += '<div class="mnp-plan-name">' + escapeHtml(planDisplayName(plan)) + '</div>';
+    var dates = formatPlanDates(plan);
+    if (dates) {
+      html += '<div class="mnp-plan-dates">' + escapeHtml(dates) + '</div>';
+    }
     if (plan.totalKcal != null) {
       html += '<div class="mnp-plan-kcal">' + escapeHtml(String(plan.totalKcal)) + ' kcal/día</div>';
-    }
-    if (plan.startDate) {
-      html += '<div class="mnp-muted mt-1">Desde ' + escapeHtml(formatLocalDate(plan.startDate)) + '</div>';
+    } else if (isWeeklyPlan(plan)) {
+      html += '<div class="mnp-plan-kcal">Menú según el día de la semana</div>';
     }
     html += '</div>';
+    html += '<span class="mnp-chip ' + chipClass(plan.status) + '">' + escapeHtml(statusLabel(plan.status)) + '</span>';
+    if (tappable && plan.assignmentId != null) {
+      html += '<i class="fas fa-chevron-right mnp-chevron" aria-hidden="true"></i>';
+    }
+    html += '</div></div>';
+    return html;
+  }
 
-    html += '<div class="mnp-card-title">Ingestas del día</div>';
-    html += '<div class="mnp-card">';
-    var ingestas = (detail && detail.ingestas) ? detail.ingestas : [];
-    if (!ingestas.length) {
-      html += '<div class="mnp-empty">Este plan aún no tiene ingestas.</div>';
-    } else {
-      ingestas.forEach(function (ingesta) {
-        var count = itemCount(ingesta);
-        var kcal = ingesta.totalKcal != null ? ingesta.totalKcal : '—';
-        html += '<div class="mnp-ingesta">';
-        html += '<div class="mnp-ingesta-icon"><i class="fas fa-utensils"></i></div>';
-        html += '<div class="mnp-ingesta-body">';
-        html += '<div class="mnp-ingesta-tipo">' + escapeHtml(ingesta.tipo || 'Ingesta') + '</div>';
-        html += '<div class="mnp-ingesta-meta">' + escapeHtml(String(count)) + ' elementos · '
-          + escapeHtml(String(kcal)) + ' kcal</div>';
-        html += '</div></div>';
+  function visiblePlans(data) {
+    var plans = (data && data.plans && data.plans.length) ? data.plans.slice() : [];
+    if (!plans.length && data && data.activePlan) {
+      plans = [data.activePlan];
+    }
+    if (state.activeOnly) {
+      plans = plans.filter(function (plan) {
+        return plan && plan.status === 'ACTIVE';
       });
     }
-    html += '</div>';
+    return plans;
+  }
 
+  function renderDiet(data) {
+    var plans = visiblePlans(data);
+    var html = '<div class="mnp-screen-title mb-2">Planes de dieta</div>';
+    html += '<label class="mnp-filter">';
+    html += '<span>Solo planes activos</span>';
+    html += '<input type="checkbox" id="mnpActiveOnly"' + (state.activeOnly ? ' checked' : '') + '>';
+    html += '</label>';
+    if (!plans.length) {
+      html += '<div class="mnp-card mnp-card-sage"><div class="mnp-empty">No hay planes con estos filtros.</div></div>';
+      return html;
+    }
+    plans.forEach(function (plan) {
+      html += renderPlanCard(plan, true);
+    });
     return html;
+  }
+
+  function renderStackHeader(title) {
+    return '<button type="button" class="mnp-back" id="mnpStackBack">'
+      + '<i class="fas fa-chevron-left" aria-hidden="true"></i>'
+      + '<span>' + escapeHtml(title) + '</span></button>';
+  }
+
+  function renderIngestaCard(ingesta, index) {
+    var count = itemCount(ingesta);
+    var kcal = ingesta.totalKcal != null ? ingesta.totalKcal : '—';
+    var thumb = firstPlatilloImage(ingesta);
+    var html = '<div class="mnp-card mnp-tappable mnp-ingesta-card" data-mnp-open-ingesta="'
+      + index + '" role="button" tabindex="0">';
+    html += '<div class="mnp-ingesta">';
+    if (thumb) {
+      html += '<img class="mnp-thumb" src="' + escapeHtml(thumb) + '" alt="">';
+    } else {
+      html += '<div class="mnp-ingesta-icon"><i class="fas fa-utensils"></i></div>';
+    }
+    html += '<div class="mnp-ingesta-body">';
+    html += '<div class="mnp-ingesta-tipo">' + escapeHtml(ingesta.tipo || 'Ingesta') + '</div>';
+    html += '<div class="mnp-ingesta-meta">' + escapeHtml(String(count)) + ' elementos · '
+      + escapeHtml(String(kcal)) + ' kcal</div>';
+    html += '</div>';
+    html += '<i class="fas fa-chevron-right mnp-chevron" aria-hidden="true"></i>';
+    html += '</div></div>';
+    return html;
+  }
+
+  function renderMealsScreen(detail) {
+    var weekly = isWeeklyPlan(detail);
+    var html = renderStackHeader('Plan alimentario');
+    html += '<div class="mnp-screen-title">' + escapeHtml(planDisplayName(detail)) + '</div>';
+    if (weekly) {
+      html += '<div class="mnp-muted mb-2">Aquí ves el menú de hoy. Tu nutriólogo asignó un plan por día de la semana.</div>';
+    } else if (detail.totalKcal != null) {
+      html += '<div class="mnp-muted mb-2">' + escapeHtml(String(detail.totalKcal)) + ' kcal/día</div>';
+    }
+    html += '<div class="d-flex align-items-center mb-3">';
+    html += '<span class="mnp-chip ' + chipClass(detail.status) + '">' + escapeHtml(statusLabel(detail.status)) + '</span>';
+    var dates = formatPlanDates(detail);
+    if (dates) {
+      html += '<span class="mnp-plan-dates ml-2">' + escapeHtml(dates) + '</span>';
+    }
+    html += '</div>';
+    html += '<div class="mnp-card-title">' + (weekly ? 'Menú de hoy' : 'Ingestas del día') + '</div>';
+    var ingestas = detail.ingestas || [];
+    if (!ingestas.length) {
+      html += '<div class="mnp-empty">No hay ingestas en este plan.</div>';
+    } else {
+      ingestas.forEach(function (ingesta, index) {
+        html += renderIngestaCard(ingesta, index);
+      });
+    }
+    return html;
+  }
+
+  function renderFoodTile(nombre, quantity, kcal, imageUrl) {
+    var html = '<div class="mnp-card">';
+    html += '<div class="mnp-food-tile">';
+    if (imageUrl) {
+      html += '<img class="mnp-thumb" src="' + escapeHtml(imageUrl) + '" alt="">';
+    } else {
+      html += '<div class="mnp-ingesta-icon"><i class="fas fa-utensils"></i></div>';
+    }
+    html += '<div class="mnp-ingesta-body">';
+    html += '<div class="mnp-ingesta-tipo">' + escapeHtml(nombre || '') + '</div>';
+    html += '<div class="mnp-ingesta-meta">' + escapeHtml(quantity) + '</div>';
+    html += '</div>';
+    if (kcal != null) {
+      html += '<div class="mnp-food-kcal">' + escapeHtml(String(kcal)) + ' kcal</div>';
+    }
+    html += '</div></div>';
+    return html;
+  }
+
+  function renderIngestaScreen(detail, index) {
+    var ingestas = (detail && detail.ingestas) ? detail.ingestas : [];
+    var ingesta = ingestas[index];
+    if (!ingesta) {
+      return renderStackHeader('Ingesta') + '<div class="mnp-empty">No se encontró la ingesta.</div>';
+    }
+    var count = itemCount(ingesta);
+    var kcal = ingesta.totalKcal != null ? ingesta.totalKcal : '—';
+    var html = renderStackHeader(ingesta.tipo || 'Ingesta');
+    html += '<div class="mnp-muted mb-3">' + escapeHtml(String(count)) + ' elementos · '
+      + escapeHtml(String(kcal)) + ' kcal</div>';
+    var platillos = ingesta.platillos || [];
+    var alimentos = ingesta.alimentos || [];
+    if (!platillos.length && !alimentos.length) {
+      html += '<div class="mnp-empty">No hay platillos ni alimentos en esta ingesta.</div>';
+      return html;
+    }
+    platillos.forEach(function (platillo) {
+      html += renderFoodTile(platillo.nombre, portionLabel(platillo.porciones, null), platillo.kcal, platillo.imageUrl);
+    });
+    alimentos.forEach(function (alimento) {
+      html += renderFoodTile(alimento.nombre, portionLabel(alimento.porciones, alimento.unidad), alimento.kcal, null);
+    });
+    return html;
+  }
+
+  function hideStack() {
+    state.stack = [];
+    $('#mnpPreviewContent').removeClass('is-stacked');
+    $('#mnpStackPanel').attr('hidden', true).empty();
+  }
+
+  function renderStack() {
+    var top = state.stack.length ? state.stack[state.stack.length - 1] : null;
+    if (!top) {
+      hideStack();
+      return;
+    }
+    var detail = state.detailCache[String(top.assignmentId)];
+    var html = '';
+    if (top.type === 'loading') {
+      html = renderStackHeader('Plan alimentario') + '<div class="mnp-empty">Cargando plan…</div>';
+    } else if (top.type === 'error') {
+      html = renderStackHeader('Plan alimentario')
+        + '<div class="mnp-empty">' + escapeHtml(top.message || 'No se pudo cargar el plan.') + '</div>';
+    } else if (!detail) {
+      html = renderStackHeader('Plan alimentario')
+        + '<div class="mnp-empty">No se pudo cargar el plan.</div>';
+    } else if (top.type === 'ingesta') {
+      html = renderIngestaScreen(detail, top.ingestaIndex);
+    } else {
+      html = renderMealsScreen(detail);
+    }
+    $('#mnpHomePanel, #mnpDietPanel').attr('hidden', true);
+    $('#mnpStackPanel').html(html).removeAttr('hidden');
+    $('#mnpPreviewContent').addClass('is-stacked');
+  }
+
+  function openPlan(assignmentId, fromTab) {
+    if (assignmentId == null || assignmentId === '') {
+      return;
+    }
+    var cached = state.detailCache[String(assignmentId)];
+    if (cached) {
+      state.stack = [{type: 'meals', assignmentId: assignmentId, from: fromTab || 'diet'}];
+      renderStack();
+      return;
+    }
+    state.stack = [{type: 'loading', assignmentId: assignmentId, from: fromTab || 'diet'}];
+    renderStack();
+    $.ajax({
+      url: previewUrl(state.pacienteId) + '/diet-plans/' + assignmentId,
+      method: 'GET',
+      dataType: 'json'
+    }).done(function (payload) {
+      if (!isCurrentPlanRequest(assignmentId)) {
+        return;
+      }
+      if (!payload || payload.success === false || !payload.plan) {
+        state.stack = [{
+          type: 'error',
+          assignmentId: assignmentId,
+          from: fromTab || 'diet',
+          message: (payload && payload.error) || 'No se pudo cargar el plan.'
+        }];
+        renderStack();
+        return;
+      }
+      cachePlanDetail(payload.plan);
+      state.stack = [{type: 'meals', assignmentId: assignmentId, from: fromTab || 'diet'}];
+      renderStack();
+    }).fail(function (xhr) {
+      if (!isCurrentPlanRequest(assignmentId)) {
+        return;
+      }
+      var msg = 'No se pudo cargar el plan.';
+      if (xhr.responseJSON) {
+        msg = xhr.responseJSON.message || xhr.responseJSON.error || msg;
+      }
+      state.stack = [{
+        type: 'error',
+        assignmentId: assignmentId,
+        from: fromTab || 'diet',
+        message: msg
+      }];
+      renderStack();
+    });
+  }
+
+  function isCurrentPlanRequest(assignmentId) {
+    var top = state.stack.length ? state.stack[0] : null;
+    return !!(top && String(top.assignmentId) === String(assignmentId));
+  }
+
+  function openIngesta(index) {
+    var top = state.stack.length ? state.stack[state.stack.length - 1] : null;
+    if (!top || top.assignmentId == null) {
+      return;
+    }
+    state.stack.push({
+      type: 'ingesta',
+      assignmentId: top.assignmentId,
+      from: top.from,
+      ingestaIndex: index
+    });
+    renderStack();
+  }
+
+  function popStack() {
+    if (!state.stack.length) {
+      return;
+    }
+    var leaving = state.stack.pop();
+    if (state.stack.length) {
+      renderStack();
+      return;
+    }
+    hideStack();
+    activateTab(leaving && leaving.from === 'home' ? 'home' : 'diet');
   }
 
   function showError(message) {
@@ -302,6 +597,10 @@
   }
 
   function showContent(data) {
+    state.data = data;
+    state.detailCache = {};
+    cachePlanDetail(data && data.activePlanDetail);
+    hideStack();
     $('#mnpPreviewLoading').hide();
     $('#mnpPreviewError').hide();
     $('#mnpHomePanel').html(renderHome(data));
@@ -311,8 +610,10 @@
   }
 
   function activateTab(tab) {
+    $('#mnpPreviewContent').removeClass('is-stacked');
+    $('#mnpStackPanel').attr('hidden', true);
     $('.mnp-tab').removeClass('active');
-    $('.mnp-panel').attr('hidden', true);
+    $('#mnpHomePanel, #mnpDietPanel').attr('hidden', true);
     if (tab === 'diet') {
       $('#mnpTabDiet').addClass('active');
       $('#mnpDietPanel').removeAttr('hidden');
@@ -324,6 +625,10 @@
 
   function openPreview(pacienteId) {
     var $modal = $('#pacienteMobilePreviewModal');
+    state.pacienteId = pacienteId;
+    state.activeOnly = false;
+    state.detailCache = {};
+    state.stack = [];
     showLoading();
     $modal.modal('show');
 
@@ -356,14 +661,53 @@
       openPreview(pacienteId);
     });
 
+    $(document).on('click', '#mnpTabDiet', function (e) {
+      e.preventDefault();
+      hideStack();
+      activateTab('diet');
+    });
+
     $(document).on('click', '#mnpTabHome', function (e) {
       e.preventDefault();
+      hideStack();
       activateTab('home');
     });
 
-    $(document).on('click', '#mnpTabDiet', function (e) {
+    $(document).on('click', '[data-mnp-open-plan]', function (e) {
       e.preventDefault();
-      activateTab('diet');
+      var assignmentId = $(this).attr('data-mnp-open-plan');
+      var fromTab = $('#mnpHomePanel').attr('hidden') ? 'diet' : 'home';
+      openPlan(assignmentId, fromTab);
+    });
+
+    $(document).on('click', '[data-mnp-open-ingesta]', function (e) {
+      e.preventDefault();
+      openIngesta(Number($(this).attr('data-mnp-open-ingesta')));
+    });
+
+    $(document).on('click', '#mnpStackBack', function (e) {
+      e.preventDefault();
+      popStack();
+    });
+
+    $(document).on('change', '#mnpActiveOnly', function () {
+      state.activeOnly = $(this).is(':checked');
+      if (state.data) {
+        $('#mnpDietPanel').html(renderDiet(state.data));
+      }
+    });
+
+    $(document).on('keydown', '.mnp-tappable', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        $(this).trigger('click');
+      }
+    });
+
+    $('#pacienteMobilePreviewModal').on('hidden.bs.modal', function () {
+      hideStack();
+      state.data = null;
+      state.detailCache = {};
     });
   }
 

--- a/src/main/resources/templates/sbadmin/pacientes/listado.html
+++ b/src/main/resources/templates/sbadmin/pacientes/listado.html
@@ -133,6 +133,7 @@
                   <div class="mnp-phone-body">
                     <div id="mnpHomePanel" class="mnp-panel"></div>
                     <div id="mnpDietPanel" class="mnp-panel" hidden></div>
+                    <div id="mnpStackPanel" class="mnp-panel mnp-stack-panel" hidden></div>
                   </div>
                   <nav class="mnp-tabbar" aria-label="Navegación de preview">
                     <button type="button" class="mnp-tab active" id="mnpTabHome">

--- a/src/test/java/com/nutriconsultas/paciente/PacienteMobilePreviewRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteMobilePreviewRestControllerTest.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,7 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
+import com.nutriconsultas.mobile.dto.DietPlanDetailDto;
 import com.nutriconsultas.paciente.preview.PacienteMobilePreviewService;
 import com.nutriconsultas.paciente.preview.PatientMobilePreviewDto;
 
@@ -36,7 +39,7 @@ class PacienteMobilePreviewRestControllerTest {
 	@Test
 	void getPreview_returnsSuccessPayload() {
 		final PatientMobilePreviewDto preview = new PatientMobilePreviewDto("María", "Lic. Ana", null, null, null, null,
-				null);
+				List.of(), null);
 		when(pacienteMobilePreviewService.buildPreview(eq(1L), eq(NUTRITIONIST_SUB))).thenReturn(preview);
 
 		final ResponseEntity<Map<String, Object>> response = controller.getPreview(1L, principal());
@@ -44,7 +47,8 @@ class PacienteMobilePreviewRestControllerTest {
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 		assertThat(response.getBody()).containsEntry("success", true)
 			.containsEntry("firstName", "María")
-			.containsEntry("nutritionistDisplayName", "Lic. Ana");
+			.containsEntry("nutritionistDisplayName", "Lic. Ana")
+			.containsKey("plans");
 		verify(pacienteMobilePreviewService).buildPreview(1L, NUTRITIONIST_SUB);
 	}
 
@@ -57,6 +61,31 @@ class PacienteMobilePreviewRestControllerTest {
 
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
 		assertThat(response.getBody()).containsEntry("success", false).containsEntry("error", "Paciente no encontrado");
+	}
+
+	@Test
+	void getDietPlanDetail_returnsPlanPayload() {
+		final DietPlanDetailDto plan = new DietPlanDetailDto(55L, PacienteDietaStatus.ACTIVE, LocalDate.of(2026, 3, 16),
+				null, null, "Plan hipocalórico", 1800, 90.0, 55.0, 200.0, List.of());
+		when(pacienteMobilePreviewService.getPlanDetail(eq(1L), eq(NUTRITIONIST_SUB), eq(55L))).thenReturn(plan);
+
+		final ResponseEntity<Map<String, Object>> response = controller.getDietPlanDetail(1L, 55L, principal());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).containsEntry("success", true).containsEntry("plan", plan);
+		verify(pacienteMobilePreviewService).getPlanDetail(1L, NUTRITIONIST_SUB, 55L);
+	}
+
+	@Test
+	void getDietPlanDetail_returnsNotFoundWhenMissing() {
+		when(pacienteMobilePreviewService.getPlanDetail(eq(1L), eq(NUTRITIONIST_SUB), eq(55L)))
+			.thenThrow(new IllegalArgumentException("Plan alimentario no encontrado"));
+
+		final ResponseEntity<Map<String, Object>> response = controller.getDietPlanDetail(1L, 55L, principal());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(response.getBody()).containsEntry("success", false)
+			.containsEntry("error", "Plan alimentario no encontrado");
 	}
 
 	private static OidcUser principal() {

--- a/src/test/java/com/nutriconsultas/paciente/preview/PacienteMobilePreviewServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/preview/PacienteMobilePreviewServiceTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.nutriconsultas.calendar.EventStatus;
 import com.nutriconsultas.mobile.MobilePatientDietPlanService;
@@ -74,6 +76,8 @@ class PacienteMobilePreviewServiceTest {
 
 		final DietPlanSummaryDto summary = new DietPlanSummaryDto(55L, PacienteDietaStatus.ACTIVE,
 				LocalDate.of(2026, 3, 16), null, null, "Plan hipocalórico", 1800, 90.0, 55.0, 200.0);
+		when(mobilePatientDietPlanService.listDietPlans(eq(10L), eq(0), eq(50), eq(false)))
+			.thenReturn(new PagedResponse<>(List.of(summary), 0, 50, 1, 1, true));
 		when(mobilePatientDietPlanService.listDietPlans(eq(10L), eq(0), eq(1), eq(true)))
 			.thenReturn(new PagedResponse<>(List.of(summary), 0, 1, 1, 1, true));
 
@@ -102,6 +106,7 @@ class PacienteMobilePreviewServiceTest {
 		assertThat(preview.activePlanDetail()).isEqualTo(detail);
 		assertThat(preview.nextVisit()).isEqualTo(visit);
 		assertThat(preview.activePlanDetail().ingestas()).hasSize(1);
+		assertThat(preview.plans()).containsExactly(summary);
 	}
 
 	@Test
@@ -110,6 +115,8 @@ class PacienteMobilePreviewServiceTest {
 		when(pacienteService.findByIdAndUserId(11L, USER_ID)).thenReturn(paciente);
 		when(mobilePatientProgressService.getSnapshot(11L)).thenReturn(new PatientProgressSnapshotDto(null, null, null,
 				null, null, null, null, null, null, null, null, null, null, null));
+		when(mobilePatientDietPlanService.listDietPlans(eq(11L), eq(0), eq(50), eq(false)))
+			.thenReturn(new PagedResponse<>(List.of(), 0, 50, 0, 0, true));
 		when(mobilePatientDietPlanService.listDietPlans(eq(11L), eq(0), eq(1), eq(true)))
 			.thenReturn(new PagedResponse<>(List.of(), 0, 1, 0, 0, true));
 		when(mobilePatientVisitService.listVisits(eq(11L), eq(0), eq(20), eq(EventStatus.SCHEDULED), any(Instant.class),
@@ -122,6 +129,7 @@ class PacienteMobilePreviewServiceTest {
 		assertThat(preview.firstName()).isEqualTo("Juan");
 		assertThat(preview.activePlan()).isNull();
 		assertThat(preview.activePlanDetail()).isNull();
+		assertThat(preview.plans()).isEmpty();
 		assertThat(preview.nextVisit()).isNull();
 		assertThat(preview.nutritionistDisplayName()).isNull();
 		verify(mobilePatientDietPlanService, never()).getDietPlanDetail(any(), any());
@@ -135,6 +143,66 @@ class PacienteMobilePreviewServiceTest {
 			.hasMessageContaining("Paciente no encontrado");
 		verify(mobilePatientProgressService, never()).getSnapshot(any());
 		verify(mobilePatientDietPlanService, never()).listDietPlans(any(), anyInt(), anyInt(), anyBoolean());
+	}
+
+	@Test
+	void buildPreview_includesAllAssignedPlans() {
+		final Paciente paciente = paciente(12L, "Ana Ruiz", "Ana");
+		when(pacienteService.findByIdAndUserId(12L, USER_ID)).thenReturn(paciente);
+		when(mobilePatientProgressService.getSnapshot(12L)).thenReturn(new PatientProgressSnapshotDto(null, null, null,
+				null, null, null, null, null, null, null, null, null, null, null));
+
+		final DietPlanSummaryDto active = new DietPlanSummaryDto(55L, PacienteDietaStatus.ACTIVE,
+				LocalDate.of(2026, 8, 1), null, null, "Plan hipocalórico", 1800, 90.0, 55.0, 200.0);
+		final DietPlanSummaryDto completed = new DietPlanSummaryDto(40L, PacienteDietaStatus.COMPLETED,
+				LocalDate.of(2026, 1, 10), LocalDate.of(2026, 3, 10), null, "Plan previo", 1600, 80.0, 50.0, 180.0);
+		when(mobilePatientDietPlanService.listDietPlans(eq(12L), eq(0), eq(50), eq(false)))
+			.thenReturn(new PagedResponse<>(List.of(active, completed), 0, 50, 2, 1, true));
+		when(mobilePatientDietPlanService.listDietPlans(eq(12L), eq(0), eq(1), eq(true)))
+			.thenReturn(new PagedResponse<>(List.of(active), 0, 1, 1, 1, true));
+
+		final DietPlanDetailDto detail = new DietPlanDetailDto(55L, PacienteDietaStatus.ACTIVE,
+				LocalDate.of(2026, 8, 1), null, null, "Plan hipocalórico", 1800, 90.0, 55.0, 200.0, List.of());
+		when(mobilePatientDietPlanService.getDietPlanDetail(12L, 55L)).thenReturn(detail);
+		when(mobilePatientVisitService.listVisits(eq(12L), eq(0), eq(20), eq(EventStatus.SCHEDULED), any(Instant.class),
+				isNull()))
+			.thenReturn(new PagedResponse<>(List.of(), 0, 20, 0, 0, true));
+		when(nutritionistProfileRepository.findByUserId(USER_ID)).thenReturn(Optional.empty());
+
+		final PatientMobilePreviewDto preview = service.buildPreview(12L, USER_ID);
+
+		assertThat(preview.activePlan()).isEqualTo(active);
+		assertThat(preview.plans()).containsExactly(active, completed);
+	}
+
+	@Test
+	void getPlanDetail_returnsDetailWhenPatientOwned() {
+		when(pacienteService.findByIdAndUserId(10L, USER_ID)).thenReturn(paciente(10L, "María López", "María"));
+		final DietPlanDetailDto detail = new DietPlanDetailDto(55L, PacienteDietaStatus.ACTIVE,
+				LocalDate.of(2026, 3, 16), null, null, "Plan hipocalórico", 1800, 90.0, 55.0, 200.0,
+				List.of(new DietIngestaDto("Desayuno", 450, 20.0, 10.0, 50.0, List.of(), List.of())));
+		when(mobilePatientDietPlanService.getDietPlanDetail(10L, 55L)).thenReturn(detail);
+
+		assertThat(service.getPlanDetail(10L, USER_ID, 55L)).isEqualTo(detail);
+	}
+
+	@Test
+	void getPlanDetail_throwsWhenPatientNotOwned() {
+		when(pacienteService.findByIdAndUserId(10L, USER_ID)).thenReturn(null);
+
+		assertThatThrownBy(() -> service.getPlanDetail(10L, USER_ID, 55L)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Paciente no encontrado");
+		verify(mobilePatientDietPlanService, never()).getDietPlanDetail(any(), any());
+	}
+
+	@Test
+	void getPlanDetail_throwsWhenPlanMissing() {
+		when(pacienteService.findByIdAndUserId(10L, USER_ID)).thenReturn(paciente(10L, "María López", "María"));
+		when(mobilePatientDietPlanService.getDietPlanDetail(10L, 55L))
+			.thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+		assertThatThrownBy(() -> service.getPlanDetail(10L, USER_ID, 55L)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Plan alimentario no encontrado");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- The patient app simulator now lists all assigned diet plans (not only the active one) and matches the mobile flow: tap a plan, then an ingesta, to see platillos and alimentos.
- Home-card taps open the active plan detail; the Planes tab includes the “Solo planes activos” filter.
- Adds `GET /rest/pacientes/{id}/mobile-preview/diet-plans/{assignmentId}` so non-active plans load on demand.

## Test plan
- [ ] Open Vista previa de la app from the patient list for a patient with an active plan; tap the home plan card and confirm meals/ingestas open.
- [ ] Switch to Planes; confirm multiple assignments appear and the active-only filter works.
- [ ] Tap a completed/historical plan and confirm its ingestas and items load.
- [ ] Use the back control to return from ingesta → plan → list/home.


Made with [Cursor](https://cursor.com)