### PR TITLE
Fix weekly diet assignment 500s and weekday PDF print

### DIFF
--- a/src/main/java/com/nutriconsultas/dieta/DietaPdfService.java
+++ b/src/main/java/com/nutriconsultas/dieta/DietaPdfService.java
@@ -18,6 +18,8 @@ import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
 import com.nutriconsultas.paciente.PacienteDietaStatus;
+import com.nutriconsultas.paciente.PacienteDietaWeekday;
+import com.nutriconsultas.paciente.PacienteDietaWeekdayRepository;
 import com.nutriconsultas.paciente.PacienteRepository;
 import com.nutriconsultas.profile.NutritionistBrandingHelper;
 import com.nutriconsultas.profile.NutritionistProfile;
@@ -89,6 +91,9 @@ public class DietaPdfService {
 
 	@Autowired
 	private PacienteDietaRepository pacienteDietaRepository;
+
+	@Autowired
+	private PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository;
 
 	@Autowired
 	private PacienteRepository pacienteRepository;
@@ -171,6 +176,12 @@ public class DietaPdfService {
 		if (!assignments.isEmpty()) {
 			return assignments.get(0);
 		}
+		final PacienteDieta weekdayAssignment = pacienteDietaWeekdayRepository.findFirstByDietaId(dietaId)
+			.map(PacienteDietaWeekday::getPacienteDieta)
+			.orElse(null);
+		if (weekdayAssignment != null) {
+			return weekdayAssignment;
+		}
 		if (DietaCatalogConstants.isPatientAssignment(dieta) && dieta.getPacienteId() != null) {
 			return pacienteDietaRepository.findByPacienteId(dieta.getPacienteId())
 				.stream()
@@ -196,7 +207,10 @@ public class DietaPdfService {
 		if (assignment.getDieta() == null || assignment.getDieta().getId() == null) {
 			throw new IllegalArgumentException("Assignment has no dieta");
 		}
-		final Long dietaId = assignment.getDieta().getId();
+		return generatePdfForAssignment(assignment, assignment.getDieta().getId());
+	}
+
+	public byte[] generatePdfForAssignment(@NonNull final PacienteDieta assignment, @NonNull final Long dietaId) {
 		log.info("Generating PDF for assignment id: {} dieta id: {}", assignment.getId(), dietaId);
 		final Dieta dieta = dietaService.getDieta(dietaId);
 		if (dieta == null) {
@@ -206,8 +220,16 @@ public class DietaPdfService {
 	}
 
 	public ResponseEntity<byte[]> buildAssignmentPdfResponse(@NonNull final PacienteDieta assignment) {
-		final byte[] pdfBytes = generatePdfForAssignment(assignment);
-		final Dieta dieta = assignment.getDieta();
+		if (assignment.getDieta() == null || assignment.getDieta().getId() == null) {
+			throw new IllegalArgumentException("Assignment has no dieta");
+		}
+		return buildAssignmentPdfResponse(assignment, assignment.getDieta().getId());
+	}
+
+	public ResponseEntity<byte[]> buildAssignmentPdfResponse(@NonNull final PacienteDieta assignment,
+			@NonNull final Long dietaId) {
+		final byte[] pdfBytes = generatePdfForAssignment(assignment, dietaId);
+		final Dieta dieta = dietaService.getDieta(dietaId);
 		final String fileName = (dieta != null && dieta.getNombre() != null ? dieta.getNombre() : "dieta") + ".pdf";
 		return ResponseEntity.ok()
 			.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + fileName + "\"")

--- a/src/main/java/com/nutriconsultas/dieta/IngredientePlatilloIngestaRestController.java
+++ b/src/main/java/com/nutriconsultas/dieta/IngredientePlatilloIngestaRestController.java
@@ -3,6 +3,7 @@ package com.nutriconsultas.dieta;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -233,7 +234,7 @@ public class IngredientePlatilloIngestaRestController extends AbstractGridContro
 						+ "<i class='fas fa-trash fa-sm fa-fw'></i></button>"
 				: "";
 		return Arrays.asList(row.getAlimento().getNombreAlimento(), buildCantidadCell(row, canModify), row.getUnidad(),
-				row.getPesoNeto().toString(), actions);
+				Objects.toString(row.getPesoNeto(), ""), actions);
 	}
 
 	private String buildCantidadCell(final IngredientePlatilloIngesta row, final boolean canModify) {

--- a/src/main/java/com/nutriconsultas/paciente/PacienteController.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteController.java
@@ -1222,19 +1222,13 @@ public class PacienteController extends AbstractAuthorizedController {
 			return ResponseEntity.notFound().build();
 		}
 		verifyPatientOwnership(paciente, userId);
-		// Verify dieta exists and is assigned to this patient
-		final List<PacienteDieta> assignments = pacienteDietaRepository.findByPacienteId(pacienteId);
-		final PacienteDieta pacienteDieta = assignments.stream()
-			.filter(a -> a.getDieta() != null && a.getDieta().getId().equals(dietaId))
-			.findFirst()
-			.orElse(null);
+		final PacienteDieta pacienteDieta = pacienteDietaService.findAssignmentContainingDieta(pacienteId, dietaId);
 		if (pacienteDieta == null) {
 			log.error("Dieta {} is not assigned to patient {}", dietaId, pacienteId);
 			return ResponseEntity.notFound().build();
 		}
-		// Generate PDF with patient information included
 		pacienteDieta.setPaciente(paciente);
-		return dietaPdfService.buildAssignmentPdfResponse(pacienteDieta);
+		return dietaPdfService.buildAssignmentPdfResponse(pacienteDieta, dietaId);
 	}
 
 	/**

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaService.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaService.java
@@ -36,6 +36,9 @@ public interface PacienteDietaService {
 
 	List<PacienteDietaWeekday> findWeekdaySlots(@NonNull Long assignmentId);
 
+	@Nullable
+	PacienteDieta findAssignmentContainingDieta(@NonNull Long pacienteId, @NonNull Long dietaId);
+
 	List<Dieta> resolveDietsForGroceryList(@NonNull PacienteDieta assignment);
 
 	List<DietGroceryListItemDto> buildGroceryList(@NonNull PacienteDieta assignment);

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaServiceImpl.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaServiceImpl.java
@@ -166,6 +166,27 @@ public class PacienteDietaServiceImpl implements PacienteDietaService {
 
 	@Override
 	@Transactional(readOnly = true)
+	@Nullable
+	public PacienteDieta findAssignmentContainingDieta(@NonNull final Long pacienteId, @NonNull final Long dietaId) {
+		PacienteDieta result = null;
+		for (final PacienteDieta assignment : pacienteDietaRepository.findByPacienteId(pacienteId)) {
+			if (assignment.getDieta() != null && dietaId.equals(assignment.getDieta().getId())) {
+				result = assignment;
+				break;
+			}
+		}
+		if (result == null) {
+			result = pacienteDietaWeekdayRepository.findFirstByDietaId(dietaId)
+				.map(PacienteDietaWeekday::getPacienteDieta)
+				.filter(assignment -> assignment.getPaciente() != null
+						&& pacienteId.equals(assignment.getPaciente().getId()))
+				.orElse(null);
+		}
+		return result;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
 	public List<Dieta> resolveDietsForGroceryList(@NonNull final PacienteDieta assignment) {
 		if (assignment.isWeeklyAssignment()) {
 			final List<Dieta> diets = new ArrayList<>();
@@ -236,50 +257,81 @@ public class PacienteDietaServiceImpl implements PacienteDietaService {
 
 	private void mergeWeekdaySlots(final PacienteDieta assignment, final Map<Integer, Long> weekdayCatalogDietaIds,
 			final Long pacienteId, final String userId) {
+		final List<PacienteDietaWeekday> existingSlots = pacienteDietaWeekdayRepository
+			.findByPacienteDietaIdOrderByDayOfWeekAsc(assignment.getId());
 		final Map<Integer, PacienteDietaWeekday> existingByDay = new LinkedHashMap<>();
-		for (final PacienteDietaWeekday slot : pacienteDietaWeekdayRepository
-			.findByPacienteDietaIdOrderByDayOfWeekAsc(assignment.getId())) {
+		for (final PacienteDietaWeekday slot : existingSlots) {
 			if (slot.getDayOfWeek() != null) {
 				existingByDay.put(slot.getDayOfWeek(), slot);
 			}
 		}
-		pacienteDietaWeekdayRepository.deleteByPacienteDietaId(assignment.getId());
+		removeWeekdaySlots(existingSlots);
 		final Map<Integer, Long> normalized = normalizeWeekdayMap(weekdayCatalogDietaIds);
 		for (final int day : PacienteDietaWeekdayLabels.ISO_DAYS_MONDAY_FIRST) {
-			final Long catalogDietaId = normalized.get(day);
-			if (catalogDietaId != null) {
-				persistWeekdaySlot(assignment, day, catalogDietaId, pacienteId, userId);
+			final Long submittedDietaId = normalized.get(day);
+			if (submittedDietaId != null) {
+				applyWeekdaySelection(assignment, day, submittedDietaId, existingByDay.get(day), pacienteId, userId);
 			}
 			else if (existingByDay.containsKey(day)) {
-				final PacienteDietaWeekday retained = existingByDay.get(day);
-				final PacienteDietaWeekday slot = new PacienteDietaWeekday();
-				slot.setPacienteDieta(assignment);
-				slot.setDayOfWeek(day);
-				slot.setDieta(retained.getDieta());
-				pacienteDietaWeekdayRepository.save(slot);
+				retainWeekdaySlot(assignment, day, existingByDay.get(day));
 			}
 		}
 	}
 
 	private void replaceWeekdaySlots(final PacienteDieta assignment, final Map<Integer, Long> weekdayCatalogDietaIds,
 			final Long pacienteId, final String userId) {
-		pacienteDietaWeekdayRepository.deleteByPacienteDietaId(assignment.getId());
+		removeWeekdaySlots(pacienteDietaWeekdayRepository.findByPacienteDietaIdOrderByDayOfWeekAsc(assignment.getId()));
 		final Map<Integer, Long> normalized = normalizeWeekdayMap(weekdayCatalogDietaIds);
 		for (final Map.Entry<Integer, Long> entry : normalized.entrySet()) {
 			persistWeekdaySlot(assignment, entry.getKey(), entry.getValue(), pacienteId, userId);
 		}
 	}
 
-	private void persistWeekdaySlot(final PacienteDieta assignment, final int day, final Long catalogDietaId,
-			final Long pacienteId, final String userId) {
-		final Dieta sourceDieta = dietaRepository.findById(catalogDietaId)
-			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado dieta con id " + catalogDietaId));
-		assertAssignableCatalogDieta(sourceDieta);
-		final Dieta patientCopy = dietaService.copyDietaForPatientAssignment(catalogDietaId, pacienteId, userId);
+	private void removeWeekdaySlots(final List<PacienteDietaWeekday> existingSlots) {
+		if (!existingSlots.isEmpty()) {
+			pacienteDietaWeekdayRepository.deleteAll(existingSlots);
+		}
+		pacienteDietaWeekdayRepository.flush();
+	}
+
+	private void applyWeekdaySelection(final PacienteDieta assignment, final int day, final Long submittedDietaId,
+			final PacienteDietaWeekday existingSlot, final Long pacienteId, final String userId) {
+		if (existingSlot != null && existingSlot.getDieta() != null
+				&& submittedDietaId.equals(existingSlot.getDieta().getId())) {
+			retainWeekdaySlot(assignment, day, existingSlot);
+		}
+		else {
+			persistWeekdaySlot(assignment, day, submittedDietaId, pacienteId, userId);
+		}
+	}
+
+	private void retainWeekdaySlot(final PacienteDieta assignment, final int day,
+			final PacienteDietaWeekday existingSlot) {
 		final PacienteDietaWeekday slot = new PacienteDietaWeekday();
 		slot.setPacienteDieta(assignment);
 		slot.setDayOfWeek(day);
-		slot.setDieta(patientCopy);
+		slot.setDieta(existingSlot.getDieta());
+		pacienteDietaWeekdayRepository.save(slot);
+	}
+
+	private void persistWeekdaySlot(final PacienteDieta assignment, final int day, final Long submittedDietaId,
+			final Long pacienteId, final String userId) {
+		final Dieta sourceDieta = dietaRepository.findById(submittedDietaId)
+			.orElseThrow(() -> new IllegalArgumentException("No se ha encontrado dieta con id " + submittedDietaId));
+		final Dieta slotDieta;
+		if (DietaCatalogConstants.isPatientAssignment(sourceDieta)) {
+			if (!Objects.equals(pacienteId, sourceDieta.getPacienteId())) {
+				throw new IllegalArgumentException("No se puede asignar una dieta exclusiva de otro paciente");
+			}
+			slotDieta = sourceDieta;
+		}
+		else {
+			slotDieta = dietaService.copyDietaForPatientAssignment(submittedDietaId, pacienteId, userId);
+		}
+		final PacienteDietaWeekday slot = new PacienteDietaWeekday();
+		slot.setPacienteDieta(assignment);
+		slot.setDayOfWeek(day);
+		slot.setDieta(slotDieta);
 		pacienteDietaWeekdayRepository.save(slot);
 	}
 

--- a/src/main/java/com/nutriconsultas/paciente/PacienteDietaWeekdayRepository.java
+++ b/src/main/java/com/nutriconsultas/paciente/PacienteDietaWeekdayRepository.java
@@ -1,6 +1,7 @@
 package com.nutriconsultas.paciente;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,6 +11,6 @@ public interface PacienteDietaWeekdayRepository extends JpaRepository<PacienteDi
 
 	List<PacienteDietaWeekday> findByPacienteDietaIdOrderByDayOfWeekAsc(Long pacienteDietaId);
 
-	void deleteByPacienteDietaId(Long pacienteDietaId);
+	Optional<PacienteDietaWeekday> findFirstByDietaId(Long dietaId);
 
 }

--- a/src/main/resources/templates/sbadmin/dietas/printable.html
+++ b/src/main/resources/templates/sbadmin/dietas/printable.html
@@ -329,7 +329,7 @@
 		<div class="ingesta-content">
 			<!-- Platillos -->
 			<div th:each="platillo : ${ingesta.platillos}" class="platillo-item">
-				<div class="item-name" th:text="${platillo.name + (platillo.portions != null && platillo.portions > 1 ? ' (' + platillo.portions + ' porciones)' : '')}">Platillo</div>
+				<div class="item-name" th:text="${platillo.name}">Platillo</div>
 				<div class="item-details">
 					<div th:if="${platillo.recommendations != null && !platillo.recommendations.isEmpty()}" class="recommendations" th:text="${'Recomendaciones: ' + platillo.recommendations}"></div>
 					<div th:if="${platillo.ingredientes != null && !platillo.ingredientes.isEmpty()}">
@@ -379,7 +379,7 @@
 
 			<!-- Alimentos -->
 			<div th:each="alimento : ${ingesta.alimentos}" class="alimento-item">
-				<div class="item-name" th:text="${alimento.name + (alimento.portions != null && alimento.portions > 1 ? ' (' + alimento.displayCantidad + ' porción' + (alimento.portions > 1 ? 'es' : '') + ')' : '')}">Alimento</div>
+				<div class="item-name" th:text="${alimento.name}">Alimento</div>
 				<div class="item-details" th:if="${alimento.alimento != null && (alimento.alimento.cantSugerida != null || alimento.unidad != null)}">
 					<div style="margin-top: 3px;">
 						<span th:text="${alimento.displayCantidad}"></span>

--- a/src/test/java/com/nutriconsultas/dieta/DietaPdfServiceTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/DietaPdfServiceTest.java
@@ -26,6 +26,8 @@ import com.nutriconsultas.paciente.Paciente;
 import com.nutriconsultas.paciente.PacienteDieta;
 import com.nutriconsultas.paciente.PacienteDietaRepository;
 import com.nutriconsultas.paciente.PacienteDietaStatus;
+import com.nutriconsultas.paciente.PacienteDietaWeekday;
+import com.nutriconsultas.paciente.PacienteDietaWeekdayRepository;
 import com.nutriconsultas.paciente.PacienteRepository;
 
 import lombok.extern.slf4j.Slf4j;
@@ -43,6 +45,9 @@ public class DietaPdfServiceTest {
 
 	@Mock
 	private PacienteDietaRepository pacienteDietaRepository;
+
+	@Mock
+	private PacienteDietaWeekdayRepository pacienteDietaWeekdayRepository;
 
 	@Mock
 	private PacienteRepository pacienteRepository;
@@ -226,6 +231,49 @@ public class DietaPdfServiceTest {
 		assertThatThrownBy(() -> dietaPdfService.generatePdfForAssignment(pacienteDieta))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("no dieta");
+	}
+
+	@Test
+	public void testGeneratePdfForAssignmentWithExplicitDietaId() {
+		final PacienteDieta weekly = new PacienteDieta();
+		weekly.setId(25L);
+		weekly.setStatus(PacienteDietaStatus.ACTIVE);
+
+		when(dietaService.getDieta(83L)).thenReturn(dieta);
+		when(templateEngine.process(eq("sbadmin/dietas/printable"), any(Context.class)))
+			.thenReturn("<html><body>Test</body></html>");
+
+		final byte[] pdfBytes = dietaPdfService.generatePdfForAssignment(weekly, 83L);
+
+		assertThat(pdfBytes).isNotNull();
+		assertThat(pdfBytes.length).isGreaterThan(0);
+	}
+
+	@Test
+	public void testGeneratePdfResolvesWeeklyWeekdayAssignment() {
+		dieta.setPacienteId(3L);
+		final Paciente paciente = new Paciente();
+		paciente.setId(3L);
+		final PacienteDieta weekly = new PacienteDieta();
+		weekly.setId(25L);
+		weekly.setPaciente(paciente);
+		weekly.setStatus(PacienteDietaStatus.ACTIVE);
+		final PacienteDietaWeekday monday = new PacienteDietaWeekday();
+		monday.setPacienteDieta(weekly);
+		monday.setDieta(dieta);
+
+		when(dietaService.getDieta(1L)).thenReturn(dieta);
+		when(pacienteDietaRepository.findByDietaId(1L)).thenReturn(new ArrayList<>());
+		when(pacienteDietaWeekdayRepository.findFirstByDietaId(1L)).thenReturn(Optional.of(monday));
+		when(templateEngine.process(eq("sbadmin/dietas/printable"), any(Context.class)))
+			.thenReturn("<html><body>Test</body></html>");
+
+		final ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+		dietaPdfService.generatePdf(1L, true);
+
+		verify(templateEngine).process(eq("sbadmin/dietas/printable"), contextCaptor.capture());
+		assertThat(contextCaptor.getValue().getVariable("pacienteDieta")).isEqualTo(weekly);
+		assertThat(contextCaptor.getValue().getVariable("paciente")).isEqualTo(paciente);
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/dieta/IngredientePlatilloIngestaRestControllerTest.java
+++ b/src/test/java/com/nutriconsultas/dieta/IngredientePlatilloIngestaRestControllerTest.java
@@ -171,6 +171,17 @@ public class IngredientePlatilloIngestaRestControllerTest {
 		final java.util.List<String> row = controller.toStringList(ingrediente);
 
 		assertThat(row.get(1)).contains("inline-platillo-ingesta-cantidad-input");
+		assertThat(row.get(3)).isEqualTo("100");
+	}
+
+	@Test
+	public void testToStringListAllowsNullPesoNeto() {
+		ingrediente.setPesoNeto(null);
+
+		final java.util.List<String> row = controller.toStringList(ingrediente);
+
+		assertThat(row.get(0)).isEqualTo("Arroz");
+		assertThat(row.get(3)).isEmpty();
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/paciente/EditarDietaWeeklyUiIntegrationTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/EditarDietaWeeklyUiIntegrationTest.java
@@ -3,11 +3,14 @@ package com.nutriconsultas.paciente;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,6 +52,8 @@ class EditarDietaWeeklyUiIntegrationTest {
 
 	private PacienteDieta assignment;
 
+	private Dieta weekdayDieta;
+
 	@BeforeEach
 	void seedWeeklyAssignment() {
 		paciente = new Paciente();
@@ -58,14 +63,15 @@ class EditarDietaWeeklyUiIntegrationTest {
 		paciente.setDob(Date.from(LocalDate.of(1990, 1, 1).atStartOfDay(ZoneId.systemDefault()).toInstant()));
 		paciente = pacienteRepository.saveAndFlush(paciente);
 
-		final Dieta dieta = new Dieta();
-		dieta.setNombre("Dieta semanal prueba");
-		dieta.setUserId(OWNER_SUB);
-		dieta.setEnergia(1800);
-		dieta.setProteina(90.0);
-		dieta.setLipidos(50.0);
-		dieta.setHidratosDeCarbono(200.0);
-		final Dieta savedDieta = dietaRepository.saveAndFlush(dieta);
+		weekdayDieta = new Dieta();
+		weekdayDieta.setNombre("Dieta semanal prueba");
+		weekdayDieta.setUserId(OWNER_SUB);
+		weekdayDieta.setPacienteId(paciente.getId());
+		weekdayDieta.setEnergia(1800);
+		weekdayDieta.setProteina(90.0);
+		weekdayDieta.setLipidos(50.0);
+		weekdayDieta.setHidratosDeCarbono(200.0);
+		weekdayDieta = dietaRepository.saveAndFlush(weekdayDieta);
 
 		assignment = new PacienteDieta();
 		assignment.setPaciente(paciente);
@@ -77,7 +83,7 @@ class EditarDietaWeeklyUiIntegrationTest {
 		final PacienteDietaWeekday monday = new PacienteDietaWeekday();
 		monday.setPacienteDieta(assignment);
 		monday.setDayOfWeek(1);
-		monday.setDieta(savedDieta);
+		monday.setDieta(weekdayDieta);
 		pacienteDietaWeekdayRepository.saveAndFlush(monday);
 	}
 
@@ -93,6 +99,24 @@ class EditarDietaWeeklyUiIntegrationTest {
 		assertThat(html).contains("Plan semanal");
 		assertThat(html).contains("Menú por día");
 		assertThat(html).contains("Dieta semanal prueba");
+	}
+
+	@Test
+	void editarDieta_saveResubmitsExistingPatientCopyWithoutServerError() throws Exception {
+		mockMvc
+			.perform(post("/admin/pacientes/{pacienteId}/dietas/{id}/editar", paciente.getId(), assignment.getId())
+				.with(oidcLogin().idToken(token -> token.subject(OWNER_SUB).claim("name", "Tester")))
+				.param("startDate", LocalDate.now().toString())
+				.param("status", "ACTIVE")
+				.param("weekdayDietaId_1", String.valueOf(weekdayDieta.getId())))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/pacientes/" + paciente.getId() + "/dietas"));
+
+		final List<PacienteDietaWeekday> slots = pacienteDietaWeekdayRepository
+			.findByPacienteDietaIdOrderByDayOfWeekAsc(assignment.getId());
+		assertThat(slots).hasSize(1);
+		assertThat(slots.get(0).getDieta().getId()).isEqualTo(weekdayDieta.getId());
+		assertThat(slots.get(0).getDayOfWeek()).isEqualTo(1);
 	}
 
 }

--- a/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteControllerTest.java
@@ -80,6 +80,9 @@ public class PacienteControllerTest {
 	private com.nutriconsultas.dieta.DietaRepository dietaRepository;
 
 	@Mock
+	private com.nutriconsultas.dieta.DietaPdfService dietaPdfService;
+
+	@Mock
 	private ClinicalExamService clinicalExamService;
 
 	@Mock
@@ -1157,6 +1160,36 @@ public class PacienteControllerTest {
 		assertThat(result).isEqualTo("redirect:/admin/pacientes/1/dietas");
 		verify(pacienteDietaService).cancelAssignment(1L);
 		log.info("finished testCancelarAsignacionDieta");
+	}
+
+	@Test
+	public void testPrintDietaFromPatientWeeklyWeekdayCopy() {
+		final PacienteDieta weekly = new PacienteDieta();
+		weekly.setId(25L);
+		weekly.setPaciente(paciente);
+		weekly.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
+		final byte[] pdfBytes = new byte[] { 37, 80, 68, 70 };
+		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
+		when(pacienteDietaService.findAssignmentContainingDieta(1L, 83L)).thenReturn(weekly);
+		when(dietaPdfService.buildAssignmentPdfResponse(weekly, 83L)).thenReturn(
+				ResponseEntity.ok().contentType(org.springframework.http.MediaType.APPLICATION_PDF).body(pdfBytes));
+
+		final ResponseEntity<byte[]> result = controller.printDietaFromPatient(1L, 83L, principal);
+
+		assertThat(result.getStatusCode().is2xxSuccessful()).isTrue();
+		assertThat(result.getBody()).isEqualTo(pdfBytes);
+		verify(dietaPdfService).buildAssignmentPdfResponse(weekly, 83L);
+	}
+
+	@Test
+	public void testPrintDietaFromPatientReturnsNotFoundWhenDietaNotAssigned() {
+		when(pacienteRepository.findByIdAndUserId(1L, TEST_USER_ID)).thenReturn(java.util.Optional.of(paciente));
+		when(pacienteDietaService.findAssignmentContainingDieta(1L, 83L)).thenReturn(null);
+
+		final ResponseEntity<byte[]> result = controller.printDietaFromPatient(1L, 83L, principal);
+
+		assertThat(result.getStatusCode().is4xxClientError()).isTrue();
+		verify(dietaPdfService, org.mockito.Mockito.never()).buildAssignmentPdfResponse(any(), any());
 	}
 
 	@Test

--- a/src/test/java/com/nutriconsultas/paciente/PacienteDietaServiceTest.java
+++ b/src/test/java/com/nutriconsultas/paciente/PacienteDietaServiceTest.java
@@ -3,6 +3,7 @@ package com.nutriconsultas.paciente;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -16,6 +17,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -410,6 +412,7 @@ public class PacienteDietaServiceTest {
 			saved.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
 			return Optional.of(saved);
 		});
+		when(pacienteDietaWeekdayRepository.findByPacienteDietaIdOrderByDayOfWeekAsc(10L)).thenReturn(List.of());
 		when(pacienteDietaWeekdayRepository.save(any(PacienteDietaWeekday.class)))
 			.thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -424,8 +427,138 @@ public class PacienteDietaServiceTest {
 
 		assertThat(result).isNotNull();
 		assertThat(result.getAssignmentType()).isEqualTo(PacienteDietaAssignmentType.WEEKLY);
-		verify(pacienteDietaWeekdayRepository).deleteByPacienteDietaId(10L);
+		verify(pacienteDietaWeekdayRepository, never()).deleteAll(any());
+		verify(pacienteDietaWeekdayRepository).flush();
 		verify(pacienteDietaWeekdayRepository, org.mockito.Mockito.times(2)).save(any(PacienteDietaWeekday.class));
+	}
+
+	@Test
+	public void testUpdateWeeklyAssignmentKeepsExistingPatientCopyWithoutRecopying() {
+		final PacienteDieta weekly = new PacienteDieta();
+		weekly.setId(10L);
+		weekly.setPaciente(paciente);
+		weekly.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
+		weekly.setStartDate(new Date());
+		weekly.setStatus(PacienteDietaStatus.ACTIVE);
+
+		final PacienteDietaWeekday monday = new PacienteDietaWeekday();
+		monday.setDayOfWeek(1);
+		monday.setDieta(patientCopyDieta);
+
+		when(pacienteDietaRepository.findById(10L)).thenReturn(Optional.of(weekly));
+		when(pacienteDietaRepository.save(weekly)).thenReturn(weekly);
+		when(pacienteDietaWeekdayRepository.findByPacienteDietaIdOrderByDayOfWeekAsc(10L)).thenReturn(List.of(monday));
+		when(pacienteDietaWeekdayRepository.save(any(PacienteDietaWeekday.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		final PacienteDieta metadata = new PacienteDieta();
+		metadata.setStartDate(weekly.getStartDate());
+		metadata.setStatus(PacienteDietaStatus.ACTIVE);
+
+		final PacienteDieta result = service.updateWeeklyAssignment(10L, Map.of(1, 99L), metadata);
+
+		assertThat(result.getId()).isEqualTo(10L);
+		final ArgumentCaptor<PacienteDietaWeekday> slotCaptor = ArgumentCaptor.forClass(PacienteDietaWeekday.class);
+		verify(pacienteDietaWeekdayRepository).save(slotCaptor.capture());
+		assertThat(slotCaptor.getValue().getDieta()).isEqualTo(patientCopyDieta);
+		assertThat(slotCaptor.getValue().getDayOfWeek()).isEqualTo(1);
+		verify(dietaService, never()).copyDietaForPatientAssignment(any(), any(), any());
+		verify(dietaRepository, never()).findById(any());
+	}
+
+	@Test
+	public void testUpdateWeeklyAssignmentReusesThisPatientCopyForNewDay() {
+		final PacienteDieta weekly = new PacienteDieta();
+		weekly.setId(10L);
+		weekly.setPaciente(paciente);
+		weekly.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
+		weekly.setStartDate(new Date());
+		weekly.setStatus(PacienteDietaStatus.ACTIVE);
+
+		when(pacienteDietaRepository.findById(10L)).thenReturn(Optional.of(weekly));
+		when(pacienteDietaRepository.save(weekly)).thenReturn(weekly);
+		when(pacienteDietaWeekdayRepository.findByPacienteDietaIdOrderByDayOfWeekAsc(10L)).thenReturn(List.of());
+		when(dietaRepository.findById(99L)).thenReturn(Optional.of(patientCopyDieta));
+		when(pacienteDietaWeekdayRepository.save(any(PacienteDietaWeekday.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		final PacienteDieta metadata = new PacienteDieta();
+		metadata.setStartDate(weekly.getStartDate());
+		metadata.setStatus(PacienteDietaStatus.ACTIVE);
+
+		service.updateWeeklyAssignment(10L, Map.of(2, 99L), metadata);
+
+		verify(dietaService, never()).copyDietaForPatientAssignment(any(), any(), any());
+		final ArgumentCaptor<PacienteDietaWeekday> slotCaptor = ArgumentCaptor.forClass(PacienteDietaWeekday.class);
+		verify(pacienteDietaWeekdayRepository).save(slotCaptor.capture());
+		assertThat(slotCaptor.getValue().getDayOfWeek()).isEqualTo(2);
+		assertThat(slotCaptor.getValue().getDieta()).isEqualTo(patientCopyDieta);
+	}
+
+	@Test
+	public void testUpdateWeeklyAssignmentCopiesCatalogDietWhenDayChanges() {
+		final PacienteDieta weekly = new PacienteDieta();
+		weekly.setId(10L);
+		weekly.setPaciente(paciente);
+		weekly.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
+		weekly.setStartDate(new Date());
+		weekly.setStatus(PacienteDietaStatus.ACTIVE);
+
+		final PacienteDietaWeekday monday = new PacienteDietaWeekday();
+		monday.setDayOfWeek(1);
+		monday.setDieta(patientCopyDieta);
+
+		final Dieta newCopy = new Dieta();
+		newCopy.setId(200L);
+		newCopy.setPacienteId(1L);
+		newCopy.setUserId(TEST_USER_ID);
+
+		when(pacienteDietaRepository.findById(10L)).thenReturn(Optional.of(weekly));
+		when(pacienteDietaRepository.save(weekly)).thenReturn(weekly);
+		when(pacienteDietaWeekdayRepository.findByPacienteDietaIdOrderByDayOfWeekAsc(10L)).thenReturn(List.of(monday));
+		when(dietaRepository.findById(1L)).thenReturn(Optional.of(sourceDieta));
+		when(dietaService.copyDietaForPatientAssignment(1L, 1L, TEST_USER_ID)).thenReturn(newCopy);
+		when(pacienteDietaWeekdayRepository.save(any(PacienteDietaWeekday.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		final PacienteDieta metadata = new PacienteDieta();
+		metadata.setStartDate(weekly.getStartDate());
+		metadata.setStatus(PacienteDietaStatus.ACTIVE);
+
+		service.updateWeeklyAssignment(10L, Map.of(1, 1L), metadata);
+
+		verify(dietaService).copyDietaForPatientAssignment(1L, 1L, TEST_USER_ID);
+		final ArgumentCaptor<PacienteDietaWeekday> slotCaptor = ArgumentCaptor.forClass(PacienteDietaWeekday.class);
+		verify(pacienteDietaWeekdayRepository).save(slotCaptor.capture());
+		assertThat(slotCaptor.getValue().getDieta()).isEqualTo(newCopy);
+	}
+
+	@Test
+	public void testUpdateWeeklyAssignmentRejectsOtherPatientCopy() {
+		final PacienteDieta weekly = new PacienteDieta();
+		weekly.setId(10L);
+		weekly.setPaciente(paciente);
+		weekly.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
+		weekly.setStartDate(new Date());
+		weekly.setStatus(PacienteDietaStatus.ACTIVE);
+
+		final Dieta otherPatientCopy = new Dieta();
+		otherPatientCopy.setId(50L);
+		otherPatientCopy.setPacienteId(999L);
+
+		when(pacienteDietaRepository.findById(10L)).thenReturn(Optional.of(weekly));
+		when(pacienteDietaRepository.save(weekly)).thenReturn(weekly);
+		when(pacienteDietaWeekdayRepository.findByPacienteDietaIdOrderByDayOfWeekAsc(10L)).thenReturn(List.of());
+		when(dietaRepository.findById(50L)).thenReturn(Optional.of(otherPatientCopy));
+
+		final PacienteDieta metadata = new PacienteDieta();
+		metadata.setStartDate(weekly.getStartDate());
+		metadata.setStatus(PacienteDietaStatus.ACTIVE);
+
+		assertThatThrownBy(() -> service.updateWeeklyAssignment(10L, Map.of(1, 50L), metadata))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("dieta exclusiva de otro paciente");
+		verify(dietaService, never()).copyDietaForPatientAssignment(any(), any(), any());
 	}
 
 	@Test
@@ -475,6 +608,51 @@ public class PacienteDietaServiceTest {
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("No se ha encontrado paciente");
 		verify(dietaService, org.mockito.Mockito.never()).createEmptyDietaForPatient(any(), any(), any());
+	}
+
+	@Test
+	public void testFindAssignmentContainingDietaMatchesDateRangeCopy() {
+		when(pacienteDietaRepository.findByPacienteId(1L)).thenReturn(List.of(pacienteDieta));
+
+		final PacienteDieta result = service.findAssignmentContainingDieta(1L, 99L);
+
+		assertThat(result).isEqualTo(pacienteDieta);
+		verify(pacienteDietaWeekdayRepository, never()).findFirstByDietaId(any());
+	}
+
+	@Test
+	public void testFindAssignmentContainingDietaMatchesWeeklyWeekdayCopy() {
+		final PacienteDieta weekly = new PacienteDieta();
+		weekly.setId(25L);
+		weekly.setPaciente(paciente);
+		weekly.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
+		final PacienteDietaWeekday monday = new PacienteDietaWeekday();
+		monday.setPacienteDieta(weekly);
+		monday.setDayOfWeek(1);
+		monday.setDieta(patientCopyDieta);
+		when(pacienteDietaRepository.findByPacienteId(1L)).thenReturn(List.of(weekly));
+		when(pacienteDietaWeekdayRepository.findFirstByDietaId(99L)).thenReturn(Optional.of(monday));
+
+		final PacienteDieta result = service.findAssignmentContainingDieta(1L, 99L);
+
+		assertThat(result).isEqualTo(weekly);
+	}
+
+	@Test
+	public void testFindAssignmentContainingDietaRejectsOtherPatientWeekday() {
+		final Paciente otherPaciente = new Paciente();
+		otherPaciente.setId(2L);
+		final PacienteDieta otherWeekly = new PacienteDieta();
+		otherWeekly.setId(30L);
+		otherWeekly.setPaciente(otherPaciente);
+		otherWeekly.setAssignmentType(PacienteDietaAssignmentType.WEEKLY);
+		final PacienteDietaWeekday monday = new PacienteDietaWeekday();
+		monday.setPacienteDieta(otherWeekly);
+		monday.setDieta(patientCopyDieta);
+		when(pacienteDietaRepository.findByPacienteId(1L)).thenReturn(List.of());
+		when(pacienteDietaWeekdayRepository.findFirstByDietaId(99L)).thenReturn(Optional.of(monday));
+
+		assertThat(service.findAssignmentContainingDieta(1L, 99L)).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Saving a weekly plan no longer 500s when the form resubmits existing patient-copy diet IDs; catalog picks still copy, and the ingredient grid tolerates null `pesoNeto`.
- Printing a weekday diet from the patient plan finds the weekly assignment instead of 404ing.
- Diet PDFs show the food name only and keep the amount/unit line (e.g. `2 pieza`), without `(2 porciones)` in the title.

## Test plan
- [ ] Assign a weekly plan, then **Guardar cambios** without changing days — should redirect, not 500
- [ ] Open a day’s platillo ingredients when some rows have null net weight — DataTable should load
- [ ] From a weekday patient diet, **Imprimir PDF** should download the plan with patient info
- [ ] PDF item names should not include `(N porciones)`; quantity stays on the line below


Made with [Cursor](https://cursor.com)