### PR TITLE
Allow fractional food quantities on diet ingestas

### DIFF
--- a/docs/api/openapi-mobile.yaml
+++ b/docs/api/openapi-mobile.yaml
@@ -2267,8 +2267,8 @@ components:
         nombre:
           type: string
         porciones:
-          type: integer
-          format: int32
+          type: number
+          format: double
         kcal:
           type: integer
           format: int32

--- a/src/main/java/com/nutriconsultas/ai/AiDraftIngestaMaterializer.java
+++ b/src/main/java/com/nutriconsultas/ai/AiDraftIngestaMaterializer.java
@@ -139,7 +139,7 @@ public class AiDraftIngestaMaterializer {
 		final AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
 		alimentoIngesta.setName(alimento.getNombreAlimento());
 		alimentoIngesta.setAlimento(alimento);
-		alimentoIngesta.setPortions(portions);
+		alimentoIngesta.setPortions((double) portions);
 		alimentoIngesta.setUnidad(alimento.getUnidad());
 		if (alimento.getEnergia() != null) {
 			alimentoIngesta.setEnergia(alimento.getEnergia() * portions);

--- a/src/main/java/com/nutriconsultas/dieta/AlimentoFormModel.java
+++ b/src/main/java/com/nutriconsultas/dieta/AlimentoFormModel.java
@@ -13,7 +13,9 @@ public class AlimentoFormModel {
 
 	private Long alimento;
 
-	private Integer porciones;
+	private Double porciones;
+
+	private String cantidad;
 
 	private String tipoPorcion;
 

--- a/src/main/java/com/nutriconsultas/dieta/AlimentoIngesta.java
+++ b/src/main/java/com/nutriconsultas/dieta/AlimentoIngesta.java
@@ -1,6 +1,8 @@
 package com.nutriconsultas.dieta;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.model.AbstractFraccionable;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -29,13 +31,14 @@ public class AlimentoIngesta {
 
 	private String name;
 
-	private Integer portions = 1;
+	private Double portions = 1.0;
 
 	@ManyToOne
 	private Alimento alimento;
 
 	@ManyToOne
 	@JoinColumn(name = "ingesta_id")
+	@JsonBackReference
 	private Ingesta ingesta;
 
 	private String unidad;
@@ -111,5 +114,17 @@ public class AlimentoIngesta {
 
 	@Column(precision = 5)
 	private Double etanol;
+
+	/**
+	 * Suggested catalog quantity scaled by the stored portion multiplier, formatted as a
+	 * cooking fraction for UI and PDF.
+	 * @return display quantity such as {@code 1/2} or {@code 1 1/2}
+	 */
+	public String getDisplayCantidad() {
+		final double multiplier = portions != null && portions > 0 ? portions : 1.0;
+		final double quantity = alimento != null && alimento.getCantSugerida() != null
+				? alimento.getCantSugerida() * multiplier : multiplier;
+		return AbstractFraccionable.formatQuantity(quantity);
+	}
 
 }

--- a/src/main/java/com/nutriconsultas/dieta/AlimentoIngestaNutrientScaler.java
+++ b/src/main/java/com/nutriconsultas/dieta/AlimentoIngestaNutrientScaler.java
@@ -1,0 +1,48 @@
+package com.nutriconsultas.dieta;
+
+import com.nutriconsultas.alimentos.Alimento;
+
+/**
+ * Scales catalog {@link Alimento} nutrients onto a standalone {@link AlimentoIngesta}.
+ * {@code AlimentoIngesta} does not extend {@code AbstractNutrible}, so
+ * {@link com.nutriconsultas.util.NutrientSummarizer} cannot be used directly.
+ */
+public final class AlimentoIngestaNutrientScaler {
+
+	private AlimentoIngestaNutrientScaler() {
+	}
+
+	public static void copyScaled(final Alimento source, final AlimentoIngesta target, final double multiplier) {
+		target.setAcidoAscorbico(scaleNullable(source.getAcidoAscorbico(), multiplier));
+		target.setAcidoFolico(scaleNullable(source.getAcidoFolico(), multiplier));
+		target.setAgMonoinsaturados(scaleNullable(source.getAgMonoinsaturados(), multiplier));
+		target.setAgPoliinsaturados(scaleNullable(source.getAgPoliinsaturados(), multiplier));
+		target.setAgSaturados(scaleNullable(source.getAgSaturados(), multiplier));
+		target.setAzucarPorEquivalente(scaleNullable(source.getAzucarPorEquivalente(), multiplier));
+		target.setCalcio(scaleNullable(source.getCalcio(), multiplier));
+		target.setCargaGlicemica(scaleNullable(source.getCargaGlicemica(), multiplier));
+		target.setColesterol(scaleNullable(source.getColesterol(), multiplier));
+		target.setEnergia(source.getEnergia() != null ? (int) (source.getEnergia() * multiplier) : null);
+		target.setFibra(scaleNullable(source.getFibra(), multiplier));
+		target.setFosforo(scaleNullable(source.getFosforo(), multiplier));
+		target.setHierro(scaleNullable(source.getHierro(), multiplier));
+		target.setHierroNoHem(scaleNullable(source.getHierroNoHem(), multiplier));
+		target.setIndiceGlicemico(scaleNullable(source.getIndiceGlicemico(), multiplier));
+		target.setEtanol(scaleNullable(source.getEtanol(), multiplier));
+		target.setHidratosDeCarbono(scaleNullable(source.getHidratosDeCarbono(), multiplier));
+		target.setLipidos(scaleNullable(source.getLipidos(), multiplier));
+		target.setPotasio(scaleNullable(source.getPotasio(), multiplier));
+		target.setProteina(scaleNullable(source.getProteina(), multiplier));
+		target.setSelenio(scaleNullable(source.getSelenio(), multiplier));
+		target.setSodio(scaleNullable(source.getSodio(), multiplier));
+		target.setVitA(scaleNullable(source.getVitA(), multiplier));
+		target.setPesoBrutoRedondeado(source.getPesoBrutoRedondeado() != null
+				? (int) Math.round(source.getPesoBrutoRedondeado() * multiplier) : null);
+		target.setPesoNeto(source.getPesoNeto() != null ? (int) Math.round(source.getPesoNeto() * multiplier) : null);
+	}
+
+	private static Double scaleNullable(final Double value, final double multiplier) {
+		return value != null ? value * multiplier : null;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/dieta/AlimentoIngestaPortions.java
+++ b/src/main/java/com/nutriconsultas/dieta/AlimentoIngestaPortions.java
@@ -72,16 +72,15 @@ public final class AlimentoIngestaPortions {
 	}
 
 	private static Double ratioFromCantidad(final String cantidad, final Alimento alimento) {
-		Double parsed;
+		Double result = null;
 		try {
-			parsed = FractionQuantityParser.parseFractionalQuantity(cantidad);
+			final Double parsed = FractionQuantityParser.parseFractionalQuantity(cantidad);
+			if (parsed != null && parsed > 0) {
+				result = parsed / catalogCantSugerida(alimento);
+			}
 		}
 		catch (final NumberFormatException ex) {
-			parsed = null;
-		}
-		Double result = null;
-		if (parsed != null && parsed > 0) {
-			result = parsed / catalogCantSugerida(alimento);
+			// Invalid fraction text is treated as missing cantidad.
 		}
 		return result;
 	}

--- a/src/main/java/com/nutriconsultas/dieta/AlimentoIngestaPortions.java
+++ b/src/main/java/com/nutriconsultas/dieta/AlimentoIngestaPortions.java
@@ -1,0 +1,97 @@
+package com.nutriconsultas.dieta;
+
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.util.FractionQuantityParser;
+
+/**
+ * Resolves the portion multiplier for a standalone alimento in a diet ingesta. The
+ * multiplier is {@code cantidad / cantSugerida} so nutritionists can enter fractions of
+ * the catalog suggested serving.
+ */
+public final class AlimentoIngestaPortions {
+
+	public static final double MIN = 0.01;
+
+	public static final double MAX = 100.0;
+
+	public static final double DEFAULT = 1.0;
+
+	private AlimentoIngestaPortions() {
+	}
+
+	public static double resolve(final AlimentoFormModel model, final Alimento alimento) {
+		double result = DEFAULT;
+		if (model != null) {
+			final String tipoPorcion = AlimentoPortionDefaults.resolveTipoPorcion(model.getTipoPorcion());
+			if (AlimentoPortionDefaults.PORCION.equals(tipoPorcion)) {
+				final Double fromCantidad = ratioFromCantidad(model.getCantidad(), alimento);
+				if (fromCantidad != null) {
+					result = fromCantidad;
+				}
+				else if (model.getPorciones() != null) {
+					result = model.getPorciones();
+				}
+			}
+			else if (model.getPorciones() != null) {
+				result = model.getPorciones();
+			}
+		}
+		return clamp(result);
+	}
+
+	public static Double fromCantidad(final String cantidad, final Alimento alimento) {
+		final Double ratio = ratioFromCantidad(cantidad, alimento);
+		Double result = null;
+		if (ratio != null) {
+			result = clamp(ratio);
+		}
+		return result;
+	}
+
+	public static Double resolveUpdate(final String cantidad, final Double porciones, final Alimento alimento) {
+		Double result = fromCantidad(cantidad, alimento);
+		if (result == null && porciones != null) {
+			result = clamp(porciones);
+		}
+		return result;
+	}
+
+	public static boolean isValid(final Double portions) {
+		return portions != null && portions >= MIN && portions <= MAX;
+	}
+
+	public static double clamp(final double portions) {
+		double result = portions;
+		if (result < MIN) {
+			result = MIN;
+		}
+		else if (result > MAX) {
+			result = MAX;
+		}
+		return result;
+	}
+
+	private static Double ratioFromCantidad(final String cantidad, final Alimento alimento) {
+		Double parsed;
+		try {
+			parsed = FractionQuantityParser.parseFractionalQuantity(cantidad);
+		}
+		catch (final NumberFormatException ex) {
+			parsed = null;
+		}
+		Double result = null;
+		if (parsed != null && parsed > 0) {
+			result = parsed / catalogCantSugerida(alimento);
+		}
+		return result;
+	}
+
+	private static double catalogCantSugerida(final Alimento alimento) {
+		double result = 1.0;
+		if (alimento != null && alimento.getCantSugerida() != null && alimento.getCantSugerida() != 0) {
+			result = alimento.getCantSugerida();
+		}
+		return result;
+	}
+
+}

--- a/src/main/java/com/nutriconsultas/dieta/DietaController.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaController.java
@@ -402,9 +402,10 @@ public class DietaController extends AbstractAuthorizedController {
 	}
 
 	@PostMapping(path = "/admin/dietas/{id}/alimentos/{alimentoIngestaId}/update")
-	public String updateAlimentoIngesta(@PathVariable @NonNull Long id, @PathVariable @NonNull Long alimentoIngestaId,
-			@RequestParam @NonNull Integer porciones, @AuthenticationPrincipal final OidcUser principal) {
-		LOGGER.debug("Actualizar alimento ingesta {} con {} porciones en dieta {}", alimentoIngestaId, porciones, id);
+	public String updateAlimentoIngesta(@PathVariable @NonNull final Long id,
+			@PathVariable @NonNull final Long alimentoIngestaId, @RequestParam(required = false) final String cantidad,
+			@RequestParam(required = false) final Double porciones, @AuthenticationPrincipal final OidcUser principal) {
+		LOGGER.debug("Actualizar alimento ingesta {} en dieta {}", alimentoIngestaId, id);
 		final Dieta dieta = loadDietaForMutation(id, principal);
 		final Long activeIngestaId = findIngestaIdForAlimentoIngesta(dieta, alimentoIngestaId);
 		dieta.getIngestas()
@@ -414,35 +415,15 @@ public class DietaController extends AbstractAuthorizedController {
 			.findFirst()
 			.ifPresent(alimentoIngesta -> {
 				if (alimentoIngesta.getAlimento() != null) {
-					// Recalculate from original alimento
-					Alimento alimento = alimentoIngesta.getAlimento();
-					Integer newPortions = porciones != null ? porciones : 1;
-					alimentoIngesta.setPortions(newPortions);
-
-					// Recalculate nutritional values from original alimento
-					if (alimento.getEnergia() != null) {
-						alimentoIngesta.setEnergia((int) (alimento.getEnergia() * newPortions));
+					final Double newPortions = AlimentoIngestaPortions.resolveUpdate(cantidad, porciones,
+							alimentoIngesta.getAlimento());
+					if (newPortions != null) {
+						alimentoIngesta.setPortions(newPortions);
+						AlimentoIngestaNutrientScaler.copyScaled(alimentoIngesta.getAlimento(), alimentoIngesta,
+								newPortions);
+						dietaService.saveDieta(dieta);
+						dietaAuthorization.auditSystemDietMutationIfNeeded(principal, dieta, "dietas.alimentos.update");
 					}
-					if (alimento.getProteina() != null) {
-						alimentoIngesta.setProteina(alimento.getProteina() * newPortions);
-					}
-					if (alimento.getLipidos() != null) {
-						alimentoIngesta.setLipidos(alimento.getLipidos() * newPortions);
-					}
-					if (alimento.getHidratosDeCarbono() != null) {
-						alimentoIngesta.setHidratosDeCarbono(alimento.getHidratosDeCarbono() * newPortions);
-					}
-					if (alimento.getPesoBrutoRedondeado() != null) {
-						alimentoIngesta.setPesoBrutoRedondeado(alimento.getPesoBrutoRedondeado() * newPortions);
-					}
-					if (alimento.getPesoNeto() != null) {
-						alimentoIngesta.setPesoNeto(alimento.getPesoNeto() * newPortions);
-					}
-					// Update other nutritional values
-					updateAlimentoIngestaNutritionalValues(alimentoIngesta, alimento, newPortions);
-
-					dietaService.saveDieta(dieta);
-					dietaAuthorization.auditSystemDietMutationIfNeeded(principal, dieta, "dietas.alimentos.update");
 				}
 			});
 		return redirectToDietaEditor(id, activeIngestaId);
@@ -508,159 +489,14 @@ public class DietaController extends AbstractAuthorizedController {
 		}
 	}
 
-	private void updateAlimentoIngestaNutritionalValues(AlimentoIngesta alimentoIngesta, Alimento alimento,
-			Integer portions) {
-		if (alimento.getFibra() != null) {
-			alimentoIngesta.setFibra(alimento.getFibra() * portions);
-		}
-		if (alimento.getVitA() != null) {
-			alimentoIngesta.setVitA(alimento.getVitA() * portions);
-		}
-		if (alimento.getAcidoAscorbico() != null) {
-			alimentoIngesta.setAcidoAscorbico(alimento.getAcidoAscorbico() * portions);
-		}
-		if (alimento.getHierroNoHem() != null) {
-			alimentoIngesta.setHierroNoHem(alimento.getHierroNoHem() * portions);
-		}
-		if (alimento.getPotasio() != null) {
-			alimentoIngesta.setPotasio(alimento.getPotasio() * portions);
-		}
-		if (alimento.getIndiceGlicemico() != null) {
-			alimentoIngesta.setIndiceGlicemico(alimento.getIndiceGlicemico() * portions);
-		}
-		if (alimento.getCargaGlicemica() != null) {
-			alimentoIngesta.setCargaGlicemica(alimento.getCargaGlicemica() * portions);
-		}
-		if (alimento.getAcidoFolico() != null) {
-			alimentoIngesta.setAcidoFolico(alimento.getAcidoFolico() * portions);
-		}
-		if (alimento.getCalcio() != null) {
-			alimentoIngesta.setCalcio(alimento.getCalcio() * portions);
-		}
-		if (alimento.getHierro() != null) {
-			alimentoIngesta.setHierro(alimento.getHierro() * portions);
-		}
-		if (alimento.getSodio() != null) {
-			alimentoIngesta.setSodio(alimento.getSodio() * portions);
-		}
-		if (alimento.getAzucarPorEquivalente() != null) {
-			alimentoIngesta.setAzucarPorEquivalente(alimento.getAzucarPorEquivalente() * portions);
-		}
-		if (alimento.getSelenio() != null) {
-			alimentoIngesta.setSelenio(alimento.getSelenio() * portions);
-		}
-		if (alimento.getFosforo() != null) {
-			alimentoIngesta.setFosforo(alimento.getFosforo() * portions);
-		}
-		if (alimento.getColesterol() != null) {
-			alimentoIngesta.setColesterol(alimento.getColesterol() * portions);
-		}
-		if (alimento.getAgSaturados() != null) {
-			alimentoIngesta.setAgSaturados(alimento.getAgSaturados() * portions);
-		}
-		if (alimento.getAgMonoinsaturados() != null) {
-			alimentoIngesta.setAgMonoinsaturados(alimento.getAgMonoinsaturados() * portions);
-		}
-		if (alimento.getAgPoliinsaturados() != null) {
-			alimentoIngesta.setAgPoliinsaturados(alimento.getAgPoliinsaturados() * portions);
-		}
-		if (alimento.getEtanol() != null) {
-			alimentoIngesta.setEtanol(alimento.getEtanol() * portions);
-		}
-	}
-
-	private AlimentoIngesta mapAlimentoIngesta(Alimento alimento, AlimentoFormModel alimentoModel) {
-		AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
-		// map each field from alimento into alimento ingesta
+	private AlimentoIngesta mapAlimentoIngesta(final Alimento alimento, final AlimentoFormModel alimentoModel) {
+		final AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
+		final double portions = AlimentoIngestaPortions.resolve(alimentoModel, alimento);
 		alimentoIngesta.setName(alimento.getNombreAlimento());
 		alimentoIngesta.setAlimento(alimento);
-		alimentoIngesta.setPortions(alimentoModel.getPorciones() != null ? alimentoModel.getPorciones() : 1);
+		alimentoIngesta.setPortions(portions);
 		alimentoIngesta.setUnidad(alimento.getUnidad());
-
-		// Calculate nutritional values based on portions
-		Integer portions = alimentoIngesta.getPortions();
-		if (portions == null) {
-			portions = 1;
-		}
-
-		// Map nutritional values from alimento (which extends AbstractFraccionable)
-		// These values are already per portion, so multiply by portions
-		if (alimento.getEnergia() != null) {
-			alimentoIngesta.setEnergia((int) (alimento.getEnergia() * portions));
-		}
-		if (alimento.getProteina() != null) {
-			alimentoIngesta.setProteina(alimento.getProteina() * portions);
-		}
-		if (alimento.getLipidos() != null) {
-			alimentoIngesta.setLipidos(alimento.getLipidos() * portions);
-		}
-		if (alimento.getHidratosDeCarbono() != null) {
-			alimentoIngesta.setHidratosDeCarbono(alimento.getHidratosDeCarbono() * portions);
-		}
-		if (alimento.getPesoBrutoRedondeado() != null) {
-			alimentoIngesta.setPesoBrutoRedondeado(alimento.getPesoBrutoRedondeado() * portions);
-		}
-		if (alimento.getPesoNeto() != null) {
-			alimentoIngesta.setPesoNeto(alimento.getPesoNeto() * portions);
-		}
-		if (alimento.getFibra() != null) {
-			alimentoIngesta.setFibra(alimento.getFibra() * portions);
-		}
-		if (alimento.getVitA() != null) {
-			alimentoIngesta.setVitA(alimento.getVitA() * portions);
-		}
-		if (alimento.getAcidoAscorbico() != null) {
-			alimentoIngesta.setAcidoAscorbico(alimento.getAcidoAscorbico() * portions);
-		}
-		if (alimento.getHierroNoHem() != null) {
-			alimentoIngesta.setHierroNoHem(alimento.getHierroNoHem() * portions);
-		}
-		if (alimento.getPotasio() != null) {
-			alimentoIngesta.setPotasio(alimento.getPotasio() * portions);
-		}
-		if (alimento.getIndiceGlicemico() != null) {
-			alimentoIngesta.setIndiceGlicemico(alimento.getIndiceGlicemico() * portions);
-		}
-		if (alimento.getCargaGlicemica() != null) {
-			alimentoIngesta.setCargaGlicemica(alimento.getCargaGlicemica() * portions);
-		}
-		if (alimento.getAcidoFolico() != null) {
-			alimentoIngesta.setAcidoFolico(alimento.getAcidoFolico() * portions);
-		}
-		if (alimento.getCalcio() != null) {
-			alimentoIngesta.setCalcio(alimento.getCalcio() * portions);
-		}
-		if (alimento.getHierro() != null) {
-			alimentoIngesta.setHierro(alimento.getHierro() * portions);
-		}
-		if (alimento.getSodio() != null) {
-			alimentoIngesta.setSodio(alimento.getSodio() * portions);
-		}
-		if (alimento.getAzucarPorEquivalente() != null) {
-			alimentoIngesta.setAzucarPorEquivalente(alimento.getAzucarPorEquivalente() * portions);
-		}
-		if (alimento.getSelenio() != null) {
-			alimentoIngesta.setSelenio(alimento.getSelenio() * portions);
-		}
-		if (alimento.getFosforo() != null) {
-			alimentoIngesta.setFosforo(alimento.getFosforo() * portions);
-		}
-		if (alimento.getColesterol() != null) {
-			alimentoIngesta.setColesterol(alimento.getColesterol() * portions);
-		}
-		if (alimento.getAgSaturados() != null) {
-			alimentoIngesta.setAgSaturados(alimento.getAgSaturados() * portions);
-		}
-		if (alimento.getAgMonoinsaturados() != null) {
-			alimentoIngesta.setAgMonoinsaturados(alimento.getAgMonoinsaturados() * portions);
-		}
-		if (alimento.getAgPoliinsaturados() != null) {
-			alimentoIngesta.setAgPoliinsaturados(alimento.getAgPoliinsaturados() * portions);
-		}
-		if (alimento.getEtanol() != null) {
-			alimentoIngesta.setEtanol(alimento.getEtanol() * portions);
-		}
-
+		AlimentoIngestaNutrientScaler.copyScaled(alimento, alimentoIngesta, portions);
 		return alimentoIngesta;
 	}
 

--- a/src/main/java/com/nutriconsultas/dieta/DietaService.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaService.java
@@ -31,7 +31,7 @@ public interface DietaService {
 	void reorderAlimentosInIngesta(@NonNull Long dietaId, @NonNull Long ingestaId,
 			@NonNull List<Long> orderedAlimentoIngestaIds);
 
-	void recalculateAlimentoIngestaNutrients(@NonNull AlimentoIngesta alimentoIngesta, @NonNull Integer portions);
+	void recalculateAlimentoIngestaNutrients(@NonNull AlimentoIngesta alimentoIngesta, @NonNull Double portions);
 
 	void recalculatePlatilloIngestaNutrients(@NonNull PlatilloIngesta platilloIngesta, @NonNull Integer portions);
 

--- a/src/main/java/com/nutriconsultas/dieta/DietaServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaServiceImpl.java
@@ -248,89 +248,13 @@ public class DietaServiceImpl implements DietaService {
 
 	@Override
 	public void recalculateAlimentoIngestaNutrients(@NonNull final AlimentoIngesta alimentoIngesta,
-			@NonNull final Integer portions) {
+			@NonNull final Double portions) {
 		log.info("Recalculating nutrients for AlimentoIngesta with id {} for {} portions", alimentoIngesta.getId(),
 				portions);
 		if (alimentoIngesta.getAlimento() != null) {
-			final Alimento alimento = alimentoIngesta.getAlimento();
-			alimentoIngesta.setPortions(portions);
-
-			// Recalculate nutritional values from original alimento
-			if (alimento.getEnergia() != null) {
-				alimentoIngesta.setEnergia((int) (alimento.getEnergia() * portions));
-			}
-			if (alimento.getProteina() != null) {
-				alimentoIngesta.setProteina(alimento.getProteina() * portions);
-			}
-			if (alimento.getLipidos() != null) {
-				alimentoIngesta.setLipidos(alimento.getLipidos() * portions);
-			}
-			if (alimento.getHidratosDeCarbono() != null) {
-				alimentoIngesta.setHidratosDeCarbono(alimento.getHidratosDeCarbono() * portions);
-			}
-			if (alimento.getPesoBrutoRedondeado() != null) {
-				alimentoIngesta.setPesoBrutoRedondeado(alimento.getPesoBrutoRedondeado() * portions);
-			}
-			if (alimento.getPesoNeto() != null) {
-				alimentoIngesta.setPesoNeto(alimento.getPesoNeto() * portions);
-			}
-			if (alimento.getFibra() != null) {
-				alimentoIngesta.setFibra(alimento.getFibra() * portions);
-			}
-			if (alimento.getVitA() != null) {
-				alimentoIngesta.setVitA(alimento.getVitA() * portions);
-			}
-			if (alimento.getAcidoAscorbico() != null) {
-				alimentoIngesta.setAcidoAscorbico(alimento.getAcidoAscorbico() * portions);
-			}
-			if (alimento.getHierroNoHem() != null) {
-				alimentoIngesta.setHierroNoHem(alimento.getHierroNoHem() * portions);
-			}
-			if (alimento.getPotasio() != null) {
-				alimentoIngesta.setPotasio(alimento.getPotasio() * portions);
-			}
-			if (alimento.getIndiceGlicemico() != null) {
-				alimentoIngesta.setIndiceGlicemico(alimento.getIndiceGlicemico() * portions);
-			}
-			if (alimento.getCargaGlicemica() != null) {
-				alimentoIngesta.setCargaGlicemica(alimento.getCargaGlicemica() * portions);
-			}
-			if (alimento.getAcidoFolico() != null) {
-				alimentoIngesta.setAcidoFolico(alimento.getAcidoFolico() * portions);
-			}
-			if (alimento.getCalcio() != null) {
-				alimentoIngesta.setCalcio(alimento.getCalcio() * portions);
-			}
-			if (alimento.getHierro() != null) {
-				alimentoIngesta.setHierro(alimento.getHierro() * portions);
-			}
-			if (alimento.getSodio() != null) {
-				alimentoIngesta.setSodio(alimento.getSodio() * portions);
-			}
-			if (alimento.getAzucarPorEquivalente() != null) {
-				alimentoIngesta.setAzucarPorEquivalente(alimento.getAzucarPorEquivalente() * portions);
-			}
-			if (alimento.getSelenio() != null) {
-				alimentoIngesta.setSelenio(alimento.getSelenio() * portions);
-			}
-			if (alimento.getFosforo() != null) {
-				alimentoIngesta.setFosforo(alimento.getFosforo() * portions);
-			}
-			if (alimento.getColesterol() != null) {
-				alimentoIngesta.setColesterol(alimento.getColesterol() * portions);
-			}
-			if (alimento.getAgSaturados() != null) {
-				alimentoIngesta.setAgSaturados(alimento.getAgSaturados() * portions);
-			}
-			if (alimento.getAgMonoinsaturados() != null) {
-				alimentoIngesta.setAgMonoinsaturados(alimento.getAgMonoinsaturados() * portions);
-			}
-			if (alimento.getAgPoliinsaturados() != null) {
-				alimentoIngesta.setAgPoliinsaturados(alimento.getAgPoliinsaturados() * portions);
-			}
-			if (alimento.getEtanol() != null) {
-				alimentoIngesta.setEtanol(alimento.getEtanol() * portions);
-			}
+			final double resolvedPortions = AlimentoIngestaPortions.clamp(portions);
+			alimentoIngesta.setPortions(resolvedPortions);
+			AlimentoIngestaNutrientScaler.copyScaled(alimentoIngesta.getAlimento(), alimentoIngesta, resolvedPortions);
 		}
 	}
 

--- a/src/main/java/com/nutriconsultas/dieta/DietaTemplateValidator.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaTemplateValidator.java
@@ -137,7 +137,7 @@ public class DietaTemplateValidator extends BaseTemplateValidator {
 		final AlimentoIngesta mockAlimento = new AlimentoIngesta();
 		mockAlimento.setId(1L);
 		mockAlimento.setName("Alimento de ejemplo");
-		mockAlimento.setPortions(1);
+		mockAlimento.setPortions(1.0);
 		mockAlimento.setEnergia(100);
 		mockAlimento.setProteina(5.0);
 		mockAlimento.setLipidos(3.0);

--- a/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietasRestController.java
@@ -203,12 +203,13 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 	@PutMapping("{dietaId}/ingestas/{ingestaId}/alimentos/{alimentoIngestaId}/portions")
 	public ResponseEntity<ApiResponse<Dieta>> updateAlimentoIngestaPortions(@PathVariable @NonNull final Long dietaId,
 			@PathVariable @NonNull final Long ingestaId, @PathVariable @NonNull final Long alimentoIngestaId,
-			@RequestParam @NonNull final Integer portions, @AuthenticationPrincipal final OidcUser principal) {
+			@RequestParam @NonNull final Double portions, @AuthenticationPrincipal final OidcUser principal) {
 		log.info(
 				"starting updateAlimentoIngestaPortions with dietaId {}, ingestaId {}, alimentoIngestaId {}, portions {}.",
 				dietaId, ingestaId, alimentoIngestaId, portions);
-		if (portions < 1 || portions > 10) {
-			log.warn("Invalid portions value: {}. Must be between 1 and 10.", portions);
+		if (!AlimentoIngestaPortions.isValid(portions)) {
+			log.warn("Invalid portions value: {}. Must be between {} and {}.", portions, AlimentoIngestaPortions.MIN,
+					AlimentoIngestaPortions.MAX);
 			return ResponseEntity.badRequest().build();
 		}
 		if (principal == null) {
@@ -238,6 +239,48 @@ public class DietasRestController extends AbstractGridController<Dieta> {
 		dietaAuthorization.auditSystemDietMutationIfNeeded(principal, saved, "dietas.alimentos.update");
 		log.info("finish updateAlimentoIngestaPortions with dietaId {}, ingestaId {}, "
 				+ "alimentoIngestaId {}, portions {}.", dietaId, ingestaId, alimentoIngestaId, portions);
+		return ResponseEntity.ok(new ApiResponse<Dieta>(saved));
+	}
+
+	@PutMapping("{dietaId}/ingestas/{ingestaId}/alimentos/{alimentoIngestaId}/cantidad")
+	public ResponseEntity<ApiResponse<Dieta>> updateAlimentoIngestaCantidad(@PathVariable @NonNull final Long dietaId,
+			@PathVariable @NonNull final Long ingestaId, @PathVariable @NonNull final Long alimentoIngestaId,
+			@RequestParam @NonNull final String cantidad, @AuthenticationPrincipal final OidcUser principal) {
+		log.info(
+				"starting updateAlimentoIngestaCantidad with dietaId {}, ingestaId {}, alimentoIngestaId {}, cantidad {}.",
+				dietaId, ingestaId, alimentoIngestaId, cantidad);
+		if (principal == null) {
+			return ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();
+		}
+		final Dieta dieta = loadDietaForMutation(dietaId, principal);
+		if (dieta == null) {
+			log.warn("Dieta with id {} not found when trying to update alimentoIngesta cantidad", dietaId);
+			return ResponseEntity.notFound().build();
+		}
+		final AlimentoIngesta alimentoIngesta = dieta.getIngestas()
+			.stream()
+			.filter(ingesta -> ingesta.getId().equals(ingestaId))
+			.findFirst()
+			.flatMap(ingesta -> ingesta.getAlimentos()
+				.stream()
+				.filter(alimento -> alimento.getId().equals(alimentoIngestaId))
+				.findFirst())
+			.orElse(null);
+		if (alimentoIngesta == null || alimentoIngesta.getAlimento() == null) {
+			log.warn("AlimentoIngesta with id {} not found in ingesta {} of dieta {}", alimentoIngestaId, ingestaId,
+					dietaId);
+			return ResponseEntity.notFound().build();
+		}
+		final Double portions = AlimentoIngestaPortions.fromCantidad(cantidad, alimentoIngesta.getAlimento());
+		if (portions == null) {
+			log.warn("Invalid cantidad value: {}.", cantidad);
+			return ResponseEntity.badRequest().build();
+		}
+		dietaService.recalculateAlimentoIngestaNutrients(alimentoIngesta, portions);
+		final Dieta saved = dietaService.saveDieta(dieta);
+		dietaAuthorization.auditSystemDietMutationIfNeeded(principal, saved, "dietas.alimentos.update");
+		log.info("finish updateAlimentoIngestaCantidad with dietaId {}, ingestaId {}, "
+				+ "alimentoIngestaId {}, cantidad {}.", dietaId, ingestaId, alimentoIngestaId, cantidad);
 		return ResponseEntity.ok(new ApiResponse<Dieta>(saved));
 	}
 

--- a/src/main/java/com/nutriconsultas/dieta/PlatilloFromIngestaServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/dieta/PlatilloFromIngestaServiceImpl.java
@@ -218,7 +218,7 @@ public class PlatilloFromIngestaServiceImpl implements PlatilloFromIngestaServic
 		if (alimento == null || alimento.getId() == null) {
 			throw new IllegalArgumentException("Alimento de ingesta sin catálogo asociado");
 		}
-		final int portions = alimentoIngesta.getPortions() != null ? alimentoIngesta.getPortions() : 1;
+		final double portions = alimentoIngesta.getPortions() != null ? alimentoIngesta.getPortions() : 1.0;
 		final double catalogCant = alimento.getCantSugerida() != null ? alimento.getCantSugerida() : 1.0;
 		final double cantSugerida = catalogCant * portions;
 		final int pesoNeto = alimentoIngesta.getPesoNeto() != null ? alimentoIngesta.getPesoNeto()

--- a/src/main/java/com/nutriconsultas/dieta/PlatilloIngesta.java
+++ b/src/main/java/com/nutriconsultas/dieta/PlatilloIngesta.java
@@ -3,6 +3,7 @@ package com.nutriconsultas.dieta;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.nutriconsultas.model.AbstractNutrible;
 
@@ -62,6 +63,7 @@ public class PlatilloIngesta extends AbstractNutrible {
 
 	@ManyToOne
 	@JoinColumn(name = "ingesta_id")
+	@JsonBackReference
 	private Ingesta ingesta;
 
 	public String getImageUrl() {

--- a/src/main/java/com/nutriconsultas/mobile/DietGroceryListAggregator.java
+++ b/src/main/java/com/nutriconsultas/mobile/DietGroceryListAggregator.java
@@ -111,7 +111,7 @@ public final class DietGroceryListAggregator {
 		final MutableGroceryItem item = items.computeIfAbsent(key,
 				ignored -> new MutableGroceryItem(nombre, unidad, categoria));
 		item.mergeCategoria(categoria);
-		final int portions = alimentoIngesta.getPortions() != null ? alimentoIngesta.getPortions() : 1;
+		final double portions = alimentoIngesta.getPortions() != null ? alimentoIngesta.getPortions() : 1.0;
 		item.addFractionQuantity(portions);
 	}
 

--- a/src/main/java/com/nutriconsultas/mobile/dto/DietAlimentoDto.java
+++ b/src/main/java/com/nutriconsultas/mobile/dto/DietAlimentoDto.java
@@ -7,7 +7,7 @@ import com.nutriconsultas.dieta.AlimentoIngesta;
  * Patient-facing food item within a meal slot for mobile diet plan detail (#94, #354).
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record DietAlimentoDto(String nombre, Integer porciones, Integer kcal, String unidad, Double proteina,
+public record DietAlimentoDto(String nombre, Double porciones, Integer kcal, String unidad, Double proteina,
 		Double carbohidratos, Double grasas) {
 
 	public static DietAlimentoDto fromEntity(final AlimentoIngesta alimento) {

--- a/src/main/java/com/nutriconsultas/model/AbstractFraccionable.java
+++ b/src/main/java/com/nutriconsultas/model/AbstractFraccionable.java
@@ -35,27 +35,36 @@ public abstract class AbstractFraccionable extends AbstractNutrible {
 	 * @return formatted string with rounded fractional quantity
 	 */
 	public String getRoundedFractionalCantSugerida() {
-		if (cantSugerida == null) {
-			return "";
-		}
-		final int baseInt = (int) Math.floor(cantSugerida);
-		double bestDiff = Double.MAX_VALUE;
-		int bestIntPart = 0;
-		StandardFraction bestFraction = STANDARD_FRACTIONS[0];
+		return formatQuantity(cantSugerida);
+	}
 
-		for (int intPart = baseInt; intPart <= baseInt + 1; intPart++) {
-			for (final StandardFraction fraction : STANDARD_FRACTIONS) {
-				final double candidate = intPart + fraction.value();
-				final double diff = Math.abs(cantSugerida - candidate);
-				if (isBetterFractionMatch(diff, bestDiff, fraction, bestFraction)) {
-					bestDiff = diff;
-					bestIntPart = intPart;
-					bestFraction = fraction;
+	/**
+	 * Formats a numeric quantity as the nearest standard cooking fraction.
+	 * @param quantity quantity to format
+	 * @return formatted string, or empty when {@code quantity} is null
+	 */
+	public static String formatQuantity(final Double quantity) {
+		String result = "";
+		if (quantity != null) {
+			final int baseInt = (int) Math.floor(quantity);
+			double bestDiff = Double.MAX_VALUE;
+			int bestIntPart = 0;
+			StandardFraction bestFraction = STANDARD_FRACTIONS[0];
+
+			for (int intPart = baseInt; intPart <= baseInt + 1; intPart++) {
+				for (final StandardFraction fraction : STANDARD_FRACTIONS) {
+					final double candidate = intPart + fraction.value();
+					final double diff = Math.abs(quantity - candidate);
+					if (isBetterFractionMatch(diff, bestDiff, fraction, bestFraction)) {
+						bestDiff = diff;
+						bestIntPart = intPart;
+						bestFraction = fraction;
+					}
 				}
 			}
+			result = formatRoundedQuantity(bestIntPart, bestFraction.label());
 		}
-
-		return formatRoundedQuantity(bestIntPart, bestFraction.label());
+		return result;
 	}
 
 	/**

--- a/src/main/resources/db/changelog/changes/040-alimento-ingesta-portions-double.yaml
+++ b/src/main/resources/db/changelog/changes/040-alimento-ingesta-portions-double.yaml
@@ -1,0 +1,25 @@
+databaseChangeLog:
+  - changeSet:
+      id: 040-alimento-ingesta-portions-double-postgresql
+      author: nutriconsultas
+      dbms: postgresql
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: alimento_ingesta
+            columnName: portions
+      changes:
+        - sql:
+            sql: ALTER TABLE alimento_ingesta ALTER COLUMN portions TYPE double precision USING portions::double precision
+  - changeSet:
+      id: 040-alimento-ingesta-portions-double-h2
+      author: nutriconsultas
+      dbms: h2
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: alimento_ingesta
+            columnName: portions
+      changes:
+        - sql:
+            sql: ALTER TABLE alimento_ingesta ALTER COLUMN portions SET DATA TYPE DOUBLE PRECISION

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -116,3 +116,6 @@ databaseChangeLog:
   - include:
       file: changes/039-ai-draft-paciente.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changes/040-alimento-ingesta-portions-double.yaml
+      relativeToChangelogFile: true

--- a/src/main/resources/static/sbadmin/js/ingredient-weight-recalc.js
+++ b/src/main/resources/static/sbadmin/js/ingredient-weight-recalc.js
@@ -13,8 +13,13 @@
       return null;
     }
 
-    var hasInteger = trimmed.indexOf(' ') >= 0 || trimmed.indexOf('/') < 0;
-    var hasFraction = trimmed.indexOf('/') >= 0;
+    if (trimmed.indexOf('/') < 0) {
+      var decimalValue = parseFloat(trimmed.replace(',', '.'));
+      return isNaN(decimalValue) ? null : decimalValue;
+    }
+
+    var hasInteger = trimmed.indexOf(' ') >= 0;
+    var hasFraction = true;
     var integerPart = hasInteger ? parseInt(trimmed.split(' ')[0], 10) : 0;
     var numeratorPart;
     var denominatorPart;

--- a/src/main/resources/templates/sbadmin/dietas/formulario.html
+++ b/src/main/resources/templates/sbadmin/dietas/formulario.html
@@ -279,8 +279,9 @@
                       class="form-control"
                       id="alimentoPorciones"
                       value="1"
-                      min="1"
-                      max="3"
+                      min="0.25"
+                      max="10"
+                      step="any"
                       name="porciones" />
                   </div>
                   <div id="alimentoPortionDetails" style="display: none">
@@ -290,16 +291,12 @@
                         type="text"
                         class="form-control"
                         id="alimentoCantidad"
-                        placeholder="Cantidad" />
+                        name="cantidad"
+                        placeholder="Ej. 1/2"
+                        autocomplete="off" />
+                      <small id="alimentoUnidadLeyenda" class="form-text text-muted"></small>
                     </div>
-                    <div class="form-group">
-                      <label for="alimentoUnidad">Unidad</label>
-                      <input
-                        type="text"
-                        class="form-control"
-                        id="alimentoUnidad"
-                        disabled="true" />
-                    </div>
+                    <input type="hidden" id="alimentoUnidad" />
                     <div class="form-group">
                       <label for="alimentoPeso">Peso (g)</label>
                       <input
@@ -611,16 +608,17 @@
               <div class="modal-body">
                 <form th:action="@{/admin/dietas/{id}/alimentos/{alimentoIngestaId}/update(id=${dieta != null ? dieta.id : 0}, alimentoIngestaId=0)}" method="post" id="editAlimentoForm">
                   <div class="form-group">
-                    <label for="editPorcionesAlimento">Porciones</label>
+                    <label for="editCantidadAlimento">Cantidad</label>
                     <input
-                      type="number"
+                      type="text"
                       class="form-control"
-                      id="editPorcionesAlimento"
-                      name="porciones"
+                      id="editCantidadAlimento"
+                      name="cantidad"
                       value="1"
-                      min="1"
-                      max="3"
+                      placeholder="Ej. 1/2"
+                      autocomplete="off"
                       required />
+                    <small id="editUnidadAlimentoLeyenda" class="form-text text-muted"></small>
                   </div>
                   <button type="submit" class="btn btn-primary">Guardar</button>
                 </form>
@@ -1148,7 +1146,7 @@
                                     <button
                                       type="button"
                                       class="btn btn-primary btn-sm"
-                                      th:attr="data-dieta=${dieta.id},data-ingesta=${ingesta.id},data-alimento=${alimento.id},data-porciones=${alimento.portions}"
+                                      th:attr="data-dieta=${dieta.id},data-ingesta=${ingesta.id},data-alimento=${alimento.id},data-cantidad=${alimento.displayCantidad},data-unidad=${alimento.unidad}"
                                       data-toggle="modal"
                                       data-target="#editAlimentoModal"
                                       th:disabled="${isOwner != null && !isOwner}"
@@ -1169,37 +1167,19 @@
                                 </div>
                                 <div class="ingesta-item-details row mt-3">
                                   <div class="col-6 col-md-3 mb-2 mb-md-0">
-                                    <span class="detail-label d-block">Porciones</span>
-                                    <div class="input-group input-group-sm mt-1" style="max-width: 8.5rem;">
-                                      <div class="input-group-prepend">
-                                        <button
-                                          type="button"
-                                          class="btn btn-outline-secondary btn-sm decrease-portion"
-                                          th:attr="data-dieta=${dieta.id},data-ingesta=${ingesta.id},data-alimento=${alimento.id},data-porciones=${alimento.portions}"
-                                          th:disabled="${isOwner != null && !isOwner}"
-                                          title="Disminuir porciones">
-                                          <i class="fas fa-minus"></i>
-                                        </button>
-                                      </div>
-                                      <input
-                                        type="number"
-                                        class="form-control form-control-sm text-center portion-input"
-                                        th:attr="data-dieta=${dieta.id},data-ingesta=${ingesta.id},data-alimento=${alimento.id},value=${alimento.portions}"
-                                        min="1"
-                                        max="10"
-                                        readonly
-                                        style="background-color: #fff;" />
-                                      <div class="input-group-append">
-                                        <button
-                                          type="button"
-                                          class="btn btn-outline-secondary btn-sm increase-portion"
-                                          th:attr="data-dieta=${dieta.id},data-ingesta=${ingesta.id},data-alimento=${alimento.id},data-porciones=${alimento.portions}"
-                                          th:disabled="${isOwner != null && !isOwner}"
-                                          title="Aumentar porciones">
-                                          <i class="fas fa-plus"></i>
-                                        </button>
-                                      </div>
-                                    </div>
+                                    <span class="detail-label d-block">Cantidad</span>
+                                    <input
+                                      type="text"
+                                      class="form-control form-control-sm mt-1 inline-alimento-cantidad-input"
+                                      th:attr="data-dieta=${dieta.id},data-ingesta=${ingesta.id},data-alimento=${alimento.id},data-alimento-cant=${alimento.alimento != null ? alimento.alimento.cantSugerida : ''}"
+                                      th:value="${alimento.displayCantidad}"
+                                      th:disabled="${isOwner != null && !isOwner}"
+                                      placeholder="Ej. 1/2"
+                                      autocomplete="off"
+                                      aria-label="Cantidad" />
+                                    <small class="form-text text-muted mt-1"
+                                           th:if="${alimento.unidad != null && !#strings.isEmpty(alimento.unidad)}"
+                                           th:text="${alimento.unidad}">taza</small>
                                   </div>
                                   <div class="col-6 col-md-2 mb-2 mb-md-0">
                                     <span class="detail-label d-block">Calor&iacute;as</span>
@@ -1883,6 +1863,113 @@
             saveInlinePlatilloIngredienteCantidad($(this));
           });
 
+          var inlineAlimentoCantidadSaving = false;
+
+          function sameNumericId(left, right) {
+            return Number(left) === Number(right);
+          }
+
+          function findAlimentoIngestaInDieta(dieta, ingestaId, alimentoId) {
+            var found = null;
+            if (dieta && Array.isArray(dieta.ingestas)) {
+              dieta.ingestas.forEach(function(ingesta) {
+                if (sameNumericId(ingesta.id, ingestaId) && Array.isArray(ingesta.alimentos)) {
+                  ingesta.alimentos.forEach(function(alimento) {
+                    if (sameNumericId(alimento.id, alimentoId)) {
+                      found = alimento;
+                    }
+                  });
+                }
+              });
+            }
+            return found;
+          }
+
+          function saveInlineAlimentoCantidad($input) {
+            if (inlineAlimentoCantidadSaving || $input.prop('disabled')) {
+              return;
+            }
+            var committedValue = $input.data('committed');
+            var newCantidad = String($input.val()).trim();
+            if (committedValue === newCantidad) {
+              return;
+            }
+            var parsedCantidad = window.IngredientWeightRecalc
+              ? window.IngredientWeightRecalc.parseFractionalQuantity(newCantidad)
+              : null;
+            if (parsedCantidad == null || parsedCantidad <= 0) {
+              swal({
+                title: 'Cantidad inválida',
+                text: 'Use un valor fraccional válido (ej. 1/2, 1 1/4).',
+                type: 'error',
+                timer: 5000
+              });
+              $input.val(committedValue);
+              return;
+            }
+            var dietaId = $input.data('dieta');
+            var ingestaId = $input.data('ingesta');
+            var alimentoId = $input.data('alimento');
+            inlineAlimentoCantidadSaving = true;
+            $input.prop('disabled', true);
+            $.ajax({
+              url: '/rest/dietas/' + dietaId + '/ingestas/' + ingestaId + '/alimentos/' + alimentoId + '/cantidad',
+              type: 'PUT',
+              data: { cantidad: newCantidad },
+              dataType: 'json',
+              success: function(response) {
+                if (response && response.data) {
+                  var updatedAlimento = findAlimentoIngestaInDieta(response.data, ingestaId, alimentoId);
+                  var itemCard = $input.closest('.ingesta-item-card');
+                  if (updatedAlimento) {
+                    var displayCantidad = updatedAlimento.displayCantidad || newCantidad;
+                    $input.val(displayCantidad);
+                    $input.data('committed', displayCantidad);
+                    itemCard.find('[data-target="#editAlimentoModal"]').data('cantidad', displayCantidad);
+                    updateNutrientValues(itemCard, updatedAlimento);
+                    updatePieChart(response.data);
+                    showToast('Actualizado', 'La cantidad ha sido actualizada correctamente.', 'success');
+                  } else {
+                    $input.data('committed', newCantidad);
+                    showToast('Actualizado',
+                      'La cantidad ha sido actualizada. Algunos valores pueden necesitar recarga.',
+                      'warning');
+                  }
+                } else {
+                  $input.data('committed', newCantidad);
+                }
+              },
+              error: function(error) {
+                $input.val(committedValue);
+                showToast('Error', error.responseJSON && error.responseJSON.message
+                  ? error.responseJSON.message
+                  : 'No se pudo actualizar la cantidad del alimento.', 'error');
+              },
+              complete: function() {
+                inlineAlimentoCantidadSaving = false;
+                $input.prop('disabled', false);
+              }
+            });
+          }
+
+          $(document).on('focus', '.inline-alimento-cantidad-input', function() {
+            var $input = $(this);
+            if (!$input.data('committed')) {
+              $input.data('committed', String($input.val()).trim());
+            }
+          });
+
+          $(document).on('keydown', '.inline-alimento-cantidad-input', function(event) {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              $(this).blur();
+            }
+          });
+
+          $(document).on('blur', '.inline-alimento-cantidad-input', function() {
+            saveInlineAlimentoCantidad($(this));
+          });
+
           $(document).on('click', '.toggle-platillo-ingredientes', function() {
             var targetSelector = $(this).data('target');
             $(targetSelector).collapse('toggle');
@@ -2286,6 +2373,7 @@
               selectedAlimentoReference = null;
               $('#alimentoCantidad').val('');
               $('#alimentoUnidad').val('');
+              $('#alimentoUnidadLeyenda').text('');
               $('#alimentoPeso').val('');
               return;
             }
@@ -2299,6 +2387,7 @@
                 };
                 $('#alimentoCantidad').val(response.fractionalCantSugerida);
                 $('#alimentoUnidad').val(response.unidad);
+                $('#alimentoUnidadLeyenda').text(response.unidad || '');
                 $('#alimentoPeso').val(response.pesoNeto);
                 syncAlimentoPorcionesFromCantidad();
               }
@@ -2331,8 +2420,11 @@
             if (parsedCantidad == null || !selectedAlimentoReference.cantSugerida) {
               return;
             }
-            var porciones = Math.round(parsedCantidad / selectedAlimentoReference.cantSugerida);
-            porciones = Math.max(1, Math.min(3, porciones));
+            var porciones = parsedCantidad / selectedAlimentoReference.cantSugerida;
+            if (!isFinite(porciones) || porciones <= 0) {
+              return;
+            }
+            porciones = Math.max(0.01, Math.min(100, porciones));
             $('#alimentoPorciones').val(porciones);
           }
 
@@ -2347,6 +2439,7 @@
             modal.find('#tipoPorcion').val('porcion');
             $('#alimentoCantidad').val('');
             $('#alimentoUnidad').val('');
+            $('#alimentoUnidadLeyenda').text('');
             $('#alimentoPeso').val('');
             toggleAlimentoPortionFields();
           });
@@ -2403,12 +2496,14 @@
             var button = $(event.relatedTarget);
             var dietaId = button.data('dieta');
             var alimentoId = button.data('alimento');
-            var porciones = button.data('porciones');
+            var cantidad = button.data('cantidad');
+            var unidad = button.data('unidad');
             var modal = $(this);
             var form = modal.find('#editAlimentoForm');
             var actionUrl = '/admin/dietas/' + dietaId + '/alimentos/' + alimentoId + '/update';
             form.attr('action', actionUrl);
-            modal.find('#editPorcionesAlimento').val(porciones);
+            modal.find('#editCantidadAlimento').val(cantidad || '');
+            modal.find('#editUnidadAlimentoLeyenda').text(unidad || '');
           });
 
           // Handle increase portion buttons for platillos
@@ -2436,34 +2531,6 @@
             
             if (newPortions !== currentPortions) {
               updatePlatilloPortions(dietaId, ingestaId, platilloId, newPortions, button);
-            }
-          });
-
-          // Handle increase portion buttons for alimentos
-          $(document).on('click', '.increase-portion[data-alimento]', function () {
-            var button = $(this);
-            var dietaId = button.data('dieta');
-            var ingestaId = button.data('ingesta');
-            var alimentoId = button.data('alimento');
-            var currentPortions = parseInt(button.data('porciones')) || 1;
-            var newPortions = Math.min(currentPortions + 1, 10);
-            
-            if (newPortions !== currentPortions) {
-              updateAlimentoPortions(dietaId, ingestaId, alimentoId, newPortions, button);
-            }
-          });
-
-          // Handle decrease portion buttons for alimentos
-          $(document).on('click', '.decrease-portion[data-alimento]', function () {
-            var button = $(this);
-            var dietaId = button.data('dieta');
-            var ingestaId = button.data('ingesta');
-            var alimentoId = button.data('alimento');
-            var currentPortions = parseInt(button.data('porciones')) || 1;
-            var newPortions = Math.max(currentPortions - 1, 1);
-            
-            if (newPortions !== currentPortions) {
-              updateAlimentoPortions(dietaId, ingestaId, alimentoId, newPortions, button);
             }
           });
 
@@ -2515,73 +2582,6 @@
                     portionInput.val(updatedPlatillo.portions);
                     itemCard.find('.decrease-portion, .increase-portion').data('porciones', updatedPlatillo.portions);
                     updateNutrientValues(itemCard, updatedPlatillo);
-                    
-                    // Update pie chart if it exists
-                    updatePieChart(dieta);
-                    // Show success toast
-                    showToast('Actualizado', 'Las porciones han sido actualizadas correctamente.', 'success');
-                  } else {
-                    // If we can't find the updated item, update portion number and show warning
-                    portionInput.val(newPortions);
-                    itemCard.find('.decrease-portion, .increase-portion').data('porciones', newPortions);
-                    showToast('Actualizado', 'Las porciones han sido actualizadas. Algunos valores pueden necesitar recarga.', 'warning');
-                  }
-                } else {
-                  // If response structure is unexpected, update portion number and show warning
-                  portionInput.val(newPortions);
-                  itemCard.find('.decrease-portion, .increase-portion').data('porciones', newPortions);
-                  showToast('Actualizado', 'Las porciones han sido actualizadas. Algunos valores pueden necesitar recarga.', 'warning');
-                }
-                // Re-enable buttons
-                itemCard.find('.decrease-portion, .increase-portion').prop('disabled', false);
-              },
-              error: function (error) {
-                var errorMessage = error.responseJSON && error.responseJSON.message 
-                  ? error.responseJSON.message 
-                  : 'Error al actualizar las porciones.';
-                showToast('Error', errorMessage, 'error');
-                // Re-enable buttons
-                itemCard.find('.decrease-portion, .increase-portion').prop('disabled', false);
-              }
-            });
-          }
-
-          // Function to update alimento portions via AJAX
-          function updateAlimentoPortions(dietaId, ingestaId, alimentoId, newPortions, button) {
-            var itemCard = button.closest('.ingesta-item-card');
-            var portionInput = itemCard.find('.portion-input[data-alimento="' + alimentoId + '"]');
-            
-            // Disable buttons during update
-            button.prop('disabled', true);
-            itemCard.find('.decrease-portion, .increase-portion').prop('disabled', true);
-            
-            $.ajax({
-              url: '/rest/dietas/' + dietaId + '/ingestas/' + ingestaId + '/alimentos/' + alimentoId + '/portions',
-              type: 'PUT',
-              data: { portions: newPortions },
-              dataType: 'json',
-              success: function (response) {
-                if (response && response.data) {
-                  var dieta = response.data;
-                  // Find the updated alimento in the response
-                  var updatedAlimento = null;
-                  if (dieta.ingestas && Array.isArray(dieta.ingestas)) {
-                    dieta.ingestas.forEach(function(ingesta) {
-                      if (ingesta.id === ingestaId && ingesta.alimentos && Array.isArray(ingesta.alimentos)) {
-                        ingesta.alimentos.forEach(function(alimento) {
-                          if (alimento.id === alimentoId) {
-                            updatedAlimento = alimento;
-                          }
-                        });
-                      }
-                    });
-                  }
-                  
-                  if (updatedAlimento) {
-                    // Update portion input and buttons
-                    portionInput.val(updatedAlimento.portions);
-                    itemCard.find('.decrease-portion, .increase-portion').data('porciones', updatedAlimento.portions);
-                    updateNutrientValues(itemCard, updatedAlimento);
                     
                     // Update pie chart if it exists
                     updatePieChart(dieta);

--- a/src/main/resources/templates/sbadmin/dietas/printable.html
+++ b/src/main/resources/templates/sbadmin/dietas/printable.html
@@ -379,12 +379,11 @@
 
 			<!-- Alimentos -->
 			<div th:each="alimento : ${ingesta.alimentos}" class="alimento-item">
-				<div class="item-name" th:text="${alimento.name + (alimento.portions != null && alimento.portions > 1 ? ' (' + alimento.portions + ' porción' + (alimento.portions > 1 ? 'es' : '') + ')' : '')}">Alimento</div>
+				<div class="item-name" th:text="${alimento.name + (alimento.portions != null && alimento.portions > 1 ? ' (' + alimento.displayCantidad + ' porción' + (alimento.portions > 1 ? 'es' : '') + ')' : '')}">Alimento</div>
 				<div class="item-details" th:if="${alimento.alimento != null && (alimento.alimento.cantSugerida != null || alimento.unidad != null)}">
 					<div style="margin-top: 3px;">
-						<span th:if="${alimento.alimento.cantSugerida != null}" th:text="${alimento.alimento.getRoundedFractionalCantSugerida()}"></span>
-						<span th:if="${alimento.alimento.cantSugerida != null && alimento.unidad != null}" th:text="${' '}"></span>
-						<span th:if="${alimento.unidad != null}" th:text="${alimento.unidad}"></span>
+						<span th:text="${alimento.displayCantidad}"></span>
+						<span th:if="${alimento.unidad != null}" th:text="${' ' + alimento.unidad}"></span>
 					</div>
 				</div>
 			</div>

--- a/src/test/java/com/nutriconsultas/dieta/AlimentoIngestaNutrientScalerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/AlimentoIngestaNutrientScalerTest.java
@@ -1,0 +1,28 @@
+package com.nutriconsultas.dieta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.alimentos.Alimento;
+
+class AlimentoIngestaNutrientScalerTest {
+
+	@Test
+	void copyScaled_appliesFractionalMultiplierToMacrosAndWeight() {
+		final Alimento alimento = new Alimento();
+		alimento.setEnergia(200);
+		alimento.setProteina(20.0);
+		alimento.setPesoNeto(80);
+		alimento.setPesoBrutoRedondeado(90);
+
+		final AlimentoIngesta target = new AlimentoIngesta();
+		AlimentoIngestaNutrientScaler.copyScaled(alimento, target, 0.5);
+
+		assertThat(target.getEnergia()).isEqualTo(100);
+		assertThat(target.getProteina()).isEqualTo(10.0);
+		assertThat(target.getPesoNeto()).isEqualTo(40);
+		assertThat(target.getPesoBrutoRedondeado()).isEqualTo(45);
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/dieta/AlimentoIngestaPortionsTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/AlimentoIngestaPortionsTest.java
@@ -1,0 +1,106 @@
+package com.nutriconsultas.dieta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.alimentos.Alimento;
+
+class AlimentoIngestaPortionsTest {
+
+	@Test
+	void resolve_usesCantidadRatioAgainstCatalogSuggestedServing() {
+		final Alimento alimento = catalogAlimento(1.0);
+		final AlimentoFormModel model = new AlimentoFormModel();
+		model.setTipoPorcion(AlimentoPortionDefaults.PORCION);
+		model.setCantidad("1/2");
+		model.setPorciones(1.0);
+
+		assertThat(AlimentoIngestaPortions.resolve(model, alimento)).isEqualTo(0.5);
+	}
+
+	@Test
+	void resolve_keepsOnePortionWhenCantidadMatchesSuggestedServing() {
+		final Alimento alimento = catalogAlimento(0.5);
+		final AlimentoFormModel model = new AlimentoFormModel();
+		model.setTipoPorcion(AlimentoPortionDefaults.PORCION);
+		model.setCantidad("1/2");
+
+		assertThat(AlimentoIngestaPortions.resolve(model, alimento)).isEqualTo(1.0);
+	}
+
+	@Test
+	void resolve_fallsBackToPorcionesWhenCantidadMissing() {
+		final AlimentoFormModel model = new AlimentoFormModel();
+		model.setTipoPorcion(AlimentoPortionDefaults.PORCION);
+		model.setPorciones(2.0);
+
+		assertThat(AlimentoIngestaPortions.resolve(model, catalogAlimento(1.0))).isEqualTo(2.0);
+	}
+
+	@Test
+	void resolve_usesPorcionesForGramosType() {
+		final AlimentoFormModel model = new AlimentoFormModel();
+		model.setTipoPorcion(AlimentoPortionDefaults.GRAMOS);
+		model.setCantidad("1/2");
+		model.setPorciones(2.0);
+
+		assertThat(AlimentoIngestaPortions.resolve(model, catalogAlimento(1.0))).isEqualTo(2.0);
+	}
+
+	@Test
+	void resolve_clampsValuesOutsideAllowedRange() {
+		final AlimentoFormModel tooSmall = new AlimentoFormModel();
+		tooSmall.setTipoPorcion(AlimentoPortionDefaults.PORCION);
+		tooSmall.setCantidad("0.001");
+
+		final AlimentoFormModel tooLarge = new AlimentoFormModel();
+		tooLarge.setTipoPorcion(AlimentoPortionDefaults.GRAMOS);
+		tooLarge.setPorciones(200.0);
+
+		assertThat(AlimentoIngestaPortions.resolve(tooSmall, catalogAlimento(1.0)))
+			.isEqualTo(AlimentoIngestaPortions.MIN);
+		assertThat(AlimentoIngestaPortions.resolve(tooLarge, catalogAlimento(1.0)))
+			.isEqualTo(AlimentoIngestaPortions.MAX);
+	}
+
+	@Test
+	void isValid_acceptsFractionalPortionsWithinRange() {
+		assertThat(AlimentoIngestaPortions.isValid(0.5)).isTrue();
+		assertThat(AlimentoIngestaPortions.isValid(0.1)).isTrue();
+		assertThat(AlimentoIngestaPortions.isValid(0.001)).isFalse();
+		assertThat(AlimentoIngestaPortions.isValid(null)).isFalse();
+	}
+
+	@Test
+	void fromCantidad_keepsOnePortionWhenEnteredQuantityMatchesCatalogServing() {
+		final Alimento amaranto = catalogAlimento(0.25);
+
+		assertThat(AlimentoIngestaPortions.fromCantidad("1/4", amaranto)).isEqualTo(1.0);
+		assertThat(AlimentoIngestaPortions.fromCantidad("1", amaranto)).isEqualTo(4.0);
+	}
+
+	@Test
+	void fromCantidad_acceptsSmallFractionOfUnitCatalogServing() {
+		assertThat(AlimentoIngestaPortions.fromCantidad("1/8", catalogAlimento(1.0))).isEqualTo(0.125);
+	}
+
+	@Test
+	void resolveUpdate_prefersCantidadOverPorciones() {
+		final Double portions = AlimentoIngestaPortions.resolveUpdate("1/2", 3.0, catalogAlimento(1.0));
+
+		assertThat(portions).isEqualTo(0.5);
+	}
+
+	@Test
+	void resolveUpdate_fallsBackToPorcionesWhenCantidadMissing() {
+		assertThat(AlimentoIngestaPortions.resolveUpdate(null, 2.0, catalogAlimento(1.0))).isEqualTo(2.0);
+	}
+
+	private static Alimento catalogAlimento(final double cantSugerida) {
+		final Alimento alimento = new Alimento();
+		alimento.setCantSugerida(cantSugerida);
+		return alimento;
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/dieta/AlimentoIngestaTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/AlimentoIngestaTest.java
@@ -1,0 +1,44 @@
+package com.nutriconsultas.dieta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.nutriconsultas.alimentos.Alimento;
+
+class AlimentoIngestaTest {
+
+	@Test
+	void getDisplayCantidad_scalesCatalogQuantityByPortions() {
+		final Alimento alimento = new Alimento();
+		alimento.setCantSugerida(1.0);
+		final AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
+		alimentoIngesta.setAlimento(alimento);
+		alimentoIngesta.setPortions(0.5);
+
+		assertThat(alimentoIngesta.getDisplayCantidad()).isEqualTo("1/2");
+	}
+
+	@Test
+	void getDisplayCantidad_formatsMixedFractions() {
+		final Alimento alimento = new Alimento();
+		alimento.setCantSugerida(1.0);
+		final AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
+		alimentoIngesta.setAlimento(alimento);
+		alimentoIngesta.setPortions(1.5);
+
+		assertThat(alimentoIngesta.getDisplayCantidad()).isEqualTo("1 1/2");
+	}
+
+	@Test
+	void getDisplayCantidad_showsCatalogFractionWhenPortionsAreOne() {
+		final Alimento alimento = new Alimento();
+		alimento.setCantSugerida(0.25);
+		final AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
+		alimentoIngesta.setAlimento(alimento);
+		alimentoIngesta.setPortions(1.0);
+
+		assertThat(alimentoIngesta.getDisplayCantidad()).isEqualTo("1/4");
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/dieta/DietaControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaControllerTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -100,6 +101,8 @@ public class DietaControllerTest {
 		alimento.setNombreAlimento("Pollo");
 		alimento.setClasificacion("CARNES");
 		alimento.setUnidad("pieza");
+		alimento.setCantSugerida(1.0);
+		alimento.setPesoNeto(100);
 		alimento.setEnergia(200);
 		alimento.setProteina(25.0);
 		alimento.setLipidos(10.0);
@@ -450,6 +453,60 @@ public class DietaControllerTest {
 
 	@Test
 	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testSaveAlimentoWithFractionalCantidad() throws Exception {
+		assertThat(ingesta.getAlimentos()).isEmpty();
+
+		mockMvc
+			.perform(MockMvcRequestBuilders.post("/admin/dietas/1/alimentos/save")
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("ingestaAlimento", "1")
+				.param("alimento", "1")
+				.param("cantidad", "1/2")
+				.param("tipoPorcion", "porcion")
+				.with(oidcLogin(TEST_USER_ID))
+				.with(SecurityMockMvcRequestPostProcessors.csrf()))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(MockMvcResultMatchers.redirectedUrl("/admin/dietas/1?ingesta=1"));
+
+		final ArgumentCaptor<Dieta> dietaCaptor = ArgumentCaptor.forClass(Dieta.class);
+		verify(dietaService).saveDieta(dietaCaptor.capture());
+		final AlimentoIngesta saved = dietaCaptor.getValue().getIngestas().get(0).getAlimentos().get(0);
+		assertThat(saved.getPortions()).isEqualTo(0.5);
+		assertThat(saved.getEnergia()).isEqualTo(100);
+		assertThat(saved.getDisplayCantidad()).isEqualTo("1/2");
+		assertThat(saved.getUnidad()).isEqualTo("pieza");
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testSaveAlimentoQuarterCupWhenCatalogSuggestedIsQuarter() throws Exception {
+		alimento.setCantSugerida(0.25);
+		alimento.setUnidad("taza");
+		assertThat(ingesta.getAlimentos()).isEmpty();
+
+		mockMvc
+			.perform(MockMvcRequestBuilders.post("/admin/dietas/1/alimentos/save")
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("ingestaAlimento", "1")
+				.param("alimento", "1")
+				.param("cantidad", "1/4")
+				.param("tipoPorcion", "porcion")
+				.with(oidcLogin(TEST_USER_ID))
+				.with(SecurityMockMvcRequestPostProcessors.csrf()))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(MockMvcResultMatchers.redirectedUrl("/admin/dietas/1?ingesta=1"));
+
+		final ArgumentCaptor<Dieta> dietaCaptor = ArgumentCaptor.forClass(Dieta.class);
+		verify(dietaService).saveDieta(dietaCaptor.capture());
+		final AlimentoIngesta saved = dietaCaptor.getValue().getIngestas().get(0).getAlimentos().get(0);
+		assertThat(saved.getPortions()).isEqualTo(1.0);
+		assertThat(saved.getDisplayCantidad()).isEqualTo("1/4");
+		assertThat(saved.getUnidad()).isEqualTo("taza");
+		assertThat(saved.getEnergia()).isEqualTo(200);
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
 	public void testSaveAlimentoDefaultsTipoPorcionWhenOmitted() throws Exception {
 		mockMvc
 			.perform(MockMvcRequestBuilders.post("/admin/dietas/1/alimentos/save")
@@ -721,7 +778,7 @@ public class DietaControllerTest {
 		AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
 		alimentoIngesta.setId(1L);
 		alimentoIngesta.setName("Pollo");
-		alimentoIngesta.setPortions(1);
+		alimentoIngesta.setPortions(1.0);
 		alimentoIngesta.setEnergia(200);
 		alimentoIngesta.setProteina(25.0);
 		alimentoIngesta.setLipidos(10.0);
@@ -780,7 +837,7 @@ public class DietaControllerTest {
 		AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
 		alimentoIngesta.setId(2L);
 		alimentoIngesta.setName("Alimento sin referencia");
-		alimentoIngesta.setPortions(1);
+		alimentoIngesta.setPortions(1.0);
 		alimentoIngesta.setIngesta(ingesta);
 		// alimentoIngesta.setAlimento(null); // No alimento reference
 
@@ -803,6 +860,42 @@ public class DietaControllerTest {
 		verify(dietaService, never()).saveDieta(any(Dieta.class));
 
 		log.info("Finishing testUpdateAlimentoIngestaWithoutAlimentoReference");
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = { "ADMIN" })
+	public void testUpdateAlimentoIngestaWithCantidadRecalculatesNutrients() throws Exception {
+		final AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
+		alimentoIngesta.setId(1L);
+		alimentoIngesta.setName("Pollo");
+		alimentoIngesta.setPortions(1.0);
+		alimentoIngesta.setEnergia(200);
+		alimentoIngesta.setProteina(25.0);
+		alimentoIngesta.setLipidos(10.0);
+		alimentoIngesta.setHidratosDeCarbono(0.0);
+		alimentoIngesta.setAlimento(alimento);
+		alimentoIngesta.setIngesta(ingesta);
+
+		ingesta.setAlimentos(new ArrayList<>());
+		ingesta.getAlimentos().add(alimentoIngesta);
+
+		mockMvc
+			.perform(MockMvcRequestBuilders.post("/admin/dietas/1/alimentos/1/update")
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("cantidad", "1/2")
+				.with(oidcLogin(TEST_USER_ID))
+				.with(SecurityMockMvcRequestPostProcessors.csrf()))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(MockMvcResultMatchers.redirectedUrl("/admin/dietas/1?ingesta=1"));
+
+		final ArgumentCaptor<Dieta> dietaCaptor = ArgumentCaptor.forClass(Dieta.class);
+		verify(dietaService).saveDieta(dietaCaptor.capture());
+		final AlimentoIngesta updated = dietaCaptor.getValue().getIngestas().get(0).getAlimentos().get(0);
+		assertThat(updated.getPortions()).isEqualTo(0.5);
+		assertThat(updated.getDisplayCantidad()).isEqualTo("1/2");
+		assertThat(updated.getEnergia()).isEqualTo(100);
+		assertThat(updated.getProteina()).isEqualTo(12.5);
+		assertThat(updated.getLipidos()).isEqualTo(5.0);
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/dieta/DietaJsonSerializationTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaJsonSerializationTest.java
@@ -1,0 +1,66 @@
+package com.nutriconsultas.dieta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nutriconsultas.alimentos.Alimento;
+import com.nutriconsultas.model.ApiResponse;
+
+class DietaJsonSerializationTest {
+
+	@Test
+	void apiResponse_includesAlimentoMacrosWithoutIngestaNestingCycle() throws Exception {
+		final Dieta dieta = new Dieta();
+		dieta.setId(63L);
+		dieta.setNombre("Dieta de prueba");
+
+		final Ingesta ingesta = new Ingesta();
+		ingesta.setId(249L);
+		ingesta.setNombre("Desayuno");
+		ingesta.setDieta(dieta);
+
+		final Alimento catalogAlimento = new Alimento();
+		catalogAlimento.setId(10L);
+		catalogAlimento.setCantSugerida(0.25);
+		catalogAlimento.setUnidad("taza");
+
+		final AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
+		alimentoIngesta.setId(51L);
+		alimentoIngesta.setName("Amaranto tostado");
+		alimentoIngesta.setPortions(1.0);
+		alimentoIngesta.setEnergia(90);
+		alimentoIngesta.setProteina(3.5);
+		alimentoIngesta.setLipidos(1.5);
+		alimentoIngesta.setHidratosDeCarbono(16.0);
+		alimentoIngesta.setAlimento(catalogAlimento);
+		alimentoIngesta.setIngesta(ingesta);
+
+		final PlatilloIngesta platilloIngesta = new PlatilloIngesta();
+		platilloIngesta.setId(255L);
+		platilloIngesta.setName("Huevos");
+		platilloIngesta.setPortions(1);
+		platilloIngesta.setEnergia(150);
+		platilloIngesta.setProteina(12.0);
+		platilloIngesta.setIngesta(ingesta);
+
+		ingesta.getAlimentos().add(alimentoIngesta);
+		ingesta.getPlatillos().add(platilloIngesta);
+		dieta.getIngestas().add(ingesta);
+
+		final ObjectMapper mapper = new ObjectMapper();
+		final JsonNode json = mapper.readTree(mapper.writeValueAsString(new ApiResponse<>(dieta)));
+		final JsonNode alimentoJson = json.get("data").get("ingestas").get(0).get("alimentos").get(0);
+		final JsonNode platilloJson = json.get("data").get("ingestas").get(0).get("platillos").get(0);
+
+		assertThat(alimentoJson.get("energia").asInt()).isEqualTo(90);
+		assertThat(alimentoJson.get("proteina").asDouble()).isEqualTo(3.5);
+		assertThat(alimentoJson.get("displayCantidad").asText()).isEqualTo("1/4");
+		assertThat(alimentoJson.has("ingesta")).isFalse();
+		assertThat(platilloJson.get("energia").asInt()).isEqualTo(150);
+		assertThat(platilloJson.has("ingesta")).isFalse();
+	}
+
+}

--- a/src/test/java/com/nutriconsultas/dieta/DietaPdfServiceTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaPdfServiceTest.java
@@ -140,7 +140,7 @@ public class DietaPdfServiceTest {
 		final AlimentoIngesta alimento = new AlimentoIngesta();
 		alimento.setId(1L);
 		alimento.setName("Alimento de prueba");
-		alimento.setPortions(1);
+		alimento.setPortions(1.0);
 		alimento.setEnergia(100);
 		alimento.setProteina(5.0);
 		alimento.setLipidos(3.0);

--- a/src/test/java/com/nutriconsultas/dieta/DietaServiceTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaServiceTest.java
@@ -165,7 +165,7 @@ public class DietaServiceTest {
 		alimentoIngesta = new AlimentoIngesta();
 		alimentoIngesta.setId(1L);
 		alimentoIngesta.setName("Manzana");
-		alimentoIngesta.setPortions(2);
+		alimentoIngesta.setPortions(2.0);
 		alimentoIngesta.setAlimento(alimento);
 		alimentoIngesta.setUnidad("pieza");
 		alimentoIngesta.setPesoBrutoRedondeado(200);

--- a/src/test/java/com/nutriconsultas/dieta/DietasRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietasRestControllerTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.server.ResponseStatusException;
 
+import com.nutriconsultas.alimentos.Alimento;
 import com.nutriconsultas.dataTables.paging.Direction;
 import com.nutriconsultas.dataTables.paging.Order;
 import com.nutriconsultas.dataTables.paging.PageArray;
@@ -725,6 +726,87 @@ public class DietasRestControllerTest {
 		assertThat(result).isNotNull();
 		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
 		log.info("Finishing testDeleteAlimentoIngestaDietaNotFoundReturnsNotFound");
+	}
+
+	@Test
+	public void testUpdateAlimentoIngestaCantidadRecalculatesFromCatalogServing() {
+		final Long dietaId = 2L;
+		final Long ingestaId = 2L;
+		final Long alimentoIngestaId = 1L;
+
+		final Dieta dieta = new Dieta();
+		dieta.setId(dietaId);
+		dieta.setNombre("Dieta con Alimentos");
+		dieta.setIngestas(new ArrayList<>());
+
+		final Ingesta ingesta = new Ingesta();
+		ingesta.setId(ingestaId);
+		ingesta.setNombre("Desayuno");
+		ingesta.setDieta(dieta);
+		ingesta.setAlimentos(new ArrayList<>());
+
+		final Alimento amaranto = new Alimento();
+		amaranto.setId(10L);
+		amaranto.setCantSugerida(0.25);
+		amaranto.setUnidad("taza");
+		amaranto.setEnergia(200);
+
+		final AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
+		alimentoIngesta.setId(alimentoIngestaId);
+		alimentoIngesta.setName("Amaranto tostado");
+		alimentoIngesta.setPortions(1.0);
+		alimentoIngesta.setAlimento(amaranto);
+		alimentoIngesta.setIngesta(ingesta);
+		ingesta.getAlimentos().add(alimentoIngesta);
+		dieta.getIngestas().add(ingesta);
+
+		stubMutationAccess(dietaId, TEST_USER_ID, dieta);
+		when(dietaService.saveDieta(dieta)).thenReturn(dieta);
+
+		final ResponseEntity<ApiResponse<Dieta>> result = dietasRestController.updateAlimentoIngestaCantidad(dietaId,
+				ingestaId, alimentoIngestaId, "1/4", createMockOidcUser(TEST_USER_ID));
+
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		verify(dietaService).recalculateAlimentoIngestaNutrients(alimentoIngesta, 1.0);
+		verify(dietaService).saveDieta(dieta);
+	}
+
+	@Test
+	public void testUpdateAlimentoIngestaCantidadInvalidReturnsBadRequest() {
+		final Long dietaId = 2L;
+		final Long ingestaId = 2L;
+		final Long alimentoIngestaId = 1L;
+
+		final Dieta dieta = new Dieta();
+		dieta.setId(dietaId);
+		dieta.setNombre("Dieta con Alimentos");
+		dieta.setIngestas(new ArrayList<>());
+
+		final Ingesta ingesta = new Ingesta();
+		ingesta.setId(ingestaId);
+		ingesta.setNombre("Desayuno");
+		ingesta.setDieta(dieta);
+		ingesta.setAlimentos(new ArrayList<>());
+
+		final Alimento alimento = new Alimento();
+		alimento.setId(10L);
+		alimento.setCantSugerida(1.0);
+
+		final AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
+		alimentoIngesta.setId(alimentoIngestaId);
+		alimentoIngesta.setAlimento(alimento);
+		alimentoIngesta.setIngesta(ingesta);
+		ingesta.getAlimentos().add(alimentoIngesta);
+		dieta.getIngestas().add(ingesta);
+
+		stubMutationAccess(dietaId, TEST_USER_ID, dieta);
+
+		final ResponseEntity<ApiResponse<Dieta>> result = dietasRestController.updateAlimentoIngestaCantidad(dietaId,
+				ingestaId, alimentoIngestaId, "abc", createMockOidcUser(TEST_USER_ID));
+
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+		verify(dietaService, never()).recalculateAlimentoIngestaNutrients(any(), any());
+		verify(dietaService, never()).saveDieta(any());
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/dieta/PlatilloFromIngestaServiceTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/PlatilloFromIngestaServiceTest.java
@@ -243,7 +243,7 @@ class PlatilloFromIngestaServiceTest {
 		row.setAlimento(alimento);
 		row.setName(alimento.getNombreAlimento());
 		row.setUnidad(alimento.getUnidad());
-		row.setPortions(portions);
+		row.setPortions((double) portions);
 		row.setPesoNeto(alimento.getPesoNeto() * portions);
 		row.setPesoBrutoRedondeado(alimento.getPesoBrutoRedondeado() * portions);
 		return row;

--- a/src/test/java/com/nutriconsultas/mobile/DietGroceryListAggregatorTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/DietGroceryListAggregatorTest.java
@@ -44,7 +44,7 @@ class DietGroceryListAggregatorTest {
 		final Ingesta ingesta = ingesta("Desayuno");
 		final AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
 		alimentoIngesta.setName("Manzana");
-		alimentoIngesta.setPortions(2);
+		alimentoIngesta.setPortions(2.0);
 		alimentoIngesta.setUnidad("pieza");
 		alimentoIngesta.setAlimento(manzana);
 		ingesta.setAlimentos(List.of(alimentoIngesta));
@@ -93,7 +93,7 @@ class DietGroceryListAggregatorTest {
 	private static AlimentoIngesta standaloneAlimento(final Alimento alimento, final int portions) {
 		final AlimentoIngesta alimentoIngesta = new AlimentoIngesta();
 		alimentoIngesta.setName(alimento.getNombreAlimento());
-		alimentoIngesta.setPortions(portions);
+		alimentoIngesta.setPortions((double) portions);
 		alimentoIngesta.setUnidad("pieza");
 		alimentoIngesta.setAlimento(alimento);
 		return alimentoIngesta;

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanIntegrationTest.java
@@ -147,7 +147,7 @@ class MobilePatientDietPlanIntegrationTest {
 
 		final AlimentoIngesta alimento = new AlimentoIngesta();
 		alimento.setName("Pan integral");
-		alimento.setPortions(2);
+		alimento.setPortions(2.0);
 		alimento.setEnergia(120);
 		alimento.setUnidad("rebanada");
 		alimento.setIngesta(ingesta);

--- a/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanServiceTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/MobilePatientDietPlanServiceTest.java
@@ -250,7 +250,7 @@ class MobilePatientDietPlanServiceTest {
 		final AlimentoIngesta alimento = new AlimentoIngesta();
 		alimento.setId(40L);
 		alimento.setName("Manzana");
-		alimento.setPortions(1);
+		alimento.setPortions(1.0);
 		alimento.setEnergia(52);
 		alimento.setUnidad("pieza");
 		alimento.setProteina(0.3);

--- a/src/test/java/com/nutriconsultas/mobile/dto/DietPlatilloDtoTest.java
+++ b/src/test/java/com/nutriconsultas/mobile/dto/DietPlatilloDtoTest.java
@@ -52,7 +52,7 @@ class DietPlatilloDtoTest {
 	void fromEntity_alimentoMapsOptionalMacrosWhenPresent() {
 		final AlimentoIngesta alimento = new AlimentoIngesta();
 		alimento.setName("Manzana");
-		alimento.setPortions(1);
+		alimento.setPortions(1.0);
 		alimento.setEnergia(52);
 		alimento.setUnidad("pieza");
 		alimento.setProteina(0.3);

--- a/src/test/java/com/nutriconsultas/reports/NutritionAnalysisServiceTest.java
+++ b/src/test/java/com/nutriconsultas/reports/NutritionAnalysisServiceTest.java
@@ -217,7 +217,7 @@ public class NutritionAnalysisServiceTest {
 		final AlimentoIngesta alimento = new AlimentoIngesta();
 		alimento.setId(1L);
 		alimento.setName("Manzana");
-		alimento.setPortions(2);
+		alimento.setPortions(2.0);
 		alimento.setEnergia(100);
 		alimento.setProteina(0.5);
 		alimento.setLipidos(0.3);


### PR DESCRIPTION
## Summary
- Nutritionists can enter cooking fractions (e.g. `1/4`, `1/2`) for standalone foods on a diet ingesta instead of +/- portion buttons.
- Changing the quantity recalculates calories, protein, lipids, and carbs live, using the same AJAX diet refresh as platillo portions.
- Catalog servings like Amaranto tostado (`1/4` taza) display as the entered fraction, not as `1` taza.

## Test plan
- [ ] Add Amaranto tostado to a diet ingesta as `1/4` taza and confirm the card shows `1/4` taza, not `1` taza.
- [ ] Change the quantity to `1/2` or `1` without reloading and confirm macros on the card and the diet pie/summary update.
- [ ] Confirm platillo +/- portions still update macros live.
- [ ] Confirm Liquibase changeset `040` migrates `alimento_ingesta.portions` to double precision.


Made with [Cursor](https://cursor.com)