### PR TITLE
Replace deprecated @MockBean with @MockitoBean

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -279,7 +279,7 @@ Entities that reference `Paciente` (like `CalendarEvent`, `ClinicalExam`, `Anthr
 1. Use H2 database for tests (configured in test profile)
 2. Use `@SpringBootTest` for integration tests
 3. Use `@WebMvcTest` for controller tests
-4. Use `@MockBean` for mocking dependencies
+4. Use `@MockitoBean` for mocking Spring beans in tests (not deprecated `@MockBean`)
 5. Use Spring Security Test for security testing
 6. Test data in `src/test/resources/`
 

--- a/src/test/java/com/nutriconsultas/ai/AiDraftFlowIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/ai/AiDraftFlowIntegrationTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
@@ -87,7 +87,7 @@ class AiDraftFlowIntegrationTest {
 	@Autowired
 	private JdbcTemplate jdbcTemplate;
 
-	@MockBean
+	@MockitoBean
 	private OpenAiClientService openAiClientService;
 
 	private long catalogAlimentoId;

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInDestructiveAutoProcessIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInDestructiveAutoProcessIntegrationTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -40,7 +40,7 @@ class AppleSignInDestructiveAutoProcessIntegrationTest {
 	@Autowired
 	private PacienteRepository pacienteRepository;
 
-	@MockBean
+	@MockitoBean
 	private Auth0ManagementUserService auth0ManagementUserService;
 
 	@BeforeEach

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationFlowIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInNotificationFlowIntegrationTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -39,7 +39,7 @@ class AppleSignInNotificationFlowIntegrationTest {
 	@Autowired
 	private PacienteRepository pacienteRepository;
 
-	@MockBean
+	@MockitoBean
 	private Auth0ManagementUserService auth0ManagementUserService;
 
 	@BeforeEach

--- a/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookSecurityTest.java
+++ b/src/test/java/com/nutriconsultas/auth/apple/AppleSignInWebhookSecurityTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -28,7 +28,7 @@ class AppleSignInWebhookSecurityTest {
 	@Autowired
 	private MockMvc mockMvc;
 
-	@MockBean
+	@MockitoBean
 	private AppleSignInNotificationService notificationService;
 
 	@Test

--- a/src/test/java/com/nutriconsultas/mobile/MobileInvitationIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobileInvitationIntegrationTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -73,7 +73,7 @@ class MobileInvitationIntegrationTest {
 	@Autowired
 	private RateLimiterRegistry rateLimiterRegistry;
 
-	@MockBean
+	@MockitoBean
 	private SubscriptionEntitlementService subscriptionEntitlementService;
 
 	@BeforeEach

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanIntegrationTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -63,7 +63,7 @@ class MobilePatientDietPlanIntegrationTest {
 	@Autowired
 	private AlimentosRepository alimentosRepository;
 
-	@MockBean
+	@MockitoBean
 	private DietaPdfService dietaPdfService;
 
 	private Paciente linkedPaciente;

--- a/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationLandingControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/invitation/PatientInvitationLandingControllerTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -59,7 +59,7 @@ class PatientInvitationLandingControllerTest {
 	@Autowired
 	private RateLimiterRegistry rateLimiterRegistry;
 
-	@MockBean
+	@MockitoBean
 	private SubscriptionEntitlementService subscriptionEntitlementService;
 
 	@BeforeEach


### PR DESCRIPTION
## Summary
- Switch Spring Boot `@MockBean` to Spring Framework `@MockitoBean` in the seven integration tests that still used the deprecated annotation.
- Update `.cursorrules` so new tests follow the same replacement.

## Test plan
- [x] `mvn -DskipTests test-compile` succeeds
- [ ] Confirm IDE/lint no longer reports `MockBean` deprecation on those test classes
- [ ] CI test job on this PR is green


Made with [Cursor](https://cursor.com)